### PR TITLE
Use std=legacy with gfortran

### DIFF
--- a/examples/fft/Makefile.mk
+++ b/examples/fft/Makefile.mk
@@ -49,10 +49,10 @@ if ENABLE_OPENMP
 
     examples_fft_nas_ft_LDADD = libgeopm.la libgeopmfort.la $(MPI_FCLIBS) $(MPI_CXXLIBS)
     examples_fft_nas_ft_LDFLAGS = $(AM_LDFLAGS) $(MPI_LDFLAGS) $(OPENMP_CFLAGS)
-    examples_fft_nas_ft_FCFLAGS = -fallow-argument-mismatch -fopenmp -msse4.2 $(MPI_FCFLAGS) $(OPENMP_CFLAGS) -O3
+    examples_fft_nas_ft_FCFLAGS = -std=legacy -fopenmp -msse4.2 $(MPI_FCFLAGS) $(OPENMP_CFLAGS) -O3
     examples_fft_nas_ft_FFLAGS =  -fopenmp -msse4.2 $(MPI_FFLAGS) $(OPENMP_CFLAGS) -O3
 if HAVE_IFORT
-    examples_fft_nas_ft_FCFLAGS += -fallow-argument-mismatch -xAVX -shared-intel -mcmodel=medium -fpic
+    examples_fft_nas_ft_FCFLAGS += -std=legacy -xAVX -shared-intel -mcmodel=medium -fpic
     examples_fft_nas_ft_FFLAGS += -xAVX -shared-intel -mcmodel=medium -fpic
 endif
 endif


### PR DESCRIPTION
- This preserves backwards compatability.
- -fallow-argument-mismatch is only supported starting
  with gfortran 10.1.
- Fixes #1218 
