### PR TITLE
Remove extra closing curly brace.

### DIFF
--- a/tutorial/tutorial_region.c
+++ b/tutorial/tutorial_region.c
@@ -301,7 +301,6 @@ static int stream_profiled_omp(uint64_t region_id, size_t num_stream, double sca
             a[num_block * block + j] = b[num_block * block + j] + scalar * c[num_block * block + j];
         }
 }
-    }
 
     return err;
 }


### PR DESCRIPTION
Extra curly brace in `tutorial_region.c` causing build errors. 

Signed-off-by: Stephanie Labasan <labasan1@llnl.gov>