### PR TITLE
Add optional keys to MSR field JSON schema

### DIFF
--- a/src/Agg.cpp
+++ b/src/Agg.cpp
@@ -30,17 +30,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "config.h"
+
 #include "Agg.hpp"
 
 #include <cmath>
 
 #include <algorithm>
 #include <numeric>
+#include <map>
 
 #include "geopm_internal.h"
 #include "geopm_hash.h"
-
-#include "config.h"
+#include "Exception.hpp"
 
 namespace geopm
 {
@@ -181,5 +183,30 @@ namespace geopm
             }
         }
         return value;
+    }
+
+    std::function<double(const std::vector<double> &)> Agg::name_to_function(const std::string &name)
+    {
+        std::map<std::string, std::function<double(const std::vector<double> &)> > name_map = {
+            {"sum", sum},
+            {"average", average},
+            {"median", median},
+            {"logical_and", logical_and},
+            {"logical_or", logical_or},
+            {"region_hash", region_hash},
+            {"region_hint", region_hint},
+            {"min", min},
+            {"max", max},
+            {"stddev", stddev},
+            {"select_first", select_first},
+            {"expect_same", expect_same},
+        };
+
+        auto result = name_map.find(name);
+        if (result == name_map.end()) {
+            throw Exception("Agg::name_to_function(): unknown aggregation function: " + name,
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return result->second;
     }
 }

--- a/src/Agg.hpp
+++ b/src/Agg.hpp
@@ -34,6 +34,7 @@
 #define AGG_HPP_INCLUDE
 
 #include <vector>
+#include <functional>
 
 namespace geopm
 {
@@ -88,6 +89,10 @@ namespace geopm
             ///        to aggregate values that may be interpreted as NAN
             ///        such as raw register values.
             static double expect_same(const std::vector<double> &operand);
+            /// @brief Returns the corresponding agg function for a
+            ///        given string name.  If the name does not match
+            ///        a known function, it throws an error.
+            static std::function<double(const std::vector<double> &)> name_to_function(const std::string &name);
     };
 }
 

--- a/src/MSRIOGroup.cpp
+++ b/src/MSRIOGroup.cpp
@@ -110,21 +110,6 @@ namespace geopm
             parse_json_msrs(data);
         }
 
-        // Set up aggregation functions for MSRs.
-        // Aliases will lookup and use the agg_function for their underlying MSR.
-        set_agg_function("MSR::PERF_STATUS:FREQ", Agg::average);
-        set_agg_function("MSR::PKG_ENERGY_STATUS:ENERGY", Agg::sum);
-        set_agg_function("MSR::DRAM_ENERGY_STATUS:ENERGY", Agg::sum);
-        set_agg_function("MSR::FIXED_CTR0:INST_RETIRED_ANY", Agg::sum);
-        set_agg_function("MSR::FIXED_CTR1:CPU_CLK_UNHALTED_THREAD", Agg::sum);
-        set_agg_function("MSR::FIXED_CTR2:CPU_CLK_UNHALTED_REF_TSC", Agg::sum);
-        set_agg_function("MSR::PKG_POWER_INFO:MIN_POWER", Agg::sum);
-        set_agg_function("MSR::PKG_POWER_INFO:MAX_POWER", Agg::sum);
-        set_agg_function("MSR::PKG_POWER_INFO:THERMAL_SPEC_POWER", Agg::sum);
-        set_agg_function("MSR::THERM_STATUS:DIGITAL_READOUT", Agg::average);
-        set_agg_function("MSR::PACKAGE_THERM_STATUS:DIGITAL_READOUT", Agg::average);
-        set_agg_function("MSR::TEMPERATURE_TARGET:PROCHOT_MIN", Agg::expect_same);
-
         set_signal_description("MSR::PKG_POWER_INFO:THERMAL_SPEC_POWER",
                                "Maximum power to stay within thermal limits (TDP)");
 
@@ -171,15 +156,6 @@ namespace geopm
         register_control_alias("POWER_PACKAGE_LIMIT", "MSR::PKG_POWER_LIMIT:PL1_POWER_LIMIT");
         register_control_alias("FREQUENCY", "MSR::PERF_CTL:FREQ");
         register_control_alias("POWER_PACKAGE_TIME_WINDOW", "MSR::PKG_POWER_LIMIT:PL1_TIME_WINDOW");
-    }
-
-    void MSRIOGroup::set_agg_function(const std::string &name,
-                                      std::function<double(const std::vector<double> &)> agg_function)
-    {
-        auto it = m_signal_available.find(name);
-        if (it != m_signal_available.end()) {
-            it->second.agg_function = agg_function;
-        }
     }
 
     void MSRIOGroup::set_signal_description(const std::string &name,

--- a/src/MSRIOGroup.cpp
+++ b/src/MSRIOGroup.cpp
@@ -879,19 +879,22 @@ namespace geopm
         std::string message;
     };
 
-    void check_expected_key_values(const Json &root, std::map<std::string, json_checker> &key_check_map,
+    void check_expected_key_values(const Json &root,
+                                   const std::map<std::string, json_checker> &required_key_map,
+                                   const std::map<std::string, json_checker> &optional_key_map,
                                    const std::string &loc_message)
     {
         auto items = root.object_items();
         // check for extra keys
         for (const auto &obj : items) {
-            if (key_check_map.find(obj.first) == key_check_map.end()) {
+            if (required_key_map.find(obj.first) == required_key_map.end() &&
+                optional_key_map.find(obj.first) == optional_key_map.end()) {
                 throw Exception("MSRIOGroup::" + std::string(__func__) + "(): unexpected key \"" + obj.first + "\" found " + loc_message,
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
         }
         // check for required keys
-        for (const auto &key_check : key_check_map) {
+        for (const auto &key_check : required_key_map) {
             std::string key = key_check.first;
             json_checker key_param = key_check.second;
             if (items.find(key) == items.end()) {
@@ -902,6 +905,18 @@ namespace geopm
             if (obj.type() != key_param.json_type || !key_param.is_valid(obj)) {
                 throw Exception("MSRIOGroup::" + std::string(__func__) + "(): \"" + key + "\" " + key_param.message + " " + loc_message,
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+        }
+        // check optional keys
+        for (const auto &key_check : optional_key_map) {
+            std::string key = key_check.first;
+            json_checker key_param = key_check.second;
+            if (items.find(key) != items.end()) {
+                Json obj = root[key];
+                if (obj.type() != key_param.json_type || !key_param.is_valid(obj)) {
+                    throw Exception("MSRIOGroup::" + std::string(__func__) + "(): \"" + key + "\" " + key_param.message + " " + loc_message,
+                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                }
             }
         }
     }
@@ -937,12 +952,23 @@ namespace geopm
         return ((double)((int)(num.number_value())) == num.number_value());
     };
 
+    bool MSRIOGroup::json_check_is_valid_aggregation(const Json &obj)
+    {
+        try {
+            Agg::name_to_function(obj.string_value());
+        }
+        catch (const Exception &ex) {
+            return false;
+        }
+        return true;
+    };
+
     void MSRIOGroup::check_top_level(const Json &root)
     {
         std::map<std::string, json_checker> top_level_keys = {
             {"msrs", {Json::OBJECT, json_check_null_func, "must be an object"}}
         };
-        check_expected_key_values(root, top_level_keys, "at top level");
+        check_expected_key_values(root, top_level_keys, {}, "at top level");
     }
 
     void MSRIOGroup::check_msr_root(const Json &msr_root, const std::string &msr_name)
@@ -957,7 +983,7 @@ namespace geopm
                 {"domain", {Json::STRING, json_check_is_valid_domain, "must be a valid domain string"}},
                 {"fields", {Json::OBJECT, json_check_null_func, "must be an object"}}
         };
-        check_expected_key_values(msr_root, msr_keys, "in msr \"" + msr_name + "\"");
+        check_expected_key_values(msr_root, msr_keys, {}, "in msr \"" + msr_name + "\"");
     }
 
     void MSRIOGroup::check_msr_field(const Json &msr_field,
@@ -978,7 +1004,12 @@ namespace geopm
             {"scalar", {Json::NUMBER, json_check_null_func, "must be a number"}},
             {"writeable", {Json::BOOL, json_check_null_func, "must be a bool"}}
         };
-        check_expected_key_values(msr_field, field_checker, "in \"" + msr_name + ":" + field_name + "\"");
+        std::map<std::string, json_checker> optional_field_checker {
+            {"aggregation", {Json::STRING, json_check_is_valid_aggregation, "must be a valid aggregation function name"}},
+            {"description", {Json::STRING, json_check_null_func, "must be a string"}}
+        };
+        check_expected_key_values(msr_field, field_checker, optional_field_checker,
+                                  "in \"" + msr_name + ":" + field_name + "\"");
     }
 
     void MSRIOGroup::add_raw_msr_signal(const std::string &msr_name, int domain_type,
@@ -1015,7 +1046,9 @@ namespace geopm
                                           const std::string &msr_field_name,
                                           int domain_type,
                                           int begin_bit, int end_bit,
-                                          int function, double scalar, int units)
+                                          int function, double scalar, int units,
+                                          const std::string &agg_function,
+                                          const std::string &description)
     {
         std::string raw_msr_signal_name = M_NAME_PREFIX + msr_name + "#";
         int num_domain = m_platform_topo.num_domain(domain_type);
@@ -1031,8 +1064,8 @@ namespace geopm
             .signals = result_field_signal,
             .domain = domain_type,
             .units = units,
-            .agg_function = Agg::select_first,
-            .description = M_DEFAULT_DESCRIPTION
+            .agg_function = Agg::name_to_function(agg_function),
+            .description = description,
         };
     }
 
@@ -1040,7 +1073,8 @@ namespace geopm
                                            int domain_type,
                                            uint64_t msr_offset,
                                            int begin_bit, int end_bit,
-                                           int function, double scalar, int units)
+                                           int function, double scalar, int units,
+                                           const std::string &description)
     {
         int num_domain = m_platform_topo.num_domain(domain_type);
         std::vector<std::shared_ptr<Control> > result_field_control;
@@ -1060,7 +1094,7 @@ namespace geopm
             .controls = result_field_control,
             .domain = domain_type,
             .units = units,
-            .description = M_DEFAULT_DESCRIPTION,
+            .description = description,
         };
     }
 
@@ -1106,12 +1140,23 @@ namespace geopm
                 double scalar = field_data["scalar"].number_value();
                 int units = MSR::string_to_units(field_data["units"].string_value());
                 bool is_control = field_data["writeable"].bool_value();
+                // optional fields
+                std::string agg_function = "select_first";
+                std::string description = M_DEFAULT_DESCRIPTION;
+                if (field_data.find("aggregation") != field_data.end()) {
+                    agg_function = field_data["aggregation"].string_value();
+                }
+                if (field_data.find("description") != field_data.end()) {
+                    description = field_data["description"].string_value();
+                }
 
                 add_msr_field_signal(msr_name, sig_ctl_name, domain_type,
-                                     begin_bit, end_bit, function, scalar, units);
+                                     begin_bit, end_bit, function, scalar, units,
+                                     agg_function, description);
                 if (is_control) {
                     add_msr_field_control(sig_ctl_name, domain_type, msr_offset,
-                                          begin_bit, end_bit, function, scalar, units);
+                                          begin_bit, end_bit, function, scalar, units,
+                                          description);
                 }
             }
         }

--- a/src/MSRIOGroup.hpp
+++ b/src/MSRIOGroup.hpp
@@ -174,6 +174,7 @@ namespace geopm
             static bool json_check_is_valid_offset(const json11::Json &obj);
             static bool json_check_is_valid_domain(const json11::Json &domain);
             static bool json_check_is_integer(const json11::Json &num);
+            static bool json_check_is_valid_aggregation(const json11::Json &obj);
             // Add raw MSR as an available signal
             void add_raw_msr_signal(const std::string &msr_name, int domain_type,
                                     uint64_t msr_offset);
@@ -182,13 +183,16 @@ namespace geopm
                                       const std::string &msr_field_name,
                                       int domain_type,
                                       int begin_bit, int end_bit,
-                                      int function, double scalar, int units);
+                                      int function, double scalar, int units,
+                                      const std::string &aggregation,
+                                      const std::string &description);
             // Add a bitfield of an MSR as an available control
             void add_msr_field_control(const std::string &msr_field_name,
                                        int domain_type,
                                        uint64_t msr_offset,
                                        int begin_bit, int end_bit,
-                                       int function, double scalar, int units);
+                                       int function, double scalar, int units,
+                                       const std::string &description);
 
             static const std::string M_DEFAULT_DESCRIPTION;
             static const std::string M_PLUGIN_NAME;

--- a/src/MSRIOGroup.hpp
+++ b/src/MSRIOGroup.hpp
@@ -132,11 +132,6 @@ namespace geopm
             /// @brief Returns the filenames for user-defined MSRs if
             ///        found in the plugin path.
             static std::set<std::string> msr_data_files(void);
-            /// @brief Override the default aggregation function for a
-            ///        signal.  If signal is not available, does
-            ///        nothing.
-            void set_agg_function(const std::string &name,
-                                  std::function<double(const std::vector<double> &)> agg_function);
             /// @brief Override the default description for a signal.
             ///        If signal is not available, does nothing.
             void set_signal_description(const std::string &name,

--- a/src/msr_data_arch.cpp
+++ b/src/msr_data_arch.cpp
@@ -187,7 +187,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "celsius",
                     "scalar":    1.0,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "average"
                 },
                 "RESOLUTION": {
                     "begin_bit": 27,
@@ -335,7 +336,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "celsius",
                     "scalar":    1.0,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "average"
                 }
             }
         },
@@ -349,7 +351,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "none",
                     "scalar":    1.0,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },
@@ -363,7 +366,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "none",
                     "scalar":    1.0,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },
@@ -377,7 +381,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "none",
                     "scalar":    1.0,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },

--- a/src/msr_data_hsx.cpp
+++ b/src/msr_data_hsx.cpp
@@ -95,7 +95,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "hertz",
                     "scalar":    1e8,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "average"
                 }
             }
         },
@@ -123,7 +124,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "celsius",
                     "scalar":    1.0,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "expect_same"
                 },
                 "TCC_ACTIVE_OFFSET": {
                     "begin_bit": 24,
@@ -423,7 +425,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "joules",
                     "scalar":    6.103515625e-05,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },
@@ -437,7 +440,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MIN_POWER": {
                     "begin_bit": 16,
@@ -445,7 +449,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MAX_POWER": {
                     "begin_bit": 32,
@@ -453,7 +458,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MAX_TIME_WINDOW": {
                     "begin_bit": 48,
@@ -513,7 +519,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "joules",
                     "scalar":    1.5258789063e-05,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },

--- a/src/msr_data_knl.cpp
+++ b/src/msr_data_knl.cpp
@@ -87,7 +87,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "hertz",
                     "scalar":    1e8,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "average"
                 }
             }
         },
@@ -115,7 +116,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "celsius",
                     "scalar":    1.0,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "expect_same"
                 },
                 "TCC_ACTIVE_OFFSET": {
                     "begin_bit": 24,
@@ -363,7 +365,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "joules",
                     "scalar":    6.103515625e-05,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },
@@ -377,7 +380,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MIN_POWER": {
                     "begin_bit": 16,
@@ -385,7 +389,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MAX_POWER": {
                     "begin_bit": 32,
@@ -393,7 +398,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MAX_TIME_WINDOW": {
                     "begin_bit": 48,
@@ -445,7 +451,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "joules",
                     "scalar":    1.5258789063e-05,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },

--- a/src/msr_data_skx.cpp
+++ b/src/msr_data_skx.cpp
@@ -95,7 +95,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "hertz",
                     "scalar":    1e8,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "average"
                 }
             }
         },
@@ -123,7 +124,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "celsius",
                     "scalar":    1.0,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "expect_same"
                 },
                 "TCC_ACTIVE_OFFSET": {
                     "begin_bit": 24,
@@ -393,7 +395,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "joules",
                     "scalar":    6.103515625e-05,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },
@@ -407,7 +410,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MIN_POWER": {
                     "begin_bit": 16,
@@ -415,7 +419,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MAX_POWER": {
                     "begin_bit": 32,
@@ -423,7 +428,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MAX_TIME_WINDOW": {
                     "begin_bit": 48,
@@ -483,7 +489,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "joules",
                     "scalar":    1.5258789063e-05,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },

--- a/src/msr_data_snb.cpp
+++ b/src/msr_data_snb.cpp
@@ -95,7 +95,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "hertz",
                     "scalar":    1e8,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "average"
                 }
             }
         },
@@ -123,7 +124,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "celsius",
                     "scalar":    1.0,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "expect_same"
                 }
             }
         },
@@ -315,7 +317,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "joules",
                     "scalar":    1.5258789063e-5,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },
@@ -329,7 +332,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MIN_POWER": {
                     "begin_bit": 16,
@@ -337,7 +341,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MAX_POWER": {
                     "begin_bit": 32,
@@ -345,7 +350,8 @@ namespace geopm
                     "function":  "scale",
                     "units":     "watts",
                     "scalar":    1.25e-1,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 },
                 "MAX_TIME_WINDOW": {
                     "begin_bit": 48,
@@ -405,7 +411,8 @@ namespace geopm
                     "function":  "overflow",
                     "units":     "joules",
                     "scalar":    1.5258789063e-05,
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },

--- a/test/AggTest.cpp
+++ b/test/AggTest.cpp
@@ -36,6 +36,7 @@
 #include "geopm.h"
 #include "geopm_internal.h"
 #include "geopm_hash.h"
+#include "geopm_test.hpp"
 
 using geopm::Agg;
 
@@ -84,4 +85,23 @@ TEST(AggTest, agg_function)
 
     EXPECT_EQ(5,
               Agg::region_hint({5, 5, 5}));
+}
+
+TEST(AggTest, function_strings)
+{
+    EXPECT_TRUE(is_agg_sum(Agg::name_to_function("sum")));
+    EXPECT_TRUE(is_agg_average(Agg::name_to_function("average")));
+    EXPECT_TRUE(is_agg_median(Agg::name_to_function("median")));
+    EXPECT_TRUE(is_agg_logical_and(Agg::name_to_function("logical_and")));
+    EXPECT_TRUE(is_agg_logical_or(Agg::name_to_function("logical_or")));
+    EXPECT_TRUE(is_agg_region_hash(Agg::name_to_function("region_hash")));
+    EXPECT_TRUE(is_agg_region_hint(Agg::name_to_function("region_hint")));
+    EXPECT_TRUE(is_agg_min(Agg::name_to_function("min")));
+    EXPECT_TRUE(is_agg_max(Agg::name_to_function("max")));
+    EXPECT_TRUE(is_agg_stddev(Agg::name_to_function("stddev")));
+    EXPECT_TRUE(is_agg_select_first(Agg::name_to_function("select_first")));
+    EXPECT_TRUE(is_agg_expect_same(Agg::name_to_function("expect_same")));
+
+    GEOPM_EXPECT_THROW_MESSAGE(Agg::name_to_function("invalid"), GEOPM_ERROR_INVALID,
+                               "unknown aggregation function");
 }

--- a/test/MSRIOGroupTest.cpp
+++ b/test/MSRIOGroupTest.cpp
@@ -1207,6 +1207,18 @@ TEST_F(MSRIOGroupTest, parse_json_msrs_error_fields)
     GEOPM_EXPECT_THROW_MESSAGE(m_msrio_group->parse_json_msrs(Json(input).dump()),
                                GEOPM_ERROR_INVALID,
                                "\"writeable\" must be a bool in \"MSR_ONE:FIELD_RO\"");
+    fields = complete;
+    fields["aggregation"] = "invalid";
+    reset_input();
+    GEOPM_EXPECT_THROW_MESSAGE(m_msrio_group->parse_json_msrs(Json(input).dump()),
+                               GEOPM_ERROR_INVALID,
+                               "\"aggregation\" must be a valid aggregation function name in \"MSR_ONE:FIELD_RO\"");
+    fields = complete;
+    fields["description"] = 1.0;
+    reset_input();
+    GEOPM_EXPECT_THROW_MESSAGE(m_msrio_group->parse_json_msrs(Json(input).dump()),
+                               GEOPM_ERROR_INVALID,
+                               "\"description\" must be a string in \"MSR_ONE:FIELD_RO\"");
 }
 
 TEST_F(MSRIOGroupTest, parse_json_msrs)
@@ -1220,7 +1232,9 @@ TEST_F(MSRIOGroupTest, parse_json_msrs)
                        "function": "scale",
                        "units": "hertz",
                        "scalar": 2,
-                       "writeable": false
+                       "writeable": false,
+                       "aggregation": "average",
+                       "description": "a beautiful and clear description of a field"
                    }
                }
            },
@@ -1248,4 +1262,7 @@ TEST_F(MSRIOGroupTest, parse_json_msrs)
     for (const auto &name : expected_controls) {
         EXPECT_TRUE(controls.find(name) != controls.end()) << "Expected control " << name << " not found in IOGroup.";
     }
+    EXPECT_TRUE(is_agg_average(m_msrio_group->agg_function("MSR::MSR_ONE:FIELD_RO")));
+    EXPECT_EQ("a beautiful and clear description of a field",
+              m_msrio_group->signal_description("MSR::MSR_ONE:FIELD_RO"));
 }

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -53,6 +53,7 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/AgentFactoryTest.static_info_energy_efficient \
               test/gtest_links/AgentFactoryTest.static_info_frequency_map \
               test/gtest_links/AggTest.agg_function \
+              test/gtest_links/AggTest.function_strings \
               test/gtest_links/ApplicationSamplerTest.one_enter_exit \
               test/gtest_links/ApplicationSamplerTest.with_mpi \
               test/gtest_links/ApplicationSamplerTest.with_epoch \

--- a/test/geopm_test.hpp
+++ b/test/geopm_test.hpp
@@ -47,8 +47,14 @@ bool is_format_raw64(std::function<std::string(double)> func);
 
 bool is_agg_sum(std::function<double(const std::vector<double> &)> func);
 bool is_agg_average(std::function<double(const std::vector<double> &)> func);
+bool is_agg_median(std::function<double(const std::vector<double> &)> func);
+bool is_agg_logical_and(std::function<double(const std::vector<double> &)> func);
+bool is_agg_logical_or(std::function<double(const std::vector<double> &)> func);
+bool is_agg_region_hash(std::function<double(const std::vector<double> &)> func);
+bool is_agg_region_hint(std::function<double(const std::vector<double> &)> func);
 bool is_agg_min(std::function<double(const std::vector<double> &)> func);
 bool is_agg_max(std::function<double(const std::vector<double> &)> func);
+bool is_agg_stddev(std::function<double(const std::vector<double> &)> func);
 bool is_agg_select_first(std::function<double(const std::vector<double> &)> func);
 bool is_agg_expect_same(std::function<double(const std::vector<double> &)> func);
 

--- a/test/geopm_test_helper.cpp
+++ b/test/geopm_test_helper.cpp
@@ -32,6 +32,7 @@
 
 #include "geopm_test.hpp"
 
+#include "geopm.h"
 #include "geopm_hash.h"
 #include "Agg.hpp"
 
@@ -83,6 +84,38 @@ bool is_agg_average(std::function<double(const std::vector<double> &)> func)
     return func(example_data) == geopm::Agg::average(example_data);
 }
 
+bool is_agg_median(std::function<double(const std::vector<double> &)> func)
+{
+    return func(example_data) == geopm::Agg::median(example_data);
+}
+
+bool is_agg_logical_and(std::function<double(const std::vector<double> &)> func)
+{
+    return func({1, 1, 1}) == 1.0 &&
+           func({1, 0, 1}) == 0.0 &&
+           std::isnan(func({}));
+}
+
+bool is_agg_logical_or(std::function<double(const std::vector<double> &)> func)
+{
+    return func({1, 1, 1}) == 1.0 &&
+           func({1, 0, 1}) == 1.0 &&
+           func({0, 0, 0}) == 0.0 &&
+           std::isnan(func({}));
+}
+
+bool is_agg_region_hash(std::function<double(const std::vector<double> &)> func)
+{
+    return func({33, 44, 33}) == GEOPM_REGION_HASH_UNMARKED &&
+           func({44, 44, 44}) == 44;
+}
+
+bool is_agg_region_hint(std::function<double(const std::vector<double> &)> func)
+{
+    return func({1, 2, 3}) == GEOPM_REGION_HINT_UNKNOWN &&
+           func({2, 2, 2}) == 2;
+}
+
 bool is_agg_min(std::function<double(const std::vector<double> &)> func)
 {
     return func(example_data) == geopm::Agg::min(example_data);
@@ -93,6 +126,11 @@ bool is_agg_max(std::function<double(const std::vector<double> &)> func)
     return func(example_data) == geopm::Agg::max(example_data);
 }
 
+bool is_agg_stddev(std::function<double(const std::vector<double> &)> func)
+{
+    return func(example_data) == geopm::Agg::stddev(example_data);
+}
+
 bool is_agg_select_first(std::function<double(const std::vector<double> &)> func)
 {
     return func(example_data) == geopm::Agg::select_first(example_data);
@@ -100,6 +138,6 @@ bool is_agg_select_first(std::function<double(const std::vector<double> &)> func
 
 bool is_agg_expect_same(std::function<double(const std::vector<double> &)> func)
 {
-    double result = geopm::Agg::expect_same(example_data);
-    return !std::isnan(result) && func(example_data) == result;
+    return func({3.3, 3.3, 3.3}) == 3.3 &&
+           std::isnan(func({4.4, 4.4, 3.3, 4.4}));
 }


### PR DESCRIPTION
- Add "description" and "aggregation" as optional keys in the JSON MSR files.  If these keys are not present, the default will be used.
- Resolves #1058 

