### PR TITLE
Change geopmagent CLI policy parser to hash selectively

### DIFF
--- a/src/geopmagent_main.cpp
+++ b/src/geopmagent_main.cpp
@@ -43,6 +43,7 @@
 #include "geopm_agent.h"
 #include "geopm_error.h"
 #include "geopm_hash.h"
+#include "Agent.hpp"
 #include "OptionParser.hpp"
 
 #include "config.h"
@@ -181,7 +182,16 @@ int main(int argc, char **argv)
                 while (!err && tok != NULL) {
                     policy_vals[policy_count] = strtod(tok, &endptr);
                     if (tok == endptr) {
-                        policy_vals[policy_count] = geopm_crc32_str(tok);
+                        std::string policy_name = geopm::Agent::policy_names(agent_ptr).at(policy_count);
+                        if (policy_name.find("HASH") != std::string::npos ||
+                            policy_name.find("hash") != std::string::npos) {
+                            policy_vals[policy_count] = geopm_crc32_str(tok);
+                        }
+                        else {
+                            fprintf(stderr, "Error: %s is not a valid floating-point number; "
+                                            "use \"NAN\" to indicate default.\n", tok);
+                            err = EINVAL;
+                        }
                     }
                     ++policy_count;
                     if (policy_count > GEOPMAGENT_DOUBLE_LENGTH) {


### PR DESCRIPTION
- The change was made with 5b552886d0665e805e16c7a80f9af50168e47a4b
  to hash values that would not parse as a double.
- This changes that behavior to only hash values for parameters
  that have the string "HASH" or "hash" in the parameter name.
- Fixes #1082

-------------------------------------
```
cmcantal@mcfly:~/Git/geopm/test_integration (issue-1082)]$ python . --verbose TestIntegrationGeopmagent.test_geopmagent_command_line 
test_geopmagent_command_line (test_integration.geopm_test_integration.TestIntegrationGeopmagent) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.399s

OK
cmcantal@mcfly:~/Git/geopm/test_integration (issue-1082)]$ geopmagent -a frequency_map -p 1.0e9,1.0e9,region1,2.0e9
{"FREQ_MIN": 1000000000, "FREQ_MAX": 1000000000, "HASH_0": 1490916139, "FREQ_0": 2000000000}
cmcantal@mcfly:~/Git/geopm/test_integration (issue-1082)]$ geopmagent -a frequency_map -p 1.0e9,region1,2.0e9
Error: region1 is not a valid floating-point number; use "NAN" to indicate default.
Error: <geopm> Invalid argument
```