### PR TITLE
Add timed_stream model region for geopmbench

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -669,6 +669,8 @@ model_source_files = src/All2allModelRegion.cpp \
                      src/SpinModelRegion.hpp \
                      src/StreamModelRegion.cpp \
                      src/StreamModelRegion.hpp \
+                     src/TimedStreamModelRegion.cpp \
+                     src/TimedStreamModelRegion.hpp \
                      # end
 
 if ENABLE_MPI

--- a/copying_headers/MANIFEST.BSD3-intel
+++ b/copying_headers/MANIFEST.BSD3-intel
@@ -225,6 +225,8 @@ src/SpinModelRegion.cpp
 src/SpinModelRegion.hpp
 src/StreamModelRegion.cpp
 src/StreamModelRegion.hpp
+src/TimedStreamModelRegion.cpp
+src/TimedStreamModelRegion.hpp
 src/TimeIOGroup.cpp
 src/TimeIOGroup.hpp
 src/Tracer.cpp

--- a/ronn/geopmbench.1.ronn
+++ b/ronn/geopmbench.1.ronn
@@ -63,6 +63,10 @@ Region names can be one of the following options:
   * _stream_:
     Executes stream "triad" on a vector with length proportional to big-o.
 
+  * _timed_stream_:
+    Finds a size for a _stream_ region that runs for big-o seconds.  The search for
+    the problem size takes place during the setup phase.
+
   * _all2all_:
     All processes send buffers to all other processes. The time of this operation is
  proportional to big-o.

--- a/src/ModelRegion.cpp
+++ b/src/ModelRegion.cpp
@@ -43,6 +43,7 @@
 #include "All2allModelRegion.hpp"
 #include "DGEMMModelRegion.hpp"
 #include "StreamModelRegion.hpp"
+#include "TimedStreamModelRegion.hpp"
 #include "SpinModelRegion.hpp"
 #include "IgnoreModelRegion.hpp"
 
@@ -83,6 +84,9 @@ namespace geopm
         }
         else if (name_check(name, "stream")) {
             return geopm::make_unique<StreamModelRegion>(big_o, verbosity, do_imbalance, do_progress, do_unmarked);
+        }
+        else if (name_check(name, "timed_stream")) {
+            return geopm::make_unique<TimedStreamModelRegion>(big_o, verbosity, do_imbalance, do_progress, do_unmarked);
         }
         else if (name_check(name, "all2all")) {
             return geopm::make_unique<All2allModelRegion>(big_o, verbosity, do_imbalance, do_progress, do_unmarked);

--- a/src/TimedStreamModelRegion.cpp
+++ b/src/TimedStreamModelRegion.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TimedStreamModelRegion.hpp"
+
+#include <iostream>
+
+#include "geopm.h"
+#include "geopm_time.h"
+#include "Exception.hpp"
+
+namespace geopm
+{
+    TimedStreamModelRegion::TimedStreamModelRegion(double big_o_in,
+                                                   int verbosity,
+                                                   bool do_imbalance,
+                                                   bool do_progress,
+                                                   bool do_unmarked)
+        : StreamModelRegion(big_o_in, verbosity, do_imbalance, do_progress, do_unmarked)
+    {
+        m_name = "timed_stream";
+        int err = ModelRegion::region(GEOPM_REGION_HINT_MEMORY);
+        if (err) {
+            throw Exception("TimedStreamModelRegion::TimedStreamModelRegion()",
+                            err, __FILE__, __LINE__);
+        }
+
+        if (m_verbosity) {
+            std::cout << "Calibrating timed_stream region to " << big_o_in << " seconds.  Please wait..." << std::endl;
+        }
+        double measured_time = 0;
+        bool done = false;
+        double new_big_o = big_o_in;
+        const double EPS = big_o_in / 100.0;
+        const int MAX_ITERATIONS = 20;
+        int iteration_count = 0;
+        // Start with 1:1 ratio: assume big-o == seconds and test.  Use
+        // the measured runtime to update the ratio of big-o to time.
+        while (!done) {
+            big_o(new_big_o);
+            // warm caches
+            run();
+            geopm_time_s start;
+            geopm_time(&start);
+            run();
+            measured_time = geopm_time_since(&start);
+            if (m_verbosity) {
+                std::cout << "stream big-o=" << new_big_o << ", "
+                          << "runtime=" << measured_time << "s" << std::endl;
+            }
+            new_big_o = new_big_o * big_o_in / measured_time;
+            if (m_verbosity) {
+                std::cout << "ratio=" << (big_o_in / measured_time) << "; new big-o: " << new_big_o << std::endl;
+            }
+
+            if (fabs(measured_time - big_o_in) < EPS) {
+                done = true;
+            }
+            ++iteration_count;
+            if (!done && iteration_count == MAX_ITERATIONS) {
+                std::cout << "Warning: <geopm> could not find a big-o for requested runtime within " << MAX_ITERATIONS << " iterations. " << std::endl;
+                done = true;
+            }
+        }
+        if (m_verbosity) {
+            std::cout << "Calibration complete.  Using stream big-o of " << new_big_o << std::endl;
+        }
+        m_big_o = new_big_o;
+    }
+
+   TimedStreamModelRegion::~TimedStreamModelRegion()
+    {
+
+    }
+}

--- a/src/TimedStreamModelRegion.hpp
+++ b/src/TimedStreamModelRegion.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TIMEDSTREAMMODELREGION_HPP_INCLUDE
+#define TIMEDSTREAMMODELREGION_HPP_INCLUDE
+
+#include "StreamModelRegion.hpp"
+
+namespace geopm
+{
+    class TimedStreamModelRegion : public StreamModelRegion
+    {
+        public:
+            TimedStreamModelRegion(double big_o_in, int verbosity,
+                                   bool do_imbalance, bool do_progress,
+                                   bool do_unmarked);
+            virtual ~TimedStreamModelRegion();
+    };
+}
+
+#endif

--- a/src/geopmbench_main.cpp
+++ b/src/geopmbench_main.cpp
@@ -84,6 +84,8 @@ int main(int argc, char **argv)
 "                 stream: Executes stream \"triadd\" on a vector with\n"
 "                 length proportional to big-o.\n"
 "\n"
+"                 timed_stream: Executes stream for big-o seconds.\n"
+"\n"
 "                 dgemm: Dense matrix-matrix multiply with floating\n"
 "                 point operations proportional to big-o.\n"
 "\n"


### PR DESCRIPTION
- Learned big-o may be highly variable run-to-run without
  explictly setting OMP_NUM_THREADS.
- Resolves #863.

