### PR TITLE
Check that MPIEXEC is set first before checking value of GEOPM_LAUNCHER

### DIFF
--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -170,7 +170,7 @@ progress values recorded can be seen in the trace output.
 
 6. The model application
 ------------------------
-Tutoral 6 uses the geopmbench tool and configures it with the json
+Tutorial 6 uses the geopmbench tool and configures it with the json
 input file.  The geopmbench application is documented in the
 geopmbench(1) man page and can be use to to a wide range of
 experiments with GEOPM.  Note that geopmbench is used in most

--- a/tutorial/tutorial_0.sh
+++ b/tutorial/tutorial_0.sh
@@ -44,7 +44,18 @@ export LD_LIBRARY_PATH=$GEOPM_LIB:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" = "srun" ]; then
+if [ "$MPIEXEC" ]; then
+    # Use MPIEXEC and set GEOPM environment variables to launch the job
+    LD_PRELOAD=$GEOPM_LIB/libgeopm.so \
+    LD_DYNAMIC_WEAK=true \
+    GEOPM_CTL=process \
+    GEOPM_REPORT=tutorial_0_report \
+    GEOPM_TRACE=tutorial_0_trace \
+    $MPIEXEC \
+    ./tutorial_0
+    err=$?
+elif [ "$GEOPM_LAUNCHER" = "srun" ]; then
+    echo -e "Using srun launcher"
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -65,16 +76,6 @@ elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
                 --geopm-report=tutorial_0_report \
                 --geopm-trace=tutorial_0_trace \
                 -- ./tutorial_0
-    err=$?
-elif [ "$MPIEXEC" ]; then
-    # Use MPIEXEC and set GEOPM environment variables to launch the job
-    LD_PRELOAD=$GEOPM_LIB/libgeopm.so \
-    LD_DYNAMIC_WEAK=true \
-    GEOPM_CTL=process \
-    GEOPM_REPORT=tutorial_0_report \
-    GEOPM_TRACE=tutorial_0_trace \
-    $MPIEXEC \
-    ./tutorial_0
     err=$?
 else
     echo "Error: tutorial_0.sh: set GEOPM_LAUNCHER to 'srun' or 'apun'." 2>&1

--- a/tutorial/tutorial_1.sh
+++ b/tutorial/tutorial_1.sh
@@ -44,7 +44,17 @@ export LD_LIBRARY_PATH=$GEOPM_LIB:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" = "srun" ]; then
+if [ "$MPIEXEC" ]; then
+    # Use MPIEXEC and set GEOPM environment variables to launch the job
+    LD_PRELOAD=$GEOPM_LIB/libgeopm.so \
+    LD_DYNAMIC_WEAK=true \
+    GEOPM_CTL=process \
+    GEOPM_REPORT=tutorial_1_report \
+    GEOPM_TRACE=tutorial_1_trace \
+    $MPIEXEC \
+    ./tutorial_1
+    err=$?
+elif [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -65,16 +75,6 @@ elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
                 --geopm-report=tutorial_1_report \
                 --geopm-trace=tutorial_1_trace \
                 -- ./tutorial_1
-    err=$?
-elif [ "$MPIEXEC" ]; then
-    # Use MPIEXEC and set GEOPM environment variables to launch the job
-    LD_PRELOAD=$GEOPM_LIB/libgeopm.so \
-    LD_DYNAMIC_WEAK=true \
-    GEOPM_CTL=process \
-    GEOPM_REPORT=tutorial_1_report \
-    GEOPM_TRACE=tutorial_1_trace \
-    $MPIEXEC \
-    ./tutorial_1
     err=$?
 else
     echo "Error: tutorial_1.sh: set GEOPM_LAUNCHER to 'srun' or 'aprun'." 2>&1

--- a/tutorial/tutorial_2.sh
+++ b/tutorial/tutorial_2.sh
@@ -43,7 +43,16 @@ export LD_LIBRARY_PATH=$GEOPM_LIB:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" = "srun" ]; then
+if [ "$MPIEXEC" ]; then
+    # Use MPIEXEC and set GEOPM environment variables to launch the job
+    LD_DYNAMIC_WEAK=true \
+    GEOPM_CTL=process \
+    GEOPM_REPORT=tutorial_2_report \
+    GEOPM_TRACE=tutorial_2_trace \
+    $MPIEXEC \
+    ./tutorial_2
+    err=$?
+elif [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -62,15 +71,6 @@ elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
                 --geopm-report=tutorial_2_report \
                 --geopm-trace=tutorial_2_trace \
                 -- ./tutorial_2
-    err=$?
-elif [ "$MPIEXEC" ]; then
-    # Use MPIEXEC and set GEOPM environment variables to launch the job
-    LD_DYNAMIC_WEAK=true \
-    GEOPM_CTL=process \
-    GEOPM_REPORT=tutorial_2_report \
-    GEOPM_TRACE=tutorial_2_trace \
-    $MPIEXEC \
-    ./tutorial_2
     err=$?
 else
     echo "Error: tutorial_2.sh: set GEOPM_LAUNCHER to 'srun' or 'aprun'." 2>&1

--- a/tutorial/tutorial_3.sh
+++ b/tutorial/tutorial_3.sh
@@ -43,7 +43,24 @@ export LD_LIBRARY_PATH=$GEOPM_LIB:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" = "srun" ]; then
+if [ "$MPIEXEC" ]; then
+    GEOPM_AGENT="power_governor" \
+    LD_DYNAMIC_WEAK=true \
+    GEOPM_CTL=process \
+    GEOPM_REPORT=tutorial_3_governed_report \
+    GEOPM_TRACE=tutorial_3_governed_trace \
+    GEOPM_POLICY=tutorial_governed_policy.json \
+    $MPIEXEC ./tutorial_3 \
+    && \
+    GEOPM_AGENT="power_balancer" \
+    LD_DYNAMIC_WEAK=true \
+    GEOPM_CTL=process \
+    GEOPM_REPORT=tutorial_3_balanced_report \
+    GEOPM_TRACE=tutorial_3_balanced_trace \
+    GEOPM_POLICY=tutorial_balanced_policy.json \
+    $MPIEXEC ./tutorial_3
+    err=$?
+elif [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -87,23 +104,6 @@ elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
                 --geopm-trace=tutorial_3_balanced_trace \
                 --geopm-policy=tutorial_balanced_policy.json \
                 -- ./tutorial_3
-    err=$?
-elif [ "$MPIEXEC" ]; then
-    GEOPM_AGENT="power_governor" \
-    LD_DYNAMIC_WEAK=true \
-    GEOPM_CTL=process \
-    GEOPM_REPORT=tutorial_3_governed_report \
-    GEOPM_TRACE=tutorial_3_governed_trace \
-    GEOPM_POLICY=tutorial_governed_policy.json \
-    $MPIEXEC ./tutorial_3 \
-    && \
-    GEOPM_AGENT="power_balancer" \
-    LD_DYNAMIC_WEAK=true \
-    GEOPM_CTL=process \
-    GEOPM_REPORT=tutorial_3_balanced_report \
-    GEOPM_TRACE=tutorial_3_balanced_trace \
-    GEOPM_POLICY=tutorial_balanced_policy.json \
-    $MPIEXEC ./tutorial_3
     err=$?
 else
     echo "Error: tutorial_3.sh: set GEOPM_LAUNCHER to 'srun' or 'aprun'." 2>&1

--- a/tutorial/tutorial_4.sh
+++ b/tutorial/tutorial_4.sh
@@ -51,8 +51,24 @@ fi
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-
-if [ "$GEOPM_LAUNCHER" = "srun" ]; then
+if [ "$MPIEXEC" ]; then
+    GEOPM_AGENT="power_governor" \
+    LD_DYNAMIC_WEAK=true \
+    GEOPM_CTL=process \
+    GEOPM_REPORT=tutorial_4_governed_report \
+    GEOPM_TRACE=tutorial_4_governed_trace \
+    GEOPM_POLICY=tutorial_governed_policy.json \
+    $MPIEXEC ./tutorial_4 \
+    && \
+    GEOPM_AGENT="power_balancer" \
+    LD_DYNAMIC_WEAK=true \
+    GEOPM_PMPI_CTL=process \
+    GEOPM_REPORT=tutorial_4_balanced_report \
+    GEOPM_TRACE=tutorial_4_balanced_trace \
+    GEOPM_POLICY=tutorial_balanced_policy.json \
+    $MPIEXEC ./tutorial_4
+    err=$?
+elif [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -95,23 +111,6 @@ elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
                 --geopm-trace=tutorial_4_balanced_trace \
                 --geopm-policy=tutorial_balanced_policy.json \
                 -- ./tutorial_4
-    err=$?
-elif [ "$MPIEXEC" ]; then
-    GEOPM_AGENT="power_governor" \
-    LD_DYNAMIC_WEAK=true \
-    GEOPM_CTL=process \
-    GEOPM_REPORT=tutorial_4_governed_report \
-    GEOPM_TRACE=tutorial_4_governed_trace \
-    GEOPM_POLICY=tutorial_governed_policy.json \
-    $MPIEXEC ./tutorial_4 \
-    && \
-    GEOPM_AGENT="power_balancer" \
-    LD_DYNAMIC_WEAK=true \
-    GEOPM_PMPI_CTL=process \
-    GEOPM_REPORT=tutorial_4_balanced_report \
-    GEOPM_TRACE=tutorial_4_balanced_trace \
-    GEOPM_POLICY=tutorial_balanced_policy.json \
-    $MPIEXEC ./tutorial_4
     err=$?
 else
     echo "Error: tutorial_4.sh: set GEOPM_LAUNCHER to 'srun' or 'aprun'." 2>&1

--- a/tutorial/tutorial_5.sh
+++ b/tutorial/tutorial_5.sh
@@ -43,7 +43,16 @@ export LD_LIBRARY_PATH=$GEOPM_LIB:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" = "srun" ]; then
+if [ "$MPIEXEC" ]; then
+    # Use MPIEXEC and set GEOPM environment variables to launch the job
+    LD_DYNAMIC_WEAK=true \
+    GEOPM_CTL=process \
+    GEOPM_REPORT=tutorial_5_report \
+    GEOPM_TRACE=tutorial_5_trace \
+    $MPIEXEC \
+    ./tutorial_5
+    err=$?
+elif [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -62,15 +71,6 @@ elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
                 --geopm-report=tutorial_5_report \
                 --geopm-trace=tutorial_5_trace \
                 -- ./tutorial_5
-    err=$?
-elif [ "$MPIEXEC" ]; then
-    # Use MPIEXEC and set GEOPM environment variables to launch the job
-    LD_DYNAMIC_WEAK=true \
-    GEOPM_CTL=process \
-    GEOPM_REPORT=tutorial_5_report \
-    GEOPM_TRACE=tutorial_5_trace \
-    $MPIEXEC \
-    ./tutorial_5
     err=$?
 else
     echo "Error: tutorial_5.sh: set GEOPM_LAUNCHER to 'srun' or 'aprun'." 2>&1

--- a/tutorial/tutorial_6.sh
+++ b/tutorial/tutorial_6.sh
@@ -43,7 +43,16 @@ export LD_LIBRARY_PATH=$GEOPM_LIB:$LD_LIBRARY_PATH
 # launch geopm controller as an MPI process
 # create a report file
 # create trace files
-if [ "$GEOPM_LAUNCHER" = "srun" ]; then
+if [ "$MPIEXEC" ]; then
+    # Use MPIEXEC and set GEOPM environment variables to launch the job
+    LD_DYNAMIC_WEAK=true \
+    GEOPM_CTL=process \
+    GEOPM_REPORT=tutorial_6_report \
+    GEOPM_TRACE=tutorial_6_trace \
+    $MPIEXEC \
+    geopmbench tutorial_6_config.json
+    err=$?
+elif [ "$GEOPM_LAUNCHER" = "srun" ]; then
     # Use GEOPM launcher wrapper script with SLURM's srun
     geopmlaunch srun \
                 -N 2 \
@@ -62,15 +71,6 @@ elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
                 --geopm-report=tutorial_6_report \
                 --geopm-trace=tutorial_6_trace \
                 -- geopmbench tutorial_6_config.json
-    err=$?
-elif [ "$MPIEXEC" ]; then
-    # Use MPIEXEC and set GEOPM environment variables to launch the job
-    LD_DYNAMIC_WEAK=true \
-    GEOPM_CTL=process \
-    GEOPM_REPORT=tutorial_6_report \
-    GEOPM_TRACE=tutorial_6_trace \
-    $MPIEXEC \
-    geopmbench tutorial_6_config.json
     err=$?
 else
     echo "Error: tutorial_2.sh: set GEOPM_LAUNCHER to 'srun' or 'aprun'." 2>&1


### PR DESCRIPTION
Even if MPIEXEC is set, the `tutorial_env.sh` script sets `GEOPM_LAUNCHER`, which is checked first in the if statement of the tutorial script. 