### PR TITLE
Fix for LANG specific lscpu output.

### DIFF
--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -490,7 +490,7 @@ class Launcher(object):
         tmp_script_txt = """\
 #!/bin/bash
 if [ ! -e /tmp/geopm-lscpu.log ]; then
-    lscpu --hex > /tmp/geopm-lscpu.log && chmod a+rw /tmp/geopm-lscpu.log
+    LC_ALL=C lscpu --hex > /tmp/geopm-lscpu.log && chmod a+rw /tmp/geopm-lscpu.log
 fi
 """
         with open(tmp_script, 'w') as fid:


### PR DESCRIPTION
This only fixes the lscpu call for topology initialization,
but LC_ALL=C should be set at the appropriate spot, to cover all other system calls as well.

Signed-off-by: Matthias Maiterth <maiterth@nm.ifi.lmu.de>

