### PR TITLE
Modifications performed to make geopm compile out-of source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,6 @@
 /test/fortran/fortran_links/*
 /test_integration/geopm_test_integration
 /test_integration/geopm_test_integration.pyc
-/VERSION
 /doc/*.aux
 /doc/*.bbl
 /doc/*.blg

--- a/Makefile.am
+++ b/Makefile.am
@@ -448,11 +448,11 @@ ruby/bin/ronn:
 $(ronn_man): man/%: ruby/bin/ronn ronn/%.ronn ronn/index.txt ronn/header.txt
 	mkdir -p man
 	export GEM_PATH=`readlink -f $(top_srcdir)/ruby`:$$GEM_PATH && \
-	cd ronn && \
-	../ruby/bin/ronn --date=`date "+%Y-%m-%d"` \
+	cd $(abs_top_srcdir)/ronn && \
+	$(abs_top_builddir)/ruby/bin/ronn --date=`date "+%Y-%m-%d"` \
 	                 --organization="Intel Corporation" \
-	                 `basename $@`.ronn
-	cat ronn/header.txt ronn/`basename $@` | \
+	                 $(abs_top_srcdir)/ronn/`basename $@`.ronn
+	cat $(abs_top_srcdir)/ronn/header.txt $(abs_top_srcdir)/ronn/`basename $@` | \
 	    sed -e 's/\(#include.*\) \\fIhttp.*/\1\\fR/g' > $@
 
 # GH_PAGES TARGET


### PR DESCRIPTION
I have performed some modifications on the build system to make geopm able to compile out-of-source.
Do not hesitate in correcting/amending them in the Makefile.am

Also I have removed the VERSION file from the .gitignore as it seems to be needed. I have added a empty file in the repository for the same reason.

This might be interesting in view of compiling the geopm together with an software package suite.

Many thanks

Luigi