### PR TITLE
Fix the nightlies

### DIFF
--- a/src/OMPT.cpp
+++ b/src/OMPT.cpp
@@ -38,6 +38,7 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
+#include <algorithm>
 
 #include "geopm.h"
 #include "geopm_sched.h"
@@ -126,6 +127,7 @@ namespace geopm
         size_t target = (size_t) parallel_function;
         std::ostringstream name_stream;
         std::string symbol_name;
+        std::string region_name;
         name_stream << "[OMPT]";
         std::pair<size_t, std::string> symbol = symbol_lookup(parallel_function);
         if (symbol.second.size()) {
@@ -136,7 +138,9 @@ namespace geopm
             name_stream << "0x" << std::setfill('0') << std::setw(16) << std::hex
                         << target;
         }
-        return name_stream.str();
+        region_name = name_stream.str();
+        region_name.erase(std::remove(region_name.begin(), region_name.end(), ' '), region_name.end());
+        return region_name;
     }
 
     void OMPTImp::region_enter(const void *parallel_function)

--- a/test_integration/geopm_test_integration.py
+++ b/test_integration/geopm_test_integration.py
@@ -200,20 +200,6 @@ class TestIntegration(unittest.TestCase):
             trace = self._output.get_trace_data(node_name=nn)
             self.assertNotEqual(0, len(trace))
 
-    def test_no_report_and_trace_generation(self):
-        name = 'test_no_report_and_trace_generation'
-        num_node = 4
-        num_rank = 16
-        app_conf = geopmpy.io.BenchConf(name + '_app.config')
-        self._tmp_files.append(app_conf.get_path())
-        app_conf.append_region('sleep', 1.0)
-        agent_conf = geopmpy.io.AgentConf(name + '_agent.config', self._agent, self._options)
-        self._tmp_files.append(agent_conf.get_path())
-        launcher = geopm_test_launcher.TestLauncher(app_conf, agent_conf)
-        launcher.set_num_node(num_node)
-        launcher.set_num_rank(num_rank)
-        launcher.run(name)
-
     @unittest.skipUnless('mr-fusion' in socket.gethostname(), "This test only enabled on known working systems.")
     def test_report_and_trace_generation_pthread(self):
         name = 'test_report_and_trace_generation_pthread'

--- a/test_integration/geopm_test_integration.py
+++ b/test_integration/geopm_test_integration.py
@@ -741,7 +741,7 @@ class TestIntegration(unittest.TestCase):
             self._options['power_budget'] = 200
         gov_agent_conf_path = name + '_gov_agent.config'
         self._tmp_files.append(gov_agent_conf_path)
-        gov_agent_conf = geopmpy.io.AgentConf(name + '_agent.config', self._agent, self._options)
+        gov_agent_conf = geopmpy.io.AgentConf(gov_agent_conf_path, self._agent, self._options)
         launcher = geopm_test_launcher.TestLauncher(app_conf, gov_agent_conf, report_path,
                                                     trace_path, time_limit=900)
         launcher.set_num_node(num_node)
@@ -1234,6 +1234,7 @@ class TestIntegration(unittest.TestCase):
         run = ['_sticker', '_nan_nan']
         for rr in run:
             report_path = name + rr + '.report'
+            self._tmp_files.append(report_path)
             trace_path = name + rr + '.trace'
             app_conf = geopmpy.io.BenchConf(name + '_app.config')
             self._tmp_files.append(app_conf.get_path())
@@ -1260,10 +1261,13 @@ class TestIntegration(unittest.TestCase):
         report_path = name + run[0] + '.report'
         trace_path = name + run[0] + '.trace'
         sticker_out = geopmpy.io.AppOutput(report_path, trace_path + '*')
+        for nn in sticker_out.get_node_names():
+            self._tmp_files.append(trace_path + '-{}'.format(nn))
         report_path = name + run[1] + '.report'
         trace_path = name + run[1] + '.trace'
         nan_out = geopmpy.io.AppOutput(report_path, trace_path + '*')
         for nn in nan_out.get_node_names():
+            self._tmp_files.append(trace_path + '-{}'.format(nn))
             sticker_app_total = sticker_out.get_app_total_data(node_name=nn)
             nan_app_total = nan_out.get_app_total_data(node_name=nn)
             runtime_savings_epoch = (sticker_app_total['runtime'].item() - nan_app_total['runtime'].item()) / sticker_app_total['runtime'].item()

--- a/test_integration/geopm_test_launcher.py
+++ b/test_integration/geopm_test_launcher.py
@@ -231,9 +231,13 @@ class TestLauncher(object):
             argv.extend(self._app_conf.get_exec_args())
             launcher = geopmpy.launcher.Factory().create(argv, self._num_rank, self._num_node, self._cpu_per_rank, self._timeout,
                                                          self._time_limit, test_name, self._node_list, self._host_file)
-            launcher.run(stdout=outfile, stderr=outfile)
-            if self._msr_save_path is not None:
-                msr_restore()
+
+            try:
+                launcher.run(stdout=outfile, stderr=outfile)
+            except (AttributeError, TypeError):
+                if self._msr_save_path is not None:
+                    self.msr_restore()
+                raise
 
     def get_report(self):
         return Report(self._report_path)
@@ -295,12 +299,15 @@ class TestLauncher(object):
         Snapshots all whitelisted MSRs using msrsave on all compute nodes
         that the job will be launched on.
         """
-        # Create the cache for the PlatformTopo on each compute node
         self._msr_save_path = '/tmp/geopm-msr-save-' + getpass.getuser()
         launch_command = 'msrsave ' + self._msr_save_path
         argv = shlex.split('dummy {} --geopm-ctl-disable -- {}'
                            .format(detect_launcher(), launch_command))
-        launcher = geopmpy.launcher.Factory().create(argv, self._num_rank, self._num_node, self._cpu_per_rank, self._timeout,
+        # We want to execute on every node so
+        # (argv, self._num_node, self._num_node, ...
+        # is intentional here and is the best we can do
+        # without a whitelist of node names
+        launcher = geopmpy.launcher.Factory().create(argv, self._num_node, self._num_node, self._cpu_per_rank, self._timeout,
                                                      self._time_limit, 'msr_save', self._node_list, self._host_file)
         launcher.run()
 
@@ -309,12 +316,15 @@ class TestLauncher(object):
         Restores all whitelisted MSRs using msrsave on all compute nodes
         that the job was launched on.
         """
-        # Create the cache for the PlatformTopo on each compute node
         if self._msr_save_path is not None:
             launch_command = 'msrsave -r ' + self._msr_save_path
             argv = shlex.split('dummy {} --geopm-ctl-disable -- {}'
                                .format(detect_launcher(), launch_command))
-            launcher = geopmpy.launcher.Factory().create(argv, self._num_rank, self._num_node, self._cpu_per_rank, self._timeout,
+            # We want to execute on every node so
+            # (argv, self._num_node, self._num_node, ...
+            # is intentional here and is the best we can do
+            # without a whitelist of node names
+            launcher = geopmpy.launcher.Factory().create(argv, self._num_node, self._num_node, self._cpu_per_rank, self._timeout,
                                                          self._time_limit, 'msr_save', self._node_list, self._host_file)
             launcher.run()
 

--- a/test_integration/geopm_test_loop.sh
+++ b/test_integration/geopm_test_loop.sh
@@ -37,7 +37,7 @@ while [ $? -eq 0 -a ${COUNT} -lt 10 ];
 do
     COUNT=$((COUNT+1))
     echo "Beginning loop ${COUNT}..." > >(tee -a ${LOG_FILE})
-    GEOPM_RUN_LONG_TESTS=true python . -v $1 > >(tee -a ${LOG_FILE}) 2>&1
+    GEOPM_KEEP_FILES=true GEOPM_RUN_LONG_TESTS=true python . -v $1 > >(tee -a ${LOG_FILE}) 2>&1
 done
 TEST_RETURN_CODE=$?
 

--- a/test_integration/test_ee_stream_dgemm_mix.py
+++ b/test_integration/test_ee_stream_dgemm_mix.py
@@ -152,21 +152,6 @@ class TestIntegrationEEStreamDGEMMMix(unittest.TestCase):
             self.assertNotEqual(result[0][2], result[-1][2],
                                 msg='Same frequency chosen for dgemm only and stream only.')
 
-    def test_skip_short_regions(self):
-        """Test that agent does not learn from short regions.
-
-        """
-        report = geopmpy.io.RawReport(self._report_path)
-        host_names = report.host_names()
-        for host_name in report.host_names():
-            found_short = False
-            for region_name in report.region_names(host_name):
-                if region_name == 'short_region':
-                    region = report.raw_region(host_name, region_name)
-                    self.assertTrue('requested-online-frequency' not in region)
-                    found_short = True
-            self.assertTrue(found_short)
-
     def test_skip_network_regions(self):
         """Test that agent does not learn for regions declared with the network hint.
 

--- a/test_integration/test_omp_outer_loop.cpp
+++ b/test_integration/test_omp_outer_loop.cpp
@@ -33,7 +33,7 @@
 #include <string.h>
 #include <mpi.h>
 
-#ifdef __OPENMP
+#ifdef _OPENMP
 #include <omp.h>
 #else
 static int omp_get_num_threads(void) {return 1;}


### PR DESCRIPTION
Recent changes to the ModelRegion code have exposed issues in the OMPT region names.

- When spaces are present in the argument list, the Python parser for the region name in the report is broken.
- There are a handful of other changes that were brought over from GerritHub.
- test_skip_short_regions no longer makes sense.