### PR TITLE
Update FrequencyMapAgent and tests to match documentation

### DIFF
--- a/ronn/geopm_agent_frequency_map.7.ronn
+++ b/ronn/geopm_agent_frequency_map.7.ronn
@@ -73,7 +73,9 @@ name (see **geopm(7)**).  This name can also be passed to the
                   specified with a CPU frequency that is allowed by
                   the system.  Failure to provide this parameter,
                   setting it to an out of range value or specifying
-                  NAN will result in a runtime error.
+                  NAN will result in a runtime error, unless the policy
+                  is all NAN, in which case the agent will not exert
+                  any control.
 
   `FREQ_UNCORE`: The operating frequency for the uncore clock in units
                  of Hz.  If specified the uncore clock will operate
@@ -124,10 +126,8 @@ raised.
 
 
 ## REPORT EXTENSIONS
-The assigned frequency for each region is added to each region
-including those that were not in the policy map (which will show the
-policy default CPU frequency).
-
+The assigned frequency is added to each region's section of the report
+if that region was explicitly assigned a frequency in the policy map.
 
 ## CONTROL LOOP RATE
 The agent gates the control loop to sample the region hash and control

--- a/ronn/geopm_agent_frequency_map.7.ronn
+++ b/ronn/geopm_agent_frequency_map.7.ronn
@@ -73,9 +73,7 @@ name (see **geopm(7)**).  This name can also be passed to the
                   specified with a CPU frequency that is allowed by
                   the system.  Failure to provide this parameter,
                   setting it to an out of range value or specifying
-                  NAN will result in a runtime error, unless the policy
-                  is all NAN, in which case the agent will not exert
-                  any control.
+                  NAN will result in a runtime error.
 
   `FREQ_UNCORE`: The operating frequency for the uncore clock in units
                  of Hz.  If specified the uncore clock will operate

--- a/src/FrequencyMapAgent.cpp
+++ b/src/FrequencyMapAgent.cpp
@@ -37,6 +37,7 @@
 #include <iomanip>
 #include <iostream>
 #include <utility>
+#include <algorithm>
 
 #include "contrib/json11/json11.hpp"
 
@@ -49,60 +50,40 @@
 #include "FrequencyGovernor.hpp"
 #include "Helper.hpp"
 #include "Exception.hpp"
+#include "geopm_debug.hpp"
 #include "config.h"
 
 using json11::Json;
 
 namespace geopm
 {
-    static std::map<uint64_t, double> parse_env_map(void)
-    {
-        std::map<uint64_t, double> frequency_map;
-        std::string env_map_str = environment().frequency_map();
-        if (env_map_str.length()) {
-            std::cerr << "Warning: <geopm> Use of the GEOPM_FREQUENCY_MAP "
-                         "environment variable is deprecated. Frequency maps "
-                         "will only be set via "
-                      << FrequencyMapAgent::plugin_name()
-                      << " agent policies in the future.\n";
-            std::string err;
-            Json root = Json::parse(env_map_str, err);
-            if (!err.empty() || !root.is_object()) {
-                throw Exception("FrequencyMapAgent::" + std::string(__func__) + "(): detected a malformed json config file: " + err,
-                                GEOPM_ERROR_FILE_PARSE, __FILE__, __LINE__);
-            }
-            for (const auto &obj : root.object_items()) {
-                if (obj.second.type() != Json::NUMBER) {
-                    throw Exception("FrequencyMapAgent::" + std::string(__func__) +
-                                    ": Region best-fit frequency must be a number",
-                                    GEOPM_ERROR_FILE_PARSE, __FILE__, __LINE__);
-                }
-                uint64_t hash = geopm_crc32_str(obj.first.c_str());
-                frequency_map[hash] = obj.second.number_value();
-            }
-        }
-        return frequency_map;
-    }
-
     FrequencyMapAgent::FrequencyMapAgent()
-        : FrequencyMapAgent(platform_io(), platform_topo(), FrequencyGovernor::make_shared(), parse_env_map())
+        : FrequencyMapAgent(platform_io(), platform_topo())
     {
 
     }
 
-    FrequencyMapAgent::FrequencyMapAgent(PlatformIO &plat_io, const PlatformTopo &topo,
-                                         std::shared_ptr<FrequencyGovernor> gov, std::map<uint64_t, double> frequency_map)
+    FrequencyMapAgent::FrequencyMapAgent(PlatformIO &plat_io, const PlatformTopo &topo)
         : M_PRECISION(16)
         , M_WAIT_SEC(0.002)
         , m_platform_io(plat_io)
         , m_platform_topo(topo)
-        , m_freq_governor(gov)
-        , m_hash_freq_map(frequency_map)
-        , m_last_wait(GEOPM_TIME_REF)
-        , m_level(-1)
+        , m_wait_time(GEOPM_TIME_REF)
+        , m_uncore_min_ctl_idx(-1)
+        , m_uncore_max_ctl_idx(-1)
+        , m_last_uncore_freq(NAN)
         , m_num_children(0)
         , m_is_policy_updated(false)
-        , m_is_initialized_with_map(!frequency_map.empty())
+        , m_do_write_batch(false)
+        , m_is_adjust_initialized(false)
+        , m_freq_ctl_domain_type(GEOPM_DOMAIN_INVALID)
+        , m_num_freq_ctl_domain(0)
+        , m_core_freq_min(NAN)
+        , m_core_freq_max(NAN)
+        , m_uncore_init_min(NAN)
+        , m_uncore_init_max(NAN)
+        , m_default_freq(NAN)
+        , m_uncore_freq(NAN)
     {
 
     }
@@ -119,8 +100,7 @@ namespace geopm
 
     void FrequencyMapAgent::init(int level, const std::vector<int> &fan_in, bool is_level_root)
     {
-        m_level = level;
-        if (m_level == 0) {
+        if (level == 0) {
             m_num_children = 0;
             init_platform_io();
         }
@@ -131,14 +111,27 @@ namespace geopm
 
     void FrequencyMapAgent::validate_policy(std::vector<double> &policy) const
     {
-#ifdef GEOPM_DEBUG
-        if (!is_valid_policy_size(policy)) {
-            throw Exception("FrequencyMapAgent::" + std::string(__func__) + "(): policy vector not correctly sized.",
-                            GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+        GEOPM_DEBUG_ASSERT(policy.size() == M_NUM_POLICY,
+                           "FrequencyMapAgent::" + std::string(__func__) +
+                           "(): policy vector not correctly sized.");
+
+        if (is_all_nan(policy)) {
+            // All-NAN policy may be received before the first policy
+            return;
         }
-#endif
-        m_freq_governor->validate_policy(policy[M_POLICY_FREQ_MIN],
-                                         policy[M_POLICY_FREQ_MAX]);
+
+        if (std::isnan(policy[M_POLICY_FREQ_DEFAULT])) {
+            throw Exception("FrequencyMapAgent::" + std::string(__func__) +
+                            "(): default frequency must be provided in policy.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (policy[M_POLICY_FREQ_DEFAULT] > m_core_freq_max ||
+            policy[M_POLICY_FREQ_DEFAULT] < m_core_freq_min) {
+            throw Exception("FrequencyMapAgent::" + std::string(__func__) +
+                            "(): default frequency out of range: " +
+                            std::to_string(policy[M_POLICY_FREQ_DEFAULT]) + ".",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
 
         // Validate all (hash, frequency) pairs
         std::set<double> policy_regions;
@@ -151,6 +144,11 @@ namespace geopm
                 // memory so that regions can be input to this policy in the
                 // same form they are output from a report.
                 auto region = static_cast<uint64_t>(*it);
+                if (std::isnan(mapped_freq)) {
+                    throw Exception("FrequencyMapAgent::" + std::string(__func__) +
+                                    "(): mapped region with no frequency assigned.",
+                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                }
                 // A valid region will either set or clear its mapped frequency.
                 // Just make sure it does not have multiple definitions.
                 if (!policy_regions.insert(region).second) {
@@ -169,36 +167,52 @@ namespace geopm
         }
     }
 
+    bool FrequencyMapAgent::is_all_nan(const std::vector<double> &vec)
+    {
+        return std::all_of(vec.begin(), vec.end(),
+                           [](double x) -> bool { return std::isnan(x); });
+    }
+
     void FrequencyMapAgent::update_policy(const std::vector<double> &policy)
     {
-        m_is_policy_updated = m_freq_governor->set_frequency_bounds(
-            policy[M_POLICY_FREQ_MIN], policy[M_POLICY_FREQ_MAX]);
+        if (is_all_nan(policy)) {
+            // All-NAN policy is ignored
+            m_is_policy_updated = false;
+            return;
+        }
 
+        std::map<uint64_t, double> old_freq_map = m_hash_freq_map;
+        m_hash_freq_map.clear();
         for (auto it = policy.begin() + M_POLICY_FIRST_HASH;
-             it != policy.end() && std::next(it) != policy.end(); std::advance(it, 2)) {
+             it != policy.end() && std::next(it) != policy.end();
+             std::advance(it, 2)) {
             if (!std::isnan(*it)) {
                 auto hash = static_cast<uint64_t>(*it);
                 auto freq = *(it + 1);
-                if (std::isnan(freq)) {
-                    auto num_erased = m_hash_freq_map.erase(hash);
-                    if (num_erased != 0) {
-                        m_is_policy_updated = true;
-                    }
-                }
-                else {
-                    auto inserted = m_hash_freq_map.emplace(hash, freq);
-                    if (inserted.second) {
-                        m_is_policy_updated = true;
-                    }
-                    else {
-                        if (inserted.first->second != freq) {
-                            inserted.first->second = freq;
-                            m_is_policy_updated = true;
-                        }
-                    }
-                }
+
+                // Not valid to have NAN freq for hash.
+                // This is a logic error because it is checked by
+                // validate policy, which the controller should
+                // call before this function.
+                GEOPM_DEBUG_ASSERT(!std::isnan(freq),
+                                   "mapped region with no frequency assigned.");
+                m_hash_freq_map[hash] = freq;
             }
         }
+        m_is_policy_updated = false;
+        // check if policy changed
+        if (m_default_freq != policy[M_POLICY_FREQ_DEFAULT]) {
+            m_is_policy_updated = true;
+            m_default_freq = policy[M_POLICY_FREQ_DEFAULT];
+        }
+        if (m_hash_freq_map != old_freq_map) {
+            m_is_policy_updated = true;
+        }
+        if (!std::isnan(policy[M_POLICY_FREQ_UNCORE]) &&
+            m_uncore_freq != policy[M_POLICY_FREQ_UNCORE]) {
+            m_is_policy_updated = true;
+        }
+        m_uncore_freq = policy[M_POLICY_FREQ_UNCORE];
     }
 
     void FrequencyMapAgent::split_policy(const std::vector<double> &in_policy,
@@ -210,7 +224,7 @@ namespace geopm
                             GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
         }
         for (auto &child_policy : out_policy) {
-            if (!is_valid_policy_size(child_policy)) {
+            if (child_policy.size() != M_NUM_POLICY) {
                 throw Exception("FrequencyMapAgent::" + std::string(__func__) + "(): child_policy vector not correctly sized.",
                                 GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
             }
@@ -242,71 +256,83 @@ namespace geopm
     void FrequencyMapAgent::adjust_platform(const std::vector<double> &in_policy)
     {
         update_policy(in_policy);
+
+        m_do_write_batch = false;
+
+        if (!m_is_adjust_initialized) {
+            // adjust all controls once in case not applied by policy
+            for (size_t ctl_idx = 0; ctl_idx < (size_t) m_num_freq_ctl_domain; ++ctl_idx) {
+                // @todo: this is bad; agent should be able to use aliases
+                double val = m_platform_io.read_signal("MSR::PERF_CTL:FREQ", m_freq_ctl_domain_type, ctl_idx);
+                m_platform_io.adjust(m_freq_control_idx[ctl_idx], val);
+            }
+            m_platform_io.adjust(m_uncore_min_ctl_idx, m_uncore_init_min);
+            m_platform_io.adjust(m_uncore_max_ctl_idx, m_uncore_init_max);
+            m_is_adjust_initialized = true;
+        }
+
+        if (is_all_nan(in_policy)) {
+            // All-NAN policy may be received before the first policy
+            return;
+        }
+
         double freq = NAN;
-        double freq_min = m_freq_governor->get_frequency_min();
-        double freq_max = m_freq_governor->get_frequency_max();
-        std::vector<double> target_freq;
         for (size_t ctl_idx = 0; ctl_idx < (size_t) m_num_freq_ctl_domain; ++ctl_idx) {
-            const uint64_t curr_hash = m_last_region[ctl_idx].hash;
-            const uint64_t curr_hint = m_last_region[ctl_idx].hint;
+            const uint64_t curr_hash = m_last_hash[ctl_idx];
             auto it = m_hash_freq_map.find(curr_hash);
             if (it != m_hash_freq_map.end()) {
                 freq = it->second;
             }
             else {
-                switch(curr_hint) {
-                    // Hints for low CPU frequency
-                    case GEOPM_REGION_HINT_MEMORY:
-                    case GEOPM_REGION_HINT_NETWORK:
-                    case GEOPM_REGION_HINT_IO:
-                        freq = freq_min;
-                        break;
-
-                    // Hints for maximum CPU frequency
-                    case GEOPM_REGION_HINT_COMPUTE:
-                    case GEOPM_REGION_HINT_SERIAL:
-                    case GEOPM_REGION_HINT_PARALLEL:
-                        freq = freq_max;
-                        break;
-                    // Hint Inconclusive
-                    //case GEOPM_REGION_HINT_UNKNOWN:
-                    //case GEOPM_REGION_HINT_IGNORE:
-                    default:
-                        freq = freq_max;
-                        break;
-                }
+                freq = m_default_freq;
             }
-            m_hash_freq_map[m_last_region[ctl_idx].hash] = freq;
-            target_freq.push_back(freq);
+            if (m_last_freq[ctl_idx] != freq) {
+                m_last_freq[ctl_idx] = freq;
+                m_platform_io.adjust(m_freq_control_idx[ctl_idx], freq);
+                m_do_write_batch = true;
+            }
         }
 
-        m_freq_governor->adjust_platform(target_freq);
+        // adjust fixed uncore freq
+        if (m_last_uncore_freq != m_uncore_freq) {
+            if (!std::isnan(m_uncore_freq)) {
+                m_platform_io.adjust(m_uncore_min_ctl_idx, m_uncore_freq);
+                m_platform_io.adjust(m_uncore_max_ctl_idx, m_uncore_freq);
+                m_do_write_batch = true;
+            }
+            else if (!std::isnan(m_last_uncore_freq)) {
+                m_platform_io.adjust(m_uncore_min_ctl_idx, m_uncore_init_min);
+                m_platform_io.adjust(m_uncore_max_ctl_idx, m_uncore_init_max);
+                m_do_write_batch = true;
+            }
+            m_last_uncore_freq = m_uncore_freq;
+        }
     }
 
     bool FrequencyMapAgent::do_write_batch(void) const
     {
-        return m_freq_governor->do_write_batch();
+        return m_do_write_batch;
     }
 
     void FrequencyMapAgent::sample_platform(std::vector<double> &out_sample)
     {
         for (size_t ctl_idx = 0; ctl_idx < (size_t) m_num_freq_ctl_domain; ++ctl_idx) {
-            m_last_region[ctl_idx].hash = m_platform_io.sample(m_signal_idx[M_SIGNAL_REGION_HASH][ctl_idx]);
-            m_last_region[ctl_idx].hint = m_platform_io.sample(m_signal_idx[M_SIGNAL_REGION_HINT][ctl_idx]);
+            m_last_hash[ctl_idx] = m_platform_io.sample(m_hash_signal_idx[ctl_idx]);
         }
     }
 
     void FrequencyMapAgent::wait(void)
     {
-        while(geopm_time_since(&m_last_wait) < M_WAIT_SEC) {
+        while(geopm_time_since(&m_wait_time) < M_WAIT_SEC) {
 
         }
-        geopm_time(&m_last_wait);
+        geopm_time(&m_wait_time);
     }
 
     std::vector<std::string> FrequencyMapAgent::policy_names(void)
     {
-        std::vector<std::string> names{"FREQ_MIN", "FREQ_MAX"};
+
+        std::vector<std::string> names{"FREQ_DEFAULT", "FREQ_UNCORE"};
         names.reserve(M_NUM_POLICY);
 
         for (size_t i = 0; names.size() < M_NUM_POLICY; ++i) {
@@ -348,7 +374,6 @@ namespace geopm
     {
         std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > result;
         for (const auto &region : m_hash_freq_map) {
-            /// @todo re-implement with m_region_map and m_hash_freq_map keys as pair (hash + hint)
             result[region.first].push_back(std::make_pair("frequency-map", std::to_string(region.second)));
         }
         return result;
@@ -371,47 +396,46 @@ namespace geopm
 
     void FrequencyMapAgent::enforce_policy(const std::vector<double> &policy) const
     {
-        if (!is_valid_policy_size(policy)) {
+        if (policy.size() != M_NUM_POLICY) {
             throw Exception("FrequencyMapAgent::enforce_policy(): policy vector incorrectly sized.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        m_platform_io.write_control("FREQUENCY", GEOPM_DOMAIN_BOARD, 0, policy[M_POLICY_FREQ_MAX]);
+
+        if (is_all_nan(policy)) {
+            // All-NAN policy does nothing
+            return;
+        }
+        m_platform_io.write_control("FREQUENCY", GEOPM_DOMAIN_BOARD, 0,
+                                    policy[M_POLICY_FREQ_DEFAULT]);
+        if (!std::isnan(policy[M_POLICY_FREQ_UNCORE])) {
+                m_platform_io.write_control("MSR::UNCORE_RATIO_LIMIT:MIN_RATIO", GEOPM_DOMAIN_BOARD, 0,
+                                            policy[M_POLICY_FREQ_UNCORE]);
+                m_platform_io.write_control("MSR::UNCORE_RATIO_LIMIT:MAX_RATIO", GEOPM_DOMAIN_BOARD, 0,
+                                            policy[M_POLICY_FREQ_UNCORE]);
+        }
     }
 
     void FrequencyMapAgent::init_platform_io(void)
     {
-        const struct m_region_info_s DEFAULT_REGION { .hash = GEOPM_REGION_HASH_UNMARKED,
-                                                      .hint = GEOPM_REGION_HINT_UNKNOWN};
-        m_freq_governor->init_platform_io();
-        const int freq_ctl_domain_type = m_freq_governor->frequency_domain_type();
-        m_num_freq_ctl_domain = m_platform_topo.num_domain(freq_ctl_domain_type);
-        m_last_region = std::vector<struct m_region_info_s>(m_num_freq_ctl_domain,
-                                                            DEFAULT_REGION);
-        std::vector<std::string> signal_names = {"REGION_HASH", "REGION_HINT"};
-        for (size_t sig_idx = 0; sig_idx < signal_names.size(); ++sig_idx) {
-            m_signal_idx.push_back(std::vector<int>());
-            for (size_t ctl_idx = 0; ctl_idx < (size_t) m_num_freq_ctl_domain; ++ctl_idx) {
-                m_signal_idx[sig_idx].push_back(m_platform_io.push_signal(signal_names[sig_idx],
-                                                                          freq_ctl_domain_type,
-                                                                          ctl_idx));
-            }
+        m_freq_ctl_domain_type = m_platform_io.control_domain_type("FREQUENCY");
+        m_num_freq_ctl_domain = m_platform_topo.num_domain(m_freq_ctl_domain_type);
+        m_last_hash = std::vector<uint64_t>(m_num_freq_ctl_domain,
+                                            GEOPM_REGION_HASH_UNMARKED);
+        m_last_freq = std::vector<double>(m_num_freq_ctl_domain, NAN);
+        for (size_t ctl_idx = 0; ctl_idx < (size_t) m_num_freq_ctl_domain; ++ctl_idx) {
+            m_hash_signal_idx.push_back(m_platform_io.push_signal("REGION_HASH",
+                                                                  m_freq_ctl_domain_type,
+                                                                  ctl_idx));
+            m_freq_control_idx.push_back(m_platform_io.push_control("FREQUENCY",
+                                                                    m_freq_ctl_domain_type,
+                                                                    ctl_idx));
         }
-    }
+        m_uncore_min_ctl_idx = m_platform_io.push_control("MSR::UNCORE_RATIO_LIMIT:MIN_RATIO", GEOPM_DOMAIN_BOARD, 0);
+        m_uncore_max_ctl_idx = m_platform_io.push_control("MSR::UNCORE_RATIO_LIMIT:MAX_RATIO", GEOPM_DOMAIN_BOARD, 0);
 
-    bool FrequencyMapAgent::is_valid_policy_size(const std::vector<double> &policy) const
-    {
-        bool ret = true;
-        if (m_is_initialized_with_map) {
-            if (policy.size() != M_POLICY_FIRST_HASH) {
-                ret = false;
-            }
-        }
-        else {
-            if (policy.size() > M_NUM_POLICY ||
-                policy.size() < M_POLICY_FIRST_HASH || policy.size() % 2) {
-                ret = false;
-            }
-        }
-        return ret;
+        m_core_freq_min = m_platform_io.read_signal("FREQUENCY_MIN", GEOPM_DOMAIN_BOARD, 0);
+        m_core_freq_max = m_platform_io.read_signal("FREQUENCY_MAX", GEOPM_DOMAIN_BOARD, 0);
+        m_uncore_init_min = m_platform_io.read_signal("MSR::UNCORE_RATIO_LIMIT:MIN_RATIO", GEOPM_DOMAIN_BOARD, 0);
+        m_uncore_init_max = m_platform_io.read_signal("MSR::UNCORE_RATIO_LIMIT:MAX_RATIO", GEOPM_DOMAIN_BOARD, 0);
     }
 }

--- a/src/FrequencyMapAgent.hpp
+++ b/src/FrequencyMapAgent.hpp
@@ -47,14 +47,12 @@ namespace geopm
 {
     class PlatformIO;
     class PlatformTopo;
-    class FrequencyGovernor;
 
     class FrequencyMapAgent : public Agent
     {
         public:
             FrequencyMapAgent();
-            FrequencyMapAgent(PlatformIO &plat_io, const PlatformTopo &topo,
-                              std::shared_ptr<FrequencyGovernor> gov, std::map<uint64_t, double> frequency_map);
+            FrequencyMapAgent(PlatformIO &plat_io, const PlatformTopo &topo);
             virtual ~FrequencyMapAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
             void validate_policy(std::vector<double> &policy) const override;
@@ -83,11 +81,11 @@ namespace geopm
         private:
             void update_policy(const std::vector<double> &policy);
             void init_platform_io(void);
-            bool is_valid_policy_size(const std::vector<double> &policy) const;
+            static bool is_all_nan(const std::vector<double> &vec);
 
             enum m_policy_e {
-                M_POLICY_FREQ_MIN,
-                M_POLICY_FREQ_MAX,
+                M_POLICY_FREQ_DEFAULT,
+                M_POLICY_FREQ_UNCORE,
                 M_POLICY_FIRST_HASH,
                 M_POLICY_FIRST_FREQUENCY,
                 // The remainder of policy values can be additional pairs of
@@ -95,33 +93,31 @@ namespace geopm
                 M_NUM_POLICY = 64,
             };
 
-            enum m_signal_e {
-                M_SIGNAL_REGION_HASH,
-                M_SIGNAL_REGION_HINT,
-                M_NUM_SIGNAL,
-            };
-
-            struct m_region_info_s {
-                uint64_t hash;
-                uint64_t hint;
-                double runtime;
-                uint64_t count;
-            };
-
             const int M_PRECISION;
             const double M_WAIT_SEC;
             PlatformIO &m_platform_io;
             const PlatformTopo &m_platform_topo;
-            std::shared_ptr<FrequencyGovernor> m_freq_governor;
-            std::vector<struct m_region_info_s>  m_last_region;
+            geopm_time_s m_wait_time;
             std::map<uint64_t, double> m_hash_freq_map;
-            geopm_time_s m_last_wait;
-            std::vector<std::vector<int> > m_signal_idx;
-            int m_level;
+            std::vector<int> m_hash_signal_idx;
+            std::vector<int> m_freq_control_idx;
+            int m_uncore_min_ctl_idx;
+            int m_uncore_max_ctl_idx;
+            std::vector<uint64_t> m_last_hash;
+            std::vector<double> m_last_freq;
+            double m_last_uncore_freq;
             int m_num_children;
             bool m_is_policy_updated;
+            bool m_do_write_batch;
+            bool m_is_adjust_initialized;
+            int m_freq_ctl_domain_type;
             int m_num_freq_ctl_domain;
-            bool m_is_initialized_with_map;
+            double m_core_freq_min;
+            double m_core_freq_max;
+            double m_uncore_init_min;
+            double m_uncore_init_max;
+            double m_default_freq;
+            double m_uncore_freq;
     };
 }
 

--- a/src/FrequencyMapAgent.hpp
+++ b/src/FrequencyMapAgent.hpp
@@ -110,6 +110,7 @@ namespace geopm
             bool m_is_policy_updated;
             bool m_do_write_batch;
             bool m_is_adjust_initialized;
+            bool m_is_real_policy;
             int m_freq_ctl_domain_type;
             int m_num_freq_ctl_domain;
             double m_core_freq_min;

--- a/test/AgentFactoryTest.cpp
+++ b/test/AgentFactoryTest.cpp
@@ -136,8 +136,8 @@ TEST(AgentFactoryTest, static_info_frequency_map)
     EXPECT_EQ(64, Agent::num_policy(agent_name));
     EXPECT_EQ(0, Agent::num_sample(agent_name));
     std::vector<std::string> exp_sample = {};
-    std::vector<std::string> exp_policy = {"FREQ_MIN",
-                                           "FREQ_MAX",
+    std::vector<std::string> exp_policy = {"FREQ_DEFAULT",
+                                           "FREQ_UNCORE",
                                            "HASH_0", "FREQ_0",
                                            "HASH_1", "FREQ_1",
                                            "HASH_2", "FREQ_2",

--- a/test/FrequencyMapAgentTest.cpp
+++ b/test/FrequencyMapAgentTest.cpp
@@ -30,6 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <iostream>
 #include <fstream>
@@ -50,7 +52,6 @@
 #include "Agg.hpp"
 #include "MockPlatformIO.hpp"
 #include "MockPlatformTopo.hpp"
-#include "MockFrequencyGovernor.hpp"
 #include "PlatformTopo.hpp"
 #include "geopm.h"
 #include "geopm_test.hpp"
@@ -69,91 +70,110 @@ class FrequencyMapAgentTest : public :: testing :: Test
     protected:
         enum mock_pio_idx_e {
             REGION_HASH_IDX,
-            REGION_HINT_IDX,
             FREQ_CONTROL_IDX,
+            UNCORE_MIN_CTL_IDX,
+            UNCORE_MAX_CTL_IDX
+        };
+        enum policy_idx_e {
+            DEFAULT = 0,  // M_POLICY_FREQ_DEFAULT
+            UNCORE = 1,
+            HASH_0 = 2,
+            FREQ_0 = 3,
+            HASH_1 = 4,
+            FREQ_1 = 5,
         };
 
         void SetUp();
         void TearDown();
         static const int M_NUM_CPU = 1;
         static const size_t M_NUM_REGIONS = 5;
-        std::vector<double> m_expected_freqs;
         std::unique_ptr<FrequencyMapAgent> m_agent;
         std::vector<std::string> m_region_names;
         std::vector<uint64_t> m_region_hash;
-        std::vector<uint64_t> m_region_hint;
         std::vector<double> m_mapped_freqs;
         std::vector<double> m_default_policy;
+        size_t m_num_policy;
         double m_freq_min;
         double m_freq_max;
         double m_freq_step;
+        double m_freq_uncore_min;
+        double m_freq_uncore_max;
         std::unique_ptr<MockPlatformIO> m_platform_io;
         std::unique_ptr<MockPlatformTopo> m_platform_topo;
-        std::shared_ptr<MockFrequencyGovernor> m_governor;
 };
 
 void FrequencyMapAgentTest::SetUp()
 {
     m_platform_io = geopm::make_unique<MockPlatformIO>();
     m_platform_topo = geopm::make_unique<MockPlatformTopo>();
-    m_governor = std::make_shared<MockFrequencyGovernor>();
     ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD))
         .WillByDefault(Return(1));
     ON_CALL(*m_platform_io, push_signal("REGION_HASH", _, _))
         .WillByDefault(Return(REGION_HASH_IDX));
-    ON_CALL(*m_platform_io, push_signal("REGION_HINT", _, _))
-        .WillByDefault(Return(REGION_HINT_IDX));
+    ON_CALL(*m_platform_io, push_control("FREQUENCY", _, _))
+        .WillByDefault(Return(FREQ_CONTROL_IDX));
+    ON_CALL(*m_platform_io, push_control("MSR::UNCORE_RATIO_LIMIT:MIN_RATIO", _, _))
+        .WillByDefault(Return(UNCORE_MIN_CTL_IDX));
+    ON_CALL(*m_platform_io, push_control("MSR::UNCORE_RATIO_LIMIT:MAX_RATIO", _, _))
+        .WillByDefault(Return(UNCORE_MAX_CTL_IDX));
     ON_CALL(*m_platform_io, agg_function(_))
         .WillByDefault(Return(geopm::Agg::max));
 
     m_freq_min = 1800000000.0;
     m_freq_max = 2200000000.0;
     m_freq_step = 100000000.0;
-    ON_CALL(*m_governor, frequency_domain_type())
+    m_freq_uncore_min = 1700000000;
+    m_freq_uncore_max = 2100000000;
+    ON_CALL(*m_platform_io, control_domain_type("FREQUENCY"))
         .WillByDefault(Return(GEOPM_DOMAIN_BOARD));
-    ON_CALL(*m_governor, get_frequency_min())
+    ON_CALL(*m_platform_io, read_signal("FREQUENCY_MIN", GEOPM_DOMAIN_BOARD, 0))
         .WillByDefault(Return(m_freq_min));
-    ON_CALL(*m_governor, get_frequency_max())
+    ON_CALL(*m_platform_io, read_signal("FREQUENCY_MAX", GEOPM_DOMAIN_BOARD, 0))
         .WillByDefault(Return(m_freq_max));
-    ON_CALL(*m_governor, get_frequency_step())
+    ON_CALL(*m_platform_io, read_signal("FREQUENCY_STEP", GEOPM_DOMAIN_BOARD, 0))
         .WillByDefault(Return(m_freq_step));
-
-    // calls in constructor
-    EXPECT_CALL(*m_platform_topo, num_domain(_)).Times(AtLeast(1));
-    EXPECT_CALL(*m_platform_io, push_signal(_, _, _)).Times(AtLeast(1));
+    ON_CALL(*m_platform_io, read_signal("MSR::PERF_CTL:FREQ", _, _))
+        .WillByDefault(Return(m_freq_max));
+    ON_CALL(*m_platform_io, read_signal("MSR::UNCORE_RATIO_LIMIT:MIN_RATIO", GEOPM_DOMAIN_BOARD, 0))
+        .WillByDefault(Return(m_freq_uncore_min));
+    ON_CALL(*m_platform_io, read_signal("MSR::UNCORE_RATIO_LIMIT:MAX_RATIO", GEOPM_DOMAIN_BOARD, 0))
+        .WillByDefault(Return(m_freq_uncore_max));
 
     m_region_names = {"mapped_region0", "mapped_region1", "mapped_region2", "mapped_region3", "mapped_region4"};
     m_region_hash = {0xeffa9a8d, 0x4abb08f3, 0xa095c880, 0x5d45afe, 0x71243e97};
     m_mapped_freqs = {m_freq_max, 2100000000.0, 2000000000.0, 1900000000.0, m_freq_min};
-    m_default_policy = {m_freq_min, m_freq_max};
+    ASSERT_LT(m_freq_min, 1.9e9);
+    ASSERT_LT(2.1e9, m_freq_max);
+    m_default_policy = {m_freq_max, NAN};
 
     for (size_t i = 0; i < M_NUM_REGIONS; ++i) {
         m_default_policy.push_back(static_cast<double>(m_region_hash[i]));
         m_default_policy.push_back(m_mapped_freqs[i]);
     }
 
-    // order of hints should alternate between min and max expected frequency
-    m_region_hint = {GEOPM_REGION_HINT_COMPUTE, GEOPM_REGION_HINT_MEMORY,
-                     GEOPM_REGION_HINT_SERIAL, GEOPM_REGION_HINT_NETWORK,
-                     GEOPM_REGION_HINT_PARALLEL, GEOPM_REGION_HINT_IO,
-                     GEOPM_REGION_HINT_IGNORE, GEOPM_REGION_HINT_NETWORK,
-                     GEOPM_REGION_HINT_UNKNOWN};
-    m_expected_freqs = {m_freq_min, m_freq_max, m_freq_min, m_freq_max, m_freq_min};
-
     ASSERT_EQ(m_mapped_freqs.size(), m_region_names.size());
     ASSERT_EQ(m_mapped_freqs.size(), m_region_hash.size());
-    ASSERT_EQ(m_mapped_freqs.size(), m_expected_freqs.size());
 
     std::map<uint64_t, double> frequency_map;
     for (size_t x = 0; x < M_NUM_REGIONS; x++) {
         frequency_map[m_region_hash[x]] = m_mapped_freqs[x];
     }
 
-    m_agent = geopm::make_unique<FrequencyMapAgent>(
-        *m_platform_io, *m_platform_topo, m_governor, std::map<uint64_t, double>{});
-    // todo: this test assumes board domain is used for control
-    EXPECT_CALL(*m_governor, init_platform_io());
-    EXPECT_CALL(*m_governor, frequency_domain_type());
+    m_agent = geopm::make_unique<FrequencyMapAgent>(*m_platform_io, *m_platform_topo);
+    m_num_policy = m_agent->policy_names().size();
+
+    EXPECT_CALL(*m_platform_io, control_domain_type("FREQUENCY"));
+    EXPECT_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD));
+    EXPECT_CALL(*m_platform_io, push_signal("REGION_HASH", _, _));
+    EXPECT_CALL(*m_platform_io, push_control("FREQUENCY", _, _));
+    EXPECT_CALL(*m_platform_io, push_control("MSR::UNCORE_RATIO_LIMIT:MIN_RATIO", _, _));
+    EXPECT_CALL(*m_platform_io, push_control("MSR::UNCORE_RATIO_LIMIT:MAX_RATIO", _, _));
+    EXPECT_CALL(*m_platform_io, read_signal("FREQUENCY_MIN", _, _));
+    EXPECT_CALL(*m_platform_io, read_signal("FREQUENCY_MAX", _, _));
+    EXPECT_CALL(*m_platform_io, read_signal("MSR::UNCORE_RATIO_LIMIT:MIN_RATIO", _, _));
+    EXPECT_CALL(*m_platform_io, read_signal("MSR::UNCORE_RATIO_LIMIT:MAX_RATIO", _, _));
+
+    // leaf agent
     m_agent->init(0, {}, false);
 }
 
@@ -162,23 +182,145 @@ void FrequencyMapAgentTest::TearDown()
 
 }
 
-TEST_F(FrequencyMapAgentTest, map)
+TEST_F(FrequencyMapAgentTest, adjust_platform_map)
 {
-    for (size_t x = 0; x < M_NUM_REGIONS; x++) {
+    {
+        EXPECT_CALL(*m_platform_io, read_signal("MSR::PERF_CTL:FREQ", _, _))
+            .WillOnce(Return(m_freq_max));
+        EXPECT_CALL(*m_platform_io, adjust(FREQ_CONTROL_IDX, m_freq_max));
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MIN_CTL_IDX, m_freq_uncore_min));
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MAX_CTL_IDX, m_freq_uncore_max));
+
         EXPECT_CALL(*m_platform_io, sample(REGION_HASH_IDX))
-            .WillOnce(Return(m_region_hash[x]));
-        EXPECT_CALL(*m_platform_io, sample(REGION_HINT_IDX))
-            .WillOnce(Return(m_region_hint[x]));
-        std::vector<double> adjust_vals = {m_mapped_freqs[x]};
-        EXPECT_CALL(*m_governor, set_frequency_bounds(m_freq_min, m_freq_max));
-        EXPECT_CALL(*m_governor, adjust_platform(adjust_vals));
-        EXPECT_CALL(*m_governor, do_write_batch())
-            .WillOnce(Return(true));
+            .WillOnce(Return(m_region_hash[0]));
         std::vector<double> tmp;
         m_agent->sample_platform(tmp);
-        m_agent->adjust_platform(m_default_policy);
-        EXPECT_TRUE(m_agent->do_write_batch());
+        std::vector<double> empty_policy(m_num_policy, NAN);
+        m_agent->adjust_platform(empty_policy);
+        EXPECT_FALSE(m_agent->do_write_batch());
     }
+
+    int num_samples = 3;
+    for (size_t x = 0; x < M_NUM_REGIONS; x++) {
+        EXPECT_CALL(*m_platform_io, adjust(FREQ_CONTROL_IDX, m_mapped_freqs[x]))
+            .Times(1);
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MIN_CTL_IDX, _)).Times(0);
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MAX_CTL_IDX, _)).Times(0);
+        for (int sample = 0; sample < num_samples; ++sample) {
+            EXPECT_CALL(*m_platform_io, sample(REGION_HASH_IDX))
+                .WillOnce(Return(m_region_hash[x]));
+            std::vector<double> tmp;
+            m_agent->sample_platform(tmp);
+            m_agent->adjust_platform(m_default_policy);
+            // only write when first entering the region
+            if (sample == 0) {
+                EXPECT_TRUE(m_agent->do_write_batch());
+            }
+        }
+    }
+}
+
+TEST_F(FrequencyMapAgentTest, adjust_platform_uncore)
+{
+    std::vector<double> policy(m_num_policy, NAN);
+    {
+        EXPECT_CALL(*m_platform_io, read_signal("MSR::PERF_CTL:FREQ", _, _));
+        EXPECT_CALL(*m_platform_io, adjust(FREQ_CONTROL_IDX, m_freq_max));
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MIN_CTL_IDX, m_freq_uncore_min));
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MAX_CTL_IDX, m_freq_uncore_max));
+        m_agent->adjust_platform(policy);
+    }
+    policy = m_default_policy;
+    {
+        EXPECT_CALL(*m_platform_io, adjust(FREQ_CONTROL_IDX, m_freq_max));
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MIN_CTL_IDX, m_freq_uncore_min));
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MAX_CTL_IDX, m_freq_uncore_min));
+        policy[UNCORE] = m_freq_uncore_min;
+        m_agent->adjust_platform(policy);
+        EXPECT_TRUE(m_agent->do_write_batch());
+        // don't write again if unchanged
+        m_agent->adjust_platform(policy);
+        EXPECT_FALSE(m_agent->do_write_batch());
+    }
+    {
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MIN_CTL_IDX, m_freq_uncore_max));
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MAX_CTL_IDX, m_freq_uncore_max));
+        policy[UNCORE] = m_freq_uncore_max;
+        m_agent->adjust_platform(policy);
+        EXPECT_TRUE(m_agent->do_write_batch());
+        // don't write again if unchanged
+        m_agent->adjust_platform(policy);
+        EXPECT_FALSE(m_agent->do_write_batch());
+    }
+    // restore uncore to initial values if NAN
+    {
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MIN_CTL_IDX, m_freq_uncore_min));
+        EXPECT_CALL(*m_platform_io, adjust(UNCORE_MAX_CTL_IDX, m_freq_uncore_max));
+        policy[UNCORE] = NAN;
+        m_agent->adjust_platform(policy);
+        EXPECT_TRUE(m_agent->do_write_batch());
+        // don't write again if unchanged
+        m_agent->adjust_platform(policy);
+        EXPECT_FALSE(m_agent->do_write_batch());
+    }
+}
+
+TEST_F(FrequencyMapAgentTest, split_policy)
+{
+
+    int num_children = 2;
+    auto tree_agent = geopm::make_unique<FrequencyMapAgent>(*m_platform_io, *m_platform_topo);
+    tree_agent->init(1, {num_children}, false);
+
+
+    std::vector<double> policy(m_num_policy, NAN);
+    std::vector<std::vector<double> > out_policy(num_children, policy);
+    // do not send all NAN policy
+    tree_agent->split_policy(policy, out_policy);
+    EXPECT_FALSE(tree_agent->do_send_policy());
+
+    // send first policy
+    policy[DEFAULT] = m_freq_max;
+    tree_agent->split_policy(policy, out_policy);
+    EXPECT_TRUE(tree_agent->do_send_policy());
+    ASSERT_EQ(num_children, out_policy.size());
+    EXPECT_EQ(m_freq_max, out_policy[0][DEFAULT]);
+    EXPECT_EQ(m_freq_max, out_policy[1][DEFAULT]);
+
+    // do not send if unchanged
+    tree_agent->split_policy(policy, out_policy);
+    EXPECT_FALSE(tree_agent->do_send_policy());
+
+    // send if policy changed
+    policy[0] = m_freq_min;
+    tree_agent->split_policy(policy, out_policy);
+    EXPECT_TRUE(tree_agent->do_send_policy());
+    ASSERT_EQ(num_children, out_policy.size());
+    EXPECT_EQ(m_freq_min, out_policy[0][DEFAULT]);
+    EXPECT_EQ(m_freq_min, out_policy[1][DEFAULT]);
+
+    // send if uncore changed
+    policy[1] = m_freq_max;
+    tree_agent->split_policy(policy, out_policy);
+    EXPECT_TRUE(tree_agent->do_send_policy());
+    ASSERT_EQ(num_children, out_policy.size());
+    EXPECT_EQ(m_freq_min, out_policy[0][DEFAULT]);
+    EXPECT_EQ(m_freq_min, out_policy[1][DEFAULT]);
+    EXPECT_EQ(m_freq_max, out_policy[0][UNCORE]);
+    EXPECT_EQ(m_freq_max, out_policy[1][UNCORE]);
+
+    // NAN uncore is ignored
+    policy[1] = NAN;
+    tree_agent->split_policy(policy, out_policy);
+    EXPECT_FALSE(tree_agent->do_send_policy());
+
+#ifdef GEOPM_DEBUG
+    // NAN for a mapped region is invalid
+    policy[2] = 0xabc;
+    GEOPM_EXPECT_THROW_MESSAGE(tree_agent->split_policy(policy, out_policy),
+                               GEOPM_ERROR_LOGIC,
+                               "mapped region with no frequency assigned");
+#endif
 }
 
 TEST_F(FrequencyMapAgentTest, name)
@@ -187,56 +329,48 @@ TEST_F(FrequencyMapAgentTest, name)
     EXPECT_NE("bad_string", m_agent->plugin_name());
 }
 
-TEST_F(FrequencyMapAgentTest, hint)
-{
-    for (size_t x = 0; x < m_region_hint.size(); x++) {
-        EXPECT_CALL(*m_platform_io, sample(REGION_HASH_IDX))
-            .WillOnce(Return(0x1234 + x));
-        EXPECT_CALL(*m_platform_io, sample(REGION_HINT_IDX))
-            .WillOnce(Return(m_region_hint[x]));
-        double expected_freq = NAN;
-        switch(m_region_hint[x]) {
-            // Hints for low CPU frequency
-            case GEOPM_REGION_HINT_MEMORY:
-            case GEOPM_REGION_HINT_NETWORK:
-            case GEOPM_REGION_HINT_IO:
-                expected_freq = m_freq_min;
-                break;
-            // Hints for maximum CPU frequency
-            case GEOPM_REGION_HINT_COMPUTE:
-            case GEOPM_REGION_HINT_SERIAL:
-            case GEOPM_REGION_HINT_PARALLEL:
-                expected_freq = m_freq_max;
-                break;
-            // Hint Inconclusive
-            //case GEOPM_REGION_HINT_UNKNOWN:
-            //case GEOPM_REGION_HINT_IGNORE:
-            default:
-                expected_freq = m_freq_max;
-                break;
-        }
-        std::vector<double> tmp;
-        m_agent->sample_platform(tmp);
-        EXPECT_CALL(*m_governor, set_frequency_bounds(m_freq_min, m_freq_max));
-        std::vector<double> adjust_vals = {expected_freq};
-        EXPECT_CALL(*m_governor, adjust_platform(adjust_vals));
-        EXPECT_CALL(*m_governor, do_write_batch())
-            .WillOnce(Return(true));
-        m_agent->adjust_platform(m_default_policy);
-        EXPECT_TRUE(m_agent->do_write_batch());
-    }
-}
-
 TEST_F(FrequencyMapAgentTest, enforce_policy)
 {
-    const double limit = 1e9;
-    const std::vector<double> policy{0, limit};
+    const double core_limit = 1e9;
+    const double uncore_limit = 2e9;
+    std::vector<double> policy(m_num_policy, NAN);
+    std::vector<double> empty_policy(m_num_policy, NAN);
+    // policy with default core frequency only;
+    {
+        policy[DEFAULT] = core_limit;
+        EXPECT_CALL(*m_platform_io,
+                    write_control("FREQUENCY", GEOPM_DOMAIN_BOARD, 0, core_limit));
+        EXPECT_CALL(*m_platform_io,
+                    write_control("MSR::UNCORE_RATIO_LIMIT:MIN_RATIO", _, _, _))
+            .Times(0);
+        EXPECT_CALL(*m_platform_io,
+                    write_control("MSR::UNCORE_RATIO_LIMIT:MAX_RATIO", _, _, _))
+            .Times(0);
+        m_agent->enforce_policy(policy);
+    }
+
+    // policy with default core and uncore frequencies
+    {
+        policy[DEFAULT] = core_limit;
+        policy[UNCORE] = uncore_limit;
+        EXPECT_CALL(*m_platform_io,
+                    write_control("FREQUENCY", GEOPM_DOMAIN_BOARD, 0, core_limit));
+        EXPECT_CALL(*m_platform_io,
+                    write_control("MSR::UNCORE_RATIO_LIMIT:MIN_RATIO",
+                                  GEOPM_DOMAIN_BOARD, 0, uncore_limit));
+        EXPECT_CALL(*m_platform_io,
+                    write_control("MSR::UNCORE_RATIO_LIMIT:MAX_RATIO",
+                                  GEOPM_DOMAIN_BOARD, 0, uncore_limit));
+        m_agent->enforce_policy(policy);
+    }
+
+    // all NAN policy does no control
+    {
+        EXPECT_CALL(*m_platform_io, write_control(_, _, _, _)).Times(0);
+        m_agent->enforce_policy(empty_policy);
+    }
+
     const std::vector<double> bad_policy(123, 100);
-
-    EXPECT_CALL(*m_platform_io, write_control("FREQUENCY", GEOPM_DOMAIN_BOARD, 0, limit));
-
-    m_agent->enforce_policy(policy);
-
     EXPECT_THROW(m_agent->enforce_policy(bad_policy), geopm::Exception);
 }
 
@@ -252,11 +386,11 @@ static Json get_freq_map_json_from_policy(const std::vector<double> &policy)
 
 TEST_F(FrequencyMapAgentTest, policy_to_json)
 {
-    EXPECT_EQ(Json(Json::object{ { "FREQ_MIN", 0 }, { "FREQ_MAX", 3e9 } }),
+    EXPECT_EQ(Json(Json::object{ { "FREQ_DEFAULT", 0 }, { "FREQ_UNCORE", 3e9 } }),
               get_freq_map_json_from_policy({ 0, 3e9 }));
-    EXPECT_EQ(Json(Json::object{ { "FREQ_MIN", 0 }, { "FREQ_MAX", 1e40 } }),
+    EXPECT_EQ(Json(Json::object{ { "FREQ_DEFAULT", 0 }, { "FREQ_UNCORE", 1e40 } }),
               get_freq_map_json_from_policy({ 0, 1e40 }));
-    EXPECT_EQ(Json(Json::object{ { "FREQ_MIN", 0 }, { "FREQ_MAX", 1e-40 } }),
+    EXPECT_EQ(Json(Json::object{ { "FREQ_DEFAULT", 0 }, { "FREQ_UNCORE", 1e-40 } }),
               get_freq_map_json_from_policy({ 0, 1e-40 }));
 }
 
@@ -265,27 +399,79 @@ TEST_F(FrequencyMapAgentTest, validate_policy)
     using ::testing::Pointwise;
     using ::testing::NanSensitiveDoubleEq;
 
-    std::vector<double> policy{400, 500, 123, 456, NAN, NAN};
+    const std::vector<double> empty(m_num_policy, NAN);
+    std::vector<double> policy;
+
+    // valid policy is unmodified
+    policy = empty;
+    policy[DEFAULT] = m_freq_max;
+    policy[UNCORE] = 1.0e9;
+    policy[HASH_0] = 123;
+    policy[FREQ_0] = m_freq_min;
     m_agent->validate_policy(policy);
-    EXPECT_THAT(policy, Pointwise(NanSensitiveDoubleEq(), std::vector<double>{400, 500, 123, 456, NAN, NAN}));
+    ASSERT_EQ(m_num_policy, policy.size());
+    EXPECT_EQ(m_freq_max, policy[DEFAULT]);
+    EXPECT_EQ(1.0e9, policy[UNCORE]);
+    EXPECT_EQ(123, policy[HASH_0]);
+    EXPECT_EQ(m_freq_min, policy[FREQ_0]);
+    EXPECT_TRUE(std::isnan(policy[HASH_1]));
+    EXPECT_TRUE(std::isnan(policy[FREQ_1]));
 
-    policy = {400, 500, 123, 456, 123, 450};
-    EXPECT_THROW(m_agent->validate_policy(policy), geopm::Exception)
-        << "Region with multiple mapped frequencies";
-
-    policy = {400, 500, 123, NAN};
+    // gaps in mapped regions allowed
+    policy = empty;
+    policy[DEFAULT] = m_freq_max;
+    policy[UNCORE] = 1.0e9;
+    policy[HASH_1] = 123;
+    policy[FREQ_1] = m_freq_min;
     m_agent->validate_policy(policy);
-    EXPECT_EQ(400, policy[0]);
-    EXPECT_EQ(500, policy[1]);
-    EXPECT_EQ(123, policy[2]);
-    EXPECT_TRUE(std::isnan(policy[3]));
+    ASSERT_EQ(m_num_policy, policy.size());
+    EXPECT_EQ(m_freq_max, policy[DEFAULT]);
+    EXPECT_EQ(1.0e9, policy[UNCORE]);
+    EXPECT_TRUE(std::isnan(policy[HASH_0]));
+    EXPECT_TRUE(std::isnan(policy[FREQ_0]));
+    EXPECT_EQ(123, policy[HASH_1]);
+    EXPECT_EQ(m_freq_min, policy[FREQ_1]);
 
-    policy = {400, 500, NAN, NAN, 0x123, 2e9};
+    // all-NAN policy is accepted
+    policy = empty;
     m_agent->validate_policy(policy);
-    EXPECT_THAT(policy, Pointwise(NanSensitiveDoubleEq(), std::vector<double>{400, 500, NAN, NAN, 0x123, 2e9}))
-        << "Gap in policy";
+    EXPECT_TRUE(std::isnan(policy[DEFAULT]));
 
-    policy = {400, 500, NAN, 456};
-    EXPECT_THROW(m_agent->validate_policy(policy), geopm::Exception)
-        << "Frequency without region";
+    // default must be set if not all NAN
+    policy = empty;
+    policy[UNCORE] = 1.0e9;
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "default frequency must be provided in policy");
+
+    // default must be within system limits
+    policy[DEFAULT] = m_freq_max + 1;
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "default frequency out of range");
+    policy[DEFAULT] = m_freq_min - 1;
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "default frequency out of range");
+
+    // cannot have same region with multiple freqs
+    policy = empty;
+    policy[DEFAULT] = m_freq_max;
+    policy[HASH_0] = 123;
+    policy[HASH_1] = 123;
+    policy[FREQ_0] = m_freq_max;
+    policy[FREQ_1] = m_freq_min;
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "policy has multiple entries for region");
+
+    // mapped region cannot have NAN frequency
+    policy = empty;
+    policy[DEFAULT] = m_freq_max;
+    policy[HASH_0] = 123;
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "mapped region with no frequency assigned");
+
+    // cannot have frequency without region
+    policy = empty;
+    policy[DEFAULT] = m_freq_max;
+    policy[FREQ_0] = m_freq_min;
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "policy maps a NaN region with frequency");
 }

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -196,10 +196,10 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/FrequencyGovernorTest.validate_policy \
               test/gtest_links/FrequencyMapAgentTest.adjust_platform_map \
               test/gtest_links/FrequencyMapAgentTest.adjust_platform_uncore \
-              test/gtest_links/FrequencyMapAgentTest.hint \
               test/gtest_links/FrequencyMapAgentTest.name \
               test/gtest_links/FrequencyMapAgentTest.enforce_policy \
               test/gtest_links/FrequencyMapAgentTest.policy_to_json \
+              test/gtest_links/FrequencyMapAgentTest.split_policy \
               test/gtest_links/FrequencyMapAgentTest.validate_policy \
               test/gtest_links/HelperTest.string_begins_with \
               test/gtest_links/HelperTest.string_ends_with \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -194,8 +194,9 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/FrequencyGovernorTest.frequency_bounds_in_range \
               test/gtest_links/FrequencyGovernorTest.frequency_bounds_invalid \
               test/gtest_links/FrequencyGovernorTest.validate_policy \
+              test/gtest_links/FrequencyMapAgentTest.adjust_platform_map \
+              test/gtest_links/FrequencyMapAgentTest.adjust_platform_uncore \
               test/gtest_links/FrequencyMapAgentTest.hint \
-              test/gtest_links/FrequencyMapAgentTest.map \
               test/gtest_links/FrequencyMapAgentTest.name \
               test/gtest_links/FrequencyMapAgentTest.enforce_policy \
               test/gtest_links/FrequencyMapAgentTest.policy_to_json \

--- a/test_integration/test_frequency_hint_usage.py
+++ b/test_integration/test_frequency_hint_usage.py
@@ -181,10 +181,13 @@ class TestIntegration_frequency_hint_usage(unittest.TestCase):
         host_name = report.host_names()[0]
 
         region = report.raw_region(host_name, 'compute_region')
+        assigned_freq = report.get_field(region, 'frequency-map')
         achieved_freq = report.get_field(region, 'frequency', 'Hz')
 
         # Fmap agent should assign policy default frequency for regions not
         # in the map.
+        self.assertEqual(self._freq_default, assigned_freq,
+                         msg='Expected assigned frequency to be max from policy since this region has the COMPUTE hint. ({} != {})'.format(self._freq_default, assigned_freq))
         util.assertNear(self, self._freq_default, achieved_freq,
                         msg='Expected achieved frequency to be near default from policy. ({} !~= {})'.format(self._freq_default, achieved_freq))
 

--- a/test_integration/test_template.py.in
+++ b/test_integration/test_template.py.in
@@ -47,6 +47,8 @@ import geopmpy.error
 
 from test_integration import util
 if util.do_launch():
+    # Note: this import may be moved outside of do_launch if needed to run
+    # commands on compute nodes such as geopm_test_launcher.geopmread
     from test_integration import geopm_test_launcher
     geopmpy.error.exc_clear()
 


### PR DESCRIPTION
- Uncore can not be set to fixed frequency through the policy.
- NAN is not allowed for mapped regions.
- Removed consideration of hints.
- Fixed up integration test.
- Resolves #1052.
- Fixes #1009.

Change-Id: Ia09fe225d939cce5c3ae6c9ccf42d6e2b96dac2c
Signed-off-by: Diana Guttman <diana.r.guttman@intel.com>
Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
