### PR TITLE
fix catch-value warning from GCC 8

### DIFF
--- a/plugin/EfficientFreqDecider.cpp
+++ b/plugin/EfficientFreqDecider.cpp
@@ -181,7 +181,7 @@ namespace geopm
                         uint64_t rid = geopm_crc32_str(0, rid_str.c_str());
                         m_rid_freq_map[rid] = freq;
                     }
-                    catch (std::invalid_argument) {
+                    catch (std::invalid_argument&) {
 
                     }
                 }
@@ -288,7 +288,7 @@ namespace geopm
             try {
                 result = std::stod(env_efficient_freq_min);
             }
-            catch (std::invalid_argument) {
+            catch (std::invalid_argument&) {
 
             }
         }
@@ -307,7 +307,7 @@ namespace geopm
             try {
                 result = std::stod(env_efficient_freq_max);
             }
-            catch (std::invalid_argument) {
+            catch (std::invalid_argument&) {
 
             }
         }

--- a/src/Agent.cpp
+++ b/src/Agent.cpp
@@ -156,7 +156,7 @@ int geopm_agent_supported(const char *agent_name)
     try {
         auto tmp = geopm::agent_factory().dictionary(agent_name);
     }
-    catch (geopm::Exception ex) {
+    catch (geopm::Exception& ex) {
         if (ex.err_value() == GEOPM_ERROR_INVALID) {
             err = GEOPM_ERROR_NO_AGENT;
         }
@@ -177,7 +177,7 @@ int geopm_agent_num_policy(const char *agent_name,
         *num_policy = geopm::Agent::num_policy(
             geopm::agent_factory().dictionary(agent_name));
     }
-    catch (geopm::Exception ex) {
+    catch (geopm::Exception& ex) {
         if (ex.err_value() == GEOPM_ERROR_INVALID) {
             err = GEOPM_ERROR_NO_AGENT;
         }
@@ -199,7 +199,7 @@ int geopm_agent_num_sample(const char *agent_name,
         *num_sample = geopm::Agent::num_sample(
             geopm::agent_factory().dictionary(agent_name));
     }
-    catch (geopm::Exception ex) {
+    catch (geopm::Exception& ex) {
         if (ex.err_value() == GEOPM_ERROR_INVALID) {
             err = GEOPM_ERROR_NO_AGENT;
         }
@@ -235,7 +235,7 @@ int geopm_agent_policy_name(const char *agent_name,
                 policy_name[policy_name_max - 1] = '\0';
             }
         }
-        catch (geopm::Exception ex) {
+        catch (geopm::Exception& ex) {
             if (ex.err_value() == GEOPM_ERROR_INVALID) {
                 err = GEOPM_ERROR_NO_AGENT;
             }
@@ -272,7 +272,7 @@ int geopm_agent_sample_name(const char *agent_name,
                 sample_name[sample_name_max - 1] = '\0';
             }
         }
-        catch (geopm::Exception ex) {
+        catch (geopm::Exception& ex) {
             if (ex.err_value() == GEOPM_ERROR_INVALID) {
                 err = GEOPM_ERROR_NO_AGENT;
             }

--- a/src/ApplicationIO.cpp
+++ b/src/ApplicationIO.cpp
@@ -170,7 +170,7 @@ namespace geopm
         try {
             result = m_epoch_regulator->total_region_runtime(region_id);
         }
-        catch (Exception ex) {
+        catch (Exception& ex) {
         }
         return result;
     }
@@ -188,7 +188,7 @@ namespace geopm
         try {
             result = m_epoch_regulator->total_region_mpi_time(region_id);
         }
-        catch (Exception ex) {
+        catch (Exception& ex) {
         }
         return result;
     }
@@ -304,7 +304,7 @@ namespace geopm
         try {
             result = m_epoch_regulator->total_count(region_id);
         }
-        catch (Exception ex) {
+        catch (Exception& ex) {
         }
         return result;
     }

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -525,7 +525,7 @@ namespace geopm
                 m_tree_comm->get_policy(level, policy);
                 err = 0;
             }
-            catch (Exception ex) {
+            catch (Exception& ex) {
                 if (ex.err_value() != GEOPM_ERROR_POLICY_UNKNOWN) {
                     throw ex;
                 }
@@ -635,7 +635,7 @@ namespace geopm
                     }
                     is_converged = m_policy[level]->is_converged(GEOPM_REGION_ID_EPOCH);
                 }
-                catch (geopm::Exception ex) {
+                catch (geopm::Exception& ex) {
                     if (ex.err_value() != GEOPM_ERROR_SAMPLE_INCOMPLETE) {
                         throw ex;
                     }

--- a/src/CpuinfoIOGroup.cpp
+++ b/src/CpuinfoIOGroup.cpp
@@ -54,7 +54,7 @@ namespace geopm
             try {
                 result = 1e3 * std::stod(line);
             }
-            catch (std::invalid_argument) {
+            catch (std::invalid_argument&) {
 
             }
         }
@@ -100,7 +100,7 @@ namespace geopm
                         try {
                             result = unit_factor[unit_idx] * std::stod(value_str);
                         }
-                        catch (std::invalid_argument) {
+                        catch (std::invalid_argument&) {
 
                         }
                     }

--- a/src/EnergyEfficientAgent.cpp
+++ b/src/EnergyEfficientAgent.cpp
@@ -438,7 +438,7 @@ namespace geopm
                         uint64_t rid = geopm_crc32_str(0, rid_str.c_str());
                         m_rid_freq_map[rid] = freq;
                     }
-                    catch (std::invalid_argument) {
+                    catch (std::invalid_argument&) {
 
                     }
                 }
@@ -461,7 +461,7 @@ namespace geopm
             try {
                 result = std::stod(env_efficient_freq_min);
             }
-            catch (std::invalid_argument) {
+            catch (std::invalid_argument&) {
 
             }
         }
@@ -480,7 +480,7 @@ namespace geopm
             try {
                 result = std::stod(env_efficient_freq_max);
             }
-            catch (std::invalid_argument) {
+            catch (std::invalid_argument&) {
 
             }
         }

--- a/src/EpochRuntimeRegulator.cpp
+++ b/src/EpochRuntimeRegulator.cpp
@@ -249,7 +249,7 @@ namespace geopm
                 region_id = geopm_region_id_set_mpi(region_id);
                 result = total_region_runtime(region_id);
             }
-            catch (Exception ex) {
+            catch (Exception& ex) {
                 /// @todo catch expected exception only
             }
         }

--- a/src/MPICommSplit.cpp
+++ b/src/MPICommSplit.cpp
@@ -124,7 +124,7 @@ extern "C"
             try {
                 shmem = new geopm::SharedMemory(shmem_key.str(), sizeof(int));
             }
-            catch (geopm::Exception ex) {
+            catch (geopm::Exception& ex) {
                 if (ex.err_value() != EEXIST) {
                     throw ex;
                 }

--- a/src/MSRIOGroup.cpp
+++ b/src/MSRIOGroup.cpp
@@ -452,7 +452,7 @@ namespace geopm
                                        pair_it.second.value,
                                        pair_it.second.mask);
                 }
-                catch (Exception e) {
+                catch (Exception& e) {
                     std::cerr << e.what() << std::endl;
                 }
             }

--- a/src/PlatformTopology.cpp
+++ b/src/PlatformTopology.cpp
@@ -102,7 +102,7 @@ namespace geopm
         try {
             result = hwloc_get_nbobjs_by_type(m_topo, hwloc_domain(domain_type));
         }
-        catch (Exception ex) {
+        catch (Exception& ex) {
             if (ex.err_value() != GEOPM_ERROR_INVALID) {
                 throw ex;
             }

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -108,7 +108,7 @@ namespace geopm
             init_tprof_table(tprof_key, topo);
             init_table(sample_key);
         }
-        catch (Exception ex) {
+        catch (Exception& ex) {
             if (!m_rank) {
                 std::cerr << "Warning: <geopm> Controller handshake failed, running without geopm." << std::endl;
                 int err = ex.err_value();

--- a/src/geopmread_main.cpp
+++ b/src/geopmread_main.cpp
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
             try {
                 domain_idx = std::stoi(pos_args[2]);
             }
-            catch (std::invalid_argument) {
+            catch (std::invalid_argument&) {
                 std::cerr << "Error: invalid domain index.\n" << std::endl;
                 err = EINVAL;
             }

--- a/src/geopmwrite_main.cpp
+++ b/src/geopmwrite_main.cpp
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
             try {
                 domain_idx = std::stoi(pos_args[2]);
             }
-            catch (std::invalid_argument) {
+            catch (std::invalid_argument&) {
                 std::cerr << "Error: invalid domain index.\n" << std::endl;
                 err = EINVAL;
             }
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
                 try {
                     write_value = std::stod(pos_args[3]);
                 }
-                catch (std::invalid_argument) {
+                catch (std::invalid_argument&) {
                     std::cerr << "Error: invalid write value.\n" << std::endl;
                     err = EINVAL;
                 }

--- a/test/PlatformFactoryTest.cpp
+++ b/test/PlatformFactoryTest.cpp
@@ -109,7 +109,7 @@ TEST_F(PlatformFactoryTest, no_supported_platform)
     try {
         p = m_platform_fact.platform("rapl", true);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     ASSERT_TRUE(p == NULL);

--- a/test/PlatformImpTest.cpp
+++ b/test/PlatformImpTest.cpp
@@ -631,7 +631,7 @@ TEST_F(PlatformImpTest, negative_read_no_desc)
     try {
         (void) m_platform->msr_read(geopm::GEOPM_DOMAIN_CPU, (NUM_CPU+2), name);
     }
-    catch(geopm::Exception e) {
+    catch(geopm::Exception& e) {
         thrown = e.err_value();
     }
 
@@ -647,7 +647,7 @@ TEST_F(PlatformImpTest, negative_write_no_desc)
     try {
         m_platform->msr_write(geopm::GEOPM_DOMAIN_CPU, (NUM_CPU+2), name, value);
     }
-    catch(geopm::Exception e) {
+    catch(geopm::Exception& e) {
         thrown = e.err_value();
     }
 
@@ -664,7 +664,7 @@ TEST_F(PlatformImpTest, negative_read_bad_desc)
     try {
         (void) m_platform->msr_read(geopm::GEOPM_DOMAIN_CPU, NUM_CPU, name);
     }
-    catch(std::runtime_error e) {
+    catch(std::runtime_error& e) {
         thrown = 1;
     }
 
@@ -680,7 +680,7 @@ TEST_F(PlatformImpTest, negative_write_bad_desc)
     try {
         m_platform->msr_write(geopm::GEOPM_DOMAIN_CPU, NUM_CPU, name, value);
     }
-    catch(std::runtime_error e) {
+    catch(std::runtime_error& e) {
         thrown = 1;
     }
 
@@ -695,7 +695,7 @@ TEST_F(PlatformImpTest, negative_msr_open)
     try {
         p.msr_open(5000);
     }
-    catch(geopm::Exception e) {
+    catch(geopm::Exception& e) {
         thrown = 1;
     }
 
@@ -716,7 +716,7 @@ TEST_F(PlatformImpTest, parse_topology)
     try {
         m_platform->parse_hw_topology();
     }
-    catch(std::system_error e) {
+    catch(std::system_error& e) {
         thrown = 1;
     }
 

--- a/test/PlatformTopologyTest.cpp
+++ b/test/PlatformTopologyTest.cpp
@@ -73,7 +73,7 @@ TEST_F(PlatformTopologyTest, negative_num_domain)
     try {
         val = m_topo.num_domain(HWLOC_OBJ_TYPE_MAX);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
 

--- a/test/PolicyTest.cpp
+++ b/test/PolicyTest.cpp
@@ -227,7 +227,7 @@ TEST_F(PolicyTest, negative_unsized_vector)
     try {
         m_policy->update(13, target);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -235,7 +235,7 @@ TEST_F(PolicyTest, negative_unsized_vector)
     try {
         m_policy->target(13, target);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -243,7 +243,7 @@ TEST_F(PolicyTest, negative_unsized_vector)
     try {
         m_policy->policy_message(13, m_policy_message, child_msg);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -256,7 +256,7 @@ TEST_F(PolicyTest, negative_index_oob)
     try {
         m_policy->update(13, m_num_domain + 1, target);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -264,7 +264,7 @@ TEST_F(PolicyTest, negative_index_oob)
     try {
         m_policy->target(13, m_num_domain + 1, target);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);

--- a/test/RegionTest.cpp
+++ b/test/RegionTest.cpp
@@ -422,7 +422,7 @@ TEST_F(RegionTest, negative_region_invalid)
     try {
         m_tree_region->mean(2, GEOPM_TELEMETRY_TYPE_RUNTIME);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -430,7 +430,7 @@ TEST_F(RegionTest, negative_region_invalid)
     try {
         m_tree_region->median(2, GEOPM_TELEMETRY_TYPE_RUNTIME);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -438,7 +438,7 @@ TEST_F(RegionTest, negative_region_invalid)
     try {
         m_tree_region->std_deviation(2, GEOPM_TELEMETRY_TYPE_RUNTIME);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -446,7 +446,7 @@ TEST_F(RegionTest, negative_region_invalid)
     try {
         m_tree_region->min(2, GEOPM_TELEMETRY_TYPE_RUNTIME);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -454,7 +454,7 @@ TEST_F(RegionTest, negative_region_invalid)
     try {
         m_tree_region->max(2, GEOPM_TELEMETRY_TYPE_RUNTIME);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -462,7 +462,7 @@ TEST_F(RegionTest, negative_region_invalid)
     try {
         m_tree_region->derivative(2, GEOPM_TELEMETRY_TYPE_RUNTIME);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -470,7 +470,7 @@ TEST_F(RegionTest, negative_region_invalid)
     try {
         m_tree_region->num_sample(2, GEOPM_TELEMETRY_TYPE_RUNTIME);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -478,7 +478,7 @@ TEST_F(RegionTest, negative_region_invalid)
     try {
         m_tree_region->signal(2, GEOPM_TELEMETRY_TYPE_RUNTIME);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -490,7 +490,7 @@ TEST_F(RegionTest, negative_signal_invalid)
     try {
         m_tree_region->mean(0, GEOPM_NUM_TELEMETRY_TYPE + 1);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -498,7 +498,7 @@ TEST_F(RegionTest, negative_signal_invalid)
     try {
         m_tree_region->median(0, GEOPM_NUM_TELEMETRY_TYPE + 1);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -506,7 +506,7 @@ TEST_F(RegionTest, negative_signal_invalid)
     try {
         m_tree_region->std_deviation(0, GEOPM_NUM_TELEMETRY_TYPE + 1);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -514,7 +514,7 @@ TEST_F(RegionTest, negative_signal_invalid)
     try {
         m_tree_region->min(0, GEOPM_NUM_TELEMETRY_TYPE + 1);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -522,7 +522,7 @@ TEST_F(RegionTest, negative_signal_invalid)
     try {
         m_tree_region->max(0, GEOPM_NUM_TELEMETRY_TYPE + 1);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -530,7 +530,7 @@ TEST_F(RegionTest, negative_signal_invalid)
     try {
         m_tree_region->derivative(0, GEOPM_NUM_TELEMETRY_TYPE + 1);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -538,7 +538,7 @@ TEST_F(RegionTest, negative_signal_invalid)
     try {
         m_tree_region->num_sample(0, GEOPM_NUM_TELEMETRY_TYPE + 1);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -546,7 +546,7 @@ TEST_F(RegionTest, negative_signal_invalid)
     try {
         m_tree_region->signal(0, GEOPM_NUM_TELEMETRY_TYPE + 1);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_INVALID, thrown);
@@ -558,7 +558,7 @@ TEST_F(RegionTest, negative_signal_derivative_tree)
     try {
         m_tree_region->derivative(0, GEOPM_SAMPLE_TYPE_RUNTIME);
     }
-    catch (geopm::Exception e) {
+    catch (geopm::Exception& e) {
         thrown = e.err_value();
     }
     EXPECT_EQ(GEOPM_ERROR_NOT_IMPLEMENTED, thrown);


### PR DESCRIPTION
Signed-off-by: Reese Baird <reese.baird@intel.com>

Summary of change.

- GCC 8 warns about catch handlers that do not catch via reference. This PR changes all catches by value