### PR TITLE
Fix test_trace_runtimes

### DIFF
--- a/test_integration/geopm_test_integration.py
+++ b/test_integration/geopm_test_integration.py
@@ -432,7 +432,9 @@ class TestIntegration(unittest.TestCase):
         for nn in node_names:
             trace = self._output.get_trace_data(node_name=nn)
             app_totals = self._output.get_app_total_data(node_name=nn)
-            util.assertNear(self, trace.iloc[-1]['TIME'], app_totals['runtime'].item(), msg='Application runtime failure, node_name={}.'.format(nn))
+            util.assertNear(self, trace.iloc[-1]['TIME'] - trace.iloc[0]['TIME'],
+                            app_totals['runtime'].item(),
+                            msg='Application runtime failure, node_name={}.'.format(nn))
             # Calculate runtime totals for each region in each trace, compare to report
             tt = trace.reset_index(level='index')  # move 'index' field from multiindex to columns
             tt = tt.set_index(['REGION_HASH'], append=True)  # add region_hash column to multiindex


### PR DESCRIPTION
- Application total runtime is now based on sampling, so should be
  close to the different in last and first trace sample times.
