### PR TITLE
Add base class and one implementation of a record filter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -554,8 +554,12 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/ProfileThreadTable.hpp \
                             src/ProfileTracer.cpp \
                             src/ProfileTracer.hpp \
+                            src/ProxyEpochRecordFilter.cpp \
+                            src/ProxyEpochRecordFilter.hpp \
                             src/RawMSRSignal.cpp \
                             src/RawMSRSignal.hpp \
+                            src/RecordFilter.cpp \
+                            src/RecordFilter.hpp \
                             src/RegionAggregator.cpp \
                             src/RegionAggregator.hpp \
                             src/RegionAggregatorImp.hpp \

--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -397,4 +397,10 @@ namespace geopm
     {
         return lookup("GEOPM_RECORD_FILTER");
     }
+
+    bool EnvironmentImp::do_record_filter(void) const
+    {
+        return is_set("GEOPM_RECORD_FILTER");
+    }
+
 }

--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -150,7 +150,8 @@ namespace geopm
                 "GEOPM_PROFILE",
                 "GEOPM_FREQUENCY_MAP",
                 "GEOPM_MAX_FAN_OUT",
-                "GEOPM_OMPT_DISABLE"};
+                "GEOPM_OMPT_DISABLE",
+                "GEOPM_RECORD_FILTER"};
     }
 
     void EnvironmentImp::parse_environment()
@@ -390,5 +391,10 @@ namespace geopm
     std::string EnvironmentImp::override_config_path(void) const
     {
         return m_override_config_path;
+    }
+
+    std::string EnvironmentImp::record_filter(void) const
+    {
+        return lookup("GEOPM_RECORD_FILTER");
     }
 }

--- a/src/Environment.hpp
+++ b/src/Environment.hpp
@@ -75,6 +75,7 @@ namespace geopm
             virtual std::string default_config_path(void) const = 0;
             virtual std::string override_config_path(void) const = 0;
             virtual std::string record_filter(void) const = 0;
+            virtual bool do_record_filter(void) const = 0;
             static std::map<std::string, std::string> parse_environment_file(const std::string &env_file_path);
     };
 
@@ -118,6 +119,7 @@ namespace geopm
                                                const std::set<std::string> &user_defined_names,
                                                std::map<std::string, std::string> &name_value_map);
             std::string record_filter(void) const override;
+            bool do_record_filter(void) const override;
         protected:
             void parse_environment(void);
             bool is_set(const std::string &env_var) const;

--- a/src/Environment.hpp
+++ b/src/Environment.hpp
@@ -74,6 +74,7 @@ namespace geopm
             virtual bool do_ompt(void) const = 0;
             virtual std::string default_config_path(void) const = 0;
             virtual std::string override_config_path(void) const = 0;
+            virtual std::string record_filter(void) const = 0;
             static std::map<std::string, std::string> parse_environment_file(const std::string &env_file_path);
     };
 
@@ -116,6 +117,7 @@ namespace geopm
                                                const std::set<std::string> &all_names,
                                                const std::set<std::string> &user_defined_names,
                                                std::map<std::string, std::string> &name_value_map);
+            std::string record_filter(void) const override;
         protected:
             void parse_environment(void);
             bool is_set(const std::string &env_var) const;

--- a/src/ProxyEpochRecordFilter.cpp
+++ b/src/ProxyEpochRecordFilter.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "ProxyEpochRecordFilter.hpp"
+#include "Exception.hpp"
+
+namespace geopm
+{
+    ProxyEpochRecordFilter::ProxyEpochRecordFilter(uint64_t region_hash,
+                                                   int calls_per_epoch,
+                                                   int startup_count)
+        : m_proxy_hash(region_hash)
+        , m_num_per_epoch(calls_per_epoch)
+        , m_count(-startup_count)
+    {
+        // Hash is a CRC32, so check that it is 32 bits
+        if (m_proxy_hash > UINT32_MAX) {
+            throw Exception("ProxyEpochRecordFilter(): Parameter region_hash is out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (calls_per_epoch <= 0) {
+            throw Exception("ProxyEpochRecordFilter(): Parameter calls_per_epoch must be greater than zero",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (startup_count < 0) {
+            throw Exception("ProxyEpochRecordFilter(): Parameter startup_count must be greater than or equal to zero",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+
+    std::vector<ApplicationSampler::m_record_s> ProxyEpochRecordFilter::filter(const ApplicationSampler::m_record_s &record)
+    {
+        std::vector<ApplicationSampler::m_record_s> result;
+        if (record.event != ApplicationSampler::M_EVENT_EPOCH_COUNT) {
+            result.push_back(record);
+            if (record.event == ApplicationSampler::M_EVENT_REGION_ENTRY &&
+                record.signal == m_proxy_hash) {
+                if (m_count >= 0 &&
+                    m_count % m_num_per_epoch == 0) {
+                    ApplicationSampler::m_record_s epoch_event = record;
+                    epoch_event.event = ApplicationSampler::M_EVENT_EPOCH_COUNT;
+                    epoch_event.signal = 1 + m_count / m_num_per_epoch;
+                    result.push_back(epoch_event);
+                }
+                ++m_count;
+            }
+        }
+        return result;
+    }
+}
+

--- a/src/ProxyEpochRecordFilter.hpp
+++ b/src/ProxyEpochRecordFilter.hpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PROXYEPOCHRECORDFILTER_HPP_INCLUDE
+#define PROXYEPOCHRECORDFILTER_HPP_INCLUDE
+
+#include "RecordFilter.hpp"
+
+namespace geopm
+{
+    /// @brief Filter that can be used in place of the
+    ///        EpochRecordFilter to synthesize epoch events from a
+    ///        sequence of region entry events.  The filter also
+    ///        passes hint events through.
+    ///
+    /// This filter can be used to support signals provided by the
+    /// EpochIOGroup without the user inserting calls to
+    /// geopm_prof_epoch() into application.  Instead a region
+    /// detected through runtimes like MPI function calls or OpenMP
+    /// parallel regions can be used to identify the outer loop of an
+    /// application.  This proxy region is specified at filter
+    /// construction time by the region hash.  There are two other
+    /// constructor parameters that enable support for multiple proxy
+    /// region entries per outer loop, and for calls to the proxy
+    /// region prior to the beginning of the outer loop.  The filter
+    /// expects to be provided records collected from a single
+    /// process.
+    class ProxyEpochRecordFilter : public RecordFilter
+    {
+        public:
+            /// @brief Constructor for a process specific proxy-region
+            ///        EpochIOGroup record filter.
+            ///
+            /// @param [in] region_hash The hash for the region that
+            ///        will be used as a proxy for the epoch events.
+            ///
+            /// @param [in] calls_per_epoch Number of calls to the
+            ///        proxy region that are expected in each outer
+            ///        loop of the application per process.
+            ///
+            /// @param [in] startup_count Number of calls to the proxy
+            ///        region that are to be ignored at application
+            ///        startup.  These calls are expected prior to
+            ///        entering the outer loop of the application.
+            ProxyEpochRecordFilter(uint64_t region_hash,
+                                   int calls_per_epoch,
+                                   int startup_count);
+            /// @brief Default destructor.
+            virtual ~ProxyEpochRecordFilter() = default;
+            /// @brief If input record matches the periodic entry into
+            ///        the proxy region matching the construction
+            ///        arguments, then the output will be a vector of
+            ///        length one containing the inferred
+            ///        M_EVENT_EPOCH_COUNT event.  If the input record
+            ///        is of type M_EVENT_HINT, then returned vector
+            ///        will be a vector of length one containing this
+            ///        record.  In all other cases the method returns
+            ///        an empty vector.
+            ///
+            /// @return An empty vector or a vector of length one
+            ///         containing a record of an epoch or hint event.
+            std::vector<ApplicationSampler::m_record_s> filter(const ApplicationSampler::m_record_s &record);
+        private:
+            uint64_t m_proxy_hash;
+            int m_num_per_epoch;
+            int m_count;
+    };
+}
+
+#endif

--- a/src/ProxyEpochRecordFilter.hpp
+++ b/src/ProxyEpochRecordFilter.hpp
@@ -37,22 +37,30 @@
 
 namespace geopm
 {
-    /// @brief Filter that can be used in place of the
-    ///        EpochRecordFilter to synthesize epoch events from a
-    ///        sequence of region entry events.  The filter also
-    ///        passes hint events through.
+    /// @brief Filter that can be used to synthesize epoch events from
+    ///        a sequence of region entry events.  The filter
+    ///        suppresses received epoch events and passes through all
+    ///        other events.
     ///
-    /// This filter can be used to support signals provided by the
-    /// EpochIOGroup without the user inserting calls to
-    /// geopm_prof_epoch() into application.  Instead a region
-    /// detected through runtimes like MPI function calls or OpenMP
-    /// parallel regions can be used to identify the outer loop of an
-    /// application.  This proxy region is specified at filter
-    /// construction time by the region hash.  There are two other
-    /// constructor parameters that enable support for multiple proxy
-    /// region entries per outer loop, and for calls to the proxy
-    /// region prior to the beginning of the outer loop.  The filter
-    /// expects to be provided records collected from a single
+    /// This filter is used to insert synthetic epoch events into the
+    /// stream received by an application process.  This provides
+    /// users of the ApplicationSampler with epoch events even if the
+    /// application does not provide them directly through calls to
+    /// geopm_prof_epoch().  When this filter is selected, any epoch
+    /// events that arrive though the application calls into
+    /// geopm_prof_epoch() are removed from the record stream.  The
+    /// output of this filter is a pass through of all non-epoch
+    /// events and may include synthesized epoch events.  The epoch
+    /// events are synthesized from region entry of a specified region
+    /// that may be detected through runtimes like MPI function calls
+    /// or OpenMP parallel regions.  This proxy-region is specified at
+    /// filter construction time by the region hash.  Typically, this
+    /// region hash value is determined by inspection of a report from
+    /// a previous run.  There are two other constructor parameters
+    /// that enable support for multiple proxy-region entries per
+    /// outer loop, and for application calls into the proxy-region
+    /// prior to the beginning of the outer loop.  The filter assumes
+    /// that the provided records have been collected from a single
     /// process.
     class ProxyEpochRecordFilter : public RecordFilter
     {
@@ -64,10 +72,10 @@ namespace geopm
             ///        will be used as a proxy for the epoch events.
             ///
             /// @param [in] calls_per_epoch Number of calls to the
-            ///        proxy region that are expected in each outer
+            ///        proxy-region that are expected in each outer
             ///        loop of the application per process.
             ///
-            /// @param [in] startup_count Number of calls to the proxy
+            /// @param [in] startup_count Number of calls to the proxy-
             ///        region that are to be ignored at application
             ///        startup.  These calls are expected prior to
             ///        entering the outer loop of the application.
@@ -77,7 +85,7 @@ namespace geopm
             /// @brief Default destructor.
             virtual ~ProxyEpochRecordFilter() = default;
             /// @brief If input record matches the periodic entry into
-            ///        the proxy region matching the construction
+            ///        the proxy-region matching the construction
             ///        arguments, then the output will be a vector of
             ///        length one containing the inferred
             ///        M_EVENT_EPOCH_COUNT event.  If the input record

--- a/src/RecordFilter.cpp
+++ b/src/RecordFilter.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "RecordFilter.hpp"
+#include "ProxyEpochRecordFilter.hpp"
+#include "Helper.hpp"
+#include "Exception.hpp"
+
+namespace geopm
+{
+    std::unique_ptr<RecordFilter> RecordFilter::make_unique(const std::string &name)
+    {
+        std::unique_ptr<RecordFilter> result;
+        if (string_begins_with(name, "proxy_epoch")) {
+            uint64_t region_hash;
+            int calls_per_epoch = 1;
+            int startup_count = 0;
+            std::vector<std::string> split_name = string_split(name, ",");
+            if (split_name.size() <= 1ULL) {
+                throw Exception("RecordFilter::make_unique(): proxy_epoch type requires a hash, e.g. proxy_epoch,0x1234abcd",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            else {
+                if (split_name[0] != "proxy_epoch") {
+                    throw Exception("RecordFilter::make_unique(): Expected name of the form \"proxy_epoch,<HASH>[,<CALLS>[,<STARTUP>]]\", got: " + name,
+                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                }
+                region_hash = std::stoull(split_name[1]);
+                if (split_name.size() > 2ULL) {
+                    calls_per_epoch = std::stoi(split_name[2]);
+                }
+                if (split_name.size() > 3ULL) {
+                    startup_count = std::stoi(split_name[3]);
+                }
+                result = geopm::make_unique<ProxyEpochRecordFilter>(region_hash,
+                                                                    calls_per_epoch,
+                                                                    startup_count);
+            }
+
+        }
+        else {
+            throw Exception("RecordFilter::make_unique(): unable to parse name: " + name,
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return result;
+    }
+}
+

--- a/src/RecordFilter.hpp
+++ b/src/RecordFilter.hpp
@@ -63,6 +63,10 @@ namespace geopm
             /// @return Vector of zero or more records to update the
             ///         filtered stream.
             virtual std::vector<ApplicationSampler::m_record_s> filter(const ApplicationSampler::m_record_s &record) = 0;
+            static void parse_name_proxy_epoch(const std::string &name,
+                                               uint64_t &region_hash,
+                                               int &calls_per_epoch,
+                                               int &startup_count);
     };
 }
 

--- a/src/RecordFilter.hpp
+++ b/src/RecordFilter.hpp
@@ -63,6 +63,31 @@ namespace geopm
             /// @return Vector of zero or more records to update the
             ///         filtered stream.
             virtual std::vector<ApplicationSampler::m_record_s> filter(const ApplicationSampler::m_record_s &record) = 0;
+            /// @brief Static function that will parse the filter
+            ///        string for the proxy_epoch into the constructor
+            ///        arguments for a ProxyEpochRecordFilter.
+            ///        Failure to parse will result in a thrown
+            ///        Exception with GEOPM_ERROR_INVALID type.
+            ///
+            /// @param [in] name The filter name which is of the form
+            ///        "proxy_epoch,<HASH>[,<CALLS>[,<STARTUP>]]" The
+            ///        region hash is always parsed (i.e. required).
+            ///        If the calls per epoch is provided or if both
+            ///        the call per epoch and startup count are
+            ///        provided they are also parsed.  The default
+            ///        value for calls_per_epoch is 1 and for
+            ///        startup_count is 0.
+            ///
+            /// @param [out] region_hash The hash of the region that will
+            ///        serve as the proxy for the epoch.
+            ///
+            /// @param [out] calls_per_epoch Number of entries into
+            ///        the proxy-region expected in each outer loop of
+            ///        the application.
+            ///
+            /// @param [out] startup_count Number of entries into the
+            ///        proxy-region expected prior to the beginning of
+            ///        the outer loop of the application.
             static void parse_name_proxy_epoch(const std::string &name,
                                                uint64_t &region_hash,
                                                int &calls_per_epoch,

--- a/src/RecordFilter.hpp
+++ b/src/RecordFilter.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RECORDFILTER_HPP_INCLUDE
+#define RECORDFILTER_HPP_INCLUDE
+
+#include <vector>
+
+#include "ApplicationSampler.hpp"
+
+namespace geopm
+{
+    /// @brief Base class for filters that can be applied to
+    ///        ApplicationSampler record streams produced by a single
+    ///        process.
+    class RecordFilter
+    {
+        public:
+            static std::unique_ptr<RecordFilter> make_unique(const std::string &name);
+            /// @brief Default constructor for pure virtual interface.
+            RecordFilter() = default;
+            /// @brief Default destructor for pure virtual interface.
+            virtual ~RecordFilter() = default;
+            /// @brief Apply a filter to a stream of records.
+            ///
+            /// This method is called repeatedly by a user to update a
+            /// filtered time stream with a new record.  The input
+            /// record is used to update the state of the filter and
+            /// the method returns a vector containing any filtered
+            /// values resulting from the update.
+            ///
+            /// @param [in] record The update value to be filtered.
+            ///
+            /// @return Vector of zero or more records to update the
+            ///         filtered stream.
+            virtual std::vector<ApplicationSampler::m_record_s> filter(const ApplicationSampler::m_record_s &record) = 0;
+    };
+}
+
+#endif

--- a/test/EnvironmentTest.cpp
+++ b/test/EnvironmentTest.cpp
@@ -480,3 +480,32 @@ TEST_F(EnvironmentTest, user_disable_ompt)
 
     EXPECT_FALSE(m_env->do_ompt());
 }
+
+TEST_F(EnvironmentTest, record_filter_on)
+{
+    std::map<std::string, std::string> default_vars;
+    setenv("GEOPM_RECORD_FILTER", "proxy_epoch,0xabcd1234", 1);
+    std::map<std::string, std::string> override_vars;
+
+    vars_to_json(default_vars, M_DEFAULT_PATH);
+    vars_to_json(override_vars, M_OVERRIDE_PATH);
+
+    m_env = geopm::make_unique<EnvironmentImp>(M_DEFAULT_PATH, M_OVERRIDE_PATH);
+
+    EXPECT_TRUE(m_env->do_record_filter());
+    EXPECT_EQ("proxy_epoch,0xabcd1234", m_env->record_filter());
+}
+
+TEST_F(EnvironmentTest, record_filter_off)
+{
+    std::map<std::string, std::string> default_vars;
+    std::map<std::string, std::string> override_vars;
+
+    vars_to_json(default_vars, M_DEFAULT_PATH);
+    vars_to_json(override_vars, M_OVERRIDE_PATH);
+
+    m_env = geopm::make_unique<EnvironmentImp>(M_DEFAULT_PATH, M_OVERRIDE_PATH);
+
+    EXPECT_FALSE(m_env->do_record_filter());
+    EXPECT_EQ("", m_env->record_filter());
+}

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -184,6 +184,8 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/EnvironmentTest.default_endpoint_user_policy_override_endpoint \
               test/gtest_links/EnvironmentTest.user_policy_and_endpoint \
               test/gtest_links/EnvironmentTest.user_disable_ompt \
+              test/gtest_links/EnvironmentTest.record_filter_on \
+              test/gtest_links/EnvironmentTest.record_filter_off \
               test/gtest_links/EpochRuntimeRegulatorTest.all_ranks_enter_exit \
               test/gtest_links/EpochRuntimeRegulatorTest.epoch_runtime \
               test/gtest_links/EpochRuntimeRegulatorTest.invalid_ranks \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -356,6 +356,12 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/ProfileTestIntegration.misconfig_tprof_shmem \
               test/gtest_links/ProfileTracerTest.construct_update_destruct \
               test/gtest_links/ProfileTracerTest.format \
+              test/gtest_links/ProxyEpochRecordFilterTest.simple_conversion \
+              test/gtest_links/ProxyEpochRecordFilterTest.skip_one \
+              test/gtest_links/ProxyEpochRecordFilterTest.skip_two_off_one \
+              test/gtest_links/ProxyEpochRecordFilterTest.invalid_construct \
+              test/gtest_links/ProxyEpochRecordFilterTest.filter_in \
+              test/gtest_links/ProxyEpochRecordFilterTest.filter_out \
               test/gtest_links/RawMSRSignalTest.errors \
               test/gtest_links/RawMSRSignalTest.read \
               test/gtest_links/RawMSRSignalTest.read_batch \
@@ -526,6 +532,7 @@ test_geopm_test_SOURCES = test/AdminTest.cpp \
                           test/ProfileTableTest.cpp \
                           test/ProfileTest.cpp \
                           test/ProfileTracerTest.cpp \
+                          test/ProxyEpochRecordFilterTest.cpp \
                           test/RawMSRSignalTest.cpp \
                           test/RegionAggregatorTest.cpp \
                           test/ReporterTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -366,6 +366,9 @@ GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/RawMSRSignalTest.read \
               test/gtest_links/RawMSRSignalTest.read_batch \
               test/gtest_links/RawMSRSignalTest.setup_batch \
+              test/gtest_links/RecordFilterTest.invalid_filter_name \
+              test/gtest_links/RecordFilterTest.make_proxy_epoch \
+              test/gtest_links/RecordFilterTest.parse_name_proxy_epoch \
               test/gtest_links/RegionAggregatorTest.epoch_total \
               test/gtest_links/RegionAggregatorTest.sample_total \
               test/gtest_links/ReporterTest.generate \
@@ -534,6 +537,7 @@ test_geopm_test_SOURCES = test/AdminTest.cpp \
                           test/ProfileTracerTest.cpp \
                           test/ProxyEpochRecordFilterTest.cpp \
                           test/RawMSRSignalTest.cpp \
+                          test/RecordFilterTest.cpp \
                           test/RegionAggregatorTest.cpp \
                           test/ReporterTest.cpp \
                           test/RuntimeRegulatorTest.cpp \

--- a/test/ProxyEpochRecordFilterTest.cpp
+++ b/test/ProxyEpochRecordFilterTest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cstdint>
+#include "gtest/gtest.h"
+#include "geopm_test.hpp"
+
+#include "ProxyEpochRecordFilter.hpp"
+
+using geopm::ApplicationSampler;
+
+class ProxyEpochRecordFilterTest : public ::testing::Test
+{
+    protected:
+        void SetUp();
+        std::vector<int> m_in_events;
+        std::vector<int> m_out_events;
+};
+
+
+void ProxyEpochRecordFilterTest::SetUp()
+{
+    m_in_events = {
+        ApplicationSampler::M_EVENT_HINT,
+        ApplicationSampler::M_EVENT_REGION_ENTRY,
+        ApplicationSampler::M_EVENT_REGION_EXIT,
+        ApplicationSampler::M_EVENT_PROFILE,
+        ApplicationSampler::M_EVENT_REPORT,
+        ApplicationSampler::M_EVENT_CLAIM_CPU,
+        ApplicationSampler::M_EVENT_RELEASE_CPU,
+        ApplicationSampler::M_EVENT_NAME_KEY,
+    };
+    m_out_events = {
+        ApplicationSampler::M_EVENT_EPOCH_COUNT,
+    };
+}
+
+TEST_F(ProxyEpochRecordFilterTest, simple_conversion)
+{
+    uint64_t hash = 0xAULL;
+    ApplicationSampler::m_record_s record {0.0,
+                                           0,
+                                           ApplicationSampler::M_EVENT_REGION_ENTRY,
+                                           hash};
+    geopm::ProxyEpochRecordFilter perf(hash, 1, 0);
+    for (uint64_t count = 1; count <= 10; ++count) {
+        std::vector<ApplicationSampler::m_record_s> result = perf.filter(record);
+        ASSERT_EQ(2ULL, result.size());
+        EXPECT_EQ(0.0, result[0].time);
+        EXPECT_EQ(0, result[0].process);
+        EXPECT_EQ(ApplicationSampler::M_EVENT_REGION_ENTRY, result[0].event);
+        EXPECT_EQ(hash, result[0].signal);
+        EXPECT_EQ(0.0, result[1].time);
+        EXPECT_EQ(0, result[1].process);
+        EXPECT_EQ(ApplicationSampler::M_EVENT_EPOCH_COUNT, result[1].event);
+        EXPECT_EQ(count, result[1].signal);
+    }
+}
+
+TEST_F(ProxyEpochRecordFilterTest, skip_one)
+{
+    uint64_t hash = 0xAULL;
+    ApplicationSampler::m_record_s record {0.0,
+                                           0,
+                                           ApplicationSampler::M_EVENT_REGION_ENTRY,
+                                           hash};
+    geopm::ProxyEpochRecordFilter perf(hash, 2, 0);
+    for (uint64_t count = 1; count <= 10; ++count) {
+        std::vector<ApplicationSampler::m_record_s> result = perf.filter(record);
+        ASSERT_EQ(2ULL, result.size());
+        EXPECT_EQ(0.0, result[0].time);
+        EXPECT_EQ(0, result[0].process);
+        EXPECT_EQ(ApplicationSampler::M_EVENT_REGION_ENTRY, result[0].event);
+        EXPECT_EQ(hash, result[0].signal);
+        EXPECT_EQ(0.0, result[1].time);
+        EXPECT_EQ(0, result[1].process);
+        EXPECT_EQ(ApplicationSampler::M_EVENT_EPOCH_COUNT, result[1].event);
+        EXPECT_EQ(count, result[1].signal);
+        result = perf.filter(record);
+        ASSERT_EQ(1ULL, result.size());
+        EXPECT_EQ(0.0, result[0].time);
+        EXPECT_EQ(0, result[0].process);
+        EXPECT_EQ(ApplicationSampler::M_EVENT_REGION_ENTRY, result[0].event);
+        EXPECT_EQ(hash, result[0].signal);
+    }
+}
+
+
+TEST_F(ProxyEpochRecordFilterTest, skip_two_off_one)
+{
+    uint64_t hash = 0xAULL;
+    ApplicationSampler::m_record_s record {0.0,
+                                           0,
+                                           ApplicationSampler::M_EVENT_REGION_ENTRY,
+                                           hash};
+    geopm::ProxyEpochRecordFilter perf(hash, 3, 1);
+    std::vector<ApplicationSampler::m_record_s> result = perf.filter(record);
+    ASSERT_EQ(1ULL, result.size());
+    EXPECT_EQ(0.0, result[0].time);
+    EXPECT_EQ(0, result[0].process);
+    EXPECT_EQ(ApplicationSampler::M_EVENT_REGION_ENTRY, result[0].event);
+    EXPECT_EQ(hash, result[0].signal);
+    for (uint64_t count = 1; count <= 10; ++count) {
+        result = perf.filter(record);
+        ASSERT_EQ(2ULL, result.size());
+        EXPECT_EQ(0.0, result[0].time);
+        EXPECT_EQ(0, result[0].process);
+        EXPECT_EQ(ApplicationSampler::M_EVENT_REGION_ENTRY, result[0].event);
+        EXPECT_EQ(hash, result[0].signal);
+        EXPECT_EQ(0.0, result[1].time);
+        EXPECT_EQ(0, result[1].process);
+        EXPECT_EQ(ApplicationSampler::M_EVENT_EPOCH_COUNT, result[1].event);
+        EXPECT_EQ(count, result[1].signal);
+        result = perf.filter(record);
+        ASSERT_EQ(1ULL, result.size());
+        EXPECT_EQ(0.0, result[0].time);
+        EXPECT_EQ(0, result[0].process);
+        EXPECT_EQ(ApplicationSampler::M_EVENT_REGION_ENTRY, result[0].event);
+        EXPECT_EQ(hash, result[0].signal);
+        result = perf.filter(record);
+        ASSERT_EQ(1ULL, result.size());
+        EXPECT_EQ(0.0, result[0].time);
+        EXPECT_EQ(0, result[0].process);
+        EXPECT_EQ(ApplicationSampler::M_EVENT_REGION_ENTRY, result[0].event);
+        EXPECT_EQ(hash, result[0].signal);
+    }
+}
+
+
+TEST_F(ProxyEpochRecordFilterTest, invalid_construct)
+{
+    GEOPM_EXPECT_THROW_MESSAGE(geopm::ProxyEpochRecordFilter perf(~0ULL, 0, 0),
+                               GEOPM_ERROR_INVALID, "region_hash");
+    GEOPM_EXPECT_THROW_MESSAGE(geopm::ProxyEpochRecordFilter perf(0xAULL, 0, 0),
+                               GEOPM_ERROR_INVALID, "calls_per_epoch");
+    GEOPM_EXPECT_THROW_MESSAGE(geopm::ProxyEpochRecordFilter perf(0xAULL, -1, 0),
+                               GEOPM_ERROR_INVALID, "calls_per_epoch");
+    GEOPM_EXPECT_THROW_MESSAGE(geopm::ProxyEpochRecordFilter perf(0xAULL, 1, -1),
+                               GEOPM_ERROR_INVALID, "startup_count");
+}
+
+
+TEST_F(ProxyEpochRecordFilterTest, filter_in)
+{
+    ApplicationSampler::m_record_s record {};
+    geopm::ProxyEpochRecordFilter perf(0xAULL, 1, 0);
+    for (auto event : m_in_events) {
+        record.event = event;
+        std::vector<ApplicationSampler::m_record_s> result = perf.filter(record);
+        ASSERT_EQ(1ULL, result.size());
+        EXPECT_EQ(0.0, result[0].time);
+        EXPECT_EQ(0, result[0].process);
+        EXPECT_EQ(event, result[0].event);
+        EXPECT_EQ(0ULL, result[0].signal);
+    }
+}
+
+TEST_F(ProxyEpochRecordFilterTest, filter_out)
+{
+    ApplicationSampler::m_record_s record {};
+    std::vector<ApplicationSampler::m_record_s> result;
+    geopm::ProxyEpochRecordFilter perf(0xAULL, 1, 0);
+    for (auto event : m_out_events) {
+        record.event = event;
+        result = perf.filter(record);
+        EXPECT_EQ(0ULL, result.size());
+    }
+}

--- a/test/RecordFilterTest.cpp
+++ b/test/RecordFilterTest.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "geopm_test.hpp"
+
+#include "RecordFilter.hpp"
+
+using geopm::RecordFilter;
+
+class RecordFilterTest : public ::testing::Test
+{
+
+};
+
+
+TEST_F(RecordFilterTest, invalid_filter_name)
+{
+    GEOPM_EXPECT_THROW_MESSAGE(RecordFilter::make_unique("invalid_filter_name"),
+                               GEOPM_ERROR_INVALID,"parse name");
+}
+
+TEST_F(RecordFilterTest, make_proxy_epoch)
+{
+    std::shared_ptr<RecordFilter> filter = RecordFilter::make_unique("proxy_epoch,0xabcd1234");
+    EXPECT_TRUE(filter);
+}
+
+TEST_F(RecordFilterTest, parse_name_proxy_epoch)
+{
+    uint64_t region_hash = 42ULL;
+    int calls_per_epoch = 42;
+    int startup_count = 42;
+    RecordFilter::parse_name_proxy_epoch("proxy_epoch,0xabcd1234",
+        region_hash, calls_per_epoch, startup_count);
+    EXPECT_EQ(0xabcd1234ULL, region_hash);
+    EXPECT_EQ(1, calls_per_epoch);
+    EXPECT_EQ(0, startup_count);
+    RecordFilter::parse_name_proxy_epoch("proxy_epoch,0xabcd1235,10",
+        region_hash, calls_per_epoch, startup_count);
+    EXPECT_EQ(0xabcd1235ULL, region_hash);
+    EXPECT_EQ(10, calls_per_epoch);
+    EXPECT_EQ(0, startup_count);
+    RecordFilter::parse_name_proxy_epoch("proxy_epoch,0xabcd1236,100,1000",
+        region_hash, calls_per_epoch, startup_count);
+    EXPECT_EQ(0xabcd1236ULL, region_hash);
+    EXPECT_EQ(100, calls_per_epoch);
+    EXPECT_EQ(1000, startup_count);
+    GEOPM_EXPECT_THROW_MESSAGE(RecordFilter::parse_name_proxy_epoch("not_proxy_epoch",
+        region_hash, calls_per_epoch, startup_count),
+        GEOPM_ERROR_INVALID, "Expected name of the form");
+    GEOPM_EXPECT_THROW_MESSAGE(RecordFilter::parse_name_proxy_epoch("proxy_epoch",
+        region_hash, calls_per_epoch, startup_count),
+        GEOPM_ERROR_INVALID, "requires a hash");
+    GEOPM_EXPECT_THROW_MESSAGE(RecordFilter::parse_name_proxy_epoch("proxy_epoch,not_a_number",
+        region_hash, calls_per_epoch, startup_count),
+        GEOPM_ERROR_INVALID, "Unable to parse parameter region_hash");
+    GEOPM_EXPECT_THROW_MESSAGE(RecordFilter::parse_name_proxy_epoch("proxy_epoch,0xabcd1237,not_a_number",
+        region_hash, calls_per_epoch, startup_count),
+        GEOPM_ERROR_INVALID, "Unable to parse parameter calls_per_epoch");
+    GEOPM_EXPECT_THROW_MESSAGE(RecordFilter::parse_name_proxy_epoch("proxy_epoch,0xabcd1237,2,not_a_number",
+        region_hash, calls_per_epoch, startup_count),
+        GEOPM_ERROR_INVALID, "Unable to parse parameter startup_count");
+}

--- a/test/RecordFilterTest.cpp
+++ b/test/RecordFilterTest.cpp
@@ -36,8 +36,10 @@
 #include "geopm_test.hpp"
 
 #include "RecordFilter.hpp"
+#include "ApplicationSampler.hpp"
 
 using geopm::RecordFilter;
+using geopm::ApplicationSampler;
 
 class RecordFilterTest : public ::testing::Test
 {
@@ -54,7 +56,13 @@ TEST_F(RecordFilterTest, invalid_filter_name)
 TEST_F(RecordFilterTest, make_proxy_epoch)
 {
     std::shared_ptr<RecordFilter> filter = RecordFilter::make_unique("proxy_epoch,0xabcd1234");
-    EXPECT_TRUE(filter);
+    // Assert that the pointer is non-null
+    ASSERT_TRUE(filter);
+    ApplicationSampler::m_record_s record {0.0, 0, ApplicationSampler::M_EVENT_REGION_ENTRY, 0xabcd1234};
+    std::vector<ApplicationSampler::m_record_s> result = filter->filter(record);
+    ASSERT_EQ(2ULL, result.size());
+    EXPECT_EQ(ApplicationSampler::M_EVENT_REGION_ENTRY, result[0].event);
+    EXPECT_EQ(ApplicationSampler::M_EVENT_EPOCH_COUNT, result[1].event);
 }
 
 TEST_F(RecordFilterTest, parse_name_proxy_epoch)


### PR DESCRIPTION
- Add doxygen comments to filter classes
- Implemented simple epoch inference with the
  ProxyEpochRecordFilter
- Filtering done in the ApplicationSampler
- Add plumbing to add record filter to ApplicationSampler

Change-Id: Id5bc5b97d3cc2d5f5953d3580f6f403bb59452ce
Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
