### PR TITLE
Remove redundant '-lgeopm' from the build step of tutorials 2 to 5.

### DIFF
--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -69,25 +69,25 @@ tutorial_2.o: tutorial_2.c
 	$(MPICC) -c $^ $(CFLAGS) -o $@
 
 tutorial_2: tutorial_2.o tutorial_region.o
-	$(MPICC) $^ $(LDFLAGS) -lgeopm -o $@
+	$(MPICC) $^ $(LDFLAGS) -o $@
 
 tutorial_3.o: tutorial_3.c
 	$(MPICC) -c $^ $(CFLAGS) -o $@
 
 tutorial_3: tutorial_3.o tutorial_region.o
-	$(MPICC) $^ $(LDFLAGS) -lgeopm -o $@
+	$(MPICC) $^ $(LDFLAGS) -o $@
 
 tutorial_4.o: tutorial_4.c
 	$(MPICC) -c $^ $(CFLAGS) -o $@
 
 tutorial_4: tutorial_4.o tutorial_region.o
-	$(MPICC) $^ $(LDFLAGS) -lgeopm -lstdc++ -o $@
+	$(MPICC) $^ $(LDFLAGS) -lstdc++ -o $@
 
 tutorial_5.o: tutorial_5.c
 	$(MPICC) -c $^ $(CFLAGS) -o $@
 
 tutorial_5: tutorial_5.o tutorial_region.o
-	$(MPICC) $^ $(LDFLAGS) -lgeopm -lstdc++ -o $@
+	$(MPICC) $^ $(LDFLAGS) -lstdc++ -o $@
 
 tutorial_region.o: tutorial_region.c tutorial_region.h
 	$(MPICC) -c tutorial_region.c $(CFLAGS) -o $@


### PR DESCRIPTION
$LDFLAGS in the tutorial Makefile gets populated with '-lgeopm' through
the compiler-specific build script. The compile step for tutorials 2 to 5
has a redundant '-lgeopm' after $LDFLAGS. This change removes the
redundant '-lgeopm'.