### PR TITLE
Make tutorial shell scripts compatabile with more shell variants

### DIFF
--- a/tutorial/agent/agent_tutorial.sh
+++ b/tutorial/agent/agent_tutorial.sh
@@ -32,7 +32,7 @@
 #
 
 set err=0
-source ../tutorial_env.sh
+. ../tutorial_env.sh
 
 export PATH=$GEOPM_BINDIR:$PATH
 export PYTHONPATH=$GEOPMPY_PKGDIR:$PYTHONPATH
@@ -49,7 +49,7 @@ echo "Redirecting output to example.stdout and example.stderr."
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" == "srun" ]; then
+if [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -62,7 +62,7 @@ if [ "$GEOPM_LAUNCHER" == "srun" ]; then
                 -- geopmbench agent_tutorial_config.json \
                 1>example.stdout 2>example.stderr
     err=$?
-elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
+elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
     # Use GEOPM launcher wrapper script with ALPS's aprun
     geopmlaunch aprun \
                 -N 4 \
@@ -75,7 +75,7 @@ elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
                 -- geopmbench agent_tutorial_config.json \
                 1>example.stdout 2>example.stderr
     err=$?
-elif [ $MPIEXEC ]; then
+elif [ "$MPIEXEC" ]; then
     # Use MPIEXEC and set GEOPM environment variables to launch the job
     LD_DYNAMIC_WEAK=true \
     GEOPM_PMPI_CTL=process \

--- a/tutorial/tutorial_0.sh
+++ b/tutorial/tutorial_0.sh
@@ -32,7 +32,7 @@
 #
 
 set err=0
-source tutorial_env.sh
+. tutorial_env.sh
 
 export PATH=$GEOPM_BINDIR:$PATH
 export PYTHONPATH=$GEOPMPY_PKGDIR:$PYTHONPATH
@@ -44,7 +44,7 @@ export LD_LIBRARY_PATH=$GEOPM_LIBDIR:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" == "srun" ]; then
+if [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -55,7 +55,7 @@ if [ "$GEOPM_LAUNCHER" == "srun" ]; then
                 --geopm-trace=tutorial_0_trace \
                 -- ./tutorial_0
     err=$?
-elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
+elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
     # Use GEOPM launcher wrapper script with ALPS's aprun
     geopmlaunch aprun \
                 -N 4 \
@@ -66,7 +66,7 @@ elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
                 --geopm-trace=tutorial_0_trace \
                 -- ./tutorial_0
     err=$?
-elif [ $MPIEXEC ]; then
+elif [ "$MPIEXEC" ]; then
     # Use MPIEXEC and set GEOPM environment variables to launch the job
     LD_PRELOAD=$GEOPM_LIBDIR/libgeopm.so \
     LD_DYNAMIC_WEAK=true \

--- a/tutorial/tutorial_1.sh
+++ b/tutorial/tutorial_1.sh
@@ -32,7 +32,7 @@
 #
 
 set err=0
-source tutorial_env.sh
+. tutorial_env.sh
 
 export PATH=$GEOPM_BINDIR:$PATH
 export PYTHONPATH=$GEOPMPY_PKGDIR:$PYTHONPATH
@@ -44,7 +44,7 @@ export LD_LIBRARY_PATH=$GEOPM_LIBDIR:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" == "srun" ]; then
+if [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -55,7 +55,7 @@ if [ "$GEOPM_LAUNCHER" == "srun" ]; then
                 --geopm-trace=tutorial_1_trace \
                 -- ./tutorial_1
     err=$?
-elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
+elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
     # Use GEOPM launcher wrapper script with ALPS's aprun
     geopmlaunch aprun \
                 -N 4 \
@@ -66,7 +66,7 @@ elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
                 --geopm-trace=tutorial_1_trace \
                 -- ./tutorial_1
     err=$?
-elif [ $MPIEXEC ]; then
+elif [ "$MPIEXEC" ]; then
     # Use MPIEXEC and set GEOPM environment variables to launch the job
     LD_PRELOAD=$GEOPM_LIBDIR/libgeopm.so \
     LD_DYNAMIC_WEAK=true \

--- a/tutorial/tutorial_2.sh
+++ b/tutorial/tutorial_2.sh
@@ -32,7 +32,7 @@
 #
 
 set err=0
-source tutorial_env.sh
+. tutorial_env.sh
 
 export PATH=$GEOPM_BINDIR:$PATH
 export PYTHONPATH=$GEOPMPY_PKGDIR:$PYTHONPATH
@@ -43,7 +43,7 @@ export LD_LIBRARY_PATH=$GEOPM_LIBDIR:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" == "srun" ]; then
+if [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -53,7 +53,7 @@ if [ "$GEOPM_LAUNCHER" == "srun" ]; then
                 --geopm-trace=tutorial_2_trace \
                 -- ./tutorial_2
     err=$?
-elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
+elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
     # Use GEOPM launcher wrapper script with ALPS's aprun
     geopmlaunch aprun \
                 -N 4 \
@@ -63,7 +63,7 @@ elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
                 --geopm-trace=tutorial_2_trace \
                 -- ./tutorial_2
     err=$?
-elif [ $MPIEXEC ]; then
+elif [ "$MPIEXEC" ]; then
     # Use MPIEXEC and set GEOPM environment variables to launch the job
     LD_DYNAMIC_WEAK=true \
     GEOPM_CTL=process \

--- a/tutorial/tutorial_3.sh
+++ b/tutorial/tutorial_3.sh
@@ -32,7 +32,7 @@
 #
 
 set err=0
-source tutorial_env.sh
+. tutorial_env.sh
 
 export PATH=$GEOPM_BINDIR:$PATH
 export PYTHONPATH=$GEOPMPY_PKGDIR:$PYTHONPATH
@@ -43,7 +43,7 @@ export LD_LIBRARY_PATH=$GEOPM_LIBDIR:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" == "srun" ]; then
+if [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -66,7 +66,7 @@ if [ "$GEOPM_LAUNCHER" == "srun" ]; then
                 -- ./tutorial_3
     err=$?
 
-elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
+elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
     # Use GEOPM launcher wrapper script with ALPS's aprun
     geopmlaunch aprun \
                 -N 4 \
@@ -88,7 +88,7 @@ elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
                 --geopm-policy=tutorial_balanced_policy.json \
                 -- ./tutorial_3
     err=$?
-elif [ $MPIEXEC ]; then
+elif [ "$MPIEXEC" ]; then
     GEOPM_AGENT="power_governor" \
     LD_DYNAMIC_WEAK=true \
     GEOPM_CTL=process \

--- a/tutorial/tutorial_4.sh
+++ b/tutorial/tutorial_4.sh
@@ -32,7 +32,7 @@
 #
 
 set err=0
-source tutorial_env.sh
+. tutorial_env.sh
 
 export PATH=$GEOPM_BINDIR:$PATH
 export PYTHONPATH=$GEOPMPY_PKGDIR:$PYTHONPATH
@@ -52,7 +52,7 @@ fi
 # create a report file
 # create trace files
 
-if [ "$GEOPM_LAUNCHER" == "srun" ]; then
+if [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -74,7 +74,7 @@ if [ "$GEOPM_LAUNCHER" == "srun" ]; then
                 --geopm-policy=tutorial_balanced_policy.json \
                 -- ./tutorial_4
     err=$?
-elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
+elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
     # Use GEOPM launcher wrapper script with ALPS's aprun
     geopmlaunch aprun \
                 -N 4 \
@@ -96,7 +96,7 @@ elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
                 --geopm-policy=tutorial_balanced_policy.json \
                 -- ./tutorial_4
     err=$?
-elif [ $MPIEXEC ]; then
+elif [ "$MPIEXEC" ]; then
     GEOPM_AGENT="power_governor" \
     LD_DYNAMIC_WEAK=true \
     GEOPM_CTL=process \

--- a/tutorial/tutorial_5.sh
+++ b/tutorial/tutorial_5.sh
@@ -32,7 +32,7 @@
 #
 
 set err=0
-source tutorial_env.sh
+. tutorial_env.sh
 
 export PATH=$GEOPM_BINDIR:$PATH
 export PYTHONPATH=$GEOPMPY_PKGDIR:$PYTHONPATH
@@ -43,7 +43,7 @@ export LD_LIBRARY_PATH=$GEOPM_LIBDIR:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" == "srun" ]; then
+if [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -53,7 +53,7 @@ if [ "$GEOPM_LAUNCHER" == "srun" ]; then
                 --geopm-trace=tutorial_5_trace \
                 -- ./tutorial_5
     err=$?
-elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
+elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
     # Use GEOPM launcher wrapper script with ALPS's aprun
     geopmlaunch aprun \
                 -N 4 \
@@ -63,7 +63,7 @@ elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
                 --geopm-trace=tutorial_5_trace \
                 -- ./tutorial_5
     err=$?
-elif [ $MPIEXEC ]; then
+elif [ "$MPIEXEC" ]; then
     # Use MPIEXEC and set GEOPM environment variables to launch the job
     LD_DYNAMIC_WEAK=true \
     GEOPM_CTL=process \

--- a/tutorial/tutorial_6.sh
+++ b/tutorial/tutorial_6.sh
@@ -32,7 +32,7 @@
 #
 
 set err=0
-source tutorial_env.sh
+. tutorial_env.sh
 
 export PATH=$GEOPM_BINDIR:$PATH
 export PYTHONPATH=$GEOPMPY_PKGDIR:$PYTHONPATH
@@ -43,7 +43,7 @@ export LD_LIBRARY_PATH=$GEOPM_LIBDIR:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" == "srun" ]; then
+if [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -53,7 +53,7 @@ if [ "$GEOPM_LAUNCHER" == "srun" ]; then
                 --geopm-trace=tutorial_6_trace \
                 -- geopmbench tutorial_6_config.json
     err=$?
-elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
+elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
     # Use GEOPM launcher wrapper script with ALPS's aprun
     geopmlaunch aprun \
                 -N 4 \
@@ -63,7 +63,7 @@ elif [ "$GEOPM_LAUNCHER" == "aprun" ]; then
                 --geopm-trace=tutorial_6_trace \
                 -- geopmbench tutorial_6_config.json
     err=$?
-elif [ $MPIEXEC ]; then
+elif [ "$MPIEXEC" ]; then
     # Use MPIEXEC and set GEOPM environment variables to launch the job
     LD_DYNAMIC_WEAK=true \
     GEOPM_CTL=process \

--- a/tutorial/tutorial_build_gnu.sh
+++ b/tutorial/tutorial_build_gnu.sh
@@ -30,7 +30,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-source tutorial_env.sh
+. tutorial_env.sh
 
 # OMP_FLAGS: Flags for enabling OpenMP
 if [ ! "$OMP_FLAGS" ]; then

--- a/tutorial/tutorial_build_intel.sh
+++ b/tutorial/tutorial_build_intel.sh
@@ -30,7 +30,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-source tutorial_env.sh
+. tutorial_env.sh
 
 # OMP_FLAGS: Flags for enabling OpenMP
 if [ ! "$OMP_FLAGS" ]; then


### PR DESCRIPTION
- to eliminate syntax violation when `$GEOPM_LAUNCHER` is not set to srun or aprun and we want to use `$MPIEXEC` directly, we use quotes around the `$MPIEXEC` variable within the if test
- to use a more compatible syntax for string comparisons, we use single instead of double equal signs within the if test
- to use a more compatible syntax for sourcing files, we replace the shell specific `source` command with the dot `.` command

All changes can be reproduced by applying the following `sed` commands from within the GEOPM root directory.

```sd
$ sed -i 's/^elif \[ $MPIEXEC \]; then$/elif \[ "$MPIEXEC" \]; then/g' tutorial/tutorial_*.sh tutorial/agent/agent_tutorial.sh
$ sed -i 's/==/=/g' tutorial/tutorial_*.sh tutorial/agent/agent_tutorial.sh
$ sed -i "s/^source/./g" tutorial/tutorial_*.sh tutorial/agent/agent_tutorial.sh tutorial/tutorial_build_*.sh
```
