### PR TITLE
Deprecate the --geopm-preload option for geopmlaunch

### DIFF
--- a/ronn/geopm.7.ronn.in
+++ b/ronn/geopm.7.ronn.in
@@ -351,6 +351,12 @@ specified regardless of the values set in the calling environment.
 `OTHER ENVIRONMENT VARIABLES`
 
   * `LD_DYNAMIC_WEAK`:
+    The **geopmlaunch(1)** tool will preload libgeopm.so for all
+    applications, so the use of LD_DYNAMIC_WEAK is not required when
+    using **geopmlaunch(1)**.  When not using **geopmlaunch(1)**
+    setting LD_DYNAMIC_WEAK may be required, see next paragraph for
+    details.
+
     When dynamically linking an application to libgeopm for any
     features supported by the PMPI profiling of the MPI runtime it may
     be required that the LD_DYNAMIC_WEAK environment variable be set

--- a/ronn/geopmlaunch.1.ronn
+++ b/ronn/geopmlaunch.1.ronn
@@ -388,11 +388,6 @@ listed below.
   will override any value currently set in the environment.  See the
   ENVIRONMENT section of **geopm(7)**.
 
-* `--geopm-preload`:
-  Use LD_PRELOAD to link libgeopm.so at runtime.  This can be used to
-  enable the GEOPM runtime when an application has not been compiled
-  against libgeopm.so.
-
 * `--geopm-hyperthreads-disable`:
   Prevent the launcher from trying to use hyperthreads for pinning
   purposes when attempting to satisfy the MPI ranks / OMP threads

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -195,7 +195,9 @@ class Config(object):
         self.plugin = opts.plugin
         self.debug_attach = opts.debug_attach
         self.barrier = opts.barrier
-        self.preload = opts.preload
+        if opts.preload:
+            sys.stderr.write("Warning: <geopmpy.launcher> The --geopm-preload option is deprecated, libgeopm is always preloaded.\n")
+        self.preload = True
         self.omp_num_threads = None
         self.allow_ht_pinning = opts.allow_ht_pinning and 'GEOPM_DISABLE_HYPERTHREADS' not in os.environ
         self.ompt_disable = opts.ompt_disable
@@ -220,8 +222,7 @@ class Config(object):
         Dictionary describing the environment variables controlled by the
         configuration object.
         """
-        result = {'LD_DYNAMIC_WEAK': 'true',
-                  'OMP_PROC_BIND': 'true'}
+        result = {'OMP_PROC_BIND': 'true'}
         if self.ctl == 'pthread':
             result['MPICH_MAX_THREAD_SAFETY'] = 'multiple'
         if self.ctl in ('process', 'pthread'):

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -54,8 +54,9 @@ SLURM srun job launcher:
 
     geopmlaunch srun \
                 -N 2 -n 8 \
-                --geopm-preload --geopm-ctl=process \
-                --geopm-report=tutorial_0_report --geopm-trace=tutorial_0_trace \
+                --geopm-ctl=process \
+                --geopm-report=tutorial_0_report \
+                --geopm-trace=tutorial_0_trace \
                 -- ./tutorial_0
 
 The second method uses the geopmlaunch wrapper script for the ALPS
@@ -63,8 +64,9 @@ aprun job launcher:
 
     geopmlaunch aprun \
                 -N 4 -n 8 \
-                --geopm-preload --geopm-ctl=process \
-                --geopm-report=tutorial_0_report --geopm-trace=tutorial_0_trace \
+                --geopm-ctl=process \
+                --geopm-report=tutorial_0_report \
+                --geopm-trace=tutorial_0_trace \
                 -- ./tutorial_0
 
 If your system does not support srun or aprun launch, the third option

--- a/tutorial/tutorial_0.sh
+++ b/tutorial/tutorial_0.sh
@@ -64,7 +64,6 @@ elif [ "$GEOPM_LAUNCHER" = "srun" ]; then
     geopmlaunch srun \
                 -N ${NUM_NODES} \
                 -n ${TOTAL_RANKS} \
-                --geopm-preload \
                 --geopm-ctl=process \
                 --geopm-report=tutorial_0_report \
                 --geopm-trace=tutorial_0_trace \
@@ -75,7 +74,6 @@ elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
     geopmlaunch aprun \
                 -N ${RANKS_PER_NODE} \
                 -n ${TOTAL_RANKS} \
-                --geopm-preload \
                 --geopm-ctl=process \
                 --geopm-report=tutorial_0_report \
                 --geopm-trace=tutorial_0_trace \
@@ -86,7 +84,6 @@ elif [ "$GEOPM_LAUNCHER" = "impi" ]; then
     geopmlaunch impi \
                 -ppn ${RANKS_PER_NODE} \
                 -n ${TOTAL_RANKS} \
-                --geopm-preload \
                 --geopm-ctl=process \
                 --geopm-report=tutorial_0_report \
                 --geopm-trace=tutorial_0_trace \
@@ -98,7 +95,6 @@ elif [ "$GEOPM_LAUNCHER" = "ompi" ]; then
                 --npernode ${RANKS_PER_NODE} \
                 -n ${TOTAL_RANKS} \
                 --hostfile tutorial_hosts \
-                --geopm-preload \
                 --geopm-ctl=process \
                 --geopm-report=tutorial_0_report \
                 --geopm-trace=tutorial_0_trace \

--- a/tutorial/tutorial_1.sh
+++ b/tutorial/tutorial_1.sh
@@ -64,7 +64,6 @@ elif [ "$GEOPM_LAUNCHER" = "srun" ]; then
     geopmlaunch srun \
                 -N ${NUM_NODES} \
                 -n ${TOTAL_RANKS} \
-                --geopm-preload \
                 --geopm-ctl=process \
                 --geopm-report=tutorial_1_report \
                 --geopm-trace=tutorial_1_trace \
@@ -75,7 +74,6 @@ elif [ "$GEOPM_LAUNCHER" = "aprun" ]; then
     geopmlaunch aprun \
                 -N ${RANKS_PER_NODE} \
                 -n ${TOTAL_RANKS} \
-                --geopm-preload \
                 --geopm-ctl=process \
                 --geopm-report=tutorial_1_report \
                 --geopm-trace=tutorial_1_trace \
@@ -86,7 +84,6 @@ elif [ "$GEOPM_LAUNCHER" = "impi" ]; then
     geopmlaunch impi \
                 -ppn ${RANKS_PER_NODE} \
                 -n ${TOTAL_RANKS} \
-                --geopm-preload \
                 --geopm-ctl=process \
                 --geopm-report=tutorial_1_report \
                 --geopm-trace=tutorial_1_trace \
@@ -98,7 +95,6 @@ elif [ "$GEOPM_LAUNCHER" = "ompi" ]; then
                 --npernode ${RANKS_PER_NODE} \
                 -n ${TOTAL_RANKS} \
                 --hostfile tutorial_hosts \
-                --geopm-preload \
                 --geopm-ctl=process \
                 --geopm-report=tutorial_1_report \
                 --geopm-trace=tutorial_1_trace \


### PR DESCRIPTION
- Now the launcher always preloads libgeopm.so.
- If the user provies the option a deprecation warning is printed.
- Fixes #1032 from github issues.
