### PR TITLE
Add composite signal support to PlatformIO.read_signal

### DIFF
--- a/src/CombinedSignal.cpp
+++ b/src/CombinedSignal.cpp
@@ -109,4 +109,15 @@ namespace geopm
         }
         return result;
     }
+
+    double DifferenceCombinedSignal::sample(const std::vector<double> &values)
+    {
+#ifdef GEOPM_DEBUG
+        if (values.size() != 2) {
+            throw Exception("DifferenceCombinedSignal::sample(): expected two values to subtract for temperature.",
+                            GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+        }
+#endif
+        return values[0] - values[1];
+    }
 }

--- a/src/CombinedSignal.hpp
+++ b/src/CombinedSignal.hpp
@@ -73,6 +73,16 @@ namespace geopm
             CircularBuffer<m_sample_s> m_history;
             int m_derivative_num_fit;
     };
+
+    /// @brief Used by PlatformIO for CombinedSignals based on a
+    ///        difference between two signals.
+    class DifferenceCombinedSignal : public CombinedSignal
+    {
+        public:
+            DifferenceCombinedSignal() = default;
+            virtual ~DifferenceCombinedSignal() = default;
+            double sample(const std::vector<double> &values) override;
+    };
 }
 
 #endif

--- a/src/MSRIOGroup.cpp
+++ b/src/MSRIOGroup.cpp
@@ -151,7 +151,7 @@ namespace geopm
 
         // @todo: have MSRIOGroup handle this combined signal instead of platformIO
         register_msr_signal("TEMPERATURE_CORE_UNDER", "MSR::THERM_STATUS:DIGITAL_READOUT");
-        register_msr_signal("TEMPERATURE_PKG_UNDER", "MSR::PACKAGE_THERM_STATUS:DIGITAL_READOUT");
+        register_msr_signal("TEMPERATURE_PACKAGE_UNDER", "MSR::PACKAGE_THERM_STATUS:DIGITAL_READOUT");
         register_msr_signal("TEMPERATURE_MAX", "MSR::TEMPERATURE_TARGET:PROCHOT_MIN");
 
         register_msr_control("POWER_PACKAGE_LIMIT", "MSR::PKG_POWER_LIMIT:PL1_POWER_LIMIT");

--- a/src/PlatformIO.cpp
+++ b/src/PlatformIO.cpp
@@ -180,7 +180,7 @@ namespace geopm
                 is_found = true;
             }
             if (signal_name == "TEMPERATURE_PACKAGE") {
-                result = signal_domain_type("TEMPERATURE_PKG_UNDER");
+                result = signal_domain_type("TEMPERATURE_PACKAGE_UNDER");
                 is_found = true;
             }
         }
@@ -300,7 +300,7 @@ namespace geopm
                 under_idx = push_signal("TEMPERATURE_CORE_UNDER", domain_type, domain_idx);
             }
             else if (signal_name =="TEMPERATURE_PACKAGE") {
-                under_idx = push_signal("TEMPERATURE_PKG_UNDER", domain_type, domain_idx);
+                under_idx = push_signal("TEMPERATURE_PACKAGE_UNDER", domain_type, domain_idx);
             }
             result = m_active_signal.size();
             register_combined_signal(result,

--- a/src/geopmread_main.cpp
+++ b/src/geopmread_main.cpp
@@ -196,15 +196,7 @@ int main(int argc, char **argv)
             if (!err) {
                 try {
                     int domain_type = PlatformTopo::domain_name_to_type(pos_args[1]);
-                    int idx = platform_io.push_signal(signal_name, domain_type, domain_idx);
-                    // read_batch multiple times for derivative-based signals;
-                    // should not affect other signals
-                    for (int ii = 0; ii < 16; ++ii) {
-                        platform_io.read_batch();
-                        platform_io.sample(idx);
-                        usleep(5000);
-                    }
-                    double result = platform_io.sample(idx);
+                    double result = platform_io.read_signal(signal_name, domain_type, domain_idx);
                     std::cout << platform_io.format_function(signal_name)(result) << std::endl;
                 }
                 catch (const geopm::Exception &ex) {

--- a/test/CombinedSignalTest.cpp
+++ b/test/CombinedSignalTest.cpp
@@ -36,9 +36,11 @@
 #include "CombinedSignal.hpp"
 #include "Exception.hpp"
 #include "Agg.hpp"
+#include "config.h"
 
 using geopm::CombinedSignal;
 using geopm::DerivativeCombinedSignal;
+using geopm::DifferenceCombinedSignal;
 using geopm::Exception;
 
 TEST(CombinedSignalTest, sample_sum)
@@ -112,4 +114,25 @@ TEST(CombinedSignalTest, sample_slope_derivative)
         result = comb_signal.sample({(double)ii, sample_values[ii]});
     }
     EXPECT_NEAR(0.238, result, 0.001);
+}
+
+TEST(CombinedSignalTest, sample_difference)
+{
+    DifferenceCombinedSignal comb_signal;
+    std::vector<double> values = {0};
+#ifdef GEOPM_DEBUG
+    ASSERT_EQ(1u, values.size());
+    EXPECT_THROW(comb_signal.sample(values), Exception);
+    values = {1, 2, 3, 4};
+    ASSERT_EQ(4u, values.size());
+    EXPECT_THROW(comb_signal.sample(values), Exception);
+#endif
+
+    values = {0, 5};
+    double result = comb_signal.sample(values);
+    EXPECT_DOUBLE_EQ(-5.0, result);
+
+    values = {10, 5};
+    result = comb_signal.sample(values);
+    EXPECT_DOUBLE_EQ(5.0, result);
 }

--- a/test/RuntimeRegulatorTest.cpp
+++ b/test/RuntimeRegulatorTest.cpp
@@ -34,6 +34,7 @@
 #include "geopm_time.h"
 #include "Exception.hpp"
 #include "RuntimeRegulator.hpp"
+#include "config.h"
 
 using geopm::Exception;
 using geopm::RuntimeRegulator;

--- a/test/TreeCommLevelTest.cpp
+++ b/test/TreeCommLevelTest.cpp
@@ -39,6 +39,7 @@
 #include "TreeCommLevel.hpp"
 #include "MockComm.hpp"
 #include "geopm_test.hpp"
+#include "config.h"
 
 using geopm::TreeCommLevel;
 using geopm::TreeCommLevelImp;
@@ -265,7 +266,7 @@ TEST_F(TreeCommLevelTest, receive_up_complete)
     // errors
 #ifdef GEOPM_DEBUG
     GEOPM_EXPECT_THROW_MESSAGE(m_level_rank_1->receive_up(sample_out),
-                               GEOPM_ERROR_LOGIC, "called from rank not at root of level");
+                               GEOPM_ERROR_LOGIC, "Only zero rank of the level can call receive_up()");
 #endif
 }
 


### PR DESCRIPTION
Fixes #827.
Uses DifferenceCombinedSignal.
Also fixes a few unit tests that were missing config.h.