### PR TITLE
Signal interface and derived classes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -563,6 +563,7 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/SharedMemoryScopedLock.cpp \
                             src/SharedMemoryScopedLock.hpp \
                             src/SharedMemoryUser.hpp \
+                            src/Signal.hpp \
                             src/TimeIOGroup.cpp \
                             src/TimeIOGroup.hpp \
                             src/Tracer.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -507,6 +507,8 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/MSRControl.cpp \
                             src/MSRControl.hpp \
                             src/MSRControlImp.hpp \
+                            src/MSRFieldSignal.cpp \
+                            src/MSRFieldSignal.hpp \
                             src/MSRIO.cpp \
                             src/MSRIO.hpp \
                             src/MSRIOImp.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -465,6 +465,8 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/CSV.hpp \
                             src/DebugIOGroup.cpp \
                             src/DebugIOGroup.hpp \
+                            src/DerivativeSignal.cpp \
+                            src/DerivativeSignal.hpp \
                             src/DifferenceSignal.cpp \
                             src/DifferenceSignal.hpp \
                             src/ELF.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -465,6 +465,8 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/CSV.hpp \
                             src/DebugIOGroup.cpp \
                             src/DebugIOGroup.hpp \
+                            src/DifferenceSignal.cpp \
+                            src/DifferenceSignal.hpp \
                             src/ELF.cpp \
                             src/ELF.hpp \
                             src/Endpoint.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -546,6 +546,8 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/ProfileThread.hpp \
                             src/ProfileTracer.cpp \
                             src/ProfileTracer.hpp \
+                            src/RawMSRSignal.cpp \
+                            src/RawMSRSignal.hpp \
                             src/RegionAggregator.cpp \
                             src/RegionAggregator.hpp \
                             src/RegionAggregatorImp.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -574,6 +574,7 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/geopm.h \
                             src/geopm_agent.h \
                             src/geopm_endpoint.h \
+                            src/geopm_debug.hpp \
                             src/geopm_error.h \
                             src/geopm_hash.c \
                             src/geopm_hash.h \

--- a/src/DerivativeSignal.cpp
+++ b/src/DerivativeSignal.cpp
@@ -53,24 +53,7 @@ namespace geopm
         , m_sleep_time(sleep_time)
     {
         GEOPM_DEBUG_ASSERT(m_time_sig && m_y_sig,
-                           "underlying Signals cannot be null.");
-    }
-
-    DerivativeSignal::DerivativeSignal(const DerivativeSignal &other)
-        : m_time_sig(other.m_time_sig->clone())
-        , m_y_sig(other.m_y_sig->clone())
-        , M_NUM_SAMPLE_HISTORY(other.M_NUM_SAMPLE_HISTORY)
-        , m_history(M_NUM_SAMPLE_HISTORY)
-        , m_derivative_num_fit(0)
-        , m_is_batch_ready(false)
-        , m_sleep_time(other.m_sleep_time)
-    {
-
-    }
-
-    std::unique_ptr<Signal> DerivativeSignal::clone(void) const
-    {
-        return geopm::make_unique<DerivativeSignal>(*this);
+                           "Signal pointers for time_sig and y_sig cannot be null.");
     }
 
     void DerivativeSignal::setup_batch(void)
@@ -129,7 +112,7 @@ namespace geopm
         return compute_next(m_history, m_derivative_num_fit, time, signal);
     }
 
-    double DerivativeSignal::read(void)
+    double DerivativeSignal::read(void) const
     {
         double result = NAN;
         CircularBuffer<m_sample_s> temp_history(M_NUM_SAMPLE_HISTORY);
@@ -139,8 +122,8 @@ namespace geopm
             double signal = m_y_sig->read();
             result = compute_next(temp_history, num_fit, time, signal);
             if (ii < M_NUM_SAMPLE_HISTORY) {
-                usleep(m_sleep_time);            }
-
+                usleep(m_sleep_time);
+            }
         }
         return result;
     }

--- a/src/DerivativeSignal.cpp
+++ b/src/DerivativeSignal.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "DerivativeSignal.hpp"
+
+#include <cmath>
+#include <unistd.h>
+
+#include "Helper.hpp"
+#include "geopm_debug.hpp"
+
+namespace geopm
+{
+    DerivativeSignal::DerivativeSignal(std::shared_ptr<Signal> time_sig,
+                                       std::shared_ptr<Signal> y_sig,
+                                       int num_sample_history,
+                                       double sleep_time)
+        : m_time_sig(time_sig)
+        , m_y_sig(y_sig)
+        , M_NUM_SAMPLE_HISTORY(num_sample_history)
+        , m_history(M_NUM_SAMPLE_HISTORY)
+        , m_derivative_num_fit(0)
+        , m_is_batch_ready(false)
+        , m_sleep_time(sleep_time)
+    {
+        GEOPM_DEBUG_ASSERT(m_time_sig && m_y_sig,
+                           "underlying Signals cannot be null.");
+    }
+
+    DerivativeSignal::DerivativeSignal(const DerivativeSignal &other)
+        : m_time_sig(other.m_time_sig->clone())
+        , m_y_sig(other.m_y_sig->clone())
+        , M_NUM_SAMPLE_HISTORY(other.M_NUM_SAMPLE_HISTORY)
+        , m_history(M_NUM_SAMPLE_HISTORY)
+        , m_derivative_num_fit(0)
+        , m_is_batch_ready(false)
+        , m_sleep_time(other.m_sleep_time)
+    {
+
+    }
+
+    std::unique_ptr<Signal> DerivativeSignal::clone(void) const
+    {
+        return geopm::make_unique<DerivativeSignal>(*this);
+    }
+
+    void DerivativeSignal::setup_batch(void)
+    {
+        if (!m_is_batch_ready) {
+            m_time_sig->setup_batch();
+            m_y_sig->setup_batch();
+            m_is_batch_ready = true;
+        }
+    }
+
+    double DerivativeSignal::compute_next(CircularBuffer<m_sample_s> &history,
+                                          int &num_fit,
+                                          double time, double signal)
+    {
+        // insert time and signal
+        history.insert({time, signal});
+        if (num_fit < history.capacity()) {
+            ++num_fit;
+        }
+
+        // Least squares linear regression to approximate the
+        // derivative with noisy data.
+        double result = NAN;
+        if (num_fit >= 2) {
+            size_t buf_size = history.size();
+            double A = 0.0, B = 0.0, C = 0.0, D = 0.0;
+            double E = 1.0 / num_fit;
+            double time_0 = history.value(buf_size - num_fit).time;
+            const double sig_0 = history.value(buf_size - num_fit).sample;
+            for (size_t buf_off = buf_size - num_fit;
+                 buf_off < buf_size; ++buf_off) {
+                double tt = history.value(buf_off).time;
+                double time = tt - time_0;
+                double sig = history.value(buf_off).sample - sig_0;
+                A += time * sig;
+                B += time;
+                C += sig;
+                D += time * time;
+            }
+            double ssxx = D - B * B * E;
+            double ssxy = A - B * C * E;
+            result = ssxy / ssxx;
+        }
+        return result;
+    }
+
+    double DerivativeSignal::sample(void)
+    {
+        if (!m_is_batch_ready) {
+            throw Exception("setup_batch() must be called before sample().",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        double time = m_time_sig->sample();
+        double signal = m_y_sig->sample();
+        return compute_next(m_history, m_derivative_num_fit, time, signal);
+    }
+
+    double DerivativeSignal::read(void)
+    {
+        double result = NAN;
+        CircularBuffer<m_sample_s> temp_history(M_NUM_SAMPLE_HISTORY);
+        int num_fit = 0;
+        for (int ii = 0; ii < M_NUM_SAMPLE_HISTORY; ++ii) {
+            double time = m_time_sig->read();
+            double signal = m_y_sig->read();
+            result = compute_next(temp_history, num_fit, time, signal);
+            if (ii < M_NUM_SAMPLE_HISTORY) {
+                usleep(m_sleep_time);            }
+
+        }
+        return result;
+    }
+
+}

--- a/src/DerivativeSignal.hpp
+++ b/src/DerivativeSignal.hpp
@@ -30,36 +30,48 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SIGNAL_HPP_INCLUDE
-#define SIGNAL_HPP_INCLUDE
+#ifndef DERIVATIVESIGNAL_HPP_INCLUDE
+#define DERIVATIVESIGNAL_HPP_INCLUDE
 
-#include <functional>
+#include <memory>
+
+#include "Signal.hpp"
+#include "CircularBuffer.hpp"
 
 namespace geopm
 {
-    /// An abstract interface for all types of signals supported by an IOGroup.
-    /// Any implementation specific data should be injected in the derived class
-    /// constructor and used in setup_batch() if necessary.
-    class Signal
+    class DerivativeSignal : public Signal
     {
         public:
-            virtual ~Signal() = default;
-            /// @brief Make a copy of the signal with its own state.
-            ///        This is intended for use with read_signal() in
-            ///        the IOGroup.
-            virtual std::unique_ptr<Signal> clone(void) const = 0;
-            /// @brief Prepare the signal for being updating through
-            ///        side effects by the owner's read_batch step.
-            ///        This method should not fail if called multiple
-            ///        times, and ideally only apply the side effects
-            ///        on the first call.
-            virtual void setup_batch(void) = 0;
-            /// @brief Apply any conversions necessary to interpret
-            ///        the latest stored value as a double.
-            virtual double sample(void) = 0;
-            /// @brief Directly the value of the signal without
-            ///        affecting any pushed batch signals.
-            virtual double read(void) = 0;
+            DerivativeSignal(std::shared_ptr<Signal> time_sig,
+                             std::shared_ptr<Signal> y_sig,
+                             int read_loops, double sleep_time);
+            DerivativeSignal(const DerivativeSignal &other);
+            virtual ~DerivativeSignal() = default;
+            std::unique_ptr<Signal> clone(void) const override;
+            void setup_batch(void) override;
+            double sample(void) override;
+            double read(void) override;
+        private:
+            struct m_sample_s {
+                double time;
+                double sample;
+            };
+
+            /// Update the history buffer and compute the new derivative.
+            /// The read() and sample() methods have separate history.
+            static double compute_next(CircularBuffer<m_sample_s> &history,
+                                       int &num_fit,
+                                       double time, double signal);
+
+            std::shared_ptr<Signal> m_time_sig;
+            std::shared_ptr<Signal> m_y_sig;
+
+            const int M_NUM_SAMPLE_HISTORY;
+            CircularBuffer<m_sample_s> m_history;
+            int m_derivative_num_fit;
+            bool m_is_batch_ready;
+            double m_sleep_time;
     };
 }
 

--- a/src/DerivativeSignal.hpp
+++ b/src/DerivativeSignal.hpp
@@ -46,12 +46,11 @@ namespace geopm
             DerivativeSignal(std::shared_ptr<Signal> time_sig,
                              std::shared_ptr<Signal> y_sig,
                              int read_loops, double sleep_time);
-            DerivativeSignal(const DerivativeSignal &other);
+            DerivativeSignal(const DerivativeSignal &other) = delete;
             virtual ~DerivativeSignal() = default;
-            std::unique_ptr<Signal> clone(void) const override;
             void setup_batch(void) override;
             double sample(void) override;
-            double read(void) override;
+            double read(void) const override;
         private:
             struct m_sample_s {
                 double time;

--- a/src/DifferenceSignal.cpp
+++ b/src/DifferenceSignal.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "DifferenceSignal.hpp"
+
+#include "Exception.hpp"
+#include "Helper.hpp"
+#include "geopm_debug.hpp"
+
+namespace geopm
+{
+    DifferenceSignal::DifferenceSignal(std::shared_ptr<Signal> minuend,
+                                       std::shared_ptr<Signal> subtrahend)
+        : m_minuend(minuend)
+        , m_subtrahend(subtrahend)
+        , m_is_batch_ready(false)
+    {
+        GEOPM_DEBUG_ASSERT(m_minuend && m_subtrahend,
+                           "underlying Signals cannot be null.");
+    }
+
+    // clone is used here because derived subtype is not known
+    DifferenceSignal::DifferenceSignal(const DifferenceSignal &other)
+        : m_minuend(other.m_minuend->clone())
+        , m_subtrahend(other.m_minuend->clone())
+        , m_is_batch_ready(false)
+    {
+
+    }
+
+    std::unique_ptr<Signal> DifferenceSignal::clone(void) const
+    {
+        return geopm::make_unique<DifferenceSignal>(*this);
+    }
+
+    void DifferenceSignal::setup_batch(void)
+    {
+        if (!m_is_batch_ready) {
+            m_minuend->setup_batch();
+            m_subtrahend->setup_batch();
+            m_is_batch_ready = true;
+        }
+    }
+
+    double DifferenceSignal::sample(void)
+    {
+        if (!m_is_batch_ready) {
+            throw Exception("setup_batch() must be called before sample().",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        return m_minuend->sample() - m_subtrahend->sample();
+    }
+
+    double DifferenceSignal::read(void)
+    {
+        return m_minuend->read() - m_subtrahend->read();
+    }
+}

--- a/src/DifferenceSignal.cpp
+++ b/src/DifferenceSignal.cpp
@@ -45,21 +45,7 @@ namespace geopm
         , m_is_batch_ready(false)
     {
         GEOPM_DEBUG_ASSERT(m_minuend && m_subtrahend,
-                           "underlying Signals cannot be null.");
-    }
-
-    // clone is used here because derived subtype is not known
-    DifferenceSignal::DifferenceSignal(const DifferenceSignal &other)
-        : m_minuend(other.m_minuend->clone())
-        , m_subtrahend(other.m_minuend->clone())
-        , m_is_batch_ready(false)
-    {
-
-    }
-
-    std::unique_ptr<Signal> DifferenceSignal::clone(void) const
-    {
-        return geopm::make_unique<DifferenceSignal>(*this);
+                           "Signal pointers for minuend and subtrahend cannot be null.");
     }
 
     void DifferenceSignal::setup_batch(void)
@@ -80,7 +66,7 @@ namespace geopm
         return m_minuend->sample() - m_subtrahend->sample();
     }
 
-    double DifferenceSignal::read(void)
+    double DifferenceSignal::read(void) const
     {
         return m_minuend->read() - m_subtrahend->read();
     }

--- a/src/DifferenceSignal.hpp
+++ b/src/DifferenceSignal.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DIFFERENCESIGNAL_HPP_INCLUDE
+#define DIFFERENCESIGNAL_HPP_INCLUDE
+
+#include <memory>
+
+#include "Signal.hpp"
+
+namespace geopm
+{
+    /// A composite signal used by an IOGroup to produce a signal as
+    /// the difference of two signals.
+    class DifferenceSignal : public Signal
+    {
+        public:
+            DifferenceSignal(std::shared_ptr<Signal> minuend,
+                             std::shared_ptr<Signal> subtrahend);
+            DifferenceSignal(const DifferenceSignal &other);
+            virtual ~DifferenceSignal() = default;
+            std::unique_ptr<Signal> clone(void) const override;
+            void setup_batch(void) override;
+            double sample(void) override;
+            double read(void) override;
+        private:
+            std::shared_ptr<Signal> m_minuend;
+            std::shared_ptr<Signal> m_subtrahend;
+            bool m_is_batch_ready;
+    };
+}
+
+#endif

--- a/src/DifferenceSignal.hpp
+++ b/src/DifferenceSignal.hpp
@@ -46,12 +46,11 @@ namespace geopm
         public:
             DifferenceSignal(std::shared_ptr<Signal> minuend,
                              std::shared_ptr<Signal> subtrahend);
-            DifferenceSignal(const DifferenceSignal &other);
+            DifferenceSignal(const DifferenceSignal &other) = delete;
             virtual ~DifferenceSignal() = default;
-            std::unique_ptr<Signal> clone(void) const override;
             void setup_batch(void) override;
             double sample(void) override;
-            double read(void) override;
+            double read(void) const override;
         private:
             std::shared_ptr<Signal> m_minuend;
             std::shared_ptr<Signal> m_subtrahend;

--- a/src/MSRFieldSignal.cpp
+++ b/src/MSRFieldSignal.cpp
@@ -63,33 +63,13 @@ namespace geopm
         /// public. Alternatively, checks for these at the json
         /// parsing step would make these correctly logic errors.
         GEOPM_DEBUG_ASSERT(raw_msr != nullptr,
-                           "no valid raw Signal");
+                           "Signal pointer for raw_msr cannot be null");
         GEOPM_DEBUG_ASSERT(m_num_bit < 64, "64-bit fields are not supported");
         GEOPM_DEBUG_ASSERT(begin_bit <= end_bit,
                            "begin bit must be <= end bit");
         GEOPM_DEBUG_ASSERT(m_function >= MSR::M_FUNCTION_SCALE &&
                            m_function <= MSR::M_FUNCTION_OVERFLOW,
                            "invalid encoding function");
-    }
-
-    MSRFieldSignal::MSRFieldSignal(const MSRFieldSignal &other)
-        : m_raw_msr(other.m_raw_msr)
-        , m_shift(other.m_shift)
-        , m_num_bit(other.m_num_bit)
-        , m_mask(other.m_mask)
-        , m_subfield_max(other.m_subfield_max)
-        , m_function(other.m_function)
-        , m_scalar(other.m_scalar)
-        , m_last_field(0)
-        , m_num_overflow(0)
-        , m_is_batch_ready(false)
-    {
-
-    }
-
-    std::unique_ptr<Signal> MSRFieldSignal::clone(void) const
-    {
-        return geopm::make_unique<MSRFieldSignal>(*this);
     }
 
     void MSRFieldSignal::setup_batch(void)
@@ -102,7 +82,7 @@ namespace geopm
 
     double MSRFieldSignal::convert_raw_value(double val,
                                      uint64_t &last_field,
-                                     int &num_overflow)
+                                     int &num_overflow) const
     {
         uint64_t field = geopm_signal_to_field(val);
         uint64_t subfield = (field & m_mask) >> m_shift;
@@ -149,7 +129,7 @@ namespace geopm
         return convert_raw_value(m_raw_msr->sample(), m_last_field, m_num_overflow);
     }
 
-    double MSRFieldSignal::read(void)
+    double MSRFieldSignal::read(void) const
     {
         uint64_t last_field = 0;
         int num_overflow = 0;

--- a/src/MSRFieldSignal.cpp
+++ b/src/MSRFieldSignal.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "MSRFieldSignal.hpp"
+
+#include "geopm_hash.h"
+#include "Exception.hpp"
+#include "geopm_debug.hpp"
+#include "Helper.hpp"
+#include "MSR.hpp"  // for enums
+
+namespace geopm
+{
+    MSRFieldSignal::MSRFieldSignal(std::shared_ptr<Signal> raw_msr,
+                                   int begin_bit,
+                                   int end_bit,
+                                   int function,
+                                   double scalar)
+        : m_raw_msr(raw_msr)
+        , m_shift(begin_bit)
+        , m_num_bit(end_bit - begin_bit + 1)
+        , m_mask(((1ULL << m_num_bit) - 1) << begin_bit)
+        , m_subfield_max((1ULL << m_num_bit) - 1)
+        , m_function(function)
+        , m_scalar(scalar)
+        , m_last_field(0)
+        , m_num_overflow(0)
+        , m_is_batch_ready(false)
+    {
+        /// @todo: some of these are not logic errors if MSR data
+        /// comes from user input files or if this interface is
+        /// public. Alternatively, checks for these at the json
+        /// parsing step would make these correctly logic errors.
+        GEOPM_DEBUG_ASSERT(raw_msr != nullptr,
+                           "no valid raw Signal");
+        GEOPM_DEBUG_ASSERT(m_num_bit < 64, "64-bit fields are not supported");
+        GEOPM_DEBUG_ASSERT(begin_bit <= end_bit,
+                           "begin bit must be <= end bit");
+        GEOPM_DEBUG_ASSERT(m_function >= MSR::M_FUNCTION_SCALE &&
+                           m_function <= MSR::M_FUNCTION_OVERFLOW,
+                           "invalid encoding function");
+    }
+
+    MSRFieldSignal::MSRFieldSignal(const MSRFieldSignal &other)
+        : m_raw_msr(other.m_raw_msr)
+        , m_shift(other.m_shift)
+        , m_num_bit(other.m_num_bit)
+        , m_mask(other.m_mask)
+        , m_subfield_max(other.m_subfield_max)
+        , m_function(other.m_function)
+        , m_scalar(other.m_scalar)
+        , m_last_field(0)
+        , m_num_overflow(0)
+        , m_is_batch_ready(false)
+    {
+
+    }
+
+    std::unique_ptr<Signal> MSRFieldSignal::clone(void) const
+    {
+        return geopm::make_unique<MSRFieldSignal>(*this);
+    }
+
+    void MSRFieldSignal::setup_batch(void)
+    {
+        if (!m_is_batch_ready) {
+            m_raw_msr->setup_batch();
+            m_is_batch_ready = true;
+        }
+    }
+
+    double MSRFieldSignal::convert_raw_value(double val,
+                                     uint64_t &last_field,
+                                     int &num_overflow)
+    {
+        uint64_t field = geopm_signal_to_field(val);
+        uint64_t subfield = (field & m_mask) >> m_shift;
+        uint64_t subfield_last = (last_field & m_mask) >> m_shift;
+        double result = NAN;
+
+        uint64_t float_y, float_z;
+        switch (m_function) {
+            case MSR::M_FUNCTION_LOG_HALF:
+                // F = S * 2.0 ^ -X
+                result = 1.0 / (1ULL << subfield);
+                break;
+            case MSR::M_FUNCTION_7_BIT_FLOAT:
+                // F = S * 2 ^ Y * (1.0 + Z / 4.0)
+                // Y in bits [0:5) and Z in bits [5:7)
+                float_y = subfield & 0x1F;
+                float_z = subfield >> 5;
+                result = (1ULL << float_y) * (1.0 + float_z / 4.0);
+                break;
+            case MSR::M_FUNCTION_OVERFLOW:
+                if (subfield_last > subfield) {
+                    ++num_overflow;
+                }
+                result = subfield + ((m_subfield_max + 1.0) * num_overflow);
+                break;
+            case MSR::M_FUNCTION_SCALE:
+                result = subfield;
+                break;
+            default:
+                GEOPM_DEBUG_ASSERT(false, "invalid function type for MSRFieldSignal");
+                break;
+        }
+        result *= m_scalar;
+        last_field = field;
+        return result;
+    }
+
+    double MSRFieldSignal::sample(void)
+    {
+        if (!m_is_batch_ready) {
+            throw Exception("setup_batch() must be called before sample().",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        return convert_raw_value(m_raw_msr->sample(), m_last_field, m_num_overflow);
+    }
+
+    double MSRFieldSignal::read(void)
+    {
+        uint64_t last_field = 0;
+        int num_overflow = 0;
+        return convert_raw_value(m_raw_msr->read(), last_field, num_overflow);
+    }
+}

--- a/src/MSRFieldSignal.hpp
+++ b/src/MSRFieldSignal.hpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MSRFIELDSIGNAL_HPP_INCLUDE
+#define MSRFIELDSIGNAL_HPP_INCLUDE
+
+#include <cstdint>
+#include <cmath>
+
+#include <string>
+#include <memory>
+
+#include "Signal.hpp"
+#include "MSRIO.hpp"
+
+namespace geopm
+{
+    /// Encapsulates conversion of MSR bitfields to double signal
+    /// values in SI units.
+    /// @todo: most implementation is the same as MSREncode class.
+    /// The hope is that this class can eventually replace the use of
+    /// MSREncode.  The enum for the function comes from the MSR class.
+    class MSRFieldSignal : public Signal
+    {
+        public:
+            MSRFieldSignal(std::shared_ptr<Signal> raw_msr,
+                           int begin_bit,
+                           int end_bit,
+                           int function,
+                           double scalar);
+            MSRFieldSignal(const MSRFieldSignal &other);
+            virtual ~MSRFieldSignal() = default;
+            std::unique_ptr<Signal> clone(void) const override;
+            void setup_batch(void) override;
+            double sample(void) override;
+            double read(void) override;
+        private:
+            double convert_raw_value(double val,
+                                     uint64_t &last_field,
+                                     int &num_overflow);
+            /// Underlying raw MSR that contains the field.  This
+            /// should be a RawMSRSignal in most cases but a base
+            /// class pointer is used for testing and only the public
+            /// interface is used.
+            /// @todo: If it becomes too expensive to have another
+            /// layer of indirection, this can be replaced with a
+            /// pointer to the MSRIO and an implementation similar to
+            /// RawMSRSignal.
+            std::shared_ptr<Signal> m_raw_msr;
+            const int m_shift;
+            const int m_num_bit;
+            const uint64_t m_mask;
+            const uint64_t m_subfield_max;
+            const int m_function;
+            const double m_scalar;
+            uint64_t m_last_field;
+            int m_num_overflow;
+            bool m_is_batch_ready;
+    };
+}
+
+#endif

--- a/src/MSRFieldSignal.hpp
+++ b/src/MSRFieldSignal.hpp
@@ -57,16 +57,15 @@ namespace geopm
                            int end_bit,
                            int function,
                            double scalar);
-            MSRFieldSignal(const MSRFieldSignal &other);
+            MSRFieldSignal(const MSRFieldSignal &other) = delete;
             virtual ~MSRFieldSignal() = default;
-            std::unique_ptr<Signal> clone(void) const override;
             void setup_batch(void) override;
             double sample(void) override;
-            double read(void) override;
+            double read(void) const override;
         private:
             double convert_raw_value(double val,
                                      uint64_t &last_field,
-                                     int &num_overflow);
+                                     int &num_overflow) const;
             /// Underlying raw MSR that contains the field.  This
             /// should be a RawMSRSignal in most cases but a base
             /// class pointer is used for testing and only the public

--- a/src/MSRIO.hpp
+++ b/src/MSRIO.hpp
@@ -88,11 +88,24 @@ namespace geopm
                                       const std::vector<int> &write_cpu_idx,
                                       const std::vector<uint64_t> &write_offset,
                                       const std::vector<uint64_t> &write_mask) = 0;
+            /// @brief Extend the set of MSRs for batch read with a single offset.
+            /// @param [in] cpu_idx logical Linux PU index to read from when
+            ///         read_batch() method is called.
+            /// @param [in] offset MSR offset to be read when
+            ///        read_batch() is called.
+            /// @return The mapped memory for use by signals.
+            virtual uint64_t *add_read(int cpu_idx, uint64_t offset) = 0;
+
             /// @brief Batch read a set of MSRs configured by a
             ///        previous call to the batch_config() method.
             /// @param [out] raw_value The raw encoded MSR values to
             ///        be read.
             virtual void read_batch(std::vector<uint64_t> &raw_value) = 0;
+            /// @brief Batch read a set of MSRs configured by a
+            ///        previous call to the batch_config() method.
+            ///        The memory used to store the result should have
+            ///        been returned by add_read().
+            virtual void read_batch(void) = 0;
             /// @brief Batch write a set of MSRs configured by a
             ///        previous call to the batch_config() method.
             /// @param [in] raw_value The raw encoded MSR values to be

--- a/src/MSRIOImp.hpp
+++ b/src/MSRIOImp.hpp
@@ -56,7 +56,9 @@ namespace geopm
                               const std::vector<int> &write_cpu_idx,
                               const std::vector<uint64_t> &write_offset,
                               const std::vector<uint64_t> &write_mask) override;
+            uint64_t *add_read(int cpu_idx, uint64_t offset) override;
             void read_batch(std::vector<uint64_t> &raw_value) override;
+            void read_batch(void) override;
             void write_batch(const std::vector<uint64_t> &raw_value) override;
         private:
             struct m_msr_batch_op_s {

--- a/src/RawMSRSignal.cpp
+++ b/src/RawMSRSignal.cpp
@@ -53,21 +53,6 @@ namespace geopm
         GEOPM_DEBUG_ASSERT(m_msrio != nullptr, "no valid MSRIO object.");
     }
 
-    RawMSRSignal::RawMSRSignal(const RawMSRSignal &other)
-        : m_msrio(other.m_msrio)
-        , m_cpu(other.m_cpu)
-        , m_offset(other.m_offset)
-        , m_data(nullptr)
-        , m_is_batch_ready(false)
-    {
-
-    }
-
-    std::unique_ptr<Signal> RawMSRSignal::clone(void) const
-    {
-        return geopm::make_unique<RawMSRSignal>(*this);
-    }
-
     void RawMSRSignal::setup_batch(void)
     {
         GEOPM_DEBUG_ASSERT(m_msrio != nullptr, "no valid MSRIO object.");
@@ -92,7 +77,7 @@ namespace geopm
         return geopm_field_to_signal(*m_data);
     }
 
-    double RawMSRSignal::read(void)
+    double RawMSRSignal::read(void) const
     {
         GEOPM_DEBUG_ASSERT(m_msrio != nullptr, "no valid MSRIO object.");
 

--- a/src/RawMSRSignal.cpp
+++ b/src/RawMSRSignal.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "RawMSRSignal.hpp"
+
+#include "geopm_hash.h"
+#include "geopm_debug.hpp"
+#include "Exception.hpp"
+#include "Helper.hpp"
+
+namespace geopm
+{
+    RawMSRSignal::RawMSRSignal(std::shared_ptr<MSRIO> msrio,
+                               int cpu,
+                               uint64_t offset)
+        : m_msrio(msrio)
+        , m_cpu(cpu)
+        , m_offset(offset)
+        , m_data(nullptr)
+        , m_is_batch_ready(false)
+    {
+        GEOPM_DEBUG_ASSERT(m_msrio != nullptr, "no valid MSRIO object.");
+    }
+
+    RawMSRSignal::RawMSRSignal(const RawMSRSignal &other)
+        : m_msrio(other.m_msrio)
+        , m_cpu(other.m_cpu)
+        , m_offset(other.m_offset)
+        , m_data(nullptr)
+        , m_is_batch_ready(false)
+    {
+
+    }
+
+    std::unique_ptr<Signal> RawMSRSignal::clone(void) const
+    {
+        return geopm::make_unique<RawMSRSignal>(*this);
+    }
+
+    void RawMSRSignal::setup_batch(void)
+    {
+        GEOPM_DEBUG_ASSERT(m_msrio != nullptr, "no valid MSRIO object.");
+
+        if (!m_is_batch_ready) {
+            m_data = m_msrio->add_read(m_cpu, m_offset);
+            m_is_batch_ready = true;
+        }
+
+        GEOPM_DEBUG_ASSERT(m_data, "no memory mapped for signal value.");
+    }
+
+    double RawMSRSignal::sample(void)
+    {
+        if (!m_is_batch_ready) {
+            throw Exception("setup_batch() must be called before sample().",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_data != nullptr, "no memory mapped for signal value.");
+
+        // convert to double
+        return geopm_field_to_signal(*m_data);
+    }
+
+    double RawMSRSignal::read(void)
+    {
+        GEOPM_DEBUG_ASSERT(m_msrio != nullptr, "no valid MSRIO object.");
+
+        // convert to double
+        return geopm_field_to_signal(m_msrio->read_msr(m_cpu, m_offset));
+    }
+}

--- a/src/RawMSRSignal.hpp
+++ b/src/RawMSRSignal.hpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RAWMSRSIGNAL_HPP_INCLUDE
+#define RAWMSRSIGNAL_HPP_INCLUDE
+
+#include <cstdint>
+#include <cmath>
+
+#include <string>
+#include <memory>
+
+#include "Signal.hpp"
+#include "MSRIO.hpp"
+
+namespace geopm
+{
+    class RawMSRSignal : public Signal
+    {
+        public:
+            RawMSRSignal(std::shared_ptr<MSRIO> msrio,
+                         int cpu,
+                         uint64_t offset);
+            RawMSRSignal(const RawMSRSignal &other);
+            virtual ~RawMSRSignal() = default;
+            std::unique_ptr<Signal> clone(void) const override;
+            void setup_batch(void) override;
+            double sample(void) override;
+            double read(void) override;
+        private:
+            /// MSRIO object shared by all MSR signals in the same
+            /// batch.  This object should outlive all other data in
+            /// the Signal.
+            std::shared_ptr<MSRIO> m_msrio;
+            int m_cpu;
+            uint64_t m_offset;
+            /// Location of the data that will be updated by the
+            /// MSRIO's read_batch() calls.
+            uint64_t *m_data;
+            bool m_is_batch_ready;
+    };
+}
+
+#endif

--- a/src/RawMSRSignal.hpp
+++ b/src/RawMSRSignal.hpp
@@ -50,12 +50,11 @@ namespace geopm
             RawMSRSignal(std::shared_ptr<MSRIO> msrio,
                          int cpu,
                          uint64_t offset);
-            RawMSRSignal(const RawMSRSignal &other);
+            RawMSRSignal(const RawMSRSignal &other) = delete;
             virtual ~RawMSRSignal() = default;
-            std::unique_ptr<Signal> clone(void) const override;
             void setup_batch(void) override;
             double sample(void) override;
-            double read(void) override;
+            double read(void) const override;
         private:
             /// MSRIO object shared by all MSR signals in the same
             /// batch.  This object should outlive all other data in

--- a/src/Signal.hpp
+++ b/src/Signal.hpp
@@ -44,10 +44,6 @@ namespace geopm
     {
         public:
             virtual ~Signal() = default;
-            /// @brief Make a copy of the signal with its own state.
-            ///        This is intended for use with read_signal() in
-            ///        the IOGroup.
-            virtual std::unique_ptr<Signal> clone(void) const = 0;
             /// @brief Prepare the signal for being updating through
             ///        side effects by the owner's read_batch step.
             ///        This method should not fail if called multiple
@@ -59,7 +55,7 @@ namespace geopm
             virtual double sample(void) = 0;
             /// @brief Directly the value of the signal without
             ///        affecting any pushed batch signals.
-            virtual double read(void) = 0;
+            virtual double read(void) const = 0;
     };
 }
 

--- a/src/Signal.hpp
+++ b/src/Signal.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SIGNAL_HPP_INCLUDE
+#define SIGNAL_HPP_INCLUDE
+
+namespace geopm
+{
+    /// An abstract interface for all types of signals supported by an IOGroup.
+    /// Any implementation specific data should be injected in the derived class
+    /// constructor and used in setup_batch() if necessary.
+    class Signal
+    {
+        public:
+            virtual ~Signal() = default;
+            /// @brief Make a copy of the signal with its own state.
+            ///        This is intended for use with read_signal() in
+            ///        the IOGroup.
+            virtual std::unique_ptr<Signal> clone(void) const = 0;
+            /// @brief Prepare the signal for being updating through
+            ///        side effects by the owner's read_batch step.
+            ///        This method should not fail if called multiple
+            ///        times, and ideally only apply the side effects
+            ///        on the first call.
+            virtual void setup_batch(void) = 0;
+            /// @brief Apply any conversions necessary to interpret
+            ///        the latest stored value as a double.
+            virtual double sample(void) = 0;
+            /// @brief Directly the value of the signal without
+            ///        affecting any pushed batch signals.
+            virtual double read(void) = 0;
+    };
+}
+
+#endif

--- a/src/geopm_debug.hpp
+++ b/src/geopm_debug.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GEOPM_DEBUG_HPP_INCLUDE
+#define GEOPM_DEBUG_HPP_INCLUDE
+
+#include "config.h"  // for GEOPM_DEBUG
+
+#include "Exception.hpp"
+
+#ifdef GEOPM_DEBUG
+/// Used to check for errors that should never occur unless there is a
+/// mistake in internal logic.  These checks will be removed in
+/// release builds.
+#define GEOPM_DEBUG_ASSERT(condition, fail_message)                             \
+    if (!(condition)) {                                                         \
+        throw Exception(std::string(__func__) + ": " + fail_message,            \
+                        GEOPM_ERROR_LOGIC, __FILE__, __LINE__);                 \
+    }
+#else
+#define GEOPM_DEBUG_ASSERT(condition, fail_message)
+#endif
+
+#endif

--- a/test/DerivativeSignalTest.cpp
+++ b/test/DerivativeSignalTest.cpp
@@ -194,10 +194,10 @@ TEST_F(DerivativeSignalTest, errors)
     // cannot construct with null signals
     GEOPM_EXPECT_THROW_MESSAGE(DerivativeSignal(nullptr, m_y_sig, 0, 0),
                                GEOPM_ERROR_LOGIC,
-                               "underlying Signals cannot be null");
+                               "time_sig and y_sig cannot be null");
     GEOPM_EXPECT_THROW_MESSAGE(DerivativeSignal(m_time_sig, nullptr, 0, 0),
                                GEOPM_ERROR_LOGIC,
-                               "underlying Signals cannot be null");
+                               "time_sig and y_sig cannot be null");
 #endif
     // cannot call sample without setup_batch
     GEOPM_EXPECT_THROW_MESSAGE(m_sig->sample(), GEOPM_ERROR_RUNTIME,

--- a/test/DerivativeSignalTest.cpp
+++ b/test/DerivativeSignalTest.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "DerivativeSignal.hpp"
+#include "Helper.hpp"
+#include "MockSignal.hpp"
+#include "geopm_test.hpp"
+
+using geopm::Signal;
+using geopm::DerivativeSignal;
+
+using testing::Return;
+using testing::InvokeWithoutArgs;
+
+class DerivativeSignalTest : public ::testing::Test
+{
+    protected:
+        void SetUp(void);
+
+        std::shared_ptr<MockSignal> m_time_sig;
+        std::shared_ptr<MockSignal> m_y_sig;
+        std::unique_ptr<Signal> m_sig;
+
+        // example data
+        std::vector<double> m_sample_values_0;
+        double m_exp_slope_0;
+        std::vector<double> m_sample_values_1;
+        double m_exp_slope_1;
+        std::vector<double> m_sample_values_2;
+        double m_exp_slope_2;
+
+        int m_num_history_sample = 8;
+        double m_sleep_time = 0.001;
+};
+
+void DerivativeSignalTest::SetUp(void)
+{
+    m_time_sig = std::make_shared<MockSignal>();
+    m_y_sig = std::make_shared<MockSignal>();
+    m_sig = geopm::make_unique<DerivativeSignal>(m_time_sig, m_y_sig,
+                                                 m_num_history_sample, m_sleep_time);
+
+    // should have slope of 0.0
+    m_sample_values_0 = {5.5, 5.5, 5.5, 5.5};
+    m_exp_slope_0 = 0.0;
+
+    // should have slope of 1.0
+    m_sample_values_1 = {0.000001, 0.999999, 2.000001,
+                         2.999999, 4.000001, 4.999999,
+                         6.000001, 6.999999, 8.000001,
+                         8.999999};
+    m_exp_slope_1 = 1.0;
+
+    // should have slope of .238 with least squares fit
+    m_sample_values_2 = {0, 1, 2, 3, 0, 1, 2, 3};
+    m_exp_slope_2 = 0.238;
+}
+
+TEST_F(DerivativeSignalTest, read_flat)
+{
+    size_t ii = 0;
+    EXPECT_CALL(*m_time_sig, read()).Times(m_num_history_sample)
+        .WillRepeatedly(InvokeWithoutArgs([&ii]() {
+                    ++ii;
+                    return ii;
+                }));
+    EXPECT_CALL(*m_y_sig, read()).Times(m_num_history_sample)
+        .WillRepeatedly(Return(7.7));
+    double result = m_sig->read();
+    EXPECT_NEAR(m_exp_slope_0, result, 0.0001);
+}
+
+TEST_F(DerivativeSignalTest, read_slope_1)
+{
+    size_t ii = 0;
+    double val = 2.5;
+    EXPECT_CALL(*m_time_sig, read()).Times(m_num_history_sample)
+        .WillRepeatedly(InvokeWithoutArgs([&ii]() {
+                    ++ii;
+                    return ii;
+                }));
+    EXPECT_CALL(*m_y_sig, read()).Times(m_num_history_sample)
+        .WillRepeatedly(InvokeWithoutArgs([&val]() {
+                    val += 1.0;;
+                    return val;
+                }));
+    double result = m_sig->read();
+    EXPECT_NEAR(m_exp_slope_1, result, 0.0001);
+}
+
+TEST_F(DerivativeSignalTest, read_batch_first)
+{
+    EXPECT_CALL(*m_time_sig, setup_batch());
+    EXPECT_CALL(*m_y_sig, setup_batch());
+    m_sig->setup_batch();
+
+    EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(2.0));
+    EXPECT_CALL(*m_y_sig, sample()).WillOnce(Return(7.7));
+    double result = m_sig->sample();
+    EXPECT_TRUE(std::isnan(result));
+}
+
+TEST_F(DerivativeSignalTest, read_batch_flat)
+{
+    EXPECT_CALL(*m_time_sig, setup_batch());
+    EXPECT_CALL(*m_y_sig, setup_batch());
+    m_sig->setup_batch();
+
+    double result = NAN;
+    for (size_t ii = 0; ii < m_sample_values_0.size(); ++ii) {
+        EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(ii));
+        EXPECT_CALL(*m_y_sig, sample()).WillOnce(Return(m_sample_values_0[ii]));
+        result = m_sig->sample();
+    }
+    EXPECT_NEAR(m_exp_slope_0, result, 0.0001);
+}
+
+TEST_F(DerivativeSignalTest, read_batch_slope_1)
+{
+    EXPECT_CALL(*m_time_sig, setup_batch());
+    EXPECT_CALL(*m_y_sig, setup_batch());
+    m_sig->setup_batch();
+
+    double result = NAN;
+    for (size_t ii = 0; ii < m_sample_values_1.size(); ++ii) {
+        EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(ii));
+        EXPECT_CALL(*m_y_sig, sample()).WillOnce(Return(m_sample_values_1[ii]));
+        result = m_sig->sample();
+    }
+    EXPECT_NEAR(m_exp_slope_1, result, 0.0001);
+}
+
+TEST_F(DerivativeSignalTest, read_batch_slope_2)
+{
+    EXPECT_CALL(*m_time_sig, setup_batch());
+    EXPECT_CALL(*m_y_sig, setup_batch());
+    m_sig->setup_batch();
+
+    double result = NAN;
+    for (size_t ii = 0; ii < m_sample_values_2.size(); ++ii) {
+        EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(ii));
+        EXPECT_CALL(*m_y_sig, sample()).WillOnce(Return(m_sample_values_2[ii]));
+        result = m_sig->sample();
+    }
+    EXPECT_NEAR(m_exp_slope_2, result, 0.0001);
+}
+
+TEST_F(DerivativeSignalTest, setup_batch)
+{
+    // check that setup_batch can be safely called twice
+    EXPECT_CALL(*m_time_sig, setup_batch()).Times(1);
+    EXPECT_CALL(*m_y_sig, setup_batch()).Times(1);
+    m_sig->setup_batch();
+    m_sig->setup_batch();
+}
+
+TEST_F(DerivativeSignalTest, errors)
+{
+#ifdef GEOPM_DEBUG
+    // cannot construct with null signals
+    GEOPM_EXPECT_THROW_MESSAGE(DerivativeSignal(nullptr, m_y_sig, 0, 0),
+                               GEOPM_ERROR_LOGIC,
+                               "underlying Signals cannot be null");
+    GEOPM_EXPECT_THROW_MESSAGE(DerivativeSignal(m_time_sig, nullptr, 0, 0),
+                               GEOPM_ERROR_LOGIC,
+                               "underlying Signals cannot be null");
+#endif
+    // cannot call sample without setup_batch
+    GEOPM_EXPECT_THROW_MESSAGE(m_sig->sample(), GEOPM_ERROR_RUNTIME,
+                               "setup_batch() must be called before sample()");
+
+}

--- a/test/DifferenceSignalTest.cpp
+++ b/test/DifferenceSignalTest.cpp
@@ -103,10 +103,10 @@ TEST_F(DifferenceSignalTest, errors)
     // cannot construct with null signals
     GEOPM_EXPECT_THROW_MESSAGE(DifferenceSignal(nullptr, m_subtrahend),
                                GEOPM_ERROR_LOGIC,
-                               "underlying Signals cannot be null");
+                               "minuend and subtrahend cannot be null");
     GEOPM_EXPECT_THROW_MESSAGE(DifferenceSignal(m_minuend, nullptr),
                                GEOPM_ERROR_LOGIC,
-                               "underlying Signals cannot be null");
+                               "minuend and subtrahend cannot be null");
 #endif
 
     // cannot call sample without batch setup

--- a/test/DifferenceSignalTest.cpp
+++ b/test/DifferenceSignalTest.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "DifferenceSignal.hpp"
+#include "Helper.hpp"
+#include "geopm_test.hpp"
+#include "MockSignal.hpp"
+
+using geopm::DifferenceSignal;
+using testing::Return;
+
+class DifferenceSignalTest : public ::testing::Test
+{
+    protected:
+        void SetUp();
+        int m_domain;
+        std::shared_ptr<MockSignal> m_minuend;
+        std::shared_ptr<MockSignal> m_subtrahend;
+        std::shared_ptr<DifferenceSignal> m_sig;
+};
+
+void DifferenceSignalTest::SetUp()
+{
+    m_minuend = std::make_shared<MockSignal>();
+    m_subtrahend = std::make_shared<MockSignal>();
+    m_sig = std::make_shared<DifferenceSignal>(m_minuend, m_subtrahend);
+}
+
+TEST_F(DifferenceSignalTest, read)
+{
+    double min = 67.8;
+    double sub = 34.11;
+    double expected = min - sub;
+    EXPECT_CALL(*m_minuend, read()).WillOnce(Return(min));
+    EXPECT_CALL(*m_subtrahend, read()).WillOnce(Return(sub));
+    double result = m_sig->read();
+    EXPECT_NEAR(expected, result, 0.00001);
+}
+
+TEST_F(DifferenceSignalTest, read_batch)
+{
+    EXPECT_CALL(*m_minuend, setup_batch());
+    EXPECT_CALL(*m_subtrahend, setup_batch());
+    m_sig->setup_batch();
+
+    double min = 67.8;
+    double sub = 34.11;
+    double expected = min - sub;
+    EXPECT_CALL(*m_minuend, sample()).WillOnce(Return(min));
+    EXPECT_CALL(*m_subtrahend, sample()).WillOnce(Return(sub));
+    double result = m_sig->sample();
+    EXPECT_NEAR(expected, result, 0.00001);
+}
+
+TEST_F(DifferenceSignalTest, setup_batch)
+{
+    // setup batch can be called multiple times without further side effects
+    EXPECT_CALL(*m_minuend, setup_batch()).Times(1);
+    EXPECT_CALL(*m_subtrahend, setup_batch()).Times(1);
+    m_sig->setup_batch();
+    m_sig->setup_batch();
+}
+
+TEST_F(DifferenceSignalTest, errors)
+{
+#ifdef GEOPM_DEBUG
+    // cannot construct with null signals
+    GEOPM_EXPECT_THROW_MESSAGE(DifferenceSignal(nullptr, m_subtrahend),
+                               GEOPM_ERROR_LOGIC,
+                               "underlying Signals cannot be null");
+    GEOPM_EXPECT_THROW_MESSAGE(DifferenceSignal(m_minuend, nullptr),
+                               GEOPM_ERROR_LOGIC,
+                               "underlying Signals cannot be null");
+#endif
+
+    // cannot call sample without batch setup
+    GEOPM_EXPECT_THROW_MESSAGE(m_sig->sample(), GEOPM_ERROR_RUNTIME,
+                               "setup_batch() must be called before sample()");
+
+}

--- a/test/HelperTest.cpp
+++ b/test/HelperTest.cpp
@@ -35,7 +35,6 @@
 #include <string>
 #include <vector>
 
-#include "geopm_hash.h"
 #include "Helper.hpp"
 #include "geopm_test.hpp"
 
@@ -103,40 +102,3 @@ TEST(HelperTest, string_ends_with)
     EXPECT_FALSE(geopm::string_ends_with("", "plum"));
     EXPECT_TRUE(geopm::string_ends_with("plum", ""));
 }
-
-bool is_format_double(std::function<std::string(double)> func)
-{
-    double value = (double)0x3FF00000000000ULL;
-    std::string expected = "1.799680632343757e+16";
-    return func(value) == expected;
-}
-
-bool is_format_float(std::function<std::string(double)> func)
-{
-    double value = (double)0x3FF00000000000ULL;
-    std::string expected = "1.79968e+16";
-    return func(value) == expected;
-}
-
-bool is_format_integer(std::function<std::string(double)> func)
-{
-    double value = (double)0x3FF00000000000ULL;
-    std::string expected = "17996806323437568";
-    return func(value) == expected;
-}
-
-bool is_format_hex(std::function<std::string(double)> func)
-{
-    double value = (double)0x3FF00000000000ULL;
-    std::string expected = "0x003ff00000000000";
-    return func(value) == expected;
-}
-
-bool is_format_raw64(std::function<std::string(double)> func)
-{
-    uint64_t value_i = 0x3FF00000000000ULL;
-    double value = geopm_field_to_signal(value_i);
-    std::string expected = "0x003ff00000000000";
-    return func(value) == expected;
-}
-

--- a/test/MSRFieldSignalTest.cpp
+++ b/test/MSRFieldSignalTest.cpp
@@ -266,7 +266,7 @@ TEST_F(MSRFieldSignalTest, errors)
     // cannot construct with null underlying signal
     GEOPM_EXPECT_THROW_MESSAGE(MSRFieldSignal(nullptr, 0, 0,
                                               MSR::M_FUNCTION_SCALE, 1.0),
-                               GEOPM_ERROR_LOGIC, "no valid raw Signal");
+                               GEOPM_ERROR_LOGIC, "raw_msr cannot be null");
 
     // invalid number of bits
     GEOPM_EXPECT_THROW_MESSAGE(MSRFieldSignal(m_raw, 0, 63,

--- a/test/MSRFieldSignalTest.cpp
+++ b/test/MSRFieldSignalTest.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "MSRFieldSignal.hpp"
+#include "MSR.hpp"
+#include "Helper.hpp"
+#include "geopm_hash.h"
+#include "MockSignal.hpp"
+#include "geopm_test.hpp"
+
+using geopm::Signal;
+using geopm::MSRFieldSignal;
+using geopm::MSR;
+using geopm::string_format_float;
+using testing::Return;
+
+class MSRFieldSignalTest : public ::testing::Test
+{
+    protected:
+        void SetUp();
+
+        std::shared_ptr<MockSignal> m_raw;
+        int m_start;
+        int m_end;
+        uint64_t m_mask;
+};
+
+void MSRFieldSignalTest::SetUp()
+{
+    m_raw = std::make_shared<MockSignal>();
+    m_start = 16;
+    m_end = 23;
+}
+
+TEST_F(MSRFieldSignalTest, read_scale)
+{
+    double scalar = 1.5;
+    auto sig = geopm::make_unique<MSRFieldSignal>(m_raw, m_start, m_end,
+                                                  MSR::M_FUNCTION_SCALE, scalar);
+    uint64_t raw_val = 0xF1458321;
+    EXPECT_CALL(*m_raw, read())
+        .WillOnce(Return(geopm_field_to_signal(raw_val)));
+    double expected = 0x45 * scalar;
+    double result = sig->read();
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(MSRFieldSignalTest, read_batch_scale)
+{
+    double scalar = 2.7;
+    auto sig = geopm::make_unique<MSRFieldSignal>(m_raw, m_start, m_end,
+                                                  MSR::M_FUNCTION_SCALE, scalar);
+    EXPECT_CALL(*m_raw, setup_batch());
+    sig->setup_batch();
+    uint64_t raw_val = 0xF1678321;
+    EXPECT_CALL(*m_raw, sample())
+        .WillOnce(Return(geopm_field_to_signal(raw_val)));
+    double expected = 0x67 * scalar;
+    double result = sig->sample();
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(MSRFieldSignalTest, read_log_half)
+{
+    double scalar = 1.0;
+    auto sig = geopm::make_unique<MSRFieldSignal>(m_raw, m_start, m_end,
+                                                  MSR::M_FUNCTION_LOG_HALF,
+                                                  scalar);
+    uint64_t raw_val = 0xF1028321;  // field is 0x02
+    EXPECT_CALL(*m_raw, read())
+        .WillOnce(Return(geopm_field_to_signal(raw_val)));
+    double expected = 0.25;
+    double result = sig->read();
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(MSRFieldSignalTest, read_batch_log_half)
+{
+    double scalar = 1.0;
+    auto sig = geopm::make_unique<MSRFieldSignal>(m_raw, m_start, m_end,
+                                                  MSR::M_FUNCTION_LOG_HALF,
+                                                  scalar);
+    EXPECT_CALL(*m_raw, setup_batch());
+    sig->setup_batch();
+    uint64_t raw_val = 0xF1028321;  // field is 0x02
+    EXPECT_CALL(*m_raw, sample())
+        .WillOnce(Return(geopm_field_to_signal(raw_val)));
+    double expected = 0.25;
+    double result = sig->sample();
+    EXPECT_EQ(expected, result);
+
+}
+
+TEST_F(MSRFieldSignalTest, read_7_bit_float)
+{
+    double scalar = 3.0;
+    auto sig = geopm::make_unique<MSRFieldSignal>(m_raw, m_start, m_end,
+                                                  MSR::M_FUNCTION_7_BIT_FLOAT,
+                                                  scalar);
+    uint64_t raw_val = 0xF1418321;  // field is 0x41
+    EXPECT_CALL(*m_raw, read())
+        .WillOnce(Return(geopm_field_to_signal(raw_val)));
+    double expected = 9.0;
+    double result = sig->read();
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(MSRFieldSignalTest, read_batch_7_bit_float)
+{
+    double scalar = 3.0;
+    auto sig = geopm::make_unique<MSRFieldSignal>(m_raw, m_start, m_end,
+                                                  MSR::M_FUNCTION_7_BIT_FLOAT,
+                                                  scalar);
+    EXPECT_CALL(*m_raw, setup_batch());
+    sig->setup_batch();
+    uint64_t raw_val = 0xF1418321;  // field is 0x41
+    EXPECT_CALL(*m_raw, sample())
+        .WillOnce(Return(geopm_field_to_signal(raw_val)));
+    double expected = 9.0;
+    double result = sig->sample();
+    EXPECT_EQ(expected, result);
+
+}
+
+TEST_F(MSRFieldSignalTest, read_overflow)
+{
+    std::unique_ptr<Signal> sig = geopm::make_unique<MSRFieldSignal>(m_raw, 0, 3,
+                                                                     MSR::M_FUNCTION_OVERFLOW, 1.0);
+    double result = NAN, expected = NAN;
+    // no overflow for any sequence of values
+    expected = 5.0;
+    EXPECT_CALL(*m_raw, read())
+        .WillOnce(Return(geopm_field_to_signal(0x0005)));
+    result = sig->read();
+    EXPECT_DOUBLE_EQ(expected, result);
+
+    expected = 4.0;
+    EXPECT_CALL(*m_raw, read())
+        .WillOnce(Return(geopm_field_to_signal(0x0004)));
+    result = sig->read();
+    EXPECT_DOUBLE_EQ(expected, result);
+
+    expected = 10.0;
+    EXPECT_CALL(*m_raw, read())
+        .WillOnce(Return(geopm_field_to_signal(0x000A)));
+    result = sig->read();
+    EXPECT_DOUBLE_EQ(expected, result);
+
+    expected = 1.0;
+    EXPECT_CALL(*m_raw, read())
+        .WillOnce(Return(geopm_field_to_signal(0x0001)));
+    result = sig->read();
+    EXPECT_DOUBLE_EQ(expected, result);
+}
+
+TEST_F(MSRFieldSignalTest, read_batch_overflow)
+{
+    auto sig = geopm::make_unique<MSRFieldSignal>(m_raw, 0, 3,
+                                                  MSR::M_FUNCTION_OVERFLOW, 1.0);
+    EXPECT_CALL(*m_raw, setup_batch());
+    sig->setup_batch();
+    double result = NAN, expected = NAN;
+    // no overflow
+    expected = 5.0;
+    EXPECT_CALL(*m_raw, sample())
+        .WillOnce(Return(geopm_field_to_signal(0x0005)));
+    result = sig->sample();
+    EXPECT_DOUBLE_EQ(expected, result);
+    // one overflow
+    expected = 20.0;  // 4 + 16
+    EXPECT_CALL(*m_raw, sample())
+        .WillOnce(Return(geopm_field_to_signal(0x0004)));
+    result = sig->sample();
+    EXPECT_DOUBLE_EQ(expected, result);
+    // still one overflow
+    expected = 26.0;  // 10 + 16
+    EXPECT_CALL(*m_raw, sample())
+        .WillOnce(Return(geopm_field_to_signal(0x000A)));
+    result = sig->sample();
+    EXPECT_DOUBLE_EQ(expected, result);
+    // multiple overflow
+    expected = 33.0;  // 1 + 16 + 16
+    EXPECT_CALL(*m_raw, sample())
+        .WillOnce(Return(geopm_field_to_signal(0x0001)));
+    result = sig->sample();
+    EXPECT_DOUBLE_EQ(expected, result);
+}
+
+TEST_F(MSRFieldSignalTest, real_counter)
+{
+    // Test with real counter values
+    auto sig = geopm::make_unique<MSRFieldSignal>(m_raw, 0, 47,
+                                                  MSR::M_FUNCTION_OVERFLOW, 1.0);
+    EXPECT_CALL(*m_raw, setup_batch());
+    sig->setup_batch();
+
+    uint64_t input_value = 0xFFFFFF27AAE8;
+    EXPECT_CALL(*m_raw, sample())
+        .WillOnce(Return(geopm_field_to_signal(input_value)));
+    double of_value = sig->sample();
+    EXPECT_DOUBLE_EQ((double)input_value, of_value);
+
+    // Setup funky rollover
+    input_value = 0xFFFF000DD5D0;
+    uint64_t expected_value = input_value + (1ull << 48); // i.e. 0x1FFFF000DD5D0
+    EXPECT_CALL(*m_raw, sample())
+        .WillOnce(Return(geopm_field_to_signal(input_value)));
+    of_value = sig->sample();
+    EXPECT_DOUBLE_EQ((double)expected_value, of_value)
+                     << "\nActual is : 0x" << std::hex << (uint64_t)of_value << std::endl
+                     << "Expected is : 0x" << std::hex << expected_value << std::endl;
+                }
+
+TEST_F(MSRFieldSignalTest, setup_batch)
+{
+    auto sig = geopm::make_unique<MSRFieldSignal>(m_raw, m_start, m_end,
+                                                  MSR::M_FUNCTION_SCALE, 1.0);
+    // setup batch can be called multiple times without further side effects
+    EXPECT_CALL(*m_raw, setup_batch()).Times(1);
+    sig->setup_batch();
+    sig->setup_batch();
+
+}
+
+TEST_F(MSRFieldSignalTest, errors)
+{
+    // logic errors in contructor because this class is internal to MSRIOGroup.
+    // @todo: consider whether Signal should be public to help writers of IOGroups
+#ifdef GEOPM_DEBUG
+    // cannot construct with null underlying signal
+    GEOPM_EXPECT_THROW_MESSAGE(MSRFieldSignal(nullptr, 0, 0,
+                                              MSR::M_FUNCTION_SCALE, 1.0),
+                               GEOPM_ERROR_LOGIC, "no valid raw Signal");
+
+    // invalid number of bits
+    GEOPM_EXPECT_THROW_MESSAGE(MSRFieldSignal(m_raw, 0, 63,
+                                              MSR::M_FUNCTION_SCALE, 1.0),
+                               GEOPM_ERROR_LOGIC, "64-bit fields are not supported");
+    GEOPM_EXPECT_THROW_MESSAGE(MSRFieldSignal(m_raw, 4, 0,
+                                              MSR::M_FUNCTION_SCALE, 1.0),
+                               GEOPM_ERROR_LOGIC, "begin bit must be <= end bit");
+
+    // invalid encode function
+    GEOPM_EXPECT_THROW_MESSAGE(MSRFieldSignal(m_raw, 0, 0,
+                                              99, 1.0),
+                               GEOPM_ERROR_LOGIC, "invalid encoding function");
+#endif
+
+    // cannot call sample without batch setup
+    auto sig = geopm::make_unique<MSRFieldSignal>(m_raw, m_start, m_end,
+                                                  MSR::M_FUNCTION_SCALE, 1.0);
+    GEOPM_EXPECT_THROW_MESSAGE(sig->sample(), GEOPM_ERROR_RUNTIME,
+                               "setup_batch() must be called before sample()");
+
+}

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -320,6 +320,10 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/ProfileTestIntegration.misconfig_tprof_shmem \
               test/gtest_links/ProfileTracerTest.construct_update_destruct \
               test/gtest_links/ProfileTracerTest.format \
+              test/gtest_links/RawMSRSignalTest.errors \
+              test/gtest_links/RawMSRSignalTest.read \
+              test/gtest_links/RawMSRSignalTest.read_batch \
+              test/gtest_links/RawMSRSignalTest.setup_batch \
               test/gtest_links/RegionAggregatorTest.epoch_total \
               test/gtest_links/RegionAggregatorTest.sample_total \
               test/gtest_links/ReporterTest.generate \
@@ -447,6 +451,7 @@ test_geopm_test_SOURCES = test/AdminTest.cpp \
                           test/MockEpochRuntimeRegulator.hpp \
                           test/MockFrequencyGovernor.hpp \
                           test/MockIOGroup.hpp \
+                          test/MockMSRIO.hpp \
                           test/MockPlatformIO.hpp \
                           test/MockPlatformTopo.hpp \
                           test/MockPowerBalancer.hpp \
@@ -476,6 +481,7 @@ test_geopm_test_SOURCES = test/AdminTest.cpp \
                           test/ProfileTableTest.cpp \
                           test/ProfileTest.cpp \
                           test/ProfileTracerTest.cpp \
+                          test/RawMSRSignalTest.cpp \
                           test/RegionAggregatorTest.cpp \
                           test/ReporterTest.cpp \
                           test/RuntimeRegulatorTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -222,6 +222,7 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/MSRIOGroupTest.valid_signal_temperature \
               test/gtest_links/MSRIOGroupTest.whitelist \
               test/gtest_links/MSRIOGroupTest.write_control \
+              test/gtest_links/MSRIOTest.add_read \
               test/gtest_links/MSRIOTest.read_aligned \
               test/gtest_links/MSRIOTest.read_batch \
               test/gtest_links/MSRIOTest.read_unaligned \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -487,6 +487,7 @@ test_geopm_test_SOURCES = test/AdminTest.cpp \
                           test/TreeCommLevelTest.cpp \
                           test/TreeCommTest.cpp \
                           test/geopm_test.cpp \
+                          test/geopm_test_helper.cpp \
                           test/geopm_test.hpp \
                           # end
 

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -232,6 +232,16 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/MSRIOTest.read_unaligned \
               test/gtest_links/MSRIOTest.write \
               test/gtest_links/MSRIOTest.write_batch \
+              test/gtest_links/MSRFieldSignalTest.read_batch_7_bit_float \
+              test/gtest_links/MSRFieldSignalTest.read_batch_log_half \
+              test/gtest_links/MSRFieldSignalTest.read_batch_overflow \
+              test/gtest_links/MSRFieldSignalTest.read_batch_scale \
+              test/gtest_links/MSRFieldSignalTest.read_7_bit_float \
+              test/gtest_links/MSRFieldSignalTest.read_log_half \
+              test/gtest_links/MSRFieldSignalTest.read_overflow \
+              test/gtest_links/MSRFieldSignalTest.read_scale \
+              test/gtest_links/MSRFieldSignalTest.real_counter \
+              test/gtest_links/MSRFieldSignalTest.setup_batch \
               test/gtest_links/MSRTest.msr \
               test/gtest_links/MSRTest.msr_control \
               test/gtest_links/MSRTest.msr_overflow \
@@ -444,6 +454,7 @@ test_geopm_test_SOURCES = test/AdminTest.cpp \
                           test/IOGroupTest.cpp \
                           test/MSRIOGroupTest.cpp \
                           test/MSRIOTest.cpp \
+                          test/MSRFieldSignalTest.cpp \
                           test/MSRTest.cpp \
                           test/MockAgent.hpp \
                           test/MockApplicationIO.hpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -115,6 +115,10 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/DebugIOGroupTest.read_signal \
               test/gtest_links/DebugIOGroupTest.register_signal_error \
               test/gtest_links/DebugIOGroupTest.sample \
+              test/gtest_links/DifferenceSignalTest.errors \
+              test/gtest_links/DifferenceSignalTest.read \
+              test/gtest_links/DifferenceSignalTest.read_batch \
+              test/gtest_links/DifferenceSignalTest.setup_batch \
               test/gtest_links/EndpointTest.attach_wait_loop_timeout_throws \
               test/gtest_links/EndpointTest.detach_wait_loop_timeout_throws \
               test/gtest_links/EndpointTest.get_hostnames \
@@ -424,6 +428,7 @@ test_geopm_test_SOURCES = test/AdminTest.cpp \
                           test/CpuinfoIOGroupTest.cpp \
                           test/CSVTest.cpp \
                           test/DebugIOGroupTest.cpp \
+                          test/DifferenceSignalTest.cpp \
                           test/EndpointTest.cpp \
                           test/EndpointPolicyTracerTest.cpp \
                           test/EndpointUserTest.cpp \
@@ -466,6 +471,7 @@ test_geopm_test_SOURCES = test/AdminTest.cpp \
                           test/MockSampleScheduler.hpp \
                           test/MockSharedMemory.hpp \
                           test/MockSharedMemoryUser.hpp \
+                          test/MockSignal.hpp \
                           test/MockTracer.hpp \
                           test/MockTreeComm.hpp \
                           test/MockTreeCommLevel.hpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -115,6 +115,14 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/DebugIOGroupTest.read_signal \
               test/gtest_links/DebugIOGroupTest.register_signal_error \
               test/gtest_links/DebugIOGroupTest.sample \
+              test/gtest_links/DerivativeSignalTest.errors \
+              test/gtest_links/DerivativeSignalTest.read_batch_flat \
+              test/gtest_links/DerivativeSignalTest.read_batch_first \
+              test/gtest_links/DerivativeSignalTest.read_batch_slope_1 \
+              test/gtest_links/DerivativeSignalTest.read_batch_slope_2 \
+              test/gtest_links/DerivativeSignalTest.read_flat \
+              test/gtest_links/DerivativeSignalTest.read_slope_1 \
+              test/gtest_links/DerivativeSignalTest.setup_batch \
               test/gtest_links/DifferenceSignalTest.errors \
               test/gtest_links/DifferenceSignalTest.read \
               test/gtest_links/DifferenceSignalTest.read_batch \
@@ -438,6 +446,7 @@ test_geopm_test_SOURCES = test/AdminTest.cpp \
                           test/CpuinfoIOGroupTest.cpp \
                           test/CSVTest.cpp \
                           test/DebugIOGroupTest.cpp \
+                          test/DerivativeSignalTest.cpp \
                           test/DifferenceSignalTest.cpp \
                           test/EndpointTest.cpp \
                           test/EndpointPolicyTracerTest.cpp \

--- a/test/MockMSRIO.hpp
+++ b/test/MockMSRIO.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MOCKMSRIO_HPP_INCLUDE
+#define MOCKMSRIO_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "MSRIO.hpp"
+
+class MockMSRIO : public geopm::MSRIO
+{
+    public:
+        MOCK_METHOD2(read_msr,
+                     uint64_t(int cpu_idx, uint64_t offset));
+        MOCK_METHOD4(write_msr,
+                     void(int cpu_idx, uint64_t offset, uint64_t raw_value, uint64_t write_mask));
+        MOCK_METHOD5(config_batch,
+                     void(const std::vector<int> &read_cpu_idx, const std::vector<uint64_t> &read_offset, const std::vector<int> &write_cpu_idx, const std::vector<uint64_t> &write_offset, const std::vector<uint64_t> &write_mask));
+        MOCK_METHOD2(add_read,
+                     uint64_t*(int cpu_idx, uint64_t offset));
+        MOCK_METHOD1(read_batch,
+                     void(std::vector<uint64_t> &raw_value));
+        MOCK_METHOD0(read_batch,
+                     void(void));
+        MOCK_METHOD1(write_batch,
+                     void(const std::vector<uint64_t> &raw_value));
+};
+
+#endif

--- a/test/MockSignal.hpp
+++ b/test/MockSignal.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MOCKSIGNAL_HPP_INCLUDE
+#define MOCKSIGNAL_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "Signal.hpp"
+
+class MockSignal : public geopm::Signal
+{
+    public:
+        MOCK_CONST_METHOD0(clone,
+                           std::unique_ptr<geopm::Signal>(void));
+        MOCK_METHOD0(setup_batch,
+                     void(void));
+        MOCK_METHOD0(sample,
+                     double(void));
+        MOCK_METHOD0(read,
+                     double(void));
+};
+
+#endif

--- a/test/MockSignal.hpp
+++ b/test/MockSignal.hpp
@@ -40,14 +40,12 @@
 class MockSignal : public geopm::Signal
 {
     public:
-        MOCK_CONST_METHOD0(clone,
-                           std::unique_ptr<geopm::Signal>(void));
         MOCK_METHOD0(setup_batch,
                      void(void));
         MOCK_METHOD0(sample,
                      double(void));
-        MOCK_METHOD0(read,
-                     double(void));
+        MOCK_CONST_METHOD0(read,
+                           double(void));
 };
 
 #endif

--- a/test/PowerBalancerAgentTest.cpp
+++ b/test/PowerBalancerAgentTest.cpp
@@ -56,12 +56,6 @@ using ::testing::InvokeWithoutArgs;
 using ::testing::InSequence;
 using ::testing::AtLeast;
 
-bool is_format_double(std::function<std::string(double)> func);
-bool is_format_float(std::function<std::string(double)> func);
-bool is_format_integer(std::function<std::string(double)> func);
-bool is_format_hex(std::function<std::string(double)> func);
-bool is_format_raw64(std::function<std::string(double)> func);
-
 
 class PowerBalancerAgentTest : public ::testing::Test
 {

--- a/test/RawMSRSignalTest.cpp
+++ b/test/RawMSRSignalTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "MockMSRIO.hpp"
+#include "RawMSRSignal.hpp"
+#include "geopm_hash.h"
+#include "geopm_test.hpp"
+
+using geopm::RawMSRSignal;
+using testing::Return;
+
+TEST(RawMSRSignalTest, read)
+{
+    std::shared_ptr<MockMSRIO> m_msrio = std::make_shared<MockMSRIO>();
+    int cpu = 10;
+    uint64_t offset = 0xABC;
+    RawMSRSignal sig {m_msrio, cpu, offset};
+    uint64_t expected = 0x456;
+    EXPECT_CALL(*m_msrio, read_msr(cpu, offset))
+        .WillOnce(Return(expected));
+    double result = sig.read();
+    EXPECT_EQ(expected, geopm_signal_to_field(result));
+}
+
+TEST(RawMSRSignalTest, read_batch)
+{
+    std::shared_ptr<MockMSRIO> m_msrio = std::make_shared<MockMSRIO>();
+    int cpu = 10;
+    uint64_t offset = 0xABC;
+    RawMSRSignal sig {m_msrio, cpu, offset};
+    uint64_t mapped_mem = 0;
+    EXPECT_CALL(*m_msrio, add_read(cpu, offset))
+        .WillOnce(Return(&mapped_mem));
+    sig.setup_batch();
+
+    // mock read_batch by updating raw memory
+    uint64_t expected = 0x456;
+    mapped_mem = expected;
+
+    double result = sig.sample();
+    EXPECT_EQ(expected, geopm_signal_to_field(result));
+}
+
+TEST(RawMSRSignalTest, setup_batch)
+{
+    std::shared_ptr<MockMSRIO> m_msrio = std::make_shared<MockMSRIO>();
+    int cpu = 10;
+    uint64_t offset = 0xABC;
+    RawMSRSignal sig {m_msrio, cpu, offset};
+    uint64_t mapped_mem = 0;
+    // setup batch can be called multiple times without further side effects
+    EXPECT_CALL(*m_msrio, add_read(cpu, offset)).Times(1)
+        .WillOnce(Return(&mapped_mem));
+    sig.setup_batch();
+    sig.setup_batch();
+}
+
+TEST(RawMSRSignalTest, errors)
+{
+#ifdef GEOPM_DEBUG
+    // cannot construct with null MSRIO
+    GEOPM_EXPECT_THROW_MESSAGE(RawMSRSignal(0, nullptr, 0),
+                               GEOPM_ERROR_LOGIC, "no valid MSRIO");
+#endif
+
+    // cannot call sample without batch setup
+    std::shared_ptr<MockMSRIO> m_msrio = std::make_shared<MockMSRIO>();
+    int cpu = 10;
+    uint64_t offset = 0xABC;
+    RawMSRSignal sig {m_msrio, cpu, offset};
+    GEOPM_EXPECT_THROW_MESSAGE(sig.sample(), GEOPM_ERROR_RUNTIME,
+                               "setup_batch() must be called before sample()");
+}

--- a/test/RawMSRSignalTest.cpp
+++ b/test/RawMSRSignalTest.cpp
@@ -35,10 +35,11 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
-#include "MockMSRIO.hpp"
+#include "geopm_hash.h"
 #include "RawMSRSignal.hpp"
 #include "geopm_hash.h"
 #include "geopm_test.hpp"
+#include "MockMSRIO.hpp"
 
 using geopm::RawMSRSignal;
 using testing::Return;

--- a/test/geopm_test.hpp
+++ b/test/geopm_test.hpp
@@ -39,6 +39,12 @@
 
 #include "Exception.hpp"
 
+bool is_format_double(std::function<std::string(double)> func);
+bool is_format_float(std::function<std::string(double)> func);
+bool is_format_integer(std::function<std::string(double)> func);
+bool is_format_hex(std::function<std::string(double)> func);
+bool is_format_raw64(std::function<std::string(double)> func);
+
 /// Checks that the given statement throws a geopm::Exception with the
 /// right error code and message.  The message must be a substring of
 /// the thrown Exception's what() string.  Additional details may be

--- a/test/geopm_test_helper.cpp
+++ b/test/geopm_test_helper.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "geopm_test.hpp"
+
+#include "geopm_hash.h"
+
+bool is_format_double(std::function<std::string(double)> func)
+{
+    double value = (double)0x3FF00000000000ULL;
+    std::string expected = "1.799680632343757e+16";
+    return func(value) == expected;
+}
+
+bool is_format_float(std::function<std::string(double)> func)
+{
+    double value = (double)0x3FF00000000000ULL;
+    std::string expected = "1.79968e+16";
+    return func(value) == expected;
+}
+
+bool is_format_integer(std::function<std::string(double)> func)
+{
+    double value = (double)0x3FF00000000000ULL;
+    std::string expected = "17996806323437568";
+    return func(value) == expected;
+}
+
+bool is_format_hex(std::function<std::string(double)> func)
+{
+    double value = (double)0x3FF00000000000ULL;
+    std::string expected = "0x003ff00000000000";
+    return func(value) == expected;
+}
+
+bool is_format_raw64(std::function<std::string(double)> func)
+{
+    uint64_t value_i = 0x3FF00000000000ULL;
+    double value = geopm_field_to_signal(value_i);
+    std::string expected = "0x003ff00000000000";
+    return func(value) == expected;
+}


### PR DESCRIPTION
Adds classes that will be used to support MSRIOGroup refactoring.  These classes will replace MSRSignal, CombinedSignal & friends, and parts of the MSR + MSREncode usage in MSRIOGroup.

Resolves #1038
