### PR TITLE
Fix for EE Short Slop test low IPC and calibration issues

### DIFF
--- a/src/ScalingModelRegion.cpp
+++ b/src/ScalingModelRegion.cpp
@@ -74,10 +74,12 @@ namespace geopm
         std::fill(m_arrays[0], m_arrays[0] + m_array_len, 0.0);
         std::fill(m_arrays[1], m_arrays[1] + m_array_len, 1.0);
         std::fill(m_arrays[2], m_arrays[2] + m_array_len, 2.0);
+
         m_name = "scaling";
         m_do_imbalance = do_imbalance;
         m_do_progress = do_progress;
         m_do_unmarked = do_unmarked;
+
         big_o(big_o_in);
         err = ModelRegion::region(GEOPM_REGION_HINT_MEMORY);
         if (err) {
@@ -142,6 +144,13 @@ namespace geopm
 
     void ScalingModelRegion::big_o(double big_o_in)
     {
+        // run_atom is called 2000 times prior to calibration to
+        // resolve issues with low IPC during calibration that lead to
+        // a small num_atom value and short duration scaling model regions.
+        for (size_t prep_idx = 0; prep_idx < 2000; ++prep_idx) {
+            run_atom();
+        }
+
         geopm::Profile &prof = geopm::Profile::default_profile();
         uint64_t start_rid = prof.region("geopm_scaling_model_region_startup", GEOPM_REGION_HINT_IGNORE);
         prof.enter(start_rid);

--- a/src/ScalingModelRegion.hpp
+++ b/src/ScalingModelRegion.hpp
@@ -48,7 +48,7 @@ namespace geopm
                                bool do_imbalance,
                                bool do_progress,
                                bool do_unmarked);
-            virtual ~ScalingModelRegion() = default;
+            virtual ~ScalingModelRegion();
             void big_o(double big_o);
             void run(void);
             void run_atom(void);
@@ -61,9 +61,7 @@ namespace geopm
             size_t m_rank_per_node;
             size_t m_array_len;
             size_t m_num_atom;
-            std::vector<double> m_array_a;
-            std::vector<double> m_array_b;
-            std::vector<double> m_array_c;
+            std::vector<double *> m_arrays;
     };
 }
 


### PR DESCRIPTION
Changes to the EE short slop test and ScalingModelRegion code to address Low IPC throughout the EE short slop test and calibration issues that lead to short scaling model region

- Fix for Low IPC throughout test: Addition of memory alignment to ScalingModelRegion constructor for arrays operated on in run_atom().  
- Fix for Low IPC during instantiation leading to short ScalingModelRegion: Addition of 2000 run_atom calls pre-calibration in the big_o code to guarantee calibration occurs after low IPC region. 

