### PR TITLE
Add checks for invalid agent or policy in PolicyStore

### DIFF
--- a/scripts/test/TestPolicyStoreIntegration.py
+++ b/scripts/test/TestPolicyStoreIntegration.py
@@ -45,6 +45,16 @@ class TestPolicyStoreIntegration(unittest.TestCase):
 
         geopmpy.policy_store.set_best('frequency_map', 'p1', [0.5, 1])
         geopmpy.policy_store.set_default('frequency_map', [2, 4])
+
+        with self.assertRaises(RuntimeError):
+            geopmpy.policy_store.set_default('invalid_agent', [])
+        with self.assertRaises(RuntimeError):
+            geopmpy.policy_store.set_default('monitor', [0.5])
+        with self.assertRaises(RuntimeError):
+            geopmpy.policy_store.set_best('invalid_agent', 'pinv', [])
+        with self.assertRaises(RuntimeError):
+            geopmpy.policy_store.set_best('monitor', 'pinv', [0.5])
+
         self.assertEqual([0.5, 1], geopmpy.policy_store.get_best('frequency_map', 'p1'))
         self.assertEqual([2, 4], geopmpy.policy_store.get_best('frequency_map', 'p2'))
         with self.assertRaises(RuntimeError):

--- a/src/PolicyStoreImp.cpp
+++ b/src/PolicyStoreImp.cpp
@@ -300,6 +300,13 @@ namespace geopm
                                   const std::string &profile_name,
                                   const std::vector<double> &policy)
     {
+        // check that the policy is valid for the agent
+        size_t num_policy = Agent::num_policy(agent_name);
+        if (policy.size() > num_policy) {
+            throw Exception("PolicyStoreImp::set_best(): invalid policy for " + agent_name + " agent.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
         begin_transaction_or_throw(m_database);
         {
             // Remove existing policy values for this record in case the new
@@ -338,6 +345,13 @@ namespace geopm
     void PolicyStoreImp::set_default(const std::string &agent_name,
                                      const std::vector<double> &policy)
     {
+        // check that the policy is valid for the agent
+        size_t num_policy = Agent::num_policy(agent_name);
+        if (policy.size() > num_policy) {
+            throw Exception("PolicyStoreImp::set_default(): invalid policy for " + agent_name + " agent.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
         begin_transaction_or_throw(m_database);
         {
             // Remove existing policy values for this record in case the new

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -403,8 +403,8 @@ if ENABLE_BETA
     GTEST_TESTS += test/gtest_links/DaemonTest.get_default_policy \
                    test/gtest_links/DaemonTest.get_profile_policy \
                    test/gtest_links/PolicyStoreImpTest.self_consistent \
-                   test/gtest_links/PolicyStoreImpTest.update_policy \
                    test/gtest_links/PolicyStoreImpTest.table_precedence \
+                   test/gtest_links/PolicyStoreImpTest.update_policy \
                    # end
 endif
 

--- a/test/PolicyStoreImpTest.cpp
+++ b/test/PolicyStoreImpTest.cpp
@@ -43,6 +43,7 @@
 #include "Exception.hpp"
 #include "MockAgent.hpp"
 #include "Helper.hpp"
+#include "geopm_test.hpp"
 
 class PolicyStoreImpTest : public ::testing::Test
 {
@@ -152,6 +153,14 @@ TEST_F(PolicyStoreImpTest, update_policy)
                                 policy_store.get_best("agent_with_policy", "trimend")));
     EXPECT_TRUE(PoliciesAreSame(policy1_trim_start,
                                 policy_store.get_best("agent_with_policy", "trimstart")));
+
+    // unknown agent is invalid
+    GEOPM_EXPECT_THROW_MESSAGE(policy_store.set_best("invalid_agent", "any", policy1),
+                               GEOPM_ERROR_INVALID, "\"invalid_agent\" has not been registered");
+
+    // wrong size policy for an agent is invalid
+    GEOPM_EXPECT_THROW_MESSAGE(policy_store.set_best("agent_without_policy", "any", policy1),
+                               GEOPM_ERROR_INVALID, "invalid policy for agent");
 }
 
 TEST_F(PolicyStoreImpTest, table_precedence)
@@ -191,4 +200,12 @@ TEST_F(PolicyStoreImpTest, table_precedence)
     policy_store.set_default("agent_with_policy", {});
     EXPECT_THROW(policy_store.get_best("agent_with_policy", "unoptimizedprofile"),
                  geopm::Exception);
+
+    // unknown agent is invalid
+    GEOPM_EXPECT_THROW_MESSAGE(policy_store.set_default("invalid_agent", {}),
+                               GEOPM_ERROR_INVALID, "\"invalid_agent\" has not been registered");
+
+    // wrong size policy for an agent is invalid
+    GEOPM_EXPECT_THROW_MESSAGE(policy_store.set_default("agent_without_policy", {123}),
+                               GEOPM_ERROR_INVALID, "invalid policy for agent");
 }


### PR DESCRIPTION
- Fixes #775
- Fixes #985
