### PR TITLE
Initial updates for board accelerator support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,7 @@ if ENABLE_BETA
 endif
 
 pkginclude_HEADERS = contrib/json11/json11.hpp \
+                     src/AcceleratorTopo.hpp \
                      src/Agent.hpp \
                      src/Agg.hpp \
                      src/CircularBuffer.hpp \
@@ -434,6 +435,8 @@ endif
 
 libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             contrib/json11/json11.hpp \
+                            src/AcceleratorTopo.cpp \
+                            src/AcceleratorTopo.hpp \
                             src/Admin.cpp \
                             src/Admin.hpp \
                             src/Agent.cpp \
@@ -624,6 +627,15 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/record.cpp \
                             src/record.hpp \
                             # end
+
+if ENABLE_NVML
+    libgeopmpolicy_la_SOURCES += src/NVMLAcceleratorTopo.cpp \
+                                 src/NVMLAcceleratorTopo.hpp \
+                                 src/NVMLDevicePool.cpp \
+                                 src/NVMLDevicePool.hpp \
+                                 src/NVMLDevicePoolImp.hpp \
+                                 #end
+endif
 
 beta_source_files = src/Daemon.cpp \
                     src/Daemon.hpp \

--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,19 @@ fi
 [enable_procfs="1"]
 )
 
+AC_ARG_ENABLE([nvml],
+  [AS_HELP_STRING([--enable-nvml], [Enable GEOPM to use the NVIDIA NVML driver to support NVIDIA board accelerators])],
+[if test "x$enable_nvml" = "xno" ; then
+  enable_nvml="0"
+else
+  enable_nvml="1"
+fi
+],
+[enable_nvml="0"]
+)
+AC_SUBST([enable_nvml])
+AM_CONDITIONAL([ENABLE_NVML], [test "x$enable_nvml" = "x1"])
+
 AC_ARG_ENABLE([cnl-iogroup],
   [AS_HELP_STRING([--enable-cnl-iogroup], [Enable the CNL IOGroup])],
 [if test "x$enable_cnl_iogroup" = "xno" ; then
@@ -175,6 +188,14 @@ if test "x$enable_msrsafe_ioctl_write" = "x1" ; then
   AC_DEFINE([GEOPM_MSRSAFE_IOCTL_WRITE], [ ], [Enables use of msr-safe ioctl feature for writing (broken as of msr-safe version 1.2.0)])
 fi
 AC_SUBST([enable_msrsafe_ioctl_write])
+
+if test "x$enable_nvml" = "x1" ; then
+  ENABLE_NVML=True
+  AC_DEFINE([GEOPM_ENABLE_NVML], [ ], [Enables use of NVIDIA NVML driver to support NVIDIA Board acellerators])
+else
+  ENABLE_NVML=False
+fi
+AC_SUBST([ENABLE_NVML])
 
 AC_ARG_WITH([sqlite3], [AS_HELP_STRING([--with-sqlite3=PATH],
             [specify directory for installed sqlite3 package.])])
@@ -269,6 +290,14 @@ fi
 ],
 [enable_ronn="1"]
 )
+
+AC_ARG_WITH([libnvml], [AS_HELP_STRING([--with-libnvml=PATH],
+            [specify directory for installed libnvml package.])])
+if test "x$with_libnvml" != x; then
+  EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -I$with_libnvml/include"
+  LD_LIBRARY_PATH="$with_libnvml/lib:$LD_LIBRARY_PATH"
+  EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L$with_libnvml/lib"
+fi
 
 AC_SUBST([enable_ronn])
 AM_CONDITIONAL([ENABLE_RONN], [test "x$enable_ronn" = "x1"])
@@ -466,6 +495,16 @@ AC_CHECK_HEADER([gelf.h], [], [
     echo "missing gelf.h: ELF library is required, use --with-libelf or --with-libelf-include to specify location"
     exit -1])
 
+if test "x$enable_nvml" = "x1" ; then
+    AC_SEARCH_LIBS([nvmlSystemGetCudaDriverVersion], [nvidia-ml])
+    AC_CHECK_LIB([nvidia-ml], [nvmlSystemGetCudaDriverVersion], [], [
+        echo "missing libnvidia-ml: NVML library is required, use --with-libnvml to specify location"
+        exit -1])
+    AC_CHECK_HEADER([nvml.h], [], [
+        echo "missing nvml.h: NVML header is required, use --with-libnvml to specify location"
+        exit -1])
+fi
+
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h float.h inttypes.h malloc.h netdb.h stddef.h stdint.h stdlib.h string.h sys/socket.h unistd.h])
 
@@ -647,4 +686,5 @@ AC_MSG_RESULT([ronn               : ${enable_ronn}])
 AC_MSG_RESULT([ompt               : ${enable_ompt}])
 AC_MSG_RESULT([beta               : ${enable_beta}])
 AC_MSG_RESULT([bloat              : ${enable_bloat}])
+AC_MSG_RESULT([nvml               : ${enable_nvml}])
 AC_MSG_RESULT([===============================================================================])

--- a/configure.ac
+++ b/configure.ac
@@ -135,7 +135,7 @@ fi
 )
 
 AC_ARG_ENABLE([nvml],
-  [AS_HELP_STRING([--enable-nvml], [Enables use of the NVML driver to support NVML board accelerators])],
+  [AS_HELP_STRING([--enable-nvml], [Enables use of the NVML library to support NVML board accelerators])],
 [if test "x$enable_nvml" = "xno" ; then
   enable_nvml="0"
 else
@@ -191,11 +191,10 @@ AC_SUBST([enable_msrsafe_ioctl_write])
 
 if test "x$enable_nvml" = "x1" ; then
   ENABLE_NVML=True
-  AC_DEFINE([GEOPM_ENABLE_NVML], [ ], [Enables use of the NVML driver to support NVML board accelerators])
+  AC_DEFINE([GEOPM_ENABLE_NVML], [ ], [Enables use of the NVML library to support NVML board accelerators])
 else
   ENABLE_NVML=False
 fi
-AC_SUBST([ENABLE_NVML])
 
 AC_ARG_WITH([sqlite3], [AS_HELP_STRING([--with-sqlite3=PATH],
             [specify directory for installed sqlite3 package.])])

--- a/configure.ac
+++ b/configure.ac
@@ -135,7 +135,7 @@ fi
 )
 
 AC_ARG_ENABLE([nvml],
-  [AS_HELP_STRING([--enable-nvml], [Enable GEOPM to use the NVIDIA NVML driver to support NVIDIA board accelerators])],
+  [AS_HELP_STRING([--enable-nvml], [Enables use of the NVML driver to support NVML board accelerators])],
 [if test "x$enable_nvml" = "xno" ; then
   enable_nvml="0"
 else
@@ -191,7 +191,7 @@ AC_SUBST([enable_msrsafe_ioctl_write])
 
 if test "x$enable_nvml" = "x1" ; then
   ENABLE_NVML=True
-  AC_DEFINE([GEOPM_ENABLE_NVML], [ ], [Enables use of NVIDIA NVML driver to support NVIDIA Board acellerators])
+  AC_DEFINE([GEOPM_ENABLE_NVML], [ ], [Enables use of the NVML driver to support NVML board accelerators])
 else
   ENABLE_NVML=False
 fi

--- a/src/AcceleratorTopo.cpp
+++ b/src/AcceleratorTopo.cpp
@@ -56,7 +56,7 @@ namespace geopm
         return 0;
     }
 
-    std::set<int> AcceleratorTopo::ideal_cpu_affinitization(int domain_idx) const
+    std::set<int> AcceleratorTopo::cpu_affinity_ideal(int domain_idx) const
     {
         return {};
     }

--- a/src/AcceleratorTopo.cpp
+++ b/src/AcceleratorTopo.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "config.h"
+#include "Exception.hpp"
+#include "NVMLAcceleratorTopo.hpp"
+
+namespace geopm
+{
+
+    const AcceleratorTopo &accelerator_topo(void)
+    {
+#ifdef GEOPM_ENABLE_NVML
+        static NVMLAcceleratorTopo instance;
+#else
+        static AcceleratorTopo instance;
+#endif
+        return instance;
+    }
+
+    int AcceleratorTopo::num_accelerator() const
+    {
+        return 0;
+    }
+
+    std::set<int> AcceleratorTopo::ideal_cpu_affinitization(int domain_idx) const
+    {
+        return {};
+    }
+}

--- a/src/AcceleratorTopo.cpp
+++ b/src/AcceleratorTopo.cpp
@@ -41,7 +41,6 @@
 
 namespace geopm
 {
-
     const AcceleratorTopo &accelerator_topo(void)
     {
 #ifdef GEOPM_ENABLE_NVML
@@ -52,7 +51,7 @@ namespace geopm
         return instance;
     }
 
-    int AcceleratorTopo::num_accelerator() const
+    int AcceleratorTopo::num_accelerator(void) const
     {
         return 0;
     }

--- a/src/AcceleratorTopo.hpp
+++ b/src/AcceleratorTopo.hpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ACCELERATORTOPO_HPP_INCLUDE
+#define ACCELERATORTOPO_HPP_INCLUDE
+
+#include <cstdint>
+
+namespace geopm
+{
+    class AcceleratorTopo
+    {
+        public:
+            AcceleratorTopo() = default;
+            virtual ~AcceleratorTopo() = default;
+            /// @brief Number of accelerators on the platform.
+            virtual int num_accelerator() const;
+            /// @brief CPU Affinitization set for a particular accelerator
+            /// @param [in] domain_idx The index indicating a particular
+            ///        accelerator
+            virtual std::set<int> ideal_cpu_affinitization(int domain_idx) const;
+
+    };
+
+    const AcceleratorTopo &accelerator_topo(void);
+}
+#endif

--- a/src/AcceleratorTopo.hpp
+++ b/src/AcceleratorTopo.hpp
@@ -47,7 +47,7 @@ namespace geopm
             /// @brief CPU Affinitization set for a particular accelerator
             /// @param [in] domain_idx The index indicating a particular
             ///        accelerator
-            virtual std::set<int> ideal_cpu_affinitization(int domain_idx) const;
+            virtual std::set<int> cpu_affinity_ideal(int domain_idx) const;
     };
 
     const AcceleratorTopo &accelerator_topo(void);

--- a/src/AcceleratorTopo.hpp
+++ b/src/AcceleratorTopo.hpp
@@ -43,12 +43,11 @@ namespace geopm
             AcceleratorTopo() = default;
             virtual ~AcceleratorTopo() = default;
             /// @brief Number of accelerators on the platform.
-            virtual int num_accelerator() const;
+            virtual int num_accelerator(void) const;
             /// @brief CPU Affinitization set for a particular accelerator
             /// @param [in] domain_idx The index indicating a particular
             ///        accelerator
             virtual std::set<int> ideal_cpu_affinitization(int domain_idx) const;
-
     };
 
     const AcceleratorTopo &accelerator_topo(void);

--- a/src/NVMLAcceleratorTopo.cpp
+++ b/src/NVMLAcceleratorTopo.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <map>
+
+#include "config.h"
+#include "Exception.hpp"
+#include "NVMLDevicePool.hpp"
+#include "NVMLAcceleratorTopo.hpp"
+
+namespace geopm
+{
+
+    NVMLAcceleratorTopo::NVMLAcceleratorTopo()
+                                                  // TODO: can this be extracted from platform topo
+        : NVMLAcceleratorTopo(nvml_device_pool(), geopm_sched_num_cpu())
+    {
+    }
+
+    NVMLAcceleratorTopo::NVMLAcceleratorTopo(const NVMLDevicePool &device_pool, const int num_cpu)
+        : m_nvml_device_pool(device_pool)
+    {
+        m_num_accelerator = m_nvml_device_pool.num_accelerator();
+
+        if (m_num_accelerator == 0) {
+            std::cerr << "Warning: <geopm> NVMLAcceleratorTopo: No NVIDIA accelerators detected.\n";
+        }
+        else {
+            int cpu_remaining = 0;
+            std::vector<cpu_set_t *> ideal_affinitization_mask_vec;
+            cpu_set_t *affinitized_cpuset = NULL;
+
+            affinitized_cpuset = CPU_ALLOC(num_cpu);
+            CPU_ZERO_S(CPU_ALLOC_SIZE(num_cpu), affinitized_cpuset);
+
+            m_ideal_cpu_affinitization.resize(m_num_accelerator);
+
+            // Cache ideal affinitization due to the overhead associated with the NVML calls
+            for(int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
+                ideal_affinitization_mask_vec.push_back(m_nvml_device_pool.ideal_cpu_affinitization_mask(accel_idx));
+            }
+
+            // TODO: As an optimization this may be replacable with CPU_OR of all masks in ideal_affinitzation_mask_vec
+            //       and CPU_COUNT of the output
+            for (int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
+                for (int cpu_idx = 0; cpu_idx < num_cpu; cpu_idx++) {
+                    if (CPU_ISSET(cpu_idx, ideal_affinitization_mask_vec.at(accel_idx))) {
+                        if (CPU_ISSET(cpu_idx, affinitized_cpuset) == 0) {
+                            //if this is in this accelerator mask and has not
+                            //been picked by another accelerator
+                            CPU_SET(cpu_idx, affinitized_cpuset);
+                            ++cpu_remaining;
+                        }
+                    }
+                }
+            }
+
+            // In order to handle systems where the number of CPUs are not evenly divisble by the number of GPUs 
+            // a two pass process is used.  This does not guarantee affinitization is successful, but covers many
+            // common cases
+            for(int affinitization_attempts = 0; affinitization_attempts < 2; ++affinitization_attempts) {
+                unsigned int num_cpu_per_accelerator = cpu_remaining / m_num_accelerator;
+                if (num_cpu_per_accelerator == 0) {
+                    num_cpu_per_accelerator = cpu_remaining % m_num_accelerator;
+                }
+
+                // This is a greedy approach for mapping CPUs to accelerators, and as such may result in some CPUs
+                // not being affinitized at all.  A potential improvement is to always determine affinity
+                // for the accelerator with the fewest possible CPUs in the accelerator mask
+                for (int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
+                    unsigned int accelerator_cpu_count = 0;
+
+                    int cpu_idx = 0;
+                    while (cpu_idx < num_cpu && accelerator_cpu_count < num_cpu_per_accelerator) {
+                        if (CPU_ISSET(cpu_idx, ideal_affinitization_mask_vec.at(accel_idx))) {
+                            m_ideal_cpu_affinitization.at(accel_idx).insert(cpu_idx);
+                            --cpu_remaining;
+                            ++accelerator_cpu_count;
+
+                            // Remove this CPU from the affinity mask of all Accelerators
+                            for (int accel_idx_inner = 0; accel_idx_inner <  m_num_accelerator; ++accel_idx_inner) {
+                                CPU_CLR(cpu_idx, ideal_affinitization_mask_vec.at(accel_idx_inner));
+                            }
+                        }
+                        ++cpu_idx;
+                    }
+                }
+            }
+
+            if(cpu_remaining != 0){
+                throw Exception("NVMLAcceleratorTopo::" + std::string(__func__) +
+                                ": Failed to affinitize all valid CPUs to Accelerators.  " +
+                                std::to_string(cpu_remaining) + " CPUs remain unassociated with any accelerator.",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+        }
+
+    }
+
+    int NVMLAcceleratorTopo::num_accelerator() const
+    {
+        return m_num_accelerator;
+    }
+
+    std::set<int> NVMLAcceleratorTopo::ideal_cpu_affinitization(int accel_idx) const
+    {
+        if (accel_idx < 0 || accel_idx >= m_num_accelerator) {
+            throw Exception("NVMLAcceleratorTopo::" + std::string(__func__) + ": accel_idx " +
+                            std::to_string(accel_idx) + "  is out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_ideal_cpu_affinitization.at(accel_idx);
+    }
+}

--- a/src/NVMLAcceleratorTopo.hpp
+++ b/src/NVMLAcceleratorTopo.hpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVMLACCELERATORTOPO_HPP_INCLUDE
+#define NVMLACCELERATORTOPO_HPP_INCLUDE
+
+#include <cstdint>
+#include <vector>
+#include <set>
+
+#include "AcceleratorTopo.hpp"
+
+namespace geopm
+{
+    class NVMLDevicePool;
+
+    class NVMLAcceleratorTopo : public AcceleratorTopo
+    {
+        public:
+            NVMLAcceleratorTopo();
+            NVMLAcceleratorTopo(const NVMLDevicePool &device_pool, const int num_cpu);
+            virtual ~NVMLAcceleratorTopo() = default;
+            virtual int num_accelerator() const override;
+            virtual std::set<int> ideal_cpu_affinitization(int accel_idx) const override;
+        private:
+            const NVMLDevicePool &m_nvml_device_pool;
+
+            std::vector<std::set<int> > m_ideal_cpu_affinitization;
+            unsigned int m_num_accelerator;
+    };
+}
+#endif

--- a/src/NVMLAcceleratorTopo.hpp
+++ b/src/NVMLAcceleratorTopo.hpp
@@ -50,10 +50,10 @@ namespace geopm
             NVMLAcceleratorTopo(const NVMLDevicePool &device_pool, const int num_cpu);
             virtual ~NVMLAcceleratorTopo() = default;
             virtual int num_accelerator(void) const override;
-            virtual std::set<int> ideal_cpu_affinitization(int accel_idx) const override;
+            virtual std::set<int> cpu_affinity_ideal(int accel_idx) const override;
         private:
             const NVMLDevicePool &m_nvml_device_pool;
-            std::vector<std::set<int> > m_ideal_cpu_affinitization;
+            std::vector<std::set<int> > m_cpu_affinity_ideal;
             unsigned int m_num_accelerator;
     };
 }

--- a/src/NVMLAcceleratorTopo.hpp
+++ b/src/NVMLAcceleratorTopo.hpp
@@ -49,11 +49,10 @@ namespace geopm
             NVMLAcceleratorTopo();
             NVMLAcceleratorTopo(const NVMLDevicePool &device_pool, const int num_cpu);
             virtual ~NVMLAcceleratorTopo() = default;
-            virtual int num_accelerator() const override;
+            virtual int num_accelerator(void) const override;
             virtual std::set<int> ideal_cpu_affinitization(int accel_idx) const override;
         private:
             const NVMLDevicePool &m_nvml_device_pool;
-
             std::vector<std::set<int> > m_ideal_cpu_affinitization;
             unsigned int m_num_accelerator;
     };

--- a/src/NVMLDevicePool.cpp
+++ b/src/NVMLDevicePool.cpp
@@ -61,33 +61,22 @@ namespace geopm
 
         //Initialize NVML
         nvml_result = nvmlInit();
-        if (nvml_result != NVML_SUCCESS) {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to initialize.  Error: " +
-                            nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
-        }
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to initialize.");
 
         //Query number of NVML Accelerators
         nvml_result = nvmlDeviceGetCount(&m_num_accelerator);
-        if (nvml_result != NVML_SUCCESS) {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to query device count.  Error: " +
-                            nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
-        }
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to query device count.");
 
         //Acquire device handle for each NVML Accelerator
         m_nvml_device.resize(m_num_accelerator);
         for (unsigned int accel_idx = 0; accel_idx < m_num_accelerator; ++accel_idx) {
             nvml_result = nvmlDeviceGetHandleByIndex(accel_idx,
                                                      &m_nvml_device.at(accel_idx));
-            if (nvml_result != NVML_SUCCESS) {
-                throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                                ": NVML failed to get handle for accelerator " +
-                                std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                                GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
-            }
+            check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                              ": NVML failed to get handle for accelerator " +
+                              std::to_string(accel_idx) + ".");
         }
     }
 
@@ -106,7 +95,7 @@ namespace geopm
     void NVMLDevicePoolImp::check_nvml_result(nvmlReturn_t nvml_result, int error, std::string message) const
     {
         if (nvml_result != NVML_SUCCESS) {
-            throw Exception(message, error, __FILE__, __LINE__);
+            throw Exception(message + "  Error: " + nvmlErrorString(nvml_result), error, __FILE__, __LINE__);
         }
     }
 
@@ -140,7 +129,7 @@ namespace geopm
                                                             (unsigned long *)accel_cpuset);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get CPU Affinity bitmask for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
         return accel_cpuset;
     }
 
@@ -154,7 +143,7 @@ namespace geopm
                                          &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get SM Frequency for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
         return (uint64_t)result;
     }
 
@@ -167,7 +156,7 @@ namespace geopm
         nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get GPU Utilization for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
         return (double)result.gpu;
     }
 
@@ -180,7 +169,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetPowerUsage(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get power for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
 
         return (uint64_t)result;
     }
@@ -194,7 +183,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_MEM, NVML_CLOCK_ID_CURRENT, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get Memory Frequency for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
 
         return (uint64_t)result;
     }
@@ -208,7 +197,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetCurrentClocksThrottleReasons(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get current clock throttle reasosn for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
 
         return (uint64_t)result;
     }
@@ -222,7 +211,7 @@ namespace geopm
         nvml_result =  nvmlDeviceGetTemperature(m_nvml_device.at(accel_idx), NVML_TEMPERATURE_GPU, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get temperature for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
 
         return (uint64_t)result;
     }
@@ -236,7 +225,7 @@ namespace geopm
         nvml_result =  nvmlDeviceGetTotalEnergyConsumption(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get energy for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
 
         return (uint64_t)result;
     }
@@ -250,7 +239,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetPerformanceState(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get performance state for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
 
         return (uint64_t)result;
     }
@@ -264,7 +253,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_RX_BYTES, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get PCIE received throughput rate for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
 
         return (uint64_t)result;
     }
@@ -278,7 +267,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_TX_BYTES, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get PCIE transmitted throughput rate for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
 
         return (uint64_t)result;
     }
@@ -292,7 +281,7 @@ namespace geopm
         nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get memory utilization for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
 
         return (double)result.memory;
     }
@@ -329,7 +318,7 @@ namespace geopm
             }
             check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                               ": NVML failed to acquire running processes for accelerator " +
-                              std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                              std::to_string(accel_idx) + ".");
 
             for (int i = 0; i<temp; i++) {
                 result.push_back(process_info_list[i].pid);
@@ -338,7 +327,7 @@ namespace geopm
         else {
             check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                               ": NVML failed to acquire running processes for accelerator " +
-                              std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                              std::to_string(accel_idx) + ".");
         }
         return result;
     }
@@ -351,7 +340,7 @@ namespace geopm
         nvml_result = nvmlDeviceSetGpuLockedClocks(m_nvml_device[accel_idx], (unsigned int) min_freq, (unsigned int) max_freq);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to set sm frequency for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
     }
 
     void NVMLDevicePoolImp::frequency_reset_control(int accel_idx) const
@@ -362,7 +351,7 @@ namespace geopm
         nvml_result =  nvmlDeviceResetGpuLockedClocks(m_nvml_device[accel_idx]);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to reset sm frequency for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
     }
 
     void NVMLDevicePoolImp::power_control(int accel_idx, int setting) const
@@ -373,6 +362,6 @@ namespace geopm
         nvml_result = nvmlDeviceSetPowerManagementLimit(m_nvml_device.at(accel_idx), (unsigned int) (setting));
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to set power limit for accelerator " +
-                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+                          std::to_string(accel_idx) + ".");
     }
 }

--- a/src/NVMLDevicePool.cpp
+++ b/src/NVMLDevicePool.cpp
@@ -47,15 +47,16 @@
 namespace geopm
 {
 
-    const NVMLDevicePool &nvml_device_pool(void)
+    const NVMLDevicePool &nvml_device_pool(const int num_cpu)
     {
-        static NVMLDevicePoolImp instance;
+        static NVMLDevicePoolImp instance(num_cpu);
         return instance;
     }
 
-    NVMLDevicePoolImp::NVMLDevicePoolImp()
+    NVMLDevicePoolImp::NVMLDevicePoolImp(const int num_cpu)
+        : M_MAX_CONTEXTS(64)
+        , M_NUM_CPU(num_cpu)
     {
-        m_max_contexts = 64;
         nvmlReturn_t nvml_result;
 
         //Initialize NVML
@@ -64,28 +65,28 @@ namespace geopm
             throw Exception("NVMLDevicePool::" + std::string(__func__) +
                             ": NVML failed to initialize.  Error: " +
                             nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
         }
 
-        //Query number of NVIDIA Accelerators
+        //Query number of NVML Accelerators
         nvml_result = nvmlDeviceGetCount(&m_num_accelerator);
         if (nvml_result != NVML_SUCCESS) {
             throw Exception("NVMLDevicePool::" + std::string(__func__) +
                             ": NVML failed to query device count.  Error: " +
                             nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
         }
 
-        //Acquire device handle for each NVIDIA Accelerator
+        //Acquire device handle for each NVML Accelerator
         m_nvml_device.resize(m_num_accelerator);
-        for (unsigned int accel_idx = 0; accel_idx < m_num_accelerator; ++accel_idx){
+        for (unsigned int accel_idx = 0; accel_idx < m_num_accelerator; ++accel_idx) {
             nvml_result = nvmlDeviceGetHandleByIndex(accel_idx,
                                                      &m_nvml_device.at(accel_idx));
             if (nvml_result != NVML_SUCCESS) {
                 throw Exception("NVMLDevicePool::" + std::string(__func__) +
                                 ": NVML failed to get handle for accelerator " +
                                 std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                                GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
             }
         }
     }
@@ -93,14 +94,20 @@ namespace geopm
     NVMLDevicePoolImp::~NVMLDevicePoolImp()
     {
         //Shutdown NVML
-        nvmlReturn_t nvml_result;
-        nvml_result = nvmlShutdown();
+        nvmlReturn_t nvml_result = nvmlShutdown();
 #ifdef GEOPM_DEBUG
         if (nvml_result != NVML_SUCCESS) {
             std::cerr << "NVMLDevicePool::" << __func__ <<  ": NVML failed to shutdown."
                       << "  Error: " <<  nvmlErrorString(nvml_result) << std::endl;
         }
 #endif
+    }
+
+    void NVMLDevicePoolImp::check_nvml_result(nvmlReturn_t nvml_result, int error, std::string message) const
+    {
+        if (nvml_result != NVML_SUCCESS) {
+            throw Exception(message, error, __FILE__, __LINE__);
+        }
     }
 
     int NVMLDevicePoolImp::num_accelerator() const
@@ -120,14 +127,9 @@ namespace geopm
     cpu_set_t *NVMLDevicePoolImp::ideal_cpu_affinitization_mask(int accel_idx) const
     {
         check_accel_range(accel_idx);
-
-        cpu_set_t *accel_cpuset = NULL;
-        //TODO: can this be extracted from platform topo
-        const int num_cpu = geopm_sched_num_cpu();
-        unsigned int cpu_set_size = CPU_ALLOC_SIZE(num_cpu)/sizeof(unsigned long);
-
-        accel_cpuset = CPU_ALLOC(num_cpu);
-        CPU_ZERO_S(CPU_ALLOC_SIZE(num_cpu), accel_cpuset);
+        unsigned int cpu_set_size = CPU_ALLOC_SIZE(M_NUM_CPU)/sizeof(unsigned long);
+        cpu_set_t *accel_cpuset = CPU_ALLOC(M_NUM_CPU);
+        CPU_ZERO_S(CPU_ALLOC_SIZE(M_NUM_CPU), accel_cpuset);
 
         if (!accel_cpuset) {
             throw Exception("NVMLDevicePool: unable to allocate process CPU mask",
@@ -136,251 +138,170 @@ namespace geopm
 
         nvmlReturn_t nvml_result = nvmlDeviceGetCpuAffinity(m_nvml_device.at(accel_idx), cpu_set_size,
                                                             (unsigned long *)accel_cpuset);
-        if (NVML_SUCCESS != nvml_result) {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get CPU Affinity bitmask for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get CPU Affinity bitmask for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
         return accel_cpuset;
     }
 
-    uint64_t NVMLDevicePoolImp::frequency_status(int accel_idx) const
+    uint64_t NVMLDevicePoolImp::frequency_status_sm(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        uint64_t result = 0;
-        unsigned int temp;
+        unsigned int result;
         nvmlReturn_t nvml_result;
 
         nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_SM, NVML_CLOCK_ID_CURRENT,
-                                         &temp);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (uint64_t)temp;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get SM Frequency for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-        return result;
+                                         &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get SM Frequency for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+        return (uint64_t)result;
     }
 
     double NVMLDevicePoolImp::utilization(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        double result = NAN;
-        nvmlUtilization_t util;
+        nvmlUtilization_t result;
         nvmlReturn_t nvml_result;
 
-        nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &util);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (double) util.gpu;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get GPU Utilization for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-        return result;
+        nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get GPU Utilization for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+        return (double)result.gpu;
     }
 
     uint64_t NVMLDevicePoolImp::power(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        uint64_t result = 0;
-        unsigned int temp;
+        unsigned int result;
         nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetPowerUsage(m_nvml_device.at(accel_idx), &temp);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (uint64_t)temp;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get power for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        nvml_result = nvmlDeviceGetPowerUsage(m_nvml_device.at(accel_idx), &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get power for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
 
-        return result;
+        return (uint64_t)result;
     }
 
     uint64_t NVMLDevicePoolImp::frequency_status_mem(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        uint64_t result = 0;
-        unsigned int temp;
+        unsigned int result;
         nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_MEM, NVML_CLOCK_ID_CURRENT, &temp);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (uint64_t)temp;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get Memory Frequency for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_MEM, NVML_CLOCK_ID_CURRENT, &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get Memory Frequency for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
 
-        return result;
+        return (uint64_t)result;
     }
 
     uint64_t NVMLDevicePoolImp::throttle_reasons(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        uint64_t result = 0;
-        unsigned long long temp_ull;
+        unsigned long long result;
         nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetCurrentClocksThrottleReasons(m_nvml_device.at(accel_idx), &temp_ull);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (uint64_t)temp_ull;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get current clock throttle reasosn for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        nvml_result = nvmlDeviceGetCurrentClocksThrottleReasons(m_nvml_device.at(accel_idx), &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get current clock throttle reasosn for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
 
-        return result;
+        return (uint64_t)result;
     }
 
     uint64_t NVMLDevicePoolImp::temperature(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        uint64_t result = 0;
-        unsigned int temp;
+        unsigned int result;
         nvmlReturn_t nvml_result;
 
-        nvml_result =  nvmlDeviceGetTemperature(m_nvml_device.at(accel_idx), NVML_TEMPERATURE_GPU, &temp);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (uint64_t)temp;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get temperature for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        nvml_result =  nvmlDeviceGetTemperature(m_nvml_device.at(accel_idx), NVML_TEMPERATURE_GPU, &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get temperature for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
 
-        return result;
+        return (uint64_t)result;
     }
 
     uint64_t NVMLDevicePoolImp::energy(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        uint64_t result = 0;
-        unsigned long long temp_ull;
+        unsigned long long result;
         nvmlReturn_t nvml_result;
 
-        nvml_result =  nvmlDeviceGetTotalEnergyConsumption(m_nvml_device.at(accel_idx), &temp_ull);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (uint64_t)temp_ull;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get energy for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        nvml_result =  nvmlDeviceGetTotalEnergyConsumption(m_nvml_device.at(accel_idx), &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get energy for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
 
-        return result;
+        return (uint64_t)result;
     }
 
     uint64_t NVMLDevicePoolImp::performance_state(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        uint64_t result = 0;
-        nvmlPstates_t perf_state;
+        nvmlPstates_t result;
         nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetPerformanceState(m_nvml_device.at(accel_idx), &perf_state);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (uint64_t)perf_state;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get performance state for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        nvml_result = nvmlDeviceGetPerformanceState(m_nvml_device.at(accel_idx), &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get performance state for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
 
-        return result;
+        return (uint64_t)result;
     }
 
     uint64_t NVMLDevicePoolImp::throughput_rx_pcie(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        uint64_t result = 0;
-        unsigned int temp;
+        unsigned int result;
         nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_RX_BYTES, &temp);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (uint64_t)temp;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get PCIE received throughput rate for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_RX_BYTES, &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get PCIE received throughput rate for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
 
-        return result;
+        return (uint64_t)result;
     }
 
     uint64_t NVMLDevicePoolImp::throughput_tx_pcie(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        uint64_t result = 0;
-        unsigned int temp;
+        unsigned int result;
         nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_TX_BYTES, &temp);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (uint64_t)temp;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get PCIE transmitted throughput rate for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_TX_BYTES, &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get PCIE transmitted throughput rate for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
 
-        return result;
+        return (uint64_t)result;
     }
 
     double NVMLDevicePoolImp::utilization_mem(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        double result = NAN;
-        nvmlUtilization_t util;
+        nvmlUtilization_t result;
         nvmlReturn_t nvml_result;
 
-        nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &util);
-        if (nvml_result == NVML_SUCCESS) {
-            result = (double) util.memory;
-        }
-        else {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to get memory utilization for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get memory utilization for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
 
-        return result;
+        return (double)result.memory;
     }
 
     std::vector<int> NVMLDevicePoolImp::active_process_list(int accel_idx) const
     {
         check_accel_range(accel_idx);
         std::vector<int> result;
-        unsigned int temp = m_max_contexts;
+        unsigned int temp = M_MAX_CONTEXTS;
 
         nvmlReturn_t nvml_result;
         nvmlProcessInfo_t *process_info_list;
@@ -392,47 +313,45 @@ namespace geopm
                 result.push_back(process_info_list[i].pid);
             }
         }
-        else {
-            if (nvml_result == NVML_ERROR_INSUFFICIENT_SIZE) {
-                process_info_list = new nvmlProcessInfo_t[temp];
-                nvml_result = nvmlDeviceGetComputeRunningProcesses(m_nvml_device[accel_idx], &temp, &process_info_list[0]);
+        else if (nvml_result == NVML_ERROR_INSUFFICIENT_SIZE) {
+            // If the first attempt was unsuccessful due to process_info_list being too small the temp variable
+            // will contain the correct size.  This allows us to retry the above call with better chances of
+            // success.
 
-                if (nvml_result == NVML_SUCCESS) {
-                    for (int i = 0; i<temp; i++) {
-                        result.push_back(process_info_list[i].pid);
-                    }
-                }
-                else {
-                    throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                                    ": NVML failed to acquire running processes for accelerator " +
-                                    std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-                }
-            }
-            else {
+            process_info_list = new nvmlProcessInfo_t[temp];
+            nvml_result = nvmlDeviceGetComputeRunningProcesses(m_nvml_device[accel_idx], &temp, &process_info_list[0]);
+
+            if (nvml_result == NVML_ERROR_INSUFFICIENT_SIZE) {
                 throw Exception("NVMLDevicePool::" + std::string(__func__) +
                                 ": NVML failed to acquire running processes for accelerator " +
-                                std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                                std::to_string(accel_idx) + ".  Increase M_MAX_CONTEXTS to resolve. Error: " +
+                                nvmlErrorString(nvml_result), GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
+            check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                              ": NVML failed to acquire running processes for accelerator " +
+                              std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
+
+            for (int i = 0; i<temp; i++) {
+                result.push_back(process_info_list[i].pid);
+            }
+        }
+        else {
+            check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                              ": NVML failed to acquire running processes for accelerator " +
+                              std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
         }
         return result;
     }
 
-
-    void NVMLDevicePoolImp::frequency_control(int accel_idx, int setting) const
+    void NVMLDevicePoolImp::frequency_control_sm(int accel_idx, int min_freq, int max_freq) const
     {
         check_accel_range(accel_idx);
         nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceSetGpuLockedClocks(m_nvml_device[accel_idx], (unsigned int) setting, (unsigned int) setting);
-        if (nvml_result != NVML_SUCCESS) {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to set sm frequency for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-
+        nvml_result = nvmlDeviceSetGpuLockedClocks(m_nvml_device[accel_idx], (unsigned int) min_freq, (unsigned int) max_freq);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to set sm frequency for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
     }
 
     void NVMLDevicePoolImp::frequency_reset_control(int accel_idx) const
@@ -441,12 +360,9 @@ namespace geopm
         nvmlReturn_t nvml_result;
 
         nvml_result =  nvmlDeviceResetGpuLockedClocks(m_nvml_device[accel_idx]);
-        if (nvml_result != NVML_SUCCESS) {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to reset sm frequency for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to reset sm frequency for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
     }
 
     void NVMLDevicePoolImp::power_control(int accel_idx, int setting) const
@@ -455,11 +371,8 @@ namespace geopm
         nvmlReturn_t nvml_result;
 
         nvml_result = nvmlDeviceSetPowerManagementLimit(m_nvml_device.at(accel_idx), (unsigned int) (setting));
-        if (nvml_result != NVML_SUCCESS) {
-            throw Exception("NVMLDevicePool::" + std::string(__func__) +
-                            ": NVML failed to set power limit for accelerator " +
-                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to set power limit for accelerator " +
+                          std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result));
     }
 }

--- a/src/NVMLDevicePool.cpp
+++ b/src/NVMLDevicePool.cpp
@@ -62,12 +62,12 @@ namespace geopm
         //Initialize NVML
         nvml_result = nvmlInit();
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
-                          ": NVML failed to initialize.");
+                          ": NVML failed to initialize.", __LINE__);
 
         //Query number of NVML Accelerators
         nvml_result = nvmlDeviceGetCount(&m_num_accelerator);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
-                          ": NVML failed to query device count.");
+                          ": NVML failed to query device count.", __LINE__);
 
         //Acquire device handle for each NVML Accelerator
         m_nvml_device.resize(m_num_accelerator);
@@ -76,7 +76,7 @@ namespace geopm
                                                      &m_nvml_device.at(accel_idx));
             check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                               ": NVML failed to get handle for accelerator " +
-                              std::to_string(accel_idx) + ".");
+                              std::to_string(accel_idx) + ".", __LINE__);
         }
     }
 
@@ -92,10 +92,10 @@ namespace geopm
 #endif
     }
 
-    void NVMLDevicePoolImp::check_nvml_result(nvmlReturn_t nvml_result, int error, std::string message) const
+    void NVMLDevicePoolImp::check_nvml_result(nvmlReturn_t nvml_result, int error, std::string message, int line) const
     {
         if (nvml_result != NVML_SUCCESS) {
-            throw Exception(message + "  Error: " + nvmlErrorString(nvml_result), error, __FILE__, __LINE__);
+            throw Exception(message + "  Error: " + nvmlErrorString(nvml_result), error, __FILE__, line);
         }
     }
 
@@ -113,10 +113,10 @@ namespace geopm
         }
     }
 
-    cpu_set_t *NVMLDevicePoolImp::ideal_cpu_affinitization_mask(int accel_idx) const
+    cpu_set_t *NVMLDevicePoolImp::cpu_affinity_ideal_mask(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        unsigned int cpu_set_size = CPU_ALLOC_SIZE(M_NUM_CPU)/sizeof(unsigned long);
+        unsigned int cpu_set_size = CPU_ALLOC_SIZE(M_NUM_CPU) / sizeof(unsigned long);
         cpu_set_t *accel_cpuset = CPU_ALLOC(M_NUM_CPU);
         CPU_ZERO_S(CPU_ALLOC_SIZE(M_NUM_CPU), accel_cpuset);
 
@@ -129,7 +129,7 @@ namespace geopm
                                                             (unsigned long *)accel_cpuset);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get CPU Affinity bitmask for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
         return accel_cpuset;
     }
 
@@ -143,11 +143,11 @@ namespace geopm
                                          &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get SM Frequency for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
         return (uint64_t)result;
     }
 
-    double NVMLDevicePoolImp::utilization(int accel_idx) const
+    uint64_t NVMLDevicePoolImp::utilization(int accel_idx) const
     {
         check_accel_range(accel_idx);
         nvmlUtilization_t result;
@@ -156,8 +156,8 @@ namespace geopm
         nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get GPU Utilization for accelerator " +
-                          std::to_string(accel_idx) + ".");
-        return (double)result.gpu;
+                          std::to_string(accel_idx) + ".", __LINE__);
+        return (uint64_t)result.gpu;
     }
 
     uint64_t NVMLDevicePoolImp::power(int accel_idx) const
@@ -169,7 +169,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetPowerUsage(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get power for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
 
         return (uint64_t)result;
     }
@@ -183,7 +183,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_MEM, NVML_CLOCK_ID_CURRENT, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get Memory Frequency for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
 
         return (uint64_t)result;
     }
@@ -197,7 +197,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetCurrentClocksThrottleReasons(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get current clock throttle reasosn for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
 
         return (uint64_t)result;
     }
@@ -211,7 +211,7 @@ namespace geopm
         nvml_result =  nvmlDeviceGetTemperature(m_nvml_device.at(accel_idx), NVML_TEMPERATURE_GPU, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get temperature for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
 
         return (uint64_t)result;
     }
@@ -225,7 +225,7 @@ namespace geopm
         nvml_result =  nvmlDeviceGetTotalEnergyConsumption(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get energy for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
 
         return (uint64_t)result;
     }
@@ -239,7 +239,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetPerformanceState(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get performance state for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
 
         return (uint64_t)result;
     }
@@ -253,7 +253,7 @@ namespace geopm
         nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_RX_BYTES, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get PCIE received throughput rate for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
 
         return (uint64_t)result;
     }
@@ -267,12 +267,12 @@ namespace geopm
         nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_TX_BYTES, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get PCIE transmitted throughput rate for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
 
         return (uint64_t)result;
     }
 
-    double NVMLDevicePoolImp::utilization_mem(int accel_idx) const
+    uint64_t NVMLDevicePoolImp::utilization_mem(int accel_idx) const
     {
         check_accel_range(accel_idx);
         nvmlUtilization_t result;
@@ -281,9 +281,9 @@ namespace geopm
         nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get memory utilization for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
 
-        return (double)result.memory;
+        return (uint64_t)result.memory;
     }
 
     std::vector<int> NVMLDevicePoolImp::active_process_list(int accel_idx) const
@@ -318,7 +318,7 @@ namespace geopm
             }
             check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                               ": NVML failed to acquire running processes for accelerator " +
-                              std::to_string(accel_idx) + ".");
+                              std::to_string(accel_idx) + ".", __LINE__);
 
             for (int i = 0; i<temp; i++) {
                 result.push_back(process_info_list[i].pid);
@@ -327,7 +327,7 @@ namespace geopm
         else {
             check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                               ": NVML failed to acquire running processes for accelerator " +
-                              std::to_string(accel_idx) + ".");
+                              std::to_string(accel_idx) + ".", __LINE__);
         }
         return result;
     }
@@ -340,7 +340,7 @@ namespace geopm
         nvml_result = nvmlDeviceSetGpuLockedClocks(m_nvml_device[accel_idx], (unsigned int) min_freq, (unsigned int) max_freq);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to set sm frequency for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
     }
 
     void NVMLDevicePoolImp::frequency_reset_control(int accel_idx) const
@@ -351,7 +351,7 @@ namespace geopm
         nvml_result =  nvmlDeviceResetGpuLockedClocks(m_nvml_device[accel_idx]);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to reset sm frequency for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
     }
 
     void NVMLDevicePoolImp::power_control(int accel_idx, int setting) const
@@ -362,6 +362,6 @@ namespace geopm
         nvml_result = nvmlDeviceSetPowerManagementLimit(m_nvml_device.at(accel_idx), (unsigned int) (setting));
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to set power limit for accelerator " +
-                          std::to_string(accel_idx) + ".");
+                          std::to_string(accel_idx) + ".", __LINE__);
     }
 }

--- a/src/NVMLDevicePool.cpp
+++ b/src/NVMLDevicePool.cpp
@@ -1,0 +1,465 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cmath>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "Exception.hpp"
+#include "Agg.hpp"
+#include "Helper.hpp"
+#include "geopm_sched.h"
+
+#include "NVMLDevicePoolImp.hpp"
+
+namespace geopm
+{
+
+    const NVMLDevicePool &nvml_device_pool(void)
+    {
+        static NVMLDevicePoolImp instance;
+        return instance;
+    }
+
+    NVMLDevicePoolImp::NVMLDevicePoolImp()
+    {
+        m_max_contexts = 64;
+        nvmlReturn_t nvml_result;
+
+        //Initialize NVML
+        nvml_result = nvmlInit();
+        if (nvml_result != NVML_SUCCESS) {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to initialize.  Error: " +
+                            nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        //Query number of NVIDIA Accelerators
+        nvml_result = nvmlDeviceGetCount(&m_num_accelerator);
+        if (nvml_result != NVML_SUCCESS) {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to query device count.  Error: " +
+                            nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        //Acquire device handle for each NVIDIA Accelerator
+        m_nvml_device.resize(m_num_accelerator);
+        for (unsigned int accel_idx = 0; accel_idx < m_num_accelerator; ++accel_idx){
+            nvml_result = nvmlDeviceGetHandleByIndex(accel_idx,
+                                                     &m_nvml_device.at(accel_idx));
+            if (nvml_result != NVML_SUCCESS) {
+                throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                                ": NVML failed to get handle for accelerator " +
+                                std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+        }
+    }
+
+    NVMLDevicePoolImp::~NVMLDevicePoolImp()
+    {
+        //Shutdown NVML
+        nvmlReturn_t nvml_result;
+        nvml_result = nvmlShutdown();
+#ifdef GEOPM_DEBUG
+        if (nvml_result != NVML_SUCCESS) {
+            std::cerr << "NVMLDevicePool::" << __func__ <<  ": NVML failed to shutdown."
+                      << "  Error: " <<  nvmlErrorString(nvml_result) << std::endl;
+        }
+#endif
+    }
+
+    int NVMLDevicePoolImp::num_accelerator() const
+    {
+        return m_num_accelerator;
+    }
+
+    void NVMLDevicePoolImp::check_accel_range(int accel_idx) const
+    {
+        if (accel_idx < 0 || accel_idx >= m_num_accelerator) {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) + ": accel_idx " +
+                            std::to_string(accel_idx) + "  is out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+
+    cpu_set_t *NVMLDevicePoolImp::ideal_cpu_affinitization_mask(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+
+        cpu_set_t *accel_cpuset = NULL;
+        //TODO: can this be extracted from platform topo
+        const int num_cpu = geopm_sched_num_cpu();
+        unsigned int cpu_set_size = CPU_ALLOC_SIZE(num_cpu)/sizeof(unsigned long);
+
+        accel_cpuset = CPU_ALLOC(num_cpu);
+        CPU_ZERO_S(CPU_ALLOC_SIZE(num_cpu), accel_cpuset);
+
+        if (!accel_cpuset) {
+            throw Exception("NVMLDevicePool: unable to allocate process CPU mask",
+                            ENOMEM, __FILE__, __LINE__);
+        }
+
+        nvmlReturn_t nvml_result = nvmlDeviceGetCpuAffinity(m_nvml_device.at(accel_idx), cpu_set_size,
+                                                            (unsigned long *)accel_cpuset);
+        if (NVML_SUCCESS != nvml_result) {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get CPU Affinity bitmask for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return accel_cpuset;
+    }
+
+    uint64_t NVMLDevicePoolImp::frequency_status(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        uint64_t result = 0;
+        unsigned int temp;
+        nvmlReturn_t nvml_result;
+
+        nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_SM, NVML_CLOCK_ID_CURRENT,
+                                         &temp);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (uint64_t)temp;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get SM Frequency for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return result;
+    }
+
+    double NVMLDevicePoolImp::utilization(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        double result = NAN;
+        nvmlUtilization_t util;
+        nvmlReturn_t nvml_result;
+
+        nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &util);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (double) util.gpu;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get GPU Utilization for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return result;
+    }
+
+    uint64_t NVMLDevicePoolImp::power(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        uint64_t result = 0;
+        unsigned int temp;
+        nvmlReturn_t nvml_result;
+
+        nvml_result = nvmlDeviceGetPowerUsage(m_nvml_device.at(accel_idx), &temp);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (uint64_t)temp;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get power for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return result;
+    }
+
+    uint64_t NVMLDevicePoolImp::frequency_status_mem(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        uint64_t result = 0;
+        unsigned int temp;
+        nvmlReturn_t nvml_result;
+
+        nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_MEM, NVML_CLOCK_ID_CURRENT, &temp);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (uint64_t)temp;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get Memory Frequency for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return result;
+    }
+
+    uint64_t NVMLDevicePoolImp::throttle_reasons(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        uint64_t result = 0;
+        unsigned long long temp_ull;
+        nvmlReturn_t nvml_result;
+
+        nvml_result = nvmlDeviceGetCurrentClocksThrottleReasons(m_nvml_device.at(accel_idx), &temp_ull);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (uint64_t)temp_ull;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get current clock throttle reasosn for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return result;
+    }
+
+    uint64_t NVMLDevicePoolImp::temperature(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        uint64_t result = 0;
+        unsigned int temp;
+        nvmlReturn_t nvml_result;
+
+        nvml_result =  nvmlDeviceGetTemperature(m_nvml_device.at(accel_idx), NVML_TEMPERATURE_GPU, &temp);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (uint64_t)temp;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get temperature for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return result;
+    }
+
+    uint64_t NVMLDevicePoolImp::energy(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        uint64_t result = 0;
+        unsigned long long temp_ull;
+        nvmlReturn_t nvml_result;
+
+        nvml_result =  nvmlDeviceGetTotalEnergyConsumption(m_nvml_device.at(accel_idx), &temp_ull);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (uint64_t)temp_ull;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get energy for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return result;
+    }
+
+    uint64_t NVMLDevicePoolImp::performance_state(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        uint64_t result = 0;
+        nvmlPstates_t perf_state;
+        nvmlReturn_t nvml_result;
+
+        nvml_result = nvmlDeviceGetPerformanceState(m_nvml_device.at(accel_idx), &perf_state);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (uint64_t)perf_state;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get performance state for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return result;
+    }
+
+    uint64_t NVMLDevicePoolImp::throughput_rx_pcie(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        uint64_t result = 0;
+        unsigned int temp;
+        nvmlReturn_t nvml_result;
+
+        nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_RX_BYTES, &temp);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (uint64_t)temp;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get PCIE received throughput rate for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return result;
+    }
+
+    uint64_t NVMLDevicePoolImp::throughput_tx_pcie(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        uint64_t result = 0;
+        unsigned int temp;
+        nvmlReturn_t nvml_result;
+
+        nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_TX_BYTES, &temp);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (uint64_t)temp;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get PCIE transmitted throughput rate for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return result;
+    }
+
+    double NVMLDevicePoolImp::utilization_mem(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        double result = NAN;
+        nvmlUtilization_t util;
+        nvmlReturn_t nvml_result;
+
+        nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &util);
+        if (nvml_result == NVML_SUCCESS) {
+            result = (double) util.memory;
+        }
+        else {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to get memory utilization for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return result;
+    }
+
+    std::vector<int> NVMLDevicePoolImp::active_process_list(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        std::vector<int> result;
+        unsigned int temp = m_max_contexts;
+
+        nvmlReturn_t nvml_result;
+        nvmlProcessInfo_t *process_info_list;
+        process_info_list = new nvmlProcessInfo_t[temp];
+
+        nvml_result = nvmlDeviceGetComputeRunningProcesses(m_nvml_device[accel_idx], &temp, &process_info_list[0]);
+        if (nvml_result == NVML_SUCCESS) {
+            for (int i = 0; i<temp; i++) {
+                result.push_back(process_info_list[i].pid);
+            }
+        }
+        else {
+            if (nvml_result == NVML_ERROR_INSUFFICIENT_SIZE) {
+                process_info_list = new nvmlProcessInfo_t[temp];
+                nvml_result = nvmlDeviceGetComputeRunningProcesses(m_nvml_device[accel_idx], &temp, &process_info_list[0]);
+
+                if (nvml_result == NVML_SUCCESS) {
+                    for (int i = 0; i<temp; i++) {
+                        result.push_back(process_info_list[i].pid);
+                    }
+                }
+                else {
+                    throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                                    ": NVML failed to acquire running processes for accelerator " +
+                                    std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                }
+            }
+            else {
+                throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                                ": NVML failed to acquire running processes for accelerator " +
+                                std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+        }
+        return result;
+    }
+
+
+    void NVMLDevicePoolImp::frequency_control(int accel_idx, int setting) const
+    {
+        check_accel_range(accel_idx);
+        nvmlReturn_t nvml_result;
+
+        nvml_result = nvmlDeviceSetGpuLockedClocks(m_nvml_device[accel_idx], (unsigned int) setting, (unsigned int) setting);
+        if (nvml_result != NVML_SUCCESS) {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to set sm frequency for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+    }
+
+    void NVMLDevicePoolImp::frequency_reset_control(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        nvmlReturn_t nvml_result;
+
+        nvml_result =  nvmlDeviceResetGpuLockedClocks(m_nvml_device[accel_idx]);
+        if (nvml_result != NVML_SUCCESS) {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to reset sm frequency for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+
+    void NVMLDevicePoolImp::power_control(int accel_idx, int setting) const
+    {
+        check_accel_range(accel_idx);
+        nvmlReturn_t nvml_result;
+
+        nvml_result = nvmlDeviceSetPowerManagementLimit(m_nvml_device.at(accel_idx), (unsigned int) (setting));
+        if (nvml_result != NVML_SUCCESS) {
+            throw Exception("NVMLDevicePool::" + std::string(__func__) +
+                            ": NVML failed to set power limit for accelerator " +
+                            std::to_string(accel_idx) + ".  Error: " + nvmlErrorString(nvml_result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+}

--- a/src/NVMLDevicePool.hpp
+++ b/src/NVMLDevicePool.hpp
@@ -50,64 +50,79 @@ namespace geopm
             NVMLDevicePool() = default;
             virtual ~NVMLDevicePool() = default;
             /// @brief Number of accelerators on the platform.
+            /// @return Number of NVML accelerators
             virtual int num_accelerator(void) const = 0;
             /// @brief CPU Affinitization mask for a particular accelerator
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
-            virtual cpu_set_t *ideal_cpu_affinitization_mask(int accel_idx) const = 0;
+            /// @return CPU to Accelerator idea affinitization bitmask
+            virtual cpu_set_t *cpu_affinity_ideal_mask(int accel_idx) const = 0;
             /// @brief Get the NVML device streaming multiprocessor frequency
             //         in MHz
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
+            /// @return Accelerator streaming multiproccesor frequency in MHz
             virtual uint64_t frequency_status_sm(int accel_idx) const = 0;
             /// @brief Get the NVML device utilization metric
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
-            virtual double utilization(int accel_idx) const = 0;
+            /// @return Accelerator streaming multiprocessor utilization
+            virtual uint64_t utilization(int accel_idx) const = 0;
             /// @brief Get the NVML device power in milliwatts
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
+            /// @return Accelerator power consumption in milliwatts
             virtual uint64_t power (int accel_idx) const = 0;
             /// @brief Get the NVML device memory subsystem frequency in MHz
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
+            /// @return Accelerator memory frequency in MHz
             virtual uint64_t frequency_status_mem(int accel_idx) const = 0;
             /// @brief Get the current NVML device clock throttle reasons
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
+            /// @return Accelerator clock throttle reasons
             virtual uint64_t throttle_reasons(int accel_idx) const = 0;
             /// @brief Get the current NVML device temperature
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
+            /// @return Accelerator temperature in Celsius
             virtual uint64_t temperature(int accel_idx) const = 0;
             /// @brief Get the total energy consumed counter value for
             //         an NVML device in millijoules
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
+            /// @return Accelerator energy consumption in millijoules
             virtual uint64_t energy(int accel_idx) const = 0;
             /// @brief Get the current performance state of an NVML
             //         device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
+            /// @return Accelerator performance state
             virtual uint64_t performance_state(int accel_idx) const = 0;
             /// @brief Get the pcie rx throughput over a 20ms period for
             //         an NVML device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
+            /// @return Accelerator pcie rx throughput in kilobytes per second
             virtual uint64_t throughput_rx_pcie(int accel_idx) const = 0;
             /// @brief Get the pcie tx throughput over a 20ms period for
             //         an NVML device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
+            /// @return Accelerator pcie tx throughput in kilobytes per second
             virtual uint64_t throughput_tx_pcie(int accel_idx) const = 0;
             /// @brief Get the NVML device memory Utilization metric
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
-            virtual double utilization_mem(int accel_idx) const = 0;
-            /// @brief Get the list of PIDs actively running on an NVML
+            /// @return Accelerator memory utilization
+            virtual uint64_t utilization_mem(int accel_idx) const = 0;
+            /// @brief Get the list of PIDs with an active context on an NVML
             //         device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
+            /// @return List of PIDs that are associated with a context on the
+            //          specified NVML devic
             virtual std::vector<int> active_process_list(int accel_idx) const = 0;
 
             /// @brief Set min and max frequency for NVML device

--- a/src/NVMLDevicePool.hpp
+++ b/src/NVMLDevicePool.hpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVMLDEVICEPOOL_HPP_INCLUDE
+#define NVMLDEVICEPOOL_HPP_INCLUDE
+
+#include <vector>
+#include <string>
+#include <cstdint>
+
+#include <nvml.h>
+
+#include "geopm_sched.h"
+
+namespace geopm
+{
+
+    class NVMLDevicePool
+    {
+        public:
+            NVMLDevicePool() = default;
+            virtual ~NVMLDevicePool() = default;
+            /// @brief Number of accelerators on the platform.
+            virtual int num_accelerator(void) const = 0;
+            /// @brief CPU Affinitization mask for a particular accelerator
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual cpu_set_t *ideal_cpu_affinitization_mask(int accel_idx) const = 0;
+            /// @brief Get the NVIDIA streaming multiprocessor frequency
+            //         in MHz
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual uint64_t frequency_status(int accel_idx) const = 0;
+            /// @brief Get the NVIDIA device utilization metric
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual double utilization(int accel_idx) const = 0;
+            /// @brief Get the NVIDIA GPU Power in milliwatts
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual uint64_t power (int accel_idx) const = 0;
+            /// @brief Get the NVIDIA memory subsystem frequency in MHz
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual uint64_t frequency_status_mem(int accel_idx) const = 0;
+            /// @brief Get the current NVIDIA clock throttle reasons
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual uint64_t throttle_reasons(int accel_idx) const = 0;
+            /// @brief Get the current NVIDIA device temperature
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual uint64_t temperature(int accel_idx) const = 0;
+            /// @brief Get the total energy consumed counter value for
+            //         an NVIDIA device in millijoules
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual uint64_t energy(int accel_idx) const = 0;
+            /// @brief Get the current performance state of an NVIDIA
+            //         device
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual uint64_t performance_state(int accel_idx) const = 0;
+            /// @brief Get the pcie rx throughput over a 20ms period for
+            //         an NVIDIA device
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual uint64_t throughput_rx_pcie(int accel_idx) const = 0;
+            /// @brief Get the pcie tx throughput over a 20ms period for
+            //         an NVIDIA device
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual uint64_t throughput_tx_pcie(int accel_idx) const = 0;
+            /// @brief Get the NVIDIA device memory Utilization metric
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual double utilization_mem(int accel_idx) const = 0;
+            /// @brief Get the list of PIDs actively running on an NVIDIA
+            //         accelerator
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual std::vector<int> active_process_list(int accel_idx) const = 0;
+
+            /// @brief Set min and max frequency for NVIDIA device
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            /// @param [in] setting Target frequency in MHz
+            virtual void frequency_control(int accel_idx, int setting) const = 0;
+            /// @brief Reset min and max frequency for NVIDIA device
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            virtual void frequency_reset_control(int accel_idx) const = 0;
+            /// @brief Set power limit for NVIDIA device
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator
+            /// @param [in] setting Power cap in milliwatts
+            virtual void power_control(int accel_idx, int setting) const = 0;
+        private:
+    };
+
+    const NVMLDevicePool &nvml_device_pool(void);
+}
+
+#endif

--- a/src/NVMLDevicePool.hpp
+++ b/src/NVMLDevicePool.hpp
@@ -50,95 +50,100 @@ namespace geopm
             NVMLDevicePool() = default;
             virtual ~NVMLDevicePool() = default;
             /// @brief Number of accelerators on the platform.
-            /// @return Number of NVML accelerators
+            /// @return Number of NVML accelerators.
             virtual int num_accelerator(void) const = 0;
             /// @brief CPU Affinitization mask for a particular accelerator
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return CPU to Accelerator idea affinitization bitmask
+            ///        accelerator.
+            /// @return CPU to Accelerator idea affinitization bitmask.
             virtual cpu_set_t *cpu_affinity_ideal_mask(int accel_idx) const = 0;
             /// @brief Get the NVML device streaming multiprocessor frequency
-            //         in MHz
+            //         in MHz.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return Accelerator streaming multiproccesor frequency in MHz
+            ///        accelerator.
+            /// @return Accelerator streaming multiproccesor frequency in MHz.
             virtual uint64_t frequency_status_sm(int accel_idx) const = 0;
-            /// @brief Get the NVML device utilization metric
+            /// @brief Get the NVML device utilization metric.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
+            ///        accelerator.
             /// @return Accelerator streaming multiprocessor utilization
+            //          percentage as a whole number from 0 to 100.
             virtual uint64_t utilization(int accel_idx) const = 0;
-            /// @brief Get the NVML device power in milliwatts
+            /// @brief Get the NVML device power in milliwatts.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return Accelerator power consumption in milliwatts
+            ///        accelerator.
+            /// @return Accelerator power consumption in milliwatts.
             virtual uint64_t power (int accel_idx) const = 0;
-            /// @brief Get the NVML device memory subsystem frequency in MHz
+            /// @brief Get the NVML device memory subsystem frequency in MHz.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return Accelerator memory frequency in MHz
+            ///        accelerator.
+            /// @return Accelerator memory frequency in MHz.
             virtual uint64_t frequency_status_mem(int accel_idx) const = 0;
-            /// @brief Get the current NVML device clock throttle reasons
+            /// @brief Get the current NVML device clock throttle reasons.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return Accelerator clock throttle reasons
+            ///        accelerator.
+            /// @return Accelerator clock throttle reasons as defined 
+            //          in nvml.h.
             virtual uint64_t throttle_reasons(int accel_idx) const = 0;
-            /// @brief Get the current NVML device temperature
+            /// @brief Get the current NVML device temperature.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return Accelerator temperature in Celsius
+            ///        accelerator.
+            /// @return Accelerator temperature in Celsius.
             virtual uint64_t temperature(int accel_idx) const = 0;
             /// @brief Get the total energy consumed counter value for
-            //         an NVML device in millijoules
+            //         an NVML device in millijoules.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return Accelerator energy consumption in millijoules
+            ///        accelerator.
+            /// @return Accelerator energy consumption in millijoules.
             virtual uint64_t energy(int accel_idx) const = 0;
             /// @brief Get the current performance state of an NVML
-            //         device
+            //         device.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return Accelerator performance state
+            ///        accelerator.
+            /// @return Accelerator performance state, defined by the 
+            //          NVML API as 0 to 15, with 0 being maximum performance,
+            //          15 being minimum performance, and 32 being unknown.
             virtual uint64_t performance_state(int accel_idx) const = 0;
-            /// @brief Get the pcie rx throughput over a 20ms period for
-            //         an NVML device
+            /// @brief Get the pcie receive throughput over a 20ms period for
+            //         an NVML device.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return Accelerator pcie rx throughput in kilobytes per second
+            ///        accelerator.
+            /// @return Accelerator pcie receive throughput in kilobytes per second.
             virtual uint64_t throughput_rx_pcie(int accel_idx) const = 0;
-            /// @brief Get the pcie tx throughput over a 20ms period for
-            //         an NVML device
+            /// @brief Get the pcie transmit throughput over a 20ms period for
+            //         an NVML device.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return Accelerator pcie tx throughput in kilobytes per second
+            ///        accelerator.
+            /// @return Accelerator pcie transmit throughput in kilobytes per second.
             virtual uint64_t throughput_tx_pcie(int accel_idx) const = 0;
             /// @brief Get the NVML device memory Utilization metric
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @return Accelerator memory utilization
+            ///        accelerator.
+            /// @return Accelerator memory utilization percentage 
+            //          as a whole number from 0 to 100.
             virtual uint64_t utilization_mem(int accel_idx) const = 0;
             /// @brief Get the list of PIDs with an active context on an NVML
-            //         device
+            //         device.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
+            ///        accelerator.
             /// @return List of PIDs that are associated with a context on the
-            //          specified NVML devic
+            //          specified NVML device.
             virtual std::vector<int> active_process_list(int accel_idx) const = 0;
 
-            /// @brief Set min and max frequency for NVML device
+            /// @brief Set min and max frequency for NVML device.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @param [in] min_freq Target min frequency in MHz
-            /// @param [in] max_freq Target max frequency in MHz
+            ///        accelerator.
+            /// @param [in] min_freq Target min frequency in MHz.
+            /// @param [in] max_freq Target max frequency in MHz.
             virtual void frequency_control_sm(int accel_idx, int min_freq, int max_freq) const = 0;
-            /// @brief Reset min and max frequency for NVML device
+            /// @brief Reset min and max frequency for NVML device.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
+            ///        accelerator.
             virtual void frequency_reset_control(int accel_idx) const = 0;
-            /// @brief Set power limit for NVML device
+            /// @brief Set power limit for NVML device.
             /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator
-            /// @param [in] setting Power cap in milliwatts
+            ///        accelerator.
+            /// @param [in] setting Power cap in milliwatts.
             virtual void power_control(int accel_idx, int setting) const = 0;
         private:
     };

--- a/src/NVMLDevicePool.hpp
+++ b/src/NVMLDevicePool.hpp
@@ -55,71 +55,72 @@ namespace geopm
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual cpu_set_t *ideal_cpu_affinitization_mask(int accel_idx) const = 0;
-            /// @brief Get the NVIDIA streaming multiprocessor frequency
+            /// @brief Get the NVML device streaming multiprocessor frequency
             //         in MHz
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
-            virtual uint64_t frequency_status(int accel_idx) const = 0;
-            /// @brief Get the NVIDIA device utilization metric
+            virtual uint64_t frequency_status_sm(int accel_idx) const = 0;
+            /// @brief Get the NVML device utilization metric
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual double utilization(int accel_idx) const = 0;
-            /// @brief Get the NVIDIA GPU Power in milliwatts
+            /// @brief Get the NVML device power in milliwatts
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual uint64_t power (int accel_idx) const = 0;
-            /// @brief Get the NVIDIA memory subsystem frequency in MHz
+            /// @brief Get the NVML device memory subsystem frequency in MHz
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual uint64_t frequency_status_mem(int accel_idx) const = 0;
-            /// @brief Get the current NVIDIA clock throttle reasons
+            /// @brief Get the current NVML device clock throttle reasons
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual uint64_t throttle_reasons(int accel_idx) const = 0;
-            /// @brief Get the current NVIDIA device temperature
+            /// @brief Get the current NVML device temperature
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual uint64_t temperature(int accel_idx) const = 0;
             /// @brief Get the total energy consumed counter value for
-            //         an NVIDIA device in millijoules
+            //         an NVML device in millijoules
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual uint64_t energy(int accel_idx) const = 0;
-            /// @brief Get the current performance state of an NVIDIA
+            /// @brief Get the current performance state of an NVML
             //         device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual uint64_t performance_state(int accel_idx) const = 0;
             /// @brief Get the pcie rx throughput over a 20ms period for
-            //         an NVIDIA device
+            //         an NVML device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual uint64_t throughput_rx_pcie(int accel_idx) const = 0;
             /// @brief Get the pcie tx throughput over a 20ms period for
-            //         an NVIDIA device
+            //         an NVML device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual uint64_t throughput_tx_pcie(int accel_idx) const = 0;
-            /// @brief Get the NVIDIA device memory Utilization metric
+            /// @brief Get the NVML device memory Utilization metric
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual double utilization_mem(int accel_idx) const = 0;
-            /// @brief Get the list of PIDs actively running on an NVIDIA
-            //         accelerator
+            /// @brief Get the list of PIDs actively running on an NVML
+            //         device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual std::vector<int> active_process_list(int accel_idx) const = 0;
 
-            /// @brief Set min and max frequency for NVIDIA device
+            /// @brief Set min and max frequency for NVML device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
-            /// @param [in] setting Target frequency in MHz
-            virtual void frequency_control(int accel_idx, int setting) const = 0;
-            /// @brief Reset min and max frequency for NVIDIA device
+            /// @param [in] min_freq Target min frequency in MHz
+            /// @param [in] max_freq Target max frequency in MHz
+            virtual void frequency_control_sm(int accel_idx, int min_freq, int max_freq) const = 0;
+            /// @brief Reset min and max frequency for NVML device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             virtual void frequency_reset_control(int accel_idx) const = 0;
-            /// @brief Set power limit for NVIDIA device
+            /// @brief Set power limit for NVML device
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator
             /// @param [in] setting Power cap in milliwatts
@@ -127,7 +128,6 @@ namespace geopm
         private:
     };
 
-    const NVMLDevicePool &nvml_device_pool(void);
+    const NVMLDevicePool &nvml_device_pool(int num_cpu);
 }
-
 #endif

--- a/src/NVMLDevicePoolImp.hpp
+++ b/src/NVMLDevicePoolImp.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVMLDEVICEPOOLIMP_HPP_INCLUDE
+#define NVMLDEVICEPOOLIMP_HPP_INCLUDE
+
+#include "NVMLDevicePool.hpp"
+
+namespace geopm
+{
+
+    class NVMLDevicePoolImp : public NVMLDevicePool
+    {
+        public:
+            NVMLDevicePoolImp();
+            virtual ~NVMLDevicePoolImp();
+            virtual int num_accelerator() const override;
+            virtual cpu_set_t *ideal_cpu_affinitization_mask(int accel_idx) const override;
+            virtual uint64_t frequency_status(int accel_idx) const override;
+            virtual double utilization(int accel_idx) const override;
+            virtual uint64_t power(int accel_idx) const override;
+            virtual uint64_t frequency_status_mem(int accel_idx) const override;
+            virtual uint64_t throttle_reasons(int accel_idx) const override;
+            virtual uint64_t temperature(int accel_idx) const override;
+            virtual uint64_t energy(int accel_idx) const override;
+            virtual uint64_t performance_state(int accel_idx) const override;
+            virtual uint64_t throughput_rx_pcie(int accel_idx) const override;
+            virtual uint64_t throughput_tx_pcie(int accel_idx) const override;
+            virtual double utilization_mem(int accel_idx) const override;
+            virtual std::vector<int> active_process_list(int accel_idx) const override;
+
+            virtual void frequency_control(int accel_idx, int setting) const override;
+            virtual void frequency_reset_control(int accel_idx) const override;
+            virtual void power_control(int accel_idx, int setting) const override;
+
+        private:
+            virtual void check_accel_range(int accel_idx) const;
+
+            unsigned int m_num_accelerator;
+            std::vector<nvmlDevice_t> m_nvml_device;
+
+            unsigned int m_max_contexts;
+
+    };
+}
+
+#endif

--- a/src/NVMLDevicePoolImp.hpp
+++ b/src/NVMLDevicePoolImp.hpp
@@ -41,11 +41,11 @@ namespace geopm
     class NVMLDevicePoolImp : public NVMLDevicePool
     {
         public:
-            NVMLDevicePoolImp();
+            NVMLDevicePoolImp(const int num_cpu);
             virtual ~NVMLDevicePoolImp();
-            virtual int num_accelerator() const override;
+            virtual int num_accelerator(void) const override;
             virtual cpu_set_t *ideal_cpu_affinitization_mask(int accel_idx) const override;
-            virtual uint64_t frequency_status(int accel_idx) const override;
+            virtual uint64_t frequency_status_sm(int accel_idx) const override;
             virtual double utilization(int accel_idx) const override;
             virtual uint64_t power(int accel_idx) const override;
             virtual uint64_t frequency_status_mem(int accel_idx) const override;
@@ -58,19 +58,17 @@ namespace geopm
             virtual double utilization_mem(int accel_idx) const override;
             virtual std::vector<int> active_process_list(int accel_idx) const override;
 
-            virtual void frequency_control(int accel_idx, int setting) const override;
+            virtual void frequency_control_sm(int accel_idx, int min_freq, int max_freq) const override;
             virtual void frequency_reset_control(int accel_idx) const override;
             virtual void power_control(int accel_idx, int setting) const override;
 
         private:
+            const unsigned int M_MAX_CONTEXTS;
+            const unsigned int M_NUM_CPU;
             virtual void check_accel_range(int accel_idx) const;
-
+            virtual void check_nvml_result(nvmlReturn_t nvml_result, int error, std::string message) const;
             unsigned int m_num_accelerator;
             std::vector<nvmlDevice_t> m_nvml_device;
-
-            unsigned int m_max_contexts;
-
     };
 }
-
 #endif

--- a/src/NVMLDevicePoolImp.hpp
+++ b/src/NVMLDevicePoolImp.hpp
@@ -44,9 +44,9 @@ namespace geopm
             NVMLDevicePoolImp(const int num_cpu);
             virtual ~NVMLDevicePoolImp();
             virtual int num_accelerator(void) const override;
-            virtual cpu_set_t *ideal_cpu_affinitization_mask(int accel_idx) const override;
+            virtual cpu_set_t *cpu_affinity_ideal_mask(int accel_idx) const override;
             virtual uint64_t frequency_status_sm(int accel_idx) const override;
-            virtual double utilization(int accel_idx) const override;
+            virtual uint64_t utilization(int accel_idx) const override;
             virtual uint64_t power(int accel_idx) const override;
             virtual uint64_t frequency_status_mem(int accel_idx) const override;
             virtual uint64_t throttle_reasons(int accel_idx) const override;
@@ -55,7 +55,7 @@ namespace geopm
             virtual uint64_t performance_state(int accel_idx) const override;
             virtual uint64_t throughput_rx_pcie(int accel_idx) const override;
             virtual uint64_t throughput_tx_pcie(int accel_idx) const override;
-            virtual double utilization_mem(int accel_idx) const override;
+            virtual uint64_t utilization_mem(int accel_idx) const override;
             virtual std::vector<int> active_process_list(int accel_idx) const override;
 
             virtual void frequency_control_sm(int accel_idx, int min_freq, int max_freq) const override;
@@ -66,7 +66,7 @@ namespace geopm
             const unsigned int M_MAX_CONTEXTS;
             const unsigned int M_NUM_CPU;
             virtual void check_accel_range(int accel_idx) const;
-            virtual void check_nvml_result(nvmlReturn_t nvml_result, int error, std::string message) const;
+            virtual void check_nvml_result(nvmlReturn_t nvml_result, int error, std::string message, int line) const;
             unsigned int m_num_accelerator;
             std::vector<nvmlDevice_t> m_nvml_device;
     };

--- a/src/PlatformTopo.cpp
+++ b/src/PlatformTopo.cpp
@@ -98,9 +98,18 @@ namespace geopm
     }
 
     PlatformTopoImp::PlatformTopoImp(const std::string &test_cache_file_name)
+        : PlatformTopoImp(test_cache_file_name, accelerator_topo())
+    {
+        std::map<std::string, std::string> lscpu_map;
+        lscpu(lscpu_map);
+        parse_lscpu(lscpu_map, m_num_package, m_core_per_package, m_thread_per_core);
+        parse_lscpu_numa(lscpu_map, m_numa_map);
+    }
+
+    PlatformTopoImp::PlatformTopoImp(const std::string &test_cache_file_name, const AcceleratorTopo &accelerator_topo)
         : M_TEST_CACHE_FILE_NAME(test_cache_file_name)
         , m_do_fclose(true)
-        , m_accelerator_topo(accelerator_topo())
+        , m_accelerator_topo(accelerator_topo)
     {
         std::map<std::string, std::string> lscpu_map;
         lscpu(lscpu_map);
@@ -271,7 +280,7 @@ namespace geopm
                 case GEOPM_DOMAIN_BOARD_ACCELERATOR:
                     for(int accel_idx = 0; (accel_idx <  m_accelerator_topo.num_accelerator()) && (result == -1); ++accel_idx) {
                         std::set <int> affin = m_accelerator_topo.ideal_cpu_affinitization(accel_idx);
-                        if (affin.find(cpu_idx) != affin.end()){
+                        if (affin.find(cpu_idx) != affin.end()) {
                             result = accel_idx;
                         }
                     }

--- a/src/PlatformTopo.cpp
+++ b/src/PlatformTopo.cpp
@@ -269,7 +269,7 @@ namespace geopm
                     }
                     break;
                 case GEOPM_DOMAIN_BOARD_ACCELERATOR:
-                    for(int accel_idx = 0; accel_idx <  m_accelerator_topo.num_accelerator(); ++accel_idx) {
+                    for(int accel_idx = 0; (accel_idx <  m_accelerator_topo.num_accelerator()) && (result == -1); ++accel_idx) {
                         std::set <int> affin = m_accelerator_topo.ideal_cpu_affinitization(accel_idx);
                         if (affin.find(cpu_idx) != affin.end()){
                             result = accel_idx;
@@ -280,7 +280,7 @@ namespace geopm
                 case GEOPM_DOMAIN_BOARD_NIC:
                 case GEOPM_DOMAIN_PACKAGE_NIC:
                 case GEOPM_DOMAIN_PACKAGE_ACCELERATOR:
-                    // @todo Add support for package memory NIC and accelerators to domain_idx() method.
+                    /// @todo Add support for package memory NIC and package accelerators to domain_idx() method.
                     throw Exception("PlatformTopoImp::domain_idx() no support yet for PACKAGE_MEMORY, NIC, or ACCELERATOR",
                                     GEOPM_ERROR_NOT_IMPLEMENTED, __FILE__, __LINE__);
                     break;
@@ -332,7 +332,7 @@ namespace geopm
         }
         else if (outer_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR &&
                  inner_domain == GEOPM_DOMAIN_CPU) {
-            // To support mapping CPU signals to ACCELERATOR domain (e.g. power)
+            // To support mapping CPU signals to ACCELERATOR domain
             result = true;
         }
         return result;

--- a/src/PlatformTopo.cpp
+++ b/src/PlatformTopo.cpp
@@ -192,7 +192,7 @@ namespace geopm
                 }
                 break;
             case GEOPM_DOMAIN_BOARD_ACCELERATOR:
-                cpu_idx = m_accelerator_topo.ideal_cpu_affinitization(domain_idx);
+                cpu_idx = m_accelerator_topo.cpu_affinity_ideal(domain_idx);
                 break;
             case GEOPM_DOMAIN_PACKAGE:
                 for (int thread_idx = 0;
@@ -279,7 +279,7 @@ namespace geopm
                     break;
                 case GEOPM_DOMAIN_BOARD_ACCELERATOR:
                     for(int accel_idx = 0; (accel_idx <  m_accelerator_topo.num_accelerator()) && (result == -1); ++accel_idx) {
-                        std::set <int> affin = m_accelerator_topo.ideal_cpu_affinitization(accel_idx);
+                        std::set<int> affin = m_accelerator_topo.cpu_affinity_ideal(accel_idx);
                         if (affin.find(cpu_idx) != affin.end()) {
                             result = accel_idx;
                         }

--- a/src/PlatformTopoImp.hpp
+++ b/src/PlatformTopoImp.hpp
@@ -45,6 +45,7 @@ namespace geopm
         public:
             PlatformTopoImp();
             PlatformTopoImp(const std::string &test_cache_file_name);
+            PlatformTopoImp(const std::string &test_cache_file_name, const AcceleratorTopo &accelerator_topo);
             virtual ~PlatformTopoImp() = default;
             int num_domain(int domain_type) const override;
             int domain_idx(int domain_type,

--- a/src/PlatformTopoImp.hpp
+++ b/src/PlatformTopoImp.hpp
@@ -38,6 +38,8 @@
 
 namespace geopm
 {
+    class AcceleratorTopo;
+
     class PlatformTopoImp : public PlatformTopo
     {
         public:
@@ -74,6 +76,8 @@ namespace geopm
             int m_core_per_package;
             int m_thread_per_core;
             std::vector<std::set<int> > m_numa_map;
+
+            const AcceleratorTopo &m_accelerator_topo;
     };
 }
 #endif

--- a/src/PlatformTopoImp.hpp
+++ b/src/PlatformTopoImp.hpp
@@ -76,7 +76,6 @@ namespace geopm
             int m_core_per_package;
             int m_thread_per_core;
             std::vector<std::set<int> > m_numa_map;
-
             const AcceleratorTopo &m_accelerator_topo;
     };
 }

--- a/test/AcceleratorTopoTest.cpp
+++ b/test/AcceleratorTopoTest.cpp
@@ -48,22 +48,7 @@ using geopm::AcceleratorTopo;
 using geopm::Exception;
 using testing::Return;
 
-class AcceleratorTopoTest : public :: testing :: Test
-{
-    protected:
-        void SetUp();
-        void TearDown();
-};
-
-void AcceleratorTopoTest::SetUp()
-{
-}
-
-void AcceleratorTopoTest::TearDown()
-{
-}
-
-TEST_F(AcceleratorTopoTest, default_config)
+TEST(AcceleratorTopoTest, default_config)
 {
     std::unique_ptr<AcceleratorTopo> topo;
     topo = geopm::make_unique<AcceleratorTopo>();

--- a/test/AcceleratorTopoTest.cpp
+++ b/test/AcceleratorTopoTest.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <unistd.h>
+#include <limits.h>
+
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "config.h"
+#include "Helper.hpp"
+#include "Exception.hpp"
+#include "AcceleratorTopo.hpp"
+
+using geopm::AcceleratorTopo;
+using geopm::Exception;
+using testing::Return;
+
+class AcceleratorTopoTest : public :: testing :: Test
+{
+    protected:
+        void SetUp();
+        void TearDown();
+};
+
+void AcceleratorTopoTest::SetUp()
+{
+}
+
+void AcceleratorTopoTest::TearDown()
+{
+}
+
+TEST_F(AcceleratorTopoTest, default_config)
+{
+    std::unique_ptr<AcceleratorTopo> topo;
+    topo = geopm::make_unique<AcceleratorTopo>();
+    EXPECT_EQ(0, topo->num_accelerator());
+    EXPECT_EQ(topo->ideal_cpu_affinitization(0), std::set<int>{});
+}

--- a/test/AcceleratorTopoTest.cpp
+++ b/test/AcceleratorTopoTest.cpp
@@ -53,5 +53,5 @@ TEST(AcceleratorTopoTest, default_config)
     std::unique_ptr<AcceleratorTopo> topo;
     topo = geopm::make_unique<AcceleratorTopo>();
     EXPECT_EQ(0, topo->num_accelerator());
-    EXPECT_EQ(topo->ideal_cpu_affinitization(0), std::set<int>{});
+    EXPECT_EQ(topo->cpu_affinity_ideal(0), std::set<int>{});
 }

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -557,6 +557,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
                           test/MSRIOTest.cpp \
                           test/MSRFieldControlTest.cpp \
                           test/MSRFieldSignalTest.cpp \
+                          test/MockAcceleratorTopo.hpp \
                           test/MockAgent.hpp \
                           test/MockApplicationIO.hpp \
                           test/MockApplicationSampler.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -35,7 +35,8 @@ if ENABLE_MPI
     check_PROGRAMS += test/geopm_mpi_test_api
 endif
 
-GTEST_TESTS = test/gtest_links/AdminTest.agent_no_policy \
+GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
+              test/gtest_links/AdminTest.agent_no_policy \
               test/gtest_links/AdminTest.config_default \
               test/gtest_links/AdminTest.config_override \
               test/gtest_links/AdminTest.dup_config \
@@ -476,6 +477,20 @@ if ENABLE_OMPT
                    # end
 endif
 
+if ENABLE_NVML
+    GTEST_TESTS += test/gtest_links/NVMLAcceleratorTopoTest.hpe_sx40_default_config \
+                   test/gtest_links/NVMLAcceleratorTopoTest.no_gpu_config \
+                   test/gtest_links/NVMLAcceleratorTopoTest.mutex_affinitization_config \
+                   test/gtest_links/NVMLAcceleratorTopoTest.equidistant_affinitization_config \
+                   test/gtest_links/NVMLAcceleratorTopoTest.n1_superset_n_affinitization_config \
+                   test/gtest_links/NVMLAcceleratorTopoTest.greedbuster_affinitization_config \
+                   test/gtest_links/NVMLAcceleratorTopoTest.hpe_6500_affinitization_config \
+                   test/gtest_links/NVMLAcceleratorTopoTest.uneven_affinitization_config \
+                   test/gtest_links/NVMLAcceleratorTopoTest.high_cpu_count_config \
+                   test/gtest_links/NVMLAcceleratorTopoTest.high_cpu_count_gaps_config \
+                   # end
+endif
+
 TESTS_ENVIRONMENT = PYTHON='$(PYTHON)'
 
 TESTS += $(GTEST_TESTS) \
@@ -503,7 +518,8 @@ EXTRA_DIST += test/InternalProfile.cpp \
               # end
               # FK: FIXME: Add new traceout file names here.
 
-test_geopm_test_SOURCES = test/AdminTest.cpp \
+test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
+                          test/AdminTest.cpp \
                           test/AgentFactoryTest.cpp \
                           test/AggTest.cpp \
                           test/ApplicationIOTest.cpp \
@@ -614,10 +630,20 @@ beta_test_sources = test/DaemonTest.cpp \
                     test/PolicyStoreImpTest.cpp \
                     # end
 
+nvml_test_sources = test/NVMLAcceleratorTopoTest.cpp \
+                    test/MockNVMLDevicePool.hpp \
+                    # end
+
 if ENABLE_BETA
     test_geopm_test_SOURCES += $(beta_test_sources)
 else
     EXTRA_DIST += $(beta_test_sources)
+endif
+
+if ENABLE_NVML
+    test_geopm_test_SOURCES += $(nvml_test_sources)
+else
+    EXTRA_DIST += $(nvml_test_sources)
 endif
 
 if ENABLE_OMPT

--- a/test/MockAcceleratorTopo.hpp
+++ b/test/MockAcceleratorTopo.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MOCKACCELERATORTOPO_HPP_INCLUDE
+#define MOCKACCELERATORTOPO_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "AcceleratorTopo.hpp"
+
+class MockAcceleratorTopo : public geopm::AcceleratorTopo
+{
+    public:
+        MOCK_CONST_METHOD0(num_accelerator,
+                           int(void));
+        MOCK_CONST_METHOD1(ideal_cpu_affinitization,
+                           std::set<int>(int));
+};
+
+#endif

--- a/test/MockAcceleratorTopo.hpp
+++ b/test/MockAcceleratorTopo.hpp
@@ -42,7 +42,7 @@ class MockAcceleratorTopo : public geopm::AcceleratorTopo
     public:
         MOCK_CONST_METHOD0(num_accelerator,
                            int(void));
-        MOCK_CONST_METHOD1(ideal_cpu_affinitization,
+        MOCK_CONST_METHOD1(cpu_affinity_ideal,
                            std::set<int>(int));
 };
 

--- a/test/MockNVMLDevicePool.hpp
+++ b/test/MockNVMLDevicePool.hpp
@@ -45,35 +45,37 @@ class MockNVMLDevicePool : public geopm::NVMLDevicePool
         MOCK_CONST_METHOD1(ideal_cpu_affinitization_mask,
                            cpu_set_t *(int));
         MOCK_CONST_METHOD1(frequency_status,
-                          uint64_t(int));
+                           uint64_t(int));
+        MOCK_CONST_METHOD1(frequency_status_sm,
+                           uint64_t(int));
         MOCK_CONST_METHOD1(utilization,
-                          double(int));
+                           double(int));
         MOCK_CONST_METHOD1(power ,
-                          uint64_t(int));
+                           uint64_t(int));
         MOCK_CONST_METHOD1(frequency_status_mem,
-                          uint64_t(int));
+                           uint64_t(int));
         MOCK_CONST_METHOD1(throttle_reasons,
-                          uint64_t(int));
+                           uint64_t(int));
         MOCK_CONST_METHOD1(temperature,
-                          uint64_t(int));
+                           uint64_t(int));
         MOCK_CONST_METHOD1(energy,
-                          uint64_t(int));
+                           uint64_t(int));
         MOCK_CONST_METHOD1(performance_state,
-                          uint64_t(int));
+                           uint64_t(int));
         MOCK_CONST_METHOD1(throughput_rx_pcie,
-                          uint64_t(int));
+                           uint64_t(int));
         MOCK_CONST_METHOD1(throughput_tx_pcie,
-                          uint64_t(int));
+                           uint64_t(int));
         MOCK_CONST_METHOD1(utilization_mem,
-                          double(int));
+                           double(int));
         MOCK_CONST_METHOD1(active_process_list,
-                          std::vector<int>(int));
-        MOCK_CONST_METHOD2(frequency_control,
-                          void(int, int));
+                           std::vector<int>(int));
+        MOCK_CONST_METHOD3(frequency_control_sm,
+                           void(int, int, int));
         MOCK_CONST_METHOD1(frequency_reset_control,
-                          void(int));
+                           void(int));
         MOCK_CONST_METHOD2(power_control,
-                          void(int, int));
+                           void(int, int));
 };
 
 #endif

--- a/test/MockNVMLDevicePool.hpp
+++ b/test/MockNVMLDevicePool.hpp
@@ -42,14 +42,14 @@ class MockNVMLDevicePool : public geopm::NVMLDevicePool
     public:
         MOCK_CONST_METHOD0(num_accelerator,
                            int(void));
-        MOCK_CONST_METHOD1(ideal_cpu_affinitization_mask,
+        MOCK_CONST_METHOD1(cpu_affinity_ideal_mask,
                            cpu_set_t *(int));
         MOCK_CONST_METHOD1(frequency_status,
                            uint64_t(int));
         MOCK_CONST_METHOD1(frequency_status_sm,
                            uint64_t(int));
         MOCK_CONST_METHOD1(utilization,
-                           double(int));
+                           uint64_t(int));
         MOCK_CONST_METHOD1(power ,
                            uint64_t(int));
         MOCK_CONST_METHOD1(frequency_status_mem,
@@ -67,7 +67,7 @@ class MockNVMLDevicePool : public geopm::NVMLDevicePool
         MOCK_CONST_METHOD1(throughput_tx_pcie,
                            uint64_t(int));
         MOCK_CONST_METHOD1(utilization_mem,
-                           double(int));
+                           uint64_t(int));
         MOCK_CONST_METHOD1(active_process_list,
                            std::vector<int>(int));
         MOCK_CONST_METHOD3(frequency_control_sm,

--- a/test/MockNVMLDevicePool.hpp
+++ b/test/MockNVMLDevicePool.hpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MOCKNVMLDEVICEPOOL_HPP_INCLUDE
+#define MOCKNVMLDEVICEPOOL_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "NVMLDevicePool.hpp"
+
+class MockNVMLDevicePool : public geopm::NVMLDevicePool
+{
+    public:
+        MOCK_CONST_METHOD0(num_accelerator,
+                           int(void));
+        MOCK_CONST_METHOD1(ideal_cpu_affinitization_mask,
+                           cpu_set_t *(int));
+        MOCK_CONST_METHOD1(frequency_status,
+                          uint64_t(int));
+        MOCK_CONST_METHOD1(utilization,
+                          double(int));
+        MOCK_CONST_METHOD1(power ,
+                          uint64_t(int));
+        MOCK_CONST_METHOD1(frequency_status_mem,
+                          uint64_t(int));
+        MOCK_CONST_METHOD1(throttle_reasons,
+                          uint64_t(int));
+        MOCK_CONST_METHOD1(temperature,
+                          uint64_t(int));
+        MOCK_CONST_METHOD1(energy,
+                          uint64_t(int));
+        MOCK_CONST_METHOD1(performance_state,
+                          uint64_t(int));
+        MOCK_CONST_METHOD1(throughput_rx_pcie,
+                          uint64_t(int));
+        MOCK_CONST_METHOD1(throughput_tx_pcie,
+                          uint64_t(int));
+        MOCK_CONST_METHOD1(utilization_mem,
+                          double(int));
+        MOCK_CONST_METHOD1(active_process_list,
+                          std::vector<int>(int));
+        MOCK_CONST_METHOD2(frequency_control,
+                          void(int, int));
+        MOCK_CONST_METHOD1(frequency_reset_control,
+                          void(int));
+        MOCK_CONST_METHOD2(power_control,
+                          void(int, int));
+};
+
+#endif

--- a/test/NVMLAcceleratorTopoTest.cpp
+++ b/test/NVMLAcceleratorTopoTest.cpp
@@ -44,6 +44,7 @@
 #include "Exception.hpp"
 #include "MockNVMLDevicePool.hpp"
 #include "NVMLAcceleratorTopo.hpp"
+#include "geopm_test.hpp"
 
 using geopm::NVMLAcceleratorTopo;
 using geopm::Exception;
@@ -70,22 +71,22 @@ void NVMLAcceleratorTopoTest::TearDown()
 //Test case: Mock num_accelerator = 0 so we hit the appropriate warning and throw on affinitization requests.
 TEST_F(NVMLAcceleratorTopoTest, no_gpu_config)
 {
-    int num_accelerator = 0;
-    int num_cpu = 40;
+    const int num_accelerator = 0;
+    const int num_cpu = 40;
 
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
-    EXPECT_EQ(0, topo.num_accelerator());
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
 
-    EXPECT_THROW(topo.ideal_cpu_affinitization(0), geopm::Exception);
+    GEOPM_EXPECT_THROW_MESSAGE(topo.ideal_cpu_affinitization(num_accelerator), GEOPM_ERROR_INVALID, "accel_idx 0 is out of range");
 }
 
 //Test case: The HPE SX40 default system configuration
 TEST_F(NVMLAcceleratorTopoTest, hpe_sx40_default_config)
 {
-    int num_accelerator = 4;
-    int num_cpu = 40;
+    const int num_accelerator = 4;
+    const int num_cpu = 40;
 
     unsigned long accel_bitmask[num_accelerator];
     accel_bitmask[0] = 0x00000fffff;
@@ -100,14 +101,14 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_sx40_default_config)
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
-    EXPECT_EQ(4, topo.num_accelerator());
-    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
     cpus_allowed_set[0] = {0,1,2,3,4,5,6,7,8,9};
     cpus_allowed_set[1] = {10,11,12,13,14,15,16,17,18,19};
     cpus_allowed_set[2] = {20,21,22,23,24,25,26,27,28,29};
     cpus_allowed_set[3] = {30,31,32,33,34,35,36,37,38,39};
 
-    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
@@ -115,8 +116,8 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_sx40_default_config)
 //Test case: All cpus are associated with one and only one GPUs
 TEST_F(NVMLAcceleratorTopoTest, mutex_affinitization_config)
 {
-    int num_accelerator = 4;
-    int num_cpu = 40;
+    const int num_accelerator = 4;
+    const int num_cpu = 40;
 
     unsigned long accel_bitmask[num_accelerator];
     accel_bitmask[0] = 0x00000003ff;
@@ -130,14 +131,14 @@ TEST_F(NVMLAcceleratorTopoTest, mutex_affinitization_config)
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
-    EXPECT_EQ(4, topo.num_accelerator());
-    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
     cpus_allowed_set[0] = {0,1,2,3,4,5,6,7,8,9};
     cpus_allowed_set[1] = {10,11,12,13,14,15,16,17,18,19};
     cpus_allowed_set[2] = {20,21,22,23,24,25,26,27,28,29};
     cpus_allowed_set[3] = {30,31,32,33,34,35,36,37,38,39};
 
-    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
@@ -145,8 +146,8 @@ TEST_F(NVMLAcceleratorTopoTest, mutex_affinitization_config)
 //Test case: All cpus are associated with all GPUs
 TEST_F(NVMLAcceleratorTopoTest, equidistant_affinitization_config)
 {
-    int num_accelerator = 4;
-    int num_cpu = 40;
+    const int num_accelerator = 4;
+    const int num_cpu = 40;
 
     unsigned long accel_bitmask[num_accelerator];
     accel_bitmask[0] = 0xffffffffff;
@@ -161,14 +162,14 @@ TEST_F(NVMLAcceleratorTopoTest, equidistant_affinitization_config)
 
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
 
-    EXPECT_EQ(4, topo.num_accelerator());
-    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
     cpus_allowed_set[0] = {0,1,2,3,4,5,6,7,8,9};
     cpus_allowed_set[1] = {10,11,12,13,14,15,16,17,18,19};
     cpus_allowed_set[2] = {20,21,22,23,24,25,26,27,28,29};
     cpus_allowed_set[3] = {30,31,32,33,34,35,36,37,38,39};
 
-    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
@@ -176,8 +177,8 @@ TEST_F(NVMLAcceleratorTopoTest, equidistant_affinitization_config)
 //Test case:  Accel N+1 associates with all CPUs of Accel N, but not vice versa
 TEST_F(NVMLAcceleratorTopoTest, n1_superset_n_affinitization_config)
 {
-    int num_accelerator = 4;
-    int num_cpu = 40;
+    const int num_accelerator = 4;
+    const int num_cpu = 40;
 
     unsigned long accel_bitmask[num_accelerator];
     accel_bitmask[0] = 0xfffffff000;
@@ -192,14 +193,14 @@ TEST_F(NVMLAcceleratorTopoTest, n1_superset_n_affinitization_config)
 
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
 
-    EXPECT_EQ(4, topo.num_accelerator());
-    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
     cpus_allowed_set[0] = {12,13,14,15,16,17,18,19,20,21};
     cpus_allowed_set[1] = {8 ,9 ,10,11,22,23,24,25,26,27};
     cpus_allowed_set[2] = {4 ,5 ,6 ,7 ,28,29,30,31,32,33};
     cpus_allowed_set[3] = {0 ,1 ,2 ,3 ,34,35,36,37,38,39};
 
-    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
@@ -207,8 +208,8 @@ TEST_F(NVMLAcceleratorTopoTest, n1_superset_n_affinitization_config)
 //Test case:  Last accelerator has the smallest map, and the entire map will be 'stolen' to cause starvation
 TEST_F(NVMLAcceleratorTopoTest, greedbuster_affinitization_config)
 {
-    int num_accelerator = 4;
-    int num_cpu = 40;
+    const int num_accelerator = 4;
+    const int num_cpu = 40;
 
     unsigned long accel_bitmask[num_accelerator];
     accel_bitmask[0] = 0xffffffffff;
@@ -221,27 +222,15 @@ TEST_F(NVMLAcceleratorTopoTest, greedbuster_affinitization_config)
     }
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
-    EXPECT_THROW(NVMLAcceleratorTopo topo(*m_device_pool, num_cpu), geopm::Exception);
-
-    //TODO: If we move away from the greedy affinitization approach this is the expected result.
-    //EXPECT_EQ(4, topo.num_accelerator());
-    //std::set<int> cpus_allowed_set[topo.num_accelerator()];
-    //cpus_allowed_set[0] = {10,11,12,13,14,15,16,17,18,19};
-    //cpus_allowed_set[1] = {20,21,22,23,24,25,26,27,28,29};
-    //cpus_allowed_set[2] = {30,31,32,33,34,35,36,37,38,39};
-    //cpus_allowed_set[3] = {0 ,1 ,2 ,3 ,4 ,5 ,6 ,7 ,8 ,9 };
-
-    //for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
-    //    ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
-    //}
+    GEOPM_EXPECT_THROW_MESSAGE(NVMLAcceleratorTopo topo(*m_device_pool, num_cpu), GEOPM_ERROR_INVALID, "Failed to affinitize all valid CPUs to Accelerators");
 }
 
-//Test case: Different GPU/CPU count, namely the HPE Apollo 6500
+//Test case: Different GPU/CPU count, namely an approximation of the HPE Apollo 6500
 //           system with 8 GPUs and 28 cores per socket.
 TEST_F(NVMLAcceleratorTopoTest, hpe_6500_affinitization_config)
 {
-    int num_accelerator = 8;
-    int num_cpu = 56;
+    const int num_accelerator = 8;
+    const int num_cpu = 56;
 
     unsigned long accel_bitmask[num_accelerator];
     accel_bitmask[0] = 0x0000000fffffff;
@@ -260,8 +249,8 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_6500_affinitization_config)
 
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
 
-    EXPECT_EQ(8, topo.num_accelerator());
-    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
     cpus_allowed_set[0] = {0 ,1 ,2 ,3 ,4 ,5 ,6 };
     cpus_allowed_set[1] = {7 ,8 ,9 ,10,11,12,13};
     cpus_allowed_set[2] = {14,15,16,17,18,19,20};
@@ -271,7 +260,7 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_6500_affinitization_config)
     cpus_allowed_set[6] = {42,43,44,45,46,47,48};
     cpus_allowed_set[7] = {49,50,51,52,53,54,55};
 
-    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
@@ -279,9 +268,8 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_6500_affinitization_config)
 //Test case: CPU count that is not evenly divisible by the accelerator count
 TEST_F(NVMLAcceleratorTopoTest, uneven_affinitization_config)
 {
-
-    int num_accelerator = 3;
-    int num_cpu =20;
+    const int num_accelerator = 3;
+    const int num_cpu =20;
 
     unsigned long accel_bitmask[num_accelerator];
     accel_bitmask[0] = 0xfffff;
@@ -295,13 +283,13 @@ TEST_F(NVMLAcceleratorTopoTest, uneven_affinitization_config)
 
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
 
-    EXPECT_EQ(3, topo.num_accelerator());
-    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
     cpus_allowed_set[0] = {0 ,1 ,2 ,3 ,4 ,5 ,18,19};
     cpus_allowed_set[1] = {6 ,7 ,8 ,9 ,10,11};
     cpus_allowed_set[2] = {12,13,14,15,16,17};
 
-    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
@@ -310,8 +298,8 @@ TEST_F(NVMLAcceleratorTopoTest, uneven_affinitization_config)
 //           This represents a system with 64 cores and 8 GPUs
 TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_config)
 {
-    int num_accelerator = 8;
-    int num_cpu = 128;
+    const int num_accelerator = 8;
+    const int num_cpu = 128;
 
     unsigned long accel_bitmask[num_accelerator][2];
     accel_bitmask[0][0] = 0xffffffffffffffff;
@@ -338,10 +326,10 @@ TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_config)
 
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
 
-    EXPECT_EQ(8, topo.num_accelerator());
-    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
 
-    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         for (int cpu_idx = 0; cpu_idx < num_cpu/topo.num_accelerator(); ++cpu_idx) {
             cpus_allowed_set[accel_idx].insert(cpu_idx+(accel_idx*16));
         }
@@ -353,8 +341,8 @@ TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_config)
 //Test case: High Core count system with sparse affinitization, to test uneven distribution with gaps.
 TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_gaps_config)
 {
-    int num_accelerator = 8;
-    int num_cpu = 128;
+    const int num_accelerator = 8;
+    const int num_cpu = 128;
 
     unsigned long accel_bitmask[num_accelerator][2];
     accel_bitmask[0][0] = 0x000000000fffffff;
@@ -381,8 +369,8 @@ TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_gaps_config)
 
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
 
-    EXPECT_EQ(8, topo.num_accelerator());
-    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
     cpus_allowed_set[0] = {0 ,1 ,2 ,3 ,4 ,5 ,6 ,7};
     cpus_allowed_set[1] = {8 ,9 ,10,11,12,13,14,15};
     cpus_allowed_set[2] = {16,17,18,19,20,21,22,23};
@@ -392,7 +380,7 @@ TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_gaps_config)
     cpus_allowed_set[6] = {44,45,46,47,48,49,50,51};
     cpus_allowed_set[7] = {52,53,54,55,123,124,125,126};
 
-    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }

--- a/test/NVMLAcceleratorTopoTest.cpp
+++ b/test/NVMLAcceleratorTopoTest.cpp
@@ -330,7 +330,7 @@ TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_config)
     std::set<int> cpus_allowed_set[num_accelerator];
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        for (int cpu_idx = 0; cpu_idx < num_cpu/topo.num_accelerator(); ++cpu_idx) {
+        for (int cpu_idx = 0; cpu_idx < num_cpu/num_accelerator; ++cpu_idx) {
             cpus_allowed_set[accel_idx].insert(cpu_idx+(accel_idx*16));
         }
 

--- a/test/NVMLAcceleratorTopoTest.cpp
+++ b/test/NVMLAcceleratorTopoTest.cpp
@@ -79,7 +79,7 @@ TEST_F(NVMLAcceleratorTopoTest, no_gpu_config)
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
     EXPECT_EQ(num_accelerator, topo.num_accelerator());
 
-    GEOPM_EXPECT_THROW_MESSAGE(topo.ideal_cpu_affinitization(num_accelerator), GEOPM_ERROR_INVALID, "accel_idx 0 is out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(topo.cpu_affinity_ideal(num_accelerator), GEOPM_ERROR_INVALID, "accel_idx 0 is out of range");
 }
 
 //Test case: The HPE SX40 default system configuration
@@ -95,7 +95,7 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_sx40_default_config)
     accel_bitmask[3] = 0xfffff00000;
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *) &accel_bitmask[accel_idx]));
+        EXPECT_CALL(*m_device_pool, cpu_affinity_ideal_mask(accel_idx)).WillOnce(Return((cpu_set_t *) &accel_bitmask[accel_idx]));
     }
 
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
@@ -109,7 +109,7 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_sx40_default_config)
     cpus_allowed_set[3] = {30,31,32,33,34,35,36,37,38,39};
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
 
@@ -126,7 +126,7 @@ TEST_F(NVMLAcceleratorTopoTest, mutex_affinitization_config)
     accel_bitmask[3] = 0xffc0000000;
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+        EXPECT_CALL(*m_device_pool, cpu_affinity_ideal_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
     }
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
@@ -139,7 +139,7 @@ TEST_F(NVMLAcceleratorTopoTest, mutex_affinitization_config)
     cpus_allowed_set[3] = {30,31,32,33,34,35,36,37,38,39};
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
 
@@ -156,7 +156,7 @@ TEST_F(NVMLAcceleratorTopoTest, equidistant_affinitization_config)
     accel_bitmask[3] = 0xffffffffff;
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+        EXPECT_CALL(*m_device_pool, cpu_affinity_ideal_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
     }
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
@@ -170,7 +170,7 @@ TEST_F(NVMLAcceleratorTopoTest, equidistant_affinitization_config)
     cpus_allowed_set[3] = {30,31,32,33,34,35,36,37,38,39};
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
 
@@ -187,7 +187,7 @@ TEST_F(NVMLAcceleratorTopoTest, n1_superset_n_affinitization_config)
     accel_bitmask[3] = 0xffffffffff;
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+        EXPECT_CALL(*m_device_pool, cpu_affinity_ideal_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
     }
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
@@ -201,7 +201,7 @@ TEST_F(NVMLAcceleratorTopoTest, n1_superset_n_affinitization_config)
     cpus_allowed_set[3] = {0 ,1 ,2 ,3 ,34,35,36,37,38,39};
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
 
@@ -218,7 +218,7 @@ TEST_F(NVMLAcceleratorTopoTest, greedbuster_affinitization_config)
     accel_bitmask[3] = 0x00000003ff;
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+        EXPECT_CALL(*m_device_pool, cpu_affinity_ideal_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
     }
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
@@ -243,7 +243,7 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_6500_affinitization_config)
     accel_bitmask[7] = 0xffffffff000000;
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+        EXPECT_CALL(*m_device_pool, cpu_affinity_ideal_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
     }
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
@@ -261,7 +261,7 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_6500_affinitization_config)
     cpus_allowed_set[7] = {49,50,51,52,53,54,55};
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
 
@@ -277,7 +277,7 @@ TEST_F(NVMLAcceleratorTopoTest, uneven_affinitization_config)
     accel_bitmask[2] = 0xfffff;
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+        EXPECT_CALL(*m_device_pool, cpu_affinity_ideal_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
     }
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
@@ -290,7 +290,7 @@ TEST_F(NVMLAcceleratorTopoTest, uneven_affinitization_config)
     cpus_allowed_set[2] = {12,13,14,15,16,17};
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
 
@@ -320,7 +320,7 @@ TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_config)
     accel_bitmask[7][1] = 0xffffffffffffffff;
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+        EXPECT_CALL(*m_device_pool, cpu_affinity_ideal_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
     }
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
@@ -334,7 +334,7 @@ TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_config)
             cpus_allowed_set[accel_idx].insert(cpu_idx+(accel_idx*16));
         }
 
-        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
 
@@ -363,7 +363,7 @@ TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_gaps_config)
     accel_bitmask[7][1] = 0xf800000000000000;
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+        EXPECT_CALL(*m_device_pool, cpu_affinity_ideal_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
     }
     EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
 
@@ -381,6 +381,6 @@ TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_gaps_config)
     cpus_allowed_set[7] = {52,53,54,55,123,124,125,126};
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }

--- a/test/NVMLAcceleratorTopoTest.cpp
+++ b/test/NVMLAcceleratorTopoTest.cpp
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <unistd.h>
+#include <limits.h>
+
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "config.h"
+#include "Helper.hpp"
+#include "Exception.hpp"
+#include "MockNVMLDevicePool.hpp"
+#include "NVMLAcceleratorTopo.hpp"
+
+using geopm::NVMLAcceleratorTopo;
+using geopm::Exception;
+using testing::Return;
+
+class NVMLAcceleratorTopoTest : public :: testing :: Test
+{
+    protected:
+        void SetUp();
+        void TearDown();
+
+        std::shared_ptr<MockNVMLDevicePool> m_device_pool;
+};
+
+void NVMLAcceleratorTopoTest::SetUp()
+{
+    m_device_pool = std::make_shared<MockNVMLDevicePool>();
+}
+
+void NVMLAcceleratorTopoTest::TearDown()
+{
+}
+
+//Test case: Mock num_accelerator = 0 so we hit the appropriate warning and throw on affinitization requests.
+TEST_F(NVMLAcceleratorTopoTest, no_gpu_config)
+{
+    int num_accelerator = 0;
+    int num_cpu = 40;
+
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
+    EXPECT_EQ(0, topo.num_accelerator());
+
+    EXPECT_THROW(topo.ideal_cpu_affinitization(0), geopm::Exception);
+}
+
+//Test case: The HPE SX40 default system configuration
+TEST_F(NVMLAcceleratorTopoTest, hpe_sx40_default_config)
+{
+    int num_accelerator = 4;
+    int num_cpu = 40;
+
+    unsigned long accel_bitmask[num_accelerator];
+    accel_bitmask[0] = 0x00000fffff;
+    accel_bitmask[1] = 0x00000fffff;
+    accel_bitmask[2] = 0xfffff00000;
+    accel_bitmask[3] = 0xfffff00000;
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *) &accel_bitmask[accel_idx]));
+    }
+
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
+    EXPECT_EQ(4, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    cpus_allowed_set[0] = {0,1,2,3,4,5,6,7,8,9};
+    cpus_allowed_set[1] = {10,11,12,13,14,15,16,17,18,19};
+    cpus_allowed_set[2] = {20,21,22,23,24,25,26,27,28,29};
+    cpus_allowed_set[3] = {30,31,32,33,34,35,36,37,38,39};
+
+    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}
+
+//Test case: All cpus are associated with one and only one GPUs
+TEST_F(NVMLAcceleratorTopoTest, mutex_affinitization_config)
+{
+    int num_accelerator = 4;
+    int num_cpu = 40;
+
+    unsigned long accel_bitmask[num_accelerator];
+    accel_bitmask[0] = 0x00000003ff;
+    accel_bitmask[1] = 0x00000ffc00;
+    accel_bitmask[2] = 0x003ff00000;
+    accel_bitmask[3] = 0xffc0000000;
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+    }
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
+    EXPECT_EQ(4, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    cpus_allowed_set[0] = {0,1,2,3,4,5,6,7,8,9};
+    cpus_allowed_set[1] = {10,11,12,13,14,15,16,17,18,19};
+    cpus_allowed_set[2] = {20,21,22,23,24,25,26,27,28,29};
+    cpus_allowed_set[3] = {30,31,32,33,34,35,36,37,38,39};
+
+    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}
+
+//Test case: All cpus are associated with all GPUs
+TEST_F(NVMLAcceleratorTopoTest, equidistant_affinitization_config)
+{
+    int num_accelerator = 4;
+    int num_cpu = 40;
+
+    unsigned long accel_bitmask[num_accelerator];
+    accel_bitmask[0] = 0xffffffffff;
+    accel_bitmask[1] = 0xffffffffff;
+    accel_bitmask[2] = 0xffffffffff;
+    accel_bitmask[3] = 0xffffffffff;
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+    }
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
+
+    EXPECT_EQ(4, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    cpus_allowed_set[0] = {0,1,2,3,4,5,6,7,8,9};
+    cpus_allowed_set[1] = {10,11,12,13,14,15,16,17,18,19};
+    cpus_allowed_set[2] = {20,21,22,23,24,25,26,27,28,29};
+    cpus_allowed_set[3] = {30,31,32,33,34,35,36,37,38,39};
+
+    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}
+
+//Test case:  Accel N+1 associates with all CPUs of Accel N, but not vice versa
+TEST_F(NVMLAcceleratorTopoTest, n1_superset_n_affinitization_config)
+{
+    int num_accelerator = 4;
+    int num_cpu = 40;
+
+    unsigned long accel_bitmask[num_accelerator];
+    accel_bitmask[0] = 0xfffffff000;
+    accel_bitmask[1] = 0xffffffff00;
+    accel_bitmask[2] = 0xfffffffff0;
+    accel_bitmask[3] = 0xffffffffff;
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+    }
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
+
+    EXPECT_EQ(4, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    cpus_allowed_set[0] = {12,13,14,15,16,17,18,19,20,21};
+    cpus_allowed_set[1] = {8 ,9 ,10,11,22,23,24,25,26,27};
+    cpus_allowed_set[2] = {4 ,5 ,6 ,7 ,28,29,30,31,32,33};
+    cpus_allowed_set[3] = {0 ,1 ,2 ,3 ,34,35,36,37,38,39};
+
+    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}
+
+//Test case:  Last accelerator has the smallest map, and the entire map will be 'stolen' to cause starvation
+TEST_F(NVMLAcceleratorTopoTest, greedbuster_affinitization_config)
+{
+    int num_accelerator = 4;
+    int num_cpu = 40;
+
+    unsigned long accel_bitmask[num_accelerator];
+    accel_bitmask[0] = 0xffffffffff;
+    accel_bitmask[1] = 0xfffffffff0;
+    accel_bitmask[2] = 0x0fffffff00;
+    accel_bitmask[3] = 0x00000003ff;
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+    }
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    EXPECT_THROW(NVMLAcceleratorTopo topo(*m_device_pool, num_cpu), geopm::Exception);
+
+    //TODO: If we move away from the greedy affinitization approach this is the expected result.
+    //EXPECT_EQ(4, topo.num_accelerator());
+    //std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    //cpus_allowed_set[0] = {10,11,12,13,14,15,16,17,18,19};
+    //cpus_allowed_set[1] = {20,21,22,23,24,25,26,27,28,29};
+    //cpus_allowed_set[2] = {30,31,32,33,34,35,36,37,38,39};
+    //cpus_allowed_set[3] = {0 ,1 ,2 ,3 ,4 ,5 ,6 ,7 ,8 ,9 };
+
+    //for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+    //    ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+    //}
+}
+
+//Test case: Different GPU/CPU count, namely the HPE Apollo 6500
+//           system with 8 GPUs and 28 cores per socket.
+TEST_F(NVMLAcceleratorTopoTest, hpe_6500_affinitization_config)
+{
+    int num_accelerator = 8;
+    int num_cpu = 56;
+
+    unsigned long accel_bitmask[num_accelerator];
+    accel_bitmask[0] = 0x0000000fffffff;
+    accel_bitmask[1] = 0x0000000fffffff;
+    accel_bitmask[2] = 0x0000000fffffff;
+    accel_bitmask[3] = 0x0000000fffffff;
+    accel_bitmask[4] = 0xffffffff000000;
+    accel_bitmask[5] = 0xffffffff000000;
+    accel_bitmask[6] = 0xffffffff000000;
+    accel_bitmask[7] = 0xffffffff000000;
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+    }
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
+
+    EXPECT_EQ(8, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    cpus_allowed_set[0] = {0 ,1 ,2 ,3 ,4 ,5 ,6 };
+    cpus_allowed_set[1] = {7 ,8 ,9 ,10,11,12,13};
+    cpus_allowed_set[2] = {14,15,16,17,18,19,20};
+    cpus_allowed_set[3] = {21,22,23,24,25,26,27};
+    cpus_allowed_set[4] = {28,29,30,31,32,33,34};
+    cpus_allowed_set[5] = {35,36,37,38,39,40,41};
+    cpus_allowed_set[6] = {42,43,44,45,46,47,48};
+    cpus_allowed_set[7] = {49,50,51,52,53,54,55};
+
+    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}
+
+//Test case: CPU count that is not evenly divisible by the accelerator count
+TEST_F(NVMLAcceleratorTopoTest, uneven_affinitization_config)
+{
+
+    int num_accelerator = 3;
+    int num_cpu =20;
+
+    unsigned long accel_bitmask[num_accelerator];
+    accel_bitmask[0] = 0xfffff;
+    accel_bitmask[1] = 0xfffff;
+    accel_bitmask[2] = 0xfffff;
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+    }
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
+
+    EXPECT_EQ(3, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    cpus_allowed_set[0] = {0 ,1 ,2 ,3 ,4 ,5 ,18,19};
+    cpus_allowed_set[1] = {6 ,7 ,8 ,9 ,10,11};
+    cpus_allowed_set[2] = {12,13,14,15,16,17};
+
+    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}
+
+//Test case: High Core count, theoretical system to test large CPU SETS.
+//           This represents a system with 64 cores and 8 GPUs
+TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_config)
+{
+    int num_accelerator = 8;
+    int num_cpu = 128;
+
+    unsigned long accel_bitmask[num_accelerator][2];
+    accel_bitmask[0][0] = 0xffffffffffffffff;
+    accel_bitmask[0][1] = 0xffffffffffffffff;
+    accel_bitmask[1][0] = 0xffffffffffffffff;
+    accel_bitmask[1][1] = 0xffffffffffffffff;
+    accel_bitmask[2][0] = 0xffffffffffffffff;
+    accel_bitmask[2][1] = 0xffffffffffffffff;
+    accel_bitmask[3][0] = 0xffffffffffffffff;
+    accel_bitmask[3][1] = 0xffffffffffffffff;
+    accel_bitmask[4][0] = 0xffffffffffffffff;
+    accel_bitmask[4][1] = 0xffffffffffffffff;
+    accel_bitmask[5][0] = 0xffffffffffffffff;
+    accel_bitmask[5][1] = 0xffffffffffffffff;
+    accel_bitmask[6][0] = 0xffffffffffffffff;
+    accel_bitmask[6][1] = 0xffffffffffffffff;
+    accel_bitmask[7][0] = 0xffffffffffffffff;
+    accel_bitmask[7][1] = 0xffffffffffffffff;
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+    }
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
+
+    EXPECT_EQ(8, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+
+    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+        for (int cpu_idx = 0; cpu_idx < num_cpu/topo.num_accelerator(); ++cpu_idx) {
+            cpus_allowed_set[accel_idx].insert(cpu_idx+(accel_idx*16));
+        }
+
+        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}
+
+//Test case: High Core count system with sparse affinitization, to test uneven distribution with gaps.
+TEST_F(NVMLAcceleratorTopoTest, high_cpu_count_gaps_config)
+{
+    int num_accelerator = 8;
+    int num_cpu = 128;
+
+    unsigned long accel_bitmask[num_accelerator][2];
+    accel_bitmask[0][0] = 0x000000000fffffff;
+    accel_bitmask[0][1] = 0x000000000000000f;
+    accel_bitmask[1][0] = 0x000000000fffffff;
+    accel_bitmask[1][1] = 0x000000000000000f;
+    accel_bitmask[2][0] = 0x000000000fffffff;
+    accel_bitmask[2][1] = 0x000000000000000f;
+    accel_bitmask[3][0] = 0x000000000fffffff;
+    accel_bitmask[3][1] = 0x000000000000000f;
+    accel_bitmask[4][0] = 0x00ffffffff000000;
+    accel_bitmask[4][1] = 0xf800000000000000;
+    accel_bitmask[5][0] = 0x00ffffffff000000;
+    accel_bitmask[5][1] = 0xf800000000000000;
+    accel_bitmask[6][0] = 0x00ffffffff000000;
+    accel_bitmask[6][1] = 0xf800000000000000;
+    accel_bitmask[7][0] = 0x00ffffffff000000;
+    accel_bitmask[7][1] = 0xf800000000000000;
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, ideal_cpu_affinitization_mask(accel_idx)).WillOnce(Return((cpu_set_t *)&accel_bitmask[accel_idx]));
+    }
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
+
+    EXPECT_EQ(8, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[topo.num_accelerator()];
+    cpus_allowed_set[0] = {0 ,1 ,2 ,3 ,4 ,5 ,6 ,7};
+    cpus_allowed_set[1] = {8 ,9 ,10,11,12,13,14,15};
+    cpus_allowed_set[2] = {16,17,18,19,20,21,22,23};
+    cpus_allowed_set[3] = {24,25,26,27,64,65,66,67};
+    cpus_allowed_set[4] = {28,29,30,31,32,33,34,35,127};
+    cpus_allowed_set[5] = {36,37,38,39,40,41,42,43};
+    cpus_allowed_set[6] = {44,45,46,47,48,49,50,51};
+    cpus_allowed_set[7] = {52,53,54,55,123,124,125,126};
+
+    for (int accel_idx = 0; accel_idx < topo.num_accelerator(); ++accel_idx) {
+        ASSERT_THAT(topo.ideal_cpu_affinitization(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}

--- a/test/PlatformTopoTest.cpp
+++ b/test/PlatformTopoTest.cpp
@@ -41,6 +41,7 @@
 #include "Helper.hpp"
 #include "PlatformTopoImp.hpp"
 #include "Exception.hpp"
+#include "config.h"
 
 using geopm::PlatformTopo;
 using geopm::PlatformTopoImp;
@@ -267,7 +268,11 @@ TEST_F(PlatformTopoTest, hsw_num_domain)
     /// @todo when implemented, add tests for each platform
     EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_BOARD_NIC));
     EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_PACKAGE_NIC));
+#ifdef GEOPM_ENABLE_NVML
+    EXPECT_GE(topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR), 0);
+#else
     EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR));
+#endif
     EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_PACKAGE_ACCELERATOR));
 
     EXPECT_THROW(topo.num_domain(GEOPM_DOMAIN_INVALID), geopm::Exception);
@@ -295,6 +300,11 @@ TEST_F(PlatformTopoTest, bdx_num_domain)
     EXPECT_EQ(72, topo.num_domain(GEOPM_DOMAIN_CPU));
     EXPECT_EQ(2, topo.num_domain(GEOPM_DOMAIN_BOARD_MEMORY));
     EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_PACKAGE_MEMORY));
+#ifdef GEOPM_ENABLE_NVML
+    EXPECT_GE(topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR), 0);
+#else
+    EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR));
+#endif
 }
 
 TEST_F(PlatformTopoTest, ppc_num_domain)
@@ -376,10 +386,16 @@ TEST_F(PlatformTopoTest, bdx_domain_idx)
     for (auto cpu_idx : cpu_set_node1) {
         EXPECT_EQ(1, topo.domain_idx(GEOPM_DOMAIN_BOARD_MEMORY, cpu_idx));
     }
+
+#ifdef GEOPM_ENABLE_NVML
+    EXPECT_GE(topo.domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, 0), -1);
+#else
+    EXPECT_EQ(-1, topo.domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, 0));
+#endif
+
     EXPECT_THROW(topo.domain_idx(GEOPM_DOMAIN_PACKAGE_MEMORY, 0), geopm::Exception);
     EXPECT_THROW(topo.domain_idx(GEOPM_DOMAIN_BOARD_NIC, 0), geopm::Exception);
     EXPECT_THROW(topo.domain_idx(GEOPM_DOMAIN_PACKAGE_NIC, 0), geopm::Exception);
-    EXPECT_THROW(topo.domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, 0), geopm::Exception);
     EXPECT_THROW(topo.domain_idx(GEOPM_DOMAIN_PACKAGE_ACCELERATOR, 0), geopm::Exception);
 }
 
@@ -566,6 +582,15 @@ TEST_F(PlatformTopoTest, bdx_domain_nested)
                                         GEOPM_DOMAIN_BOARD, 0);
     EXPECT_EQ(idx_set_expect, idx_set_actual);
 
+    // Board Accelerator
+#ifdef GEOPM_ENABLE_NVML
+    EXPECT_NO_THROW(topo.domain_nested(GEOPM_DOMAIN_CPU,
+                                       GEOPM_DOMAIN_BOARD_ACCELERATOR, 0));
+#else
+    EXPECT_THROW(topo.domain_nested(GEOPM_DOMAIN_CPU,
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR, 0), Exception);
+#endif
+
     // TODO: still to be implemented
     EXPECT_THROW(topo.domain_nested(GEOPM_DOMAIN_CPU,
                                     GEOPM_DOMAIN_PACKAGE_MEMORY, 0), Exception);
@@ -575,8 +600,6 @@ TEST_F(PlatformTopoTest, bdx_domain_nested)
                                     GEOPM_DOMAIN_PACKAGE_NIC, 0), Exception);
     EXPECT_THROW(topo.domain_nested(GEOPM_DOMAIN_CPU,
                                     GEOPM_DOMAIN_BOARD_NIC, 0), Exception);
-    EXPECT_THROW(topo.domain_nested(GEOPM_DOMAIN_CPU,
-                                    GEOPM_DOMAIN_BOARD_ACCELERATOR, 0), Exception);
 }
 
 TEST_F(PlatformTopoTest, parse_error)

--- a/test/PlatformTopoTest.cpp
+++ b/test/PlatformTopoTest.cpp
@@ -367,8 +367,8 @@ TEST_F(PlatformTopoTest, bdx_domain_idx)
         for (int cpu_idx = 0; cpu_idx < 72/num_accelerator; ++cpu_idx) {
             cpu_affin[accel_idx].insert(cpu_idx+(accel_idx*18));
         }
-        EXPECT_CALL(*m_accelerator_topo, 
-                     ideal_cpu_affinitization(accel_idx)).WillRepeatedly(Return(cpu_affin[accel_idx]));
+        EXPECT_CALL(*m_accelerator_topo,
+                     cpu_affinity_ideal(accel_idx)).WillRepeatedly(Return(cpu_affin[accel_idx]));
     }
     write_lscpu(m_bdx_lscpu_str);
     PlatformTopoImp topo(m_lscpu_file_name, *m_accelerator_topo);
@@ -477,8 +477,8 @@ TEST_F(PlatformTopoTest, bdx_domain_nested)
         for (int cpu_idx = 0; cpu_idx < 72/num_accelerator; ++cpu_idx) {
             cpu_affin[accel_idx].insert(cpu_idx+(accel_idx*18));
         }
-        EXPECT_CALL(*m_accelerator_topo, 
-                     ideal_cpu_affinitization(accel_idx)).WillRepeatedly(Return(cpu_affin[accel_idx]));
+        EXPECT_CALL(*m_accelerator_topo,
+                     cpu_affinity_ideal(accel_idx)).WillRepeatedly(Return(cpu_affin[accel_idx]));
     }
     write_lscpu(m_bdx_lscpu_str);
     PlatformTopoImp topo(m_lscpu_file_name, *m_accelerator_topo);

--- a/test/PlatformTopoTest.cpp
+++ b/test/PlatformTopoTest.cpp
@@ -42,6 +42,7 @@
 #include "PlatformTopoImp.hpp"
 #include "Exception.hpp"
 #include "config.h"
+#include "geopm_test.hpp"
 
 using geopm::PlatformTopo;
 using geopm::PlatformTopoImp;
@@ -269,7 +270,7 @@ TEST_F(PlatformTopoTest, hsw_num_domain)
     EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_BOARD_NIC));
     EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_PACKAGE_NIC));
 #ifdef GEOPM_ENABLE_NVML
-    EXPECT_GE(topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR), 0);
+    EXPECT_NO_THROW(topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR));
 #else
     EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR));
 #endif
@@ -301,7 +302,7 @@ TEST_F(PlatformTopoTest, bdx_num_domain)
     EXPECT_EQ(2, topo.num_domain(GEOPM_DOMAIN_BOARD_MEMORY));
     EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_PACKAGE_MEMORY));
 #ifdef GEOPM_ENABLE_NVML
-    EXPECT_GE(topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR), 0);
+    EXPECT_NO_THROW(topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR));
 #else
     EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR));
 #endif
@@ -388,7 +389,7 @@ TEST_F(PlatformTopoTest, bdx_domain_idx)
     }
 
 #ifdef GEOPM_ENABLE_NVML
-    EXPECT_GE(topo.domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, 0), -1);
+    EXPECT_NO_THROW(topo.domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, 0));
 #else
     EXPECT_EQ(-1, topo.domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, 0));
 #endif
@@ -589,6 +590,9 @@ TEST_F(PlatformTopoTest, bdx_domain_nested)
 #else
     EXPECT_THROW(topo.domain_nested(GEOPM_DOMAIN_CPU,
                                     GEOPM_DOMAIN_BOARD_ACCELERATOR, 0), Exception);
+    GEOPM_EXPECT_THROW_MESSAGE(topo.domain_nested(GEOPM_DOMAIN_CPU,
+                                                  GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
 #endif
 
     // TODO: still to be implemented


### PR DESCRIPTION
This PR is intended to provide basic support of the NVIDIA Management Library for monitoring and controlling NVIDIA accelerators.  It is primarily focused on discovering and enumerating the NVML devices and reporting their topology/relationship to other components in the system.  Beyond this it includes API calls in the NVMLDevicePool to support the control and monitoring of NVML Devices.

Tested with icpc (ICC) 19.0.5.281 20190815 and CUDA Toolkit version 10.2.

Signed-off-by: Lowren Lawson <lowren.h.lawson@intel.com>

Summary of change.
- Addition of an AcceleratorTopo class to provide static topology information as required by PlatformTopo
- Addition of an NVMLAcceleratorTopo implementation of the AcceleratorTopo class to provide the same for NVML devices
- Addition of an NVMLDevicePool class to act as a thin wrapper around NVML API calls of interest
- Modification of PlatformTopo to use the AcceleratorTopo in all GEOPM_DOMAIN_BOARD_ACCELERATOR cases
- Addition of Unit tests to test and mock the basic features and known corner cases of the above changes.
- Modification of the configure.ac to provide --enable-nvml and --with-libnvml options for enabling the NVML accelerator classes

Summary of additional changes in response to review.
- Modification of NVMLDevicePool to take number of cpus as an input
- Addition of MockAcceleratorTopo
- Modification of PlatformTopo to take AcceleratorTopo in construction for testing with MockAcceleratorTopo

High level overview:
![image](https://user-images.githubusercontent.com/23505009/89480238-afc92180-d749-11ea-946e-82e0d736ca48.png)