### PR TITLE
Fix pthread launch

### DIFF
--- a/ronn/geopmlaunch.1.ronn
+++ b/ronn/geopmlaunch.1.ronn
@@ -57,7 +57,7 @@ All command line options accepted by the underlying job scheduler
 with the exception of CPU affinity related options.  The wrapper
 script reinterprets the command line to pass modified options and set
 environment variables for the underlying application scheduler.  The
-GEOPM options, _geopm_opt_, are translated into environment varaibles
+GEOPM options, _geopm_opt_, are translated into environment variables
 to be interpreted by the GEOPM runtime (see the ENVIRONMENT section of
 **geopm(7)**).  The reinterpreted command line, including the
 environment modification, is printed to standard output by the script

--- a/src/ApplicationIO.cpp
+++ b/src/ApplicationIO.cpp
@@ -63,11 +63,11 @@ namespace geopm
     }
 
     ApplicationIOImp::ApplicationIOImp(const std::string &shm_key,
-                                 std::unique_ptr<ProfileSampler> sampler,
-                                 std::shared_ptr<ProfileIOSample> pio_sample,
-                                 std::unique_ptr<EpochRuntimeRegulator> epoch_regulator,
-                                 PlatformIO &platform_io,
-                                 const PlatformTopo &platform_topo)
+                                       std::unique_ptr<ProfileSampler> sampler,
+                                       std::shared_ptr<ProfileIOSample> pio_sample,
+                                       std::unique_ptr<EpochRuntimeRegulator> epoch_regulator,
+                                       PlatformIO &platform_io,
+                                       const PlatformTopo &platform_topo)
         : m_sampler(std::move(sampler))
         , m_profile_io_sample(pio_sample)
         , m_platform_io(platform_io)

--- a/src/DGEMMModelRegion.cpp
+++ b/src/DGEMMModelRegion.cpp
@@ -98,7 +98,7 @@ namespace geopm
     void DGEMMModelRegion::big_o(double big_o_in)
     {
         geopm::Profile &prof = geopm::Profile::default_profile();
-        uint64_t start_rid = prof.region("geopm_dgemm__model_region_startup", GEOPM_REGION_HINT_IGNORE);
+        uint64_t start_rid = prof.region("geopm_dgemm_model_region_startup", GEOPM_REGION_HINT_IGNORE);
         prof.enter(start_rid);
 
         if (m_big_o && m_big_o != big_o_in) {

--- a/src/DefaultProfile.cpp
+++ b/src/DefaultProfile.cpp
@@ -49,6 +49,7 @@ namespace geopm
         public:
             DefaultProfile();
             virtual ~DefaultProfile();
+            void enable_pmpi(void) override;
     };
 
     DefaultProfile::DefaultProfile()
@@ -60,6 +61,11 @@ namespace geopm
     DefaultProfile::~DefaultProfile()
     {
         g_pmpi_prof_enabled = 0;
+    }
+
+    void DefaultProfile::enable_pmpi(void)
+    {
+        g_pmpi_prof_enabled = m_is_enabled;
     }
 
     Profile &Profile::default_profile(void)
@@ -80,7 +86,8 @@ extern "C"
     {
         int err = 0;
         try {
-            geopm::Profile::default_profile();
+            geopm::Profile::default_profile().init();
+            geopm::Profile::default_profile().enable_pmpi();
         }
         catch (...) {
             err = geopm::exception_handler(std::current_exception());

--- a/src/DefaultProfile.cpp
+++ b/src/DefaultProfile.cpp
@@ -62,7 +62,6 @@ namespace geopm
         g_pmpi_prof_enabled = 0;
     }
 
-
     Profile &Profile::default_profile(void)
     {
         static geopm::DefaultProfile instance;

--- a/src/geopm_pmpi_helper.cpp
+++ b/src/geopm_pmpi_helper.cpp
@@ -252,8 +252,8 @@ static int geopm_pmpi_init(const char *exec_name)
         if (!err) {
             err = geopm_env_do_profile(&do_profile);
         }
-        if (!err &&
-            do_profile) {
+        if (!err && do_profile) {
+            // should only get called by one thread
             geopm_prof_init();
         }
 #ifdef GEOPM_DEBUG

--- a/test_integration/geopm_test_integration.py
+++ b/test_integration/geopm_test_integration.py
@@ -61,6 +61,7 @@ import geopmpy.launcher
 environment_default_path = os.path.join(util.get_config_value('GEOPM_CONFIG_PATH'), 'environment-default.json')
 environment_override_path = os.path.join(util.get_config_value('GEOPM_CONFIG_PATH'), 'environment-override.json')
 
+
 def create_frequency_map_policy(min_freq, max_freq, frequency_map, use_env=False):
     """Create a frequency map to be consumed by the frequency map agent.
 
@@ -81,7 +82,7 @@ def create_frequency_map_policy(min_freq, max_freq, frequency_map, use_env=False
             'sleep': 0x00000000536c798f,
             'MPI_Barrier': 0x000000007b561f45,
             'model-init': 0x00000000644f9787,
-            'unmarked-region': 0x00000000725e8066 }
+            'unmarked-region': 0x00000000725e8066}
 
     if use_env:
         os.environ['GEOPM_FREQUENCY_MAP'] = json.dumps(frequency_map)
@@ -94,6 +95,7 @@ def create_frequency_map_policy(min_freq, max_freq, frequency_map, use_env=False
             policy['FREQ_{}'.format(i)] = frequency
 
     return policy
+
 
 class TestIntegration(unittest.TestCase):
     def setUp(self):
@@ -151,10 +153,10 @@ class TestIntegration(unittest.TestCase):
         self._tmp_files.append(report_path)
 
         actual_policy = geopmpy.io.RawReport(report_path).meta_data()['Policy']
-        for expected_key,expected_value in expected_policy.items():
+        for expected_key, expected_value in expected_policy.items():
             self.assertEqual(expected_value, actual_policy[expected_key],
                              msg='Wrong policy value for {} (context: {})'.format(expected_key, context))
-        for actual_key,actual_value in actual_policy.items():
+        for actual_key, actual_value in actual_policy.items():
             if actual_key not in expected_policy:
                 self.assertEqual('NAN', actual_value,
                                  msg='Unexpected value for {} (context: {})'.format(actual_key, context))
@@ -413,7 +415,6 @@ class TestIntegration(unittest.TestCase):
             self.assertTrue(unmarked['sync-runtime (sec)'] >= epoch['sync-runtime (sec)'],
                             '''The sync-runtime for the unmarked region is NOT >= the Epoch sync-runtime.''')
 
-
     def test_runtime_nested(self):
         name = 'test_runtime_nested'
         report_path = name + '.report'
@@ -490,7 +491,7 @@ class TestIntegration(unittest.TestCase):
                     trace_elapsed_time = end_time - start_time
                     msg = 'for region {rn} on node {nn}'.format(rn=region_name, nn=nn)
                     self.assertNear(trace_elapsed_time, region_data['sync_runtime'].item(), msg=msg)
-            #epoch
+            # epoch
             region_data = self._output.get_report_data(node_name=nn, region='epoch')
             trace_elapsed_time = trace.iloc[-1]['TIME'] - trace['TIME'].loc[trace['EPOCH_COUNT'] == 0].iloc[0]
             msg = 'for epoch on node {nn}'.format(nn=nn)
@@ -868,7 +869,6 @@ class TestIntegration(unittest.TestCase):
                 avg_power_limit = sum(power_limits) / len(power_limits)
                 self.assertTrue(avg_power_limit <= power_budget)
 
-            min_runtime = float('nan')
             max_runtime = float('nan')
             node_names = self._output.get_node_names()
             runtime_list = []
@@ -1166,7 +1166,6 @@ class TestIntegration(unittest.TestCase):
         name = 'test_energy_efficient_single_region'
         min_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_MIN board 0")
         sticker_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_STICKER board 0")
-        freq_step = geopm_test_launcher.geopmread("CPUINFO::FREQ_STEP board 0")
         self._agent = "energy_efficient"
         report_path = name + '.report'
         trace_path = name + '.trace'
@@ -1197,7 +1196,6 @@ class TestIntegration(unittest.TestCase):
                     msg = region_name + " frequency should be minimum frequency as specified by policy"
                     self.assertEqual(region['requested-online-frequency'], min_freq, msg=msg)  # freq should reduce
 
-
     @util.skip_unless_run_long_tests()
     @util.skip_unless_cpufreq()
     @util.skip_unless_batch()
@@ -1207,9 +1205,7 @@ class TestIntegration(unittest.TestCase):
         """
         name = 'test_energy_efficient_sticker'
         min_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_MIN board 0")
-        max_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_MAX board 0")
         sticker_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_STICKER board 0")
-        freq_step = geopm_test_launcher.geopmread("CPUINFO::FREQ_STEP board 0")
         self._agent = "energy_efficient"
         num_node = 1
         num_rank = 4
@@ -1245,7 +1241,6 @@ class TestIntegration(unittest.TestCase):
             if rr == '_sticker':
                 self._options = {'frequency_min': sticker_freq,
                                  'frequency_max': sticker_freq}
-                freq = sticker_freq
             else:
                 self._options = {'frequency_min': min_freq,
                                  'frequency_max': sticker_freq}
@@ -1315,6 +1310,7 @@ class TestIntegration(unittest.TestCase):
             util.remove_file_on_compute_nodes(environment_default_path)
             self.assert_geopm_uses_policy(override_policy, test_name + '_override_no_user')
             self.assert_geopm_uses_policy(override_policy, test_name + '_override_with_user', user_policy=user_policy)
+
 
 class TestIntegrationGeopmio(unittest.TestCase):
     ''' Tests of geopmread and geopmwrite.'''
@@ -1517,7 +1513,7 @@ class TestIntegrationGeopmio(unittest.TestCase):
             '''
             try:
                 load_cpu_start()
-                time.sleep(5) # Give the load a moment to spin up
+                time.sleep(5)  # Give the load a moment to spin up
                 yield
             finally:
                 load_cpu_stop()

--- a/test_integration/geopm_test_integration.py
+++ b/test_integration/geopm_test_integration.py
@@ -1039,8 +1039,10 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(len(node_names), num_node)
         for nn in node_names:
             ignore_data = self._output.get_report_data(node_name=nn, region='ignore')
+            startup_data = self._output.get_report_data(node_name=nn,
+                                                        region='geopm_dgemm_model_region_startup')
             app_data = self._output.get_app_total_data(node_name=nn)
-            self.assertNear(ignore_data['runtime'].item(),
+            self.assertNear(ignore_data['runtime'].item() + startup_data['runtime'].item(),
                             app_data['ignore-runtime'].item(), 0.00005)
 
     @util.skip_unless_config_enable('ompt')

--- a/test_integration/geopm_test_integration.py
+++ b/test_integration/geopm_test_integration.py
@@ -202,7 +202,6 @@ class TestIntegration(unittest.TestCase):
             trace = self._output.get_trace_data(node_name=nn)
             self.assertNotEqual(0, len(trace))
 
-    @unittest.skipUnless('mr-fusion' in socket.gethostname(), "This test only enabled on known working systems.")
     def test_report_and_trace_generation_pthread(self):
         name = 'test_report_and_trace_generation_pthread'
         report_path = name + '.report'

--- a/test_integration/geopm_test_integration.py
+++ b/test_integration/geopm_test_integration.py
@@ -1349,8 +1349,8 @@ class TestIntegrationGeopmio(unittest.TestCase):
             sys.stderr.write('{} {}\n'.format(str(ex), stderr.getvalue()))
 
         for line in stdout.getvalue().splitlines():
-            if self.skip_warning_string.encode() not in line:
-                self.assertNotIn(b'Error', line)
+            if self.skip_warning_string not in line:
+                self.assertNotIn('Error', line)
 
     def test_geopmread_command_line(self):
         '''
@@ -1403,10 +1403,10 @@ class TestIntegrationGeopmio(unittest.TestCase):
 
         all_signals = []
         for line in stdout.getvalue().splitlines():
-            if self.skip_warning_string.encode() not in line:
+            if self.skip_warning_string not in line:
                 all_signals.append(line.strip())
         for sig in all_signals:
-            self.check_no_error([sig.decode(), 'board', '0'])
+            self.check_no_error([sig, 'board', '0'])
 
     @util.skip_unless_batch()
     def test_geopmread_signal_value(self):

--- a/test_integration/test_profile_policy.py
+++ b/test_integration/test_profile_policy.py
@@ -68,7 +68,7 @@ class TestIntegrationProfilePolicy(unittest.TestCase):
         geopmpy.policy_store.connect(policy_db_path)
         geopmpy.policy_store.set_default("power_balancer",
                                          [self.default_power_cap])
-        geopmpy.policy_store.set_best("power_custom", "power_balancer",
+        geopmpy.policy_store.set_best("power_balancer", "power_custom",
                                       [self.custom_power_cap, 0, 0, 0])
         geopmpy.policy_store.disconnect()
 


### PR DESCRIPTION
- Moves initialization of Profile (handshake with application) out of the constructor and calls it explicitly in geopm_pmpi_init
- Fix for test_profile_policy