### PR TITLE
Fix energy accounting for application totals in report

### DIFF
--- a/src/ApplicationIO.cpp
+++ b/src/ApplicationIO.cpp
@@ -76,9 +76,8 @@ namespace geopm
         , m_is_connected(false)
         , m_rank_per_node(-1)
         , m_epoch_regulator(std::move(epoch_regulator))
-        , m_start_energy_pkg(NAN)
-        , m_start_energy_dram(NAN)
     {
+
     }
 
     ApplicationIOImp::~ApplicationIOImp()
@@ -100,9 +99,6 @@ namespace geopm
                 platform_io().register_iogroup(geopm::make_unique<ProfileIOGroup>(m_profile_io_sample, *m_epoch_regulator));
             }
             m_is_connected = true;
-
-            m_start_energy_pkg = current_energy_pkg();
-            m_start_energy_dram = current_energy_dram();
         }
     }
 
@@ -245,62 +241,6 @@ namespace geopm
         }
 #endif
         return m_epoch_regulator->total_epoch_energy_dram();
-    }
-
-    double ApplicationIOImp::total_app_runtime(void) const
-    {
-#ifdef GEOPM_DEBUG
-        if (!m_is_connected) {
-            throw Exception("ApplicationIOImp::" + std::string(__func__) +
-                            " called before connect().",
-                            GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
-        }
-#endif
-        return m_profile_io_sample->total_app_runtime();
-    }
-
-    double ApplicationIOImp::current_energy_pkg(void) const
-    {
-        double energy = 0.0;
-        int num_package = m_platform_topo.num_domain(GEOPM_DOMAIN_PACKAGE);
-        for (int pkg = 0; pkg < num_package; ++pkg) {
-            energy += m_platform_io.read_signal("ENERGY_PACKAGE", GEOPM_DOMAIN_PACKAGE, pkg);
-        }
-        return energy;
-   }
-
-    double ApplicationIOImp::current_energy_dram(void) const
-    {
-        double energy = 0.0;
-        int num_dram = m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_MEMORY);
-        for (int dram = 0; dram < num_dram; ++dram) {
-            energy += m_platform_io.read_signal("ENERGY_DRAM", GEOPM_DOMAIN_BOARD_MEMORY, dram);
-        }
-        return energy;
-    }
-
-    double ApplicationIOImp::total_app_energy_pkg(void) const
-    {
-#ifdef GEOPM_DEBUG
-        if (!m_is_connected) {
-            throw Exception("ApplicationIOImp::" + std::string(__func__) +
-                            " called before connect().",
-                            GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
-        }
-#endif
-        return current_energy_pkg() - m_start_energy_pkg;
-    }
-
-    double ApplicationIOImp::total_app_energy_dram(void) const
-    {
-#ifdef GEOPM_DEBUG
-        if (!m_is_connected) {
-            throw Exception("ApplicationIOImp::" + std::string(__func__) +
-                            " called before connect().",
-                            GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
-        }
-#endif
-        return current_energy_dram() - m_start_energy_dram;
     }
 
     double ApplicationIOImp::total_app_runtime_mpi(void) const

--- a/src/ApplicationIO.cpp
+++ b/src/ApplicationIO.cpp
@@ -94,7 +94,6 @@ namespace geopm
             std::vector<int> cpu_rank = m_sampler->cpu_rank();
             if (m_profile_io_sample == nullptr) {
                 m_epoch_regulator = geopm::make_unique<EpochRuntimeRegulatorImp>(m_rank_per_node, m_platform_io, m_platform_topo);
-                m_epoch_regulator->init_unmarked_region();
                 m_profile_io_sample = std::make_shared<ProfileIOSampleImp>(cpu_rank, *m_epoch_regulator);
                 platform_io().register_iogroup(geopm::make_unique<ProfileIOGroup>(m_profile_io_sample, *m_epoch_regulator));
             }
@@ -104,6 +103,7 @@ namespace geopm
 
     void ApplicationIOImp::controller_ready(void)
     {
+        m_epoch_regulator->init_unmarked_region();
         m_sampler->controller_ready();
     }
 

--- a/src/ApplicationIO.hpp
+++ b/src/ApplicationIO.hpp
@@ -73,12 +73,6 @@ namespace geopm
             ///        region.
             /// @param [in] region_id The region ID.
             virtual double total_region_runtime_mpi(uint64_t region_id) const = 0;
-            /// @brief Returns the total application runtime.
-            virtual double total_app_runtime(void) const = 0;
-            /// @brief Returns the total application package energy.
-            virtual double total_app_energy_pkg(void) const = 0;
-            /// @brief Returns the total application dram energy.
-            virtual double total_app_energy_dram(void) const = 0;
             /// @brief Returns the total time spent in MPI for the
             ///        application.
             virtual double total_app_runtime_mpi(void) const = 0;
@@ -150,9 +144,6 @@ namespace geopm
             std::set<std::string> region_name_set(void) const override;
             double total_region_runtime(uint64_t region_id) const override;
             double total_region_runtime_mpi(uint64_t region_id) const override;
-            double total_app_runtime(void) const override;
-            double total_app_energy_pkg(void) const override;
-            double total_app_energy_dram(void) const override;
             double total_app_runtime_mpi(void) const override;
             double total_app_runtime_ignore(void) const override;
             int total_epoch_count(void) const override;
@@ -170,9 +161,6 @@ namespace geopm
         private:
             static constexpr size_t M_SHMEM_REGION_SIZE = 2*1024*1024;
 
-            double current_energy_pkg(void) const;
-            double current_energy_dram(void) const;
-
             std::unique_ptr<ProfileSampler> m_sampler;
             std::shared_ptr<ProfileIOSample> m_profile_io_sample;
             std::vector<std::pair<uint64_t, struct geopm_prof_message_s> > m_prof_sample;
@@ -186,8 +174,6 @@ namespace geopm
             bool m_is_connected;
             int m_rank_per_node;
             std::unique_ptr<EpochRuntimeRegulator> m_epoch_regulator;
-            double m_start_energy_pkg;
-            double m_start_energy_dram;
     };
 }
 

--- a/src/ProfileIOSample.cpp
+++ b/src/ProfileIOSample.cpp
@@ -54,13 +54,6 @@ namespace geopm
         , m_thread_progress(cpu_rank.size(), NAN)
         , m_profile_tracer(geopm::make_unique<ProfileTracerImp>())
     {
-        // This object is created when app connects
-        geopm_time(&m_app_start_time);
-
-        // Ths following is necessary because all other usages of "time zero" query the TimeIOGroup.
-        double elapsed = platform_io().read_signal("TIME", GEOPM_DOMAIN_BOARD, 0);
-        geopm_time_add(&m_app_start_time, elapsed * -1, &m_app_start_time);
-
         m_rank_idx_map = rank_to_node_local_rank(cpu_rank);
         m_cpu_rank = rank_to_node_local_rank_per_cpu(cpu_rank);
         m_num_rank = m_rank_idx_map.size();
@@ -294,11 +287,6 @@ namespace geopm
             ++cpu_idx;
         }
         return result;
-    }
-
-    double ProfileIOSampleImp::total_app_runtime(void) const
-    {
-        return geopm_time_since(&m_app_start_time);
     }
 
     std::vector<int> ProfileIOSampleImp::cpu_rank(void) const

--- a/src/ProfileIOSample.hpp
+++ b/src/ProfileIOSample.hpp
@@ -73,9 +73,6 @@ namespace geopm
             /// @brief Return the count of the given region
             ///        for the rank running on each CPU.
             virtual std::vector<int64_t> per_cpu_count() const = 0;
-            /// @brief Return the total time from the start of the
-            ///        application until now.
-            virtual double total_app_runtime(void) const = 0;
             /// @brief Returns the local-node rank running on each CPU.
             virtual std::vector<int> cpu_rank(void) const = 0;
     };
@@ -98,7 +95,6 @@ namespace geopm
             std::vector<double> per_cpu_thread_progress(void) const override;
             std::vector<double> per_cpu_runtime(uint64_t region_id) const override;
             std::vector<int64_t> per_cpu_count() const override;
-            double total_app_runtime(void) const override;
             std::vector<int> cpu_rank(void) const override;
         private:
             /// @brief Provide a mapping from global MPI to rank
@@ -124,7 +120,6 @@ namespace geopm
             };
             std::vector<double> per_rank_progress(const struct geopm_time_s &extrapolation_time) const;
 
-            struct geopm_time_s m_app_start_time;
             /// @brief A map from the MPI rank reported in the
             ///        ProfileSampler data to the node local rank
             ///        index.

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -43,6 +43,7 @@
 #include <iostream>
 #include <iomanip>
 #include <limits.h>
+#include <math.h>
 
 #include "PlatformIO.hpp"
 #include "PlatformTopo.hpp"
@@ -100,6 +101,11 @@ namespace geopm
         , m_env_signals(env_signals)
         , m_policy_path(policy_path)
         , m_do_endpoint(do_endpoint)
+        , m_app_energy_pkg_idx(-1)
+        , m_app_energy_dram_idx(-1)
+        , m_app_time_signal_idx(-1)
+        , m_start_energy_pkg(NAN)
+        , m_start_energy_dram(NAN)
     {
 
     }
@@ -111,6 +117,10 @@ namespace geopm
         m_energy_dram_idx = m_region_agg->push_signal_total("ENERGY_DRAM", GEOPM_DOMAIN_BOARD, 0);
         m_clk_core_idx = m_region_agg->push_signal_total("CYCLES_THREAD", GEOPM_DOMAIN_BOARD, 0);
         m_clk_ref_idx = m_region_agg->push_signal_total("CYCLES_REFERENCE", GEOPM_DOMAIN_BOARD, 0);
+        m_app_time_signal_idx = m_platform_io.push_signal("TIME", GEOPM_DOMAIN_BOARD, 0);
+        m_app_energy_pkg_idx = m_platform_io.push_signal("ENERGY_PACKAGE", GEOPM_DOMAIN_BOARD, 0);
+        m_app_energy_dram_idx = m_platform_io.push_signal("ENERGY_DRAM", GEOPM_DOMAIN_BOARD, 0);
+
         for (const std::string &signal_name : string_split(m_env_signals, ",")) {
             std::vector<std::string> signal_name_domain = string_split(signal_name, "@");
             if (signal_name_domain.size() == 2) {
@@ -147,6 +157,11 @@ namespace geopm
 
     void ReporterImp::update()
     {
+        if (isnan(m_start_energy_pkg) && isnan(m_start_energy_dram)) {
+            m_start_energy_pkg = m_platform_io.sample(m_app_energy_pkg_idx);
+            m_start_energy_dram = m_platform_io.sample(m_app_energy_dram_idx);
+        }
+
         m_region_agg->read_batch();
     }
 
@@ -288,13 +303,14 @@ namespace geopm
         // extra runtimes for epoch region
         report << "    epoch-runtime-ignore (sec): " << application_io.total_epoch_runtime_ignore() << std::endl;
 
-        double total_runtime = application_io.total_app_runtime();
-        double app_energy_pkg = application_io.total_app_energy_pkg();
+        double total_runtime = m_platform_io.sample(m_app_time_signal_idx);
+        double app_energy_pkg = m_platform_io.sample(m_app_energy_pkg_idx) - m_start_energy_pkg;
         double avg_power = total_runtime == 0 ? 0 : app_energy_pkg / total_runtime;
+        double app_energy_dram = m_platform_io.sample(m_app_energy_dram_idx) - m_start_energy_dram;
         report << "Application Totals:" << std::endl
                << "    runtime (sec): " << total_runtime << std::endl
                << "    package-energy (joules): " << app_energy_pkg << std::endl
-               << "    dram-energy (joules): " << application_io.total_app_energy_dram() << std::endl
+               << "    dram-energy (joules): " << app_energy_dram << std::endl
                << "    power (watts): " << avg_power << std::endl
                << "    network-time (sec): " << application_io.total_app_runtime_mpi() << std::endl
                << "    ignore-time (sec): " << application_io.total_app_runtime_ignore() << std::endl;

--- a/src/Reporter.hpp
+++ b/src/Reporter.hpp
@@ -149,6 +149,7 @@ namespace geopm
             int m_app_time_signal_idx;
             double m_start_energy_pkg;
             double m_start_energy_dram;
+            double m_start_time_signal;
     };
 }
 

--- a/src/Reporter.hpp
+++ b/src/Reporter.hpp
@@ -144,6 +144,11 @@ namespace geopm
             const std::string m_env_signals;
             const std::string m_policy_path;
             bool m_do_endpoint;
+            int m_app_energy_pkg_idx;
+            int m_app_energy_dram_idx;
+            int m_app_time_signal_idx;
+            double m_start_energy_pkg;
+            double m_start_energy_dram;
     };
 }
 

--- a/test/ApplicationIOTest.cpp
+++ b/test/ApplicationIOTest.cpp
@@ -66,8 +66,6 @@ class ApplicationIOTest : public ::testing::Test
         MockPlatformIO m_platform_io;
         MockPlatformTopo m_platform_topo;
         std::unique_ptr<ApplicationIO> m_app_io;
-        int m_energy_pkg_idx;
-        int m_energy_dram_idx;
 };
 
 void ApplicationIOTest::SetUp()
@@ -78,9 +76,6 @@ void ApplicationIOTest::SetUp()
     auto tmp_pio = std::shared_ptr<MockProfileIOSample>(m_pio_sample);
     m_epoch_regulator = new MockEpochRuntimeRegulator;
     auto tmp_reg = std::unique_ptr<MockEpochRuntimeRegulator>(m_epoch_regulator);
-
-    m_energy_pkg_idx = 18;
-    m_energy_dram_idx = 19;
 
     EXPECT_CALL(*m_sampler, initialize());
     EXPECT_CALL(*m_sampler, rank_per_node());

--- a/test/FrequencyMapAgentTest.cpp
+++ b/test/FrequencyMapAgentTest.cpp
@@ -292,7 +292,7 @@ TEST_F(FrequencyMapAgentTest, split_policy)
     policy[DEFAULT] = m_freq_max;
     tree_agent->split_policy(policy, out_policy);
     EXPECT_TRUE(tree_agent->do_send_policy());
-    ASSERT_EQ(num_children, out_policy.size());
+    ASSERT_EQ((size_t)num_children, out_policy.size());
     EXPECT_EQ(m_freq_max, out_policy[0][DEFAULT]);
     EXPECT_EQ(m_freq_max, out_policy[1][DEFAULT]);
 
@@ -304,7 +304,7 @@ TEST_F(FrequencyMapAgentTest, split_policy)
     policy[0] = m_freq_min;
     tree_agent->split_policy(policy, out_policy);
     EXPECT_TRUE(tree_agent->do_send_policy());
-    ASSERT_EQ(num_children, out_policy.size());
+    ASSERT_EQ((size_t)num_children, out_policy.size());
     EXPECT_EQ(m_freq_min, out_policy[0][DEFAULT]);
     EXPECT_EQ(m_freq_min, out_policy[1][DEFAULT]);
 
@@ -312,7 +312,7 @@ TEST_F(FrequencyMapAgentTest, split_policy)
     policy[1] = m_freq_max;
     tree_agent->split_policy(policy, out_policy);
     EXPECT_TRUE(tree_agent->do_send_policy());
-    ASSERT_EQ(num_children, out_policy.size());
+    ASSERT_EQ((size_t)num_children, out_policy.size());
     EXPECT_EQ(m_freq_min, out_policy[0][DEFAULT]);
     EXPECT_EQ(m_freq_min, out_policy[1][DEFAULT]);
     EXPECT_EQ(m_freq_max, out_policy[0][UNCORE]);

--- a/test/MockApplicationIO.hpp
+++ b/test/MockApplicationIO.hpp
@@ -54,12 +54,6 @@ class MockApplicationIO : public geopm::ApplicationIO
                            double(uint64_t region_id));
         MOCK_CONST_METHOD1(total_region_runtime_mpi,
                            double(uint64_t region_id));
-        MOCK_CONST_METHOD0(total_app_runtime,
-                           double(void));
-        MOCK_CONST_METHOD0(total_app_energy_pkg,
-                           double(void));
-        MOCK_CONST_METHOD0(total_app_energy_dram,
-                           double(void));
         MOCK_CONST_METHOD0(total_epoch_runtime_ignore,
                            double(void));
         MOCK_CONST_METHOD0(total_app_runtime_mpi,

--- a/test/ReporterTest.cpp
+++ b/test/ReporterTest.cpp
@@ -29,6 +29,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 #include <sstream>
 #include <fstream>
@@ -48,7 +49,6 @@
 #include "geopm.h"
 #include "geopm_internal.h"
 #include "geopm_hash.h"
-#include "config.h"
 
 using geopm::Reporter;
 using geopm::ReporterImp;
@@ -213,15 +213,16 @@ TEST_F(ReporterTest, generate)
     EXPECT_CALL(m_application_io, total_app_runtime_ignore()).WillOnce(Return(0.7));
     EXPECT_CALL(m_application_io, total_epoch_runtime_ignore()).WillRepeatedly(Return(0.7));
     EXPECT_CALL(m_application_io, total_epoch_runtime()).WillOnce(Return(70.0));
-    EXPECT_CALL(m_platform_io, sample(M_TIME_IDX))
-        .WillOnce(Return(56));
     EXPECT_CALL(*m_agg, read_batch);
+    EXPECT_CALL(m_platform_io, sample(M_TIME_IDX))
+        .WillOnce(Return(1))
+        .WillOnce(Return(57));
     EXPECT_CALL(m_platform_io, sample(M_ENERGY_PKG_IDX))
-        .WillOnce(Return(2222))
-        .WillOnce(Return(4444));
+        .WillOnce(Return(2223))
+        .WillOnce(Return(4445));
     EXPECT_CALL(m_platform_io, sample(M_ENERGY_DRAM_IDX))
-        .WillOnce(Return(1111))
-        .WillOnce(Return(2222));
+        .WillOnce(Return(1112))
+        .WillOnce(Return(2223));
     EXPECT_CALL(m_platform_io, read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0))
         .Times(4)
         .WillRepeatedly(Return(1.0));


### PR DESCRIPTION
- Fixes #1093 from github issues
- The ApplicationIO class must use the PlatformIO sample()
  API not read_signal() in order to properly deal with rollover
  of the energy counters issues in energy counters.