### PR TITLE
Recent hw fixup

### DIFF
--- a/src/EnergyEfficientAgent.cpp
+++ b/src/EnergyEfficientAgent.cpp
@@ -67,7 +67,6 @@ namespace geopm
                                                std::map<uint64_t, std::shared_ptr<EnergyEfficientRegion> > region_map)
         : M_PRECISION(16)
         , M_WAIT_SEC(0.002)
-        , M_MIN_LEARNING_RUNTIME(M_WAIT_SEC * 10)
         , M_POLICY_PERF_MARGIN_DEFAULT(0.10)  // max 10% performance degradation
         , m_platform_io(plat_io)
         , m_platform_topo(topo)
@@ -248,10 +247,6 @@ namespace geopm
                         throw Exception("EnergyEfficientAgent::" + std::string(__func__) +
                                         "(): region exit before entry detected.",
                                         GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
-                    }
-                    if (last_region_info.runtime != 0.0 &&
-                        last_region_info.runtime < M_MIN_LEARNING_RUNTIME) {
-                        last_region_it->second->disable();
                     }
                     // Higher is better for performance, so negate
                     last_region_it->second->update_exit(-1.0 * last_region_info.runtime);

--- a/src/EnergyEfficientAgent.hpp
+++ b/src/EnergyEfficientAgent.hpp
@@ -112,7 +112,6 @@ namespace geopm
 
             const int M_PRECISION;
             const double M_WAIT_SEC;
-            const double M_MIN_LEARNING_RUNTIME;
             const double M_POLICY_PERF_MARGIN_DEFAULT;
             PlatformIO &m_platform_io;
             const PlatformTopo &m_platform_topo;

--- a/src/EnergyEfficientRegion.cpp
+++ b/src/EnergyEfficientRegion.cpp
@@ -60,7 +60,6 @@ namespace geopm
         , m_curr_step(-1)
         , m_freq_min(freq_min)
         , m_target(0.0)
-        , m_is_disabled(false)
         , m_perf_margin(perf_margin)
     {
         /// @brief we are not clearing the m_freq_perf vector once created, such that we
@@ -99,7 +98,7 @@ namespace geopm
 
     void EnergyEfficientRegionImp::update_exit(double curr_perf_metric)
     {
-        if (m_is_learning && !m_is_disabled) {
+        if (m_is_learning) {
             auto &curr_perf_buffer = m_freq_perf[m_curr_step];
             if (!std::isnan(curr_perf_metric) && curr_perf_metric != 0.0) {
                 curr_perf_buffer->insert(curr_perf_metric);
@@ -137,11 +136,6 @@ namespace geopm
                 }
             }
         }
-    }
-
-    void EnergyEfficientRegionImp::disable(void)
-    {
-        m_is_disabled = true;
     }
 
     bool EnergyEfficientRegionImp::is_learning(void) const

--- a/src/EnergyEfficientRegion.hpp
+++ b/src/EnergyEfficientRegion.hpp
@@ -50,7 +50,6 @@ namespace geopm
             virtual double freq(void) const = 0;
             virtual void update_freq_range(double freq_min, double freq_max, double freq_step) = 0;
             virtual void update_exit(double curr_perf_metric) = 0;
-            virtual void disable(void) = 0;
             virtual bool is_learning(void) const = 0;
             static std::unique_ptr<EnergyEfficientRegion> make_unique(double freq_min, double freq_max,
                                                                       double freq_step, double perf_margin);
@@ -65,7 +64,6 @@ namespace geopm
             double freq(void) const override;
             void update_freq_range(double freq_min, double freq_max, double freq_step) override;
             void update_exit(double curr_perf_metric) override;
-            void disable(void) override;
             bool is_learning(void) const override;
         private:
             const int M_MIN_PERF_SAMPLE;
@@ -76,7 +74,6 @@ namespace geopm
             double m_freq_min;
             double m_target;
             std::vector<std::unique_ptr<CircularBuffer<double> > > m_freq_perf;
-            bool m_is_disabled;
             double m_perf_margin;
     };
 

--- a/src/FrequencyMapAgent.cpp
+++ b/src/FrequencyMapAgent.cpp
@@ -93,6 +93,7 @@ namespace geopm
     FrequencyMapAgent::FrequencyMapAgent(PlatformIO &plat_io, const PlatformTopo &topo,
                                          std::shared_ptr<FrequencyGovernor> gov, std::map<uint64_t, double> frequency_map)
         : M_PRECISION(16)
+        , M_WAIT_SEC(0.002)
         , m_platform_io(plat_io)
         , m_platform_topo(topo)
         , m_freq_governor(gov)
@@ -297,7 +298,6 @@ namespace geopm
 
     void FrequencyMapAgent::wait(void)
     {
-        static double M_WAIT_SEC = 0.005;
         while(geopm_time_since(&m_last_wait) < M_WAIT_SEC) {
 
         }

--- a/src/FrequencyMapAgent.hpp
+++ b/src/FrequencyMapAgent.hpp
@@ -109,6 +109,7 @@ namespace geopm
             };
 
             const int M_PRECISION;
+            const double M_WAIT_SEC;
             PlatformIO &m_platform_io;
             const PlatformTopo &m_platform_topo;
             std::shared_ptr<FrequencyGovernor> m_freq_governor;

--- a/test/MockEnergyEfficientRegion.hpp
+++ b/test/MockEnergyEfficientRegion.hpp
@@ -45,7 +45,6 @@ class MockEnergyEfficientRegion : public geopm::EnergyEfficientRegion
                      void(double freq_min, double freq_max, double freq_step));
         MOCK_METHOD1(update_exit,
                      void(double curr_perf_metric));
-        MOCK_METHOD0(disable, void(void));
         MOCK_CONST_METHOD0(is_learning,
                      bool(void));
 };


### PR DESCRIPTION
These changes are to patch up changes that were introduced in f4bfb179.
+ Update FrequencyMap agent gate to 2ms such that it can be compared to EE agent.
+ Update EE agent, removing minimum region runtime requirement
