### PR TITLE
gcc10 compatibility updates

### DIFF
--- a/examples/fft/Makefile.mk
+++ b/examples/fft/Makefile.mk
@@ -49,10 +49,10 @@ if ENABLE_OPENMP
 
     examples_fft_nas_ft_LDADD = libgeopm.la libgeopmfort.la $(MPI_FCLIBS) $(MPI_CXXLIBS)
     examples_fft_nas_ft_LDFLAGS = $(AM_LDFLAGS) $(MPI_LDFLAGS) $(OPENMP_CFLAGS)
-    examples_fft_nas_ft_FCFLAGS = -fopenmp -msse4.2 $(MPI_FCFLAGS) $(OPENMP_CFLAGS) -O3
+    examples_fft_nas_ft_FCFLAGS = -fallow-argument-mismatch -fopenmp -msse4.2 $(MPI_FCFLAGS) $(OPENMP_CFLAGS) -O3
     examples_fft_nas_ft_FFLAGS =  -fopenmp -msse4.2 $(MPI_FFLAGS) $(OPENMP_CFLAGS) -O3
 if HAVE_IFORT
-    examples_fft_nas_ft_FCFLAGS += -xAVX -shared-intel -mcmodel=medium -fpic
+    examples_fft_nas_ft_FCFLAGS += -fallow-argument-mismatch -xAVX -shared-intel -mcmodel=medium -fpic
     examples_fft_nas_ft_FFLAGS += -xAVX -shared-intel -mcmodel=medium -fpic
 endif
 endif

--- a/examples/fft/randi8.f
+++ b/examples/fft/randi8.f
@@ -59,7 +59,7 @@ c   arguments will generate a continuous sequence.
       parameter(d2m46=0.5d0**46)
 
       save i246m1
-      data i246m1/X'00003FFFFFFFFFFF'/
+      data i246m1/Z'00003FFFFFFFFFFF'/
 
       Lx = X
       La = A
@@ -90,7 +90,7 @@ c      parameter(i246m1=2**46-1)
       parameter(d2m46=0.5d0**46)
 
       save i246m1
-      data i246m1/X'00003FFFFFFFFFFF'/
+      data i246m1/Z'00003FFFFFFFFFFF'/
 
 c Note that the v6 compiler on an R8000 does something stupid with
 c the above. Using the following instead (or various other things)

--- a/src/ProfileTable.hpp
+++ b/src/ProfileTable.hpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <map>
 #include <set>
+#include <string>
 
 #include "geopm_internal.h"
 

--- a/src/ProxyEpochRecordFilter.cpp
+++ b/src/ProxyEpochRecordFilter.cpp
@@ -100,7 +100,7 @@ namespace geopm
         try {
             region_hash = std::stoull(split_name[1], nullptr, 0);
         }
-        catch (std::exception) {
+        catch (const std::exception &) {
             throw Exception("RecordFilter::make_unique(): Unable to parse parameter region_hash from filter name: " + name,
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -110,7 +110,7 @@ namespace geopm
             try {
                 calls_per_epoch = std::stoi(split_name[2]);
             }
-            catch (std::exception) {
+            catch (const std::exception &) {
                 throw Exception("RecordFilter::make_unique(): Unable to parse parameter calls_per_epoch from filter name: " + name,
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
@@ -119,7 +119,7 @@ namespace geopm
             try {
                 startup_count = std::stoi(split_name[3]);
             }
-            catch (std::exception) {
+            catch (const std::exception &) {
                 throw Exception("RecordFilter::make_unique(): Unable to parse parameter startup_count from filter name: " + name,
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }


### PR DESCRIPTION
Updates to enable building GEOPM using gcc10, following ['Porting to GCC 10'](https://gcc.gnu.org/gcc-10/porting_to.html) guidelines.  

Built on Fedora release 32 with gcc version 10.1.1. 

- Details of change:
Inclusion of string header in ProfileTable.hpp.
Change RecordTable usage of exceptions from value to const reference.
Change X to Z for hexidecimals in FFT example
Add -fallow-argument-mismatch to FFT makefile to change mismatched type error to a warning as a short term fix.

- Fixes #1131 from github issues.