### PR TITLE
bound function should return package limits

### DIFF
--- a/src/RAPLPlatform.cpp
+++ b/src/RAPLPlatform.cpp
@@ -141,15 +141,7 @@ namespace geopm
 
     void RAPLPlatform::bound(double &upper_bound, double &lower_bound)
     {
-        double min_pkg;
-        double max_pkg;
-        double min_dram;
-        double max_dram;
-
-        m_imp->bound(GEOPM_TELEMETRY_TYPE_PKG_ENERGY, max_pkg, min_pkg);
-        m_imp->bound(GEOPM_TELEMETRY_TYPE_DRAM_ENERGY, max_dram, min_dram);
-        upper_bound = max_pkg + max_dram;
-        lower_bound = min_pkg + min_dram;
+        m_imp->bound(GEOPM_TELEMETRY_TYPE_PKG_ENERGY, upper_bound, lower_bound);
     }
 
     void RAPLPlatform::sample(std::vector<struct geopm_msr_message_s> &msr_values)


### PR DESCRIPTION
Previously the bound function returned the sum of the package limits and the DRAM limits. This double counts DRAM if, as stated in Platform.hpp, the bound function should return the RAPL bounds.