### PR TITLE
Revert energy status units for DRAM on Broadwell

### DIFF
--- a/src/msr_hsx.cpp
+++ b/src/msr_hsx.cpp
@@ -975,7 +975,7 @@ namespace geopm
                       .domain    = IPlatformTopo::M_DOMAIN_BOARD_MEMORY,
                       .function  = IMSR::M_FUNCTION_OVERFLOW,
                       .units     = IMSR::M_UNITS_JOULES,
-                      .scalar    = 6.103515625e-05}}},
+                      .scalar    = 1.5258789063e-05}}},
                 {}),
             MSR("DRAM_PERF_STATUS", 0x61B,
                 {{"THROTTLE_TIME", (struct IMSR::m_encode_s) {


### PR DESCRIPTION
I believe the DRAM energy usage numbers for Broadwell and Haswell should be using 15.3 microJoules, instead of the value coming from RAPL_POWER_UNIT.