### PR TITLE
Update test_frequency_sane_fmap integration test

### DIFF
--- a/src/FrequencyMapAgent.cpp
+++ b/src/FrequencyMapAgent.cpp
@@ -291,8 +291,8 @@ namespace geopm
                 freq = it->second;
             }
             else {
+                m_default_freq_hash.insert(curr_hash);
                 freq = m_default_freq;
-                m_hash_freq_map[curr_hash] = m_default_freq;
             }
             if (m_last_freq[ctl_idx] != freq) {
                 m_last_freq[ctl_idx] = freq;
@@ -372,6 +372,12 @@ namespace geopm
             oss << std::setfill('\0') << std::setw(0) << std::scientific;
             oss << ": " << region.second;
         }
+        for (const auto &region : m_default_freq_hash) {
+            oss << "\n    0x" << std::hex << std::setfill('0') << std::setw(16) << std::fixed;
+            oss << region;
+            oss << std::setfill('\0') << std::setw(0) << std::scientific;
+            oss << ": " << m_default_freq;
+        }
         oss << "\n";
         result.push_back(std::make_pair("Frequency map", oss.str()));
 
@@ -383,6 +389,9 @@ namespace geopm
         std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > result;
         for (const auto &region : m_hash_freq_map) {
             result[region.first].push_back(std::make_pair("frequency-map", std::to_string(region.second)));
+        }
+        for (const auto region : m_default_freq_hash) {
+            result[region].push_back(std::make_pair("frequency-map", std::to_string(m_default_freq)));
         }
         return result;
     }

--- a/src/FrequencyMapAgent.hpp
+++ b/src/FrequencyMapAgent.hpp
@@ -38,6 +38,7 @@
 #include <string>
 #include <memory>
 #include <functional>
+#include <set>
 
 #include "geopm_time.h"
 
@@ -99,6 +100,7 @@ namespace geopm
             const PlatformTopo &m_platform_topo;
             geopm_time_s m_wait_time;
             std::map<uint64_t, double> m_hash_freq_map;
+            std::set<uint64_t> m_default_freq_hash;
             std::vector<int> m_hash_signal_idx;
             std::vector<int> m_freq_control_idx;
             int m_uncore_min_ctl_idx;


### PR DESCRIPTION
- There is a race condition where if the controller's first sample of
the region is prior to the hint change due to the entry into a network
sub-region then the report includes the map for the region otherwise it
does not.
- Update the test to supress the KeyError when learning doesn't occur
due to the race.
- Fixes #1155

Change-Id: Iee50d47c3b1b740f6cf4c7f328104e7ef80770b3
Signed-off-by: Brandon Baker <brandon.baker@intel.com>

Summary of change.

- Details of change; please include all interfaces added, removed, or modified.
- Fixes #XXX from github issues.
