### PR TITLE
Add temperature signals in MSRIOGroup

### DIFF
--- a/src/MSRIOGroup.cpp
+++ b/src/MSRIOGroup.cpp
@@ -110,6 +110,7 @@ namespace geopm
         m_func_map["MSR::PKG_POWER_INFO:MAX_POWER"] = Agg::sum;
         m_func_map["MSR::PKG_POWER_INFO:THERMAL_SPEC_POWER"] = Agg::sum;
         m_func_map["MSR::THERM_STATUS:DIGITAL_READOUT"] = Agg::average;
+        m_func_map["MSR::PACKAGE_THERM_STATUS:DIGITAL_READOUT"] = Agg::average;
         m_func_map["MSR::TEMPERATURE_TARGET:PROCHOT_MIN"] = Agg::expect_same;
 
         m_signal_desc_map["MSR::PKG_POWER_INFO:THERMAL_SPEC_POWER"] = "Maximum power to stay within thermal limits (TDP)";

--- a/src/MSRIOGroup.hpp
+++ b/src/MSRIOGroup.hpp
@@ -47,6 +47,7 @@ namespace geopm
     class MSRControl;
     class MSRIO;
     class PlatformTopo;
+    class CombinedSignal;
 
     /// @brief IOGroup that provides signals and controls based on MSRs.
     class MSRIOGroup : public IOGroup
@@ -171,6 +172,11 @@ namespace geopm
             std::map<std::string, std::string> m_signal_desc_map;
             std::map<std::string, std::string> m_control_desc_map;
             std::map<std::string, int> m_signal_units_map;
+
+            /// @todo remove with combined signal refactoring
+            static const std::set<std::string> m_combined_signal_names;
+            std::map<int, std::pair<std::vector<int>,
+                                    std::unique_ptr<CombinedSignal> > > m_combined_signals;
     };
 }
 

--- a/src/MSRImp.hpp
+++ b/src/MSRImp.hpp
@@ -83,15 +83,11 @@ namespace geopm
                       const std::vector<std::pair<std::string, struct MSR::m_encode_s> > &control);
             std::string m_name;
             uint64_t m_offset;
-            std::vector<MSREncode *> m_signal_encode;
-            std::vector<MSREncode *> m_control_encode;
+            std::vector<MSREncode> m_signal_encode;
+            std::vector<MSREncode> m_control_encode;
             std::map<std::string, int> m_signal_map;
             std::map<std::string, int> m_control_map;
             int m_domain_type;
-            const std::vector<const MSR *> m_prog_msr;
-            const std::vector<std::string> m_prog_field_name;
-            const std::vector<double> m_prog_value;
-
     };
 }
 

--- a/test/MSRIOGroupTest.cpp
+++ b/test/MSRIOGroupTest.cpp
@@ -479,7 +479,6 @@ TEST_F(MSRIOGroupTest, read_signal_temperature)
     EXPECT_NEAR(exp_temp, m_msrio_group->read_signal("MSR::TEMPERATURE_PACKAGE", GEOPM_DOMAIN_PACKAGE, 0), 0.001);
 }
 
-
 TEST_F(MSRIOGroupTest, push_signal_temperature)
 {
     ASSERT_TRUE(m_msrio_group->is_valid_signal("MSR::TEMPERATURE_TARGET:PROCHOT_MIN"));

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -209,7 +209,9 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/MSRIOGroupTest.parse_json_msrs_error_top_level \
               test/gtest_links/MSRIOGroupTest.push_control \
               test/gtest_links/MSRIOGroupTest.push_signal \
+              test/gtest_links/MSRIOGroupTest.push_signal_temperature \
               test/gtest_links/MSRIOGroupTest.read_signal \
+              test/gtest_links/MSRIOGroupTest.read_signal_temperature \
               test/gtest_links/MSRIOGroupTest.register_msr_control \
               test/gtest_links/MSRIOGroupTest.register_msr_signal \
               test/gtest_links/MSRIOGroupTest.sample \
@@ -217,6 +219,7 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/MSRIOGroupTest.signal_alias \
               test/gtest_links/MSRIOGroupTest.signal_error \
               test/gtest_links/MSRIOGroupTest.supported_cpuid \
+              test/gtest_links/MSRIOGroupTest.valid_signal_temperature \
               test/gtest_links/MSRIOGroupTest.whitelist \
               test/gtest_links/MSRIOGroupTest.write_control \
               test/gtest_links/MSRIOTest.read_aligned \


### PR DESCRIPTION
- Adds MSR::TEMPERATURE_CORE and MSR::TEMPERATURE_PACKAGE with logic similar to what is in PlatformIO.
- PlatformIO aliases are still present to allow comparison with the new signals.
- In the future, all signal types will be handled the same way without the need for specific name checks.