### PR TITLE
Fix make rpm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -243,7 +243,6 @@ EXTRA_DIST = $(TUTORIAL_DIST) \
              configure.ac \
              contrib/json11/LICENSE.txt \
              contrib/json11/README.md \
-             copying_headers/MANIFEST.BSD3-intel \
              copying_headers/MANIFEST.BSD3-llnl \
              copying_headers/MANIFEST.EXEMPT \
              copying_headers/MANIFEST.MIT-dropbox \


### PR DESCRIPTION
- Removed generated manifest file from EXTRA_DIST
