### PR TITLE
Change epoch and app total runtime test comparison

### DIFF
--- a/test_integration/geopm_test_integration.py
+++ b/test_integration/geopm_test_integration.py
@@ -370,7 +370,7 @@ class TestIntegration(unittest.TestCase):
             for signal in ['runtime (sec)', 'package-energy (joules)', 'dram-energy (joules)']:
                 util.assertNear(self, totals[signal], unmarked[signal], msg='signal={}'.format(signal))
                 util.assertNear(self, totals[signal], epoch[signal], msg='signal={}'.format(signal))
-                self.assertGreaterEqual(totals[signal], epoch[signal], msg='signal={}'.format(signal))
+                util.assertNear(self, totals[signal], epoch[signal], msg='signal={}'.format(signal))
 
             util.assertNear(self, unmarked['runtime (sec)'], unmarked['sync-runtime (sec)'])
             util.assertNear(self, epoch['runtime (sec)'], epoch['sync-runtime (sec)'])


### PR DESCRIPTION
- App total runtime is not strictly greater than epoch total because
  app total uses sampled values (i.e. sync runtime).
