### PR TITLE
Experiment scripts for monitor

### DIFF
--- a/integration/apps/Makefile.mk
+++ b/integration/apps/Makefile.mk
@@ -29,4 +29,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-EXTRA_DIST += integration/apps/__init__.py
+EXTRA_DIST += integration/apps/apps.py \
+              integration/apps/geopmbench.py \
+              integration/apps/__init__.py

--- a/integration/apps/apps.py
+++ b/integration/apps/apps.py
@@ -51,10 +51,6 @@ class AppConf(object):
         self._exec_args = exec_args
         # TODO: consider injecting num node and ranks here too
 
-    def get_num_node(self):
-        ''' Total number of nodes required by the application. '''
-        return None
-
     def get_rank_per_node(self):
         ''' Total number of ranks required by the application. '''
         return None

--- a/integration/apps/apps.py
+++ b/integration/apps/apps.py
@@ -36,11 +36,10 @@ import textwrap
 
 class AppConf(object):
     """
-    An object that contains all details needed to run an
-    application.  When used with experiment run scripts, write()
-    should be called by the run function before starting the run,
-    and get_exec_path() and get_exec_args() will be used to
-    construct command line arguments to the launcher.
+    An object that contains all details needed to run an application.
+    When used with experiment run scripts, setup(), get_exec_path(),
+    get_exec_args(), and cleanup() will be used to construct command
+    line arguments to the launcher.
     """
     @classmethod
     def name():
@@ -49,7 +48,6 @@ class AppConf(object):
     def __init__(self, exec_path, exec_args=[]):
         self._exec_path = exec_path
         self._exec_args = exec_args
-        # TODO: consider injecting num node and ranks here too
 
     def get_rank_per_node(self):
         ''' Total number of ranks required by the application. '''
@@ -60,15 +58,19 @@ class AppConf(object):
         return None
 
     def setup(self):
+        ''' Any steps to be run prior to running one iteration of the application. '''
         return ''
 
     def get_exec_path(self):
+        ''' Application executable path. '''
         return self._exec_path
 
     def get_exec_args(self):
+        ''' Command line arguments to the application. '''
         return self._exec_args
 
     def cleanup(self):
+        ''' Any steps to be run after running one iteration of the application. '''
         return ''
 
     def parse_fom(self, log_path):
@@ -79,8 +81,8 @@ class AppConf(object):
         if type(app_params) is list:
             app_params = ' '.join(self.get_exec_args())
 
-        script = textwrap.dedent('''\
-            #!/bin/bash
+        script = '''#!/bin/bash\n'''
+        script += textwrap.dedent('''\
             {setup}
             {app_exec} {app_params}
             {cleanup}

--- a/integration/apps/apps.py
+++ b/integration/apps/apps.py
@@ -1,0 +1,100 @@
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import os
+import stat
+import textwrap
+
+
+class AppConf(object):
+    """
+    An object that contains all details needed to run an
+    application.  When used with experiment run scripts, write()
+    should be called by the run function before starting the run,
+    and get_exec_path() and get_exec_args() will be used to
+    construct command line arguments to the launcher.
+    """
+    @classmethod
+    def name():
+        return "APP"
+
+    def __init__(self, exec_path, exec_args=[]):
+        self._exec_path = exec_path
+        self._exec_args = exec_args
+        # TODO: consider injecting num node and ranks here too
+
+    def get_num_node(self):
+        ''' Total number of nodes required by the application. '''
+        return None
+
+    def get_rank_per_node(self):
+        ''' Total number of ranks required by the application. '''
+        return None
+
+    def get_cpu_per_rank(self):
+        ''' Hardware threads per rank required by the application. '''
+        return None
+
+    def setup(self):
+        return ''
+
+    def get_exec_path(self):
+        return self._exec_path
+
+    def get_exec_args(self):
+        return self._exec_args
+
+    def cleanup(self):
+        return ''
+
+    def parse_fom(self, log_path):
+        return None
+
+    def make_bash(self, output_dir):
+        app_params = self.get_exec_args()
+        if type(app_params) is list:
+            app_params = ' '.join(self.get_exec_args())
+
+        script = textwrap.dedent('''\
+            #!/bin/bash
+            {setup}
+            {app_exec} {app_params}
+            {cleanup}
+        '''.format(setup=self.setup(),
+                   app_exec=self.get_exec_path(),
+                   app_params=app_params,
+                   cleanup=self.cleanup()))
+        bash_file = os.path.join(output_dir, '{}.sh'.format(self.name()))
+        with open(bash_file, 'w') as ofile:
+            ofile.write(script)
+        # read, write, execute for owner
+        os.chmod(bash_file, stat.S_IRWXU)
+        return bash_file

--- a/integration/apps/geopmbench.py
+++ b/integration/apps/geopmbench.py
@@ -1,0 +1,76 @@
+import os
+import textwrap
+
+from . import apps
+import geopmpy.io
+
+
+class DgemmAppConf(apps.AppConf):
+
+    @staticmethod
+    def name():
+        return 'DGEMM'
+
+    def __init__(self, output_dir):
+        self._bench_conf = geopmpy.io.BenchConf(os.path.join(output_dir, 'dgemm.conf'))
+        self._bench_conf.append_region('dgemm', 8.0)
+        self._bench_conf.set_loop_count(500)
+
+    def get_num_node(self):
+        # TODO: this seems bad
+        # proposal: num_nodes always an input to __init__, app throws if it can't handle.
+        # num ranks per node always an output from app conf.
+        # if you want to play with different rank configs, use different app conf
+        raise RuntimeError("<geopm> dgemm application scales to any number of nodes.")
+        return None
+
+    def get_rank_per_node(self):
+        # TODO: use self._machine_file to determine?
+        return 2
+
+    def setup(self):
+        self._bench_conf.write()
+        return ""
+
+    def get_exec_path(self):
+        # TODO: may need to find local version if not installed
+        return 'geopmbench'
+
+    def get_exec_args(self):
+        return self._bench_conf.get_path()
+
+
+# TODO: repeated code with above
+class TinyAppConf(apps.AppConf):
+    ''' A smaller DGEMM for faster turnaround when testing experiment scripts.'''
+    @staticmethod
+    def name():
+        return 'tiny'
+
+    def __init__(self, output_dir):
+        self._bench_conf = geopmpy.io.BenchConf(os.path.join(output_dir, 'tiny.conf'))
+        self._bench_conf.append_region('dgemm', 0.2)
+        self._bench_conf.set_loop_count(500)
+
+    def get_num_node(self):
+        # TODO: this seems bad
+        # proposal: num_nodes always an input to __init__, app throws if it can't handle.
+        # num ranks per node always an output from app conf.
+        # if you want to play with different rank configs, use different app conf
+        raise RuntimeError("<geopm> dgemm application scales to any number of nodes.")
+        return None
+
+    def get_rank_per_node(self):
+        # TODO: use self._machine_file to determine?
+        return 2
+
+    def setup(self):
+        self._bench_conf.write()
+        return ""
+
+    def get_exec_path(self):
+        # TODO: may need to find local version if not installed
+        return 'geopmbench'
+
+    def get_exec_args(self):
+        return self._bench_conf.get_path()

--- a/integration/apps/geopmbench.py
+++ b/integration/apps/geopmbench.py
@@ -1,5 +1,35 @@
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
 import os
-import textwrap
 
 from . import apps
 import geopmpy.io
@@ -15,14 +45,6 @@ class DgemmAppConf(apps.AppConf):
         self._bench_conf = geopmpy.io.BenchConf(os.path.join(output_dir, 'dgemm.conf'))
         self._bench_conf.append_region('dgemm', 8.0)
         self._bench_conf.set_loop_count(500)
-
-    def get_num_node(self):
-        # TODO: this seems bad
-        # proposal: num_nodes always an input to __init__, app throws if it can't handle.
-        # num ranks per node always an output from app conf.
-        # if you want to play with different rank configs, use different app conf
-        raise RuntimeError("<geopm> dgemm application scales to any number of nodes.")
-        return None
 
     def get_rank_per_node(self):
         # TODO: use self._machine_file to determine?
@@ -51,14 +73,6 @@ class TinyAppConf(apps.AppConf):
         self._bench_conf = geopmpy.io.BenchConf(os.path.join(output_dir, 'tiny.conf'))
         self._bench_conf.append_region('dgemm', 0.2)
         self._bench_conf.set_loop_count(500)
-
-    def get_num_node(self):
-        # TODO: this seems bad
-        # proposal: num_nodes always an input to __init__, app throws if it can't handle.
-        # num ranks per node always an output from app conf.
-        # if you want to play with different rank configs, use different app conf
-        raise RuntimeError("<geopm> dgemm application scales to any number of nodes.")
-        return None
 
     def get_rank_per_node(self):
         # TODO: use self._machine_file to determine?

--- a/integration/experiment/common_args.py
+++ b/integration/experiment/common_args.py
@@ -51,3 +51,32 @@ def add_show_details(parser):
         parser.add_argument('--show-details', dest='show_details',
                             action='store_true', default=False,
                             help='print additional data analysis details')
+
+
+def add_min_power(parser):
+    parser.add_argument('--min-power', dest='min_power',
+                        action='store', type=float, default=None,
+                        help='bottom power limit for the sweep')
+
+
+def add_max_power(parser):
+    parser.add_argument('--max-power', dest='max_power',
+                        action='store', type=float, default=None,
+                        help='top power limit for the sweep')
+
+
+def add_label(parser):
+    parser.add_argument('--label', action='store', default="APP",
+                        help='name of the application to use for plot titles')
+
+
+def add_min_frequency(parser):
+    parser.add_argument('--min-frequency', dest='min_frequency',
+                        action='store', type=float, default=None,
+                        help='bottom frequency limit for the sweep')
+
+
+def add_max_frequency(parser):
+    parser.add_argument('--max-frequency', dest='max_frequency',
+                        action='store', type=float, default=None,
+                        help='top frequency limit for the sweep')

--- a/integration/experiment/machine.py
+++ b/integration/experiment/machine.py
@@ -30,12 +30,11 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-import sys
 import json
 import os
 import glob
 
-import util
+from . import util
 
 
 class Machine:
@@ -91,6 +90,7 @@ class Machine:
         for sn in signal_names:
             self.signals[sn] = util.geopmread('{} board 0'.format(sn))
 
+
 def init_output_dir(output_dir):
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
@@ -105,4 +105,3 @@ def get_machine(output_dir):
     mm = Machine(output_dir)
     mm.load()
     return mm
-

--- a/integration/experiment/monitor/Makefile.mk
+++ b/integration/experiment/monitor/Makefile.mk
@@ -29,12 +29,8 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-EXTRA_DIST += integration/experiment/common_args.py \
-              integration/experiment/__init__.py \
-              integration/experiment/machine.py \
-              integration/experiment/util.py \
+EXTRA_DIST += integration/experiment/monitor/gen_plot_achieved_power.py \
+              integration/experiment/monitor/__init__.py \
+              integration/experiment/monitor/monitor.py \
+              integration/experiment/monitor/run_dgemm.py \
               # end
-
-include integration/experiment/monitor/Makefile.mk
-include integration/experiment/power_sweep/Makefile.mk
-include integration/experiment/trace_analysis/Makefile.mk

--- a/integration/experiment/monitor/__init__.py
+++ b/integration/experiment/monitor/__init__.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#

--- a/integration/experiment/monitor/gen_plot_achieved_power.py
+++ b/integration/experiment/monitor/gen_plot_achieved_power.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+'''
+Plot a histogram of the achieved power on each node from an unconstrained run.
+'''
+
+import sys
+import os
+import pandas
+import argparse
+import matplotlib.pyplot as plt
+import numpy
+
+import geopmpy.io
+
+from experiment import common_args
+from experiment import machine
+# TODO: need common thing
+from experiment.power_sweep import gen_node_efficiency
+
+
+def plot_node_power(df, app_name, min_power, max_power, step_power, output_dir,
+                    show_details=False):
+
+    # rename some columns
+    df['runtime'] = df['runtime (sec)']
+    df['network_time'] = df['network-time (sec)']
+    df['energy_pkg'] = df['package-energy (joules)']
+    df['frequency'] = df['frequency (Hz)']
+    df.set_index(['host'], inplace=True)
+
+    # TODO: per package info
+    energy_data = df.groupby(['host']).mean()['energy_pkg'].sort_values()
+    runtime_data = df.groupby(['host']).mean()['runtime'].sort_values()
+    power_data = energy_data / runtime_data
+    power_data = power_data.sort_values()
+    power_data = pandas.DataFrame(power_data, columns=['power'])
+
+    if show_details:
+        sys.stdout.write('{}\n'.format(power_data))
+
+    min_drop = min_power
+    max_drop = max_power - step_power
+    bin_size = step_power
+    xprecision = 3
+    gen_node_efficiency.generate_histogram(power_data, app_name,
+                                           min_drop, max_drop, 'power',
+                                           bin_size, xprecision, output_dir)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    common_args.add_output_dir(parser)
+    common_args.add_label(parser)
+    common_args.add_show_details(parser)
+    # common_args.add_min_power(parser)
+    # common_args.add_max_power(parser)
+
+    args, _ = parser.parse_known_args()
+    output_dir = args.output_dir
+
+    mach = machine.get_machine(output_dir)
+    min_power = mach.power_package_min()
+    max_power = mach.power_package_tdp()
+    step_power = 10
+
+    # TODO: make into utility function
+    try:
+        output = geopmpy.io.RawReportCollection("*report", dir_name=output_dir)
+    except:
+        sys.stderr.write('<geopm> Error: No report data found in {}; run a monitor experiment before using this analysis\n'.format(output_dir))
+        sys.exit(1)
+
+    plot_node_power(output.get_epoch_df(),
+                    app_name=args.label,
+                    min_power=min_power,
+                    max_power=max_power,
+                    step_power=step_power,
+                    output_dir=output_dir,
+                    show_details=args.show_details)

--- a/integration/experiment/monitor/monitor.py
+++ b/integration/experiment/monitor/monitor.py
@@ -66,7 +66,7 @@ def launch_monitor(output_dir, iterations,
                           '--geopm-report-signals=' + ','.join(report_sig)]
         extra_cli_args += experiment_cli_args
         # any arguments after run_args are passed directly to launcher
-        util.launch_run(None, app_conf, output_dir, extra_cli_args,
+        util.launch_run(None, app_conf, output_dir, extra_cli_args, log_path,
                         num_node=num_node, num_rank=num_rank)  # raw launcher factory args
 
         # Get app-reported figure of merit

--- a/integration/experiment/monitor/monitor.py
+++ b/integration/experiment/monitor/monitor.py
@@ -1,0 +1,79 @@
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+'''
+Helper functions for running the monitor agent.
+'''
+
+import os
+import time
+
+from experiment import machine
+from experiment import util
+
+
+def launch_monitor(output_dir, iterations,
+                   num_node, app_conf, experiment_cli_args, cool_off_time=60):
+    machine.init_output_dir(output_dir)
+    agent = 'monitor'
+    app_name = app_conf.name()
+    rank_per_node = app_conf.get_rank_per_node()
+    num_rank = num_node * rank_per_node
+
+    report_sig = ["CYCLES_THREAD@package", "CYCLES_REFERENCE@package",
+                  "TIME@package", "ENERGY_PACKAGE@package"]
+
+    for iteration in range(iterations):
+        uid = '{}_{}_{}'.format(app_name.lower(), agent, iteration)
+        report_path = os.path.join(output_dir, '{}.report'.format(uid))
+        trace_path = os.path.join(output_dir, '{}.trace'.format(uid))
+        profile_name = 'iteration_{}'.format(iteration)
+        log_path = os.path.join(output_dir, '{}.log'.format(uid))
+
+        # TODO: these are not passed to launcher create()
+        # some are generic enough they could be, though
+        extra_cli_args = ['--geopm-report', report_path,
+                          '--geopm-trace', trace_path,
+                          '--geopm-profile', profile_name,
+                          '--geopm-report-signals=' + ','.join(report_sig)]
+        extra_cli_args += experiment_cli_args
+        # any arguments after run_args are passed directly to launcher
+        util.launch_run(None, app_conf, output_dir, extra_cli_args,
+                        num_node=num_node, num_rank=num_rank)  # raw launcher factory args
+
+        # Get app-reported figure of merit
+        fom = app_conf.parse_fom(log_path)
+        # Append to report????????????????
+        with open(report_path, 'a') as report:
+            report.write('\nFigure of Merit: {}'.format(fom))
+
+        # rest to cool off between runs
+        time.sleep(cool_off_time)

--- a/integration/experiment/monitor/run_dgemm.py
+++ b/integration/experiment/monitor/run_dgemm.py
@@ -32,14 +32,13 @@
 #
 
 '''
-Example power sweep experiment using geopmbench.
+Run DGEMM with the monitor agent.
 '''
 
 import argparse
 
 from experiment import common_args
-from experiment.power_sweep import power_sweep
-from experiment import machine
+from experiment.monitor import monitor
 from apps import geopmbench
 
 
@@ -48,33 +47,20 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     common_args.add_output_dir(parser)
     common_args.add_nodes(parser)
-    common_args.add_min_power(parser)
-    common_args.add_max_power(parser)
-    args, extra_cli_args = parser.parse_known_args()
+
+    args, experiment_cli_args = parser.parse_known_args()
 
     output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
+    num_node = args.nodes
 
     # application parameters
-    app_conf = geopmbench.TinyAppConf(output_dir)
-    num_rank = num_nodes * app_conf.get_rank_per_node()
+    app_conf = geopmbench.DgemmAppConf(output_dir)
 
     # experiment parameters
-    min_power = args.min_power
-    max_power = args.max_power
-    step_power = 10
-    min_power, max_power = power_sweep.setup_power_bounds(mach, min_power, max_power, step_power)
     iterations = 2
-    power_sweep.launch_power_sweep(file_prefix=app_conf.name(),
-                                   output_dir=output_dir,
-                                   iterations=iterations,
-                                   min_power=min_power,
-                                   max_power=max_power,
-                                   step_power=step_power,
-                                   agent_types=['power_governor', 'power_balancer'],
-                                   num_node=num_nodes,
-                                   num_rank=num_rank,
-                                   app_conf=app_conf,
-                                   experiment_cli_args=extra_cli_args,
-                                   cool_off_time=0)
+
+    monitor.launch_monitor(output_dir=output_dir,
+                           iterations=iterations,
+                           num_node=num_node,
+                           app_conf=app_conf,
+                           experiment_cli_args=experiment_cli_args)

--- a/integration/experiment/power_sweep/Makefile.mk
+++ b/integration/experiment/power_sweep/Makefile.mk
@@ -29,12 +29,14 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-EXTRA_DIST += integration/experiment/common_args.py \
-              integration/experiment/__init__.py \
-              integration/experiment/machine.py \
-              integration/experiment/util.py \
+EXTRA_DIST += integration/experiment/power_sweep/gen_balancer_comparison.py \
+              integration/experiment/power_sweep/gen_balancer_comparison_plot.py \
+              integration/experiment/power_sweep/gen_node_efficiency.py \
+              integration/experiment/power_sweep/gen_power_sweep_summary.py \
+              integration/experiment/power_sweep/gen_plot_balancer_power_limit.py \
+              integration/experiment/power_sweep/__init__.py \
+              integration/experiment/power_sweep/power_sweep.py \
+              integration/experiment/power_sweep/README.md \
+              integration/experiment/power_sweep/run_power_sweep_dgemm.py \
+              integration/experiment/power_sweep/run_power_sweep_dgemm_tiny.py \
               # end
-
-include integration/experiment/monitor/Makefile.mk
-include integration/experiment/power_sweep/Makefile.mk
-include integration/experiment/trace_analysis/Makefile.mk

--- a/integration/experiment/power_sweep/gen_balancer_comparison_plot.py
+++ b/integration/experiment/power_sweep/gen_balancer_comparison_plot.py
@@ -237,9 +237,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     common_args.add_output_dir(parser)
     common_args.add_show_details(parser)
-    # TODO: move to common args and replace in node_efficiency
-    parser.add_argument('--label', action='store', default="",
-                        help='name of the application to use for plot titles')
+    common_args.add_label(parser)
     parser.add_argument('--normalize', action='store_true', default=False,
                         help='use normalized values')
     parser.add_argument('--speedup', action='store_true', default=False,

--- a/integration/experiment/power_sweep/gen_node_efficiency.py
+++ b/integration/experiment/power_sweep/gen_node_efficiency.py
@@ -184,10 +184,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     common_args.add_output_dir(parser)
     common_args.add_show_details(parser)
-    parser.add_argument('--label', action='store', default="APP",
-                        help='name of the application to use for plot titles')
-
+    common_args.add_label(parser)
     args, _ = parser.parse_known_args()
+
     output_dir = args.output_dir
     show_details = args.show_details
     label = args.label

--- a/integration/experiment/power_sweep/power_sweep.py
+++ b/integration/experiment/power_sweep/power_sweep.py
@@ -58,7 +58,8 @@ def setup_power_bounds(mach, min_power, max_power, step_power):
         sys.stderr.write("Warning: <geopm> run_power_sweep: Invalid or unspecified max_power; using system TDP: {}.\n".format(max_power))
 
     if (min_power < mach.power_package_min() or
-        max_power > mach.power_package_max()):
+        max_power > mach.power_package_max() or
+        min_power > max_power):
         raise RuntimeError('Power bounds are out of range for this system')
 
     return int(min_power), int(max_power)

--- a/integration/experiment/power_sweep/power_sweep.py
+++ b/integration/experiment/power_sweep/power_sweep.py
@@ -45,6 +45,7 @@ import geopmpy.io
 from experiment import util
 from experiment import machine
 
+
 def setup_power_bounds(mach, min_power, max_power, step_power):
     if min_power is None:
         # system minimum is actually too low; use 50% of TDP or min rounded up to nearest step, whichever is larger

--- a/integration/experiment/power_sweep/power_sweep.py
+++ b/integration/experiment/power_sweep/power_sweep.py
@@ -102,6 +102,7 @@ def launch_power_sweep(file_prefix, output_dir, iterations,
                 report_path = os.path.join(output_dir, '{}.report'.format(uid))
                 trace_path = os.path.join(output_dir, '{}.trace'.format(uid))
                 profile_name = 'iteration_{}'.format(iteration)
+                log_path = os.path.join(output_dir, '{}.log'.format(uid))
 
                 # TODO: these are not passed to launcher create()
                 # some are generic enough they could be, though
@@ -112,7 +113,7 @@ def launch_power_sweep(file_prefix, output_dir, iterations,
                                   '--geopm-trace-signals=' + ','.join(trace_sig)]
                 extra_cli_args += experiment_cli_args
                 # any arguments after run_args are passed directly to launcher
-                util.launch_run(agent_conf, app_conf, output_dir, extra_cli_args,
+                util.launch_run(agent_conf, app_conf, output_dir, extra_cli_args, log_path,
                                 num_node=num_node, num_rank=num_rank)  # raw launcher factory args
 
                 # rest to cool off between runs

--- a/integration/experiment/power_sweep/power_sweep.py
+++ b/integration/experiment/power_sweep/power_sweep.py
@@ -111,7 +111,7 @@ def launch_power_sweep(file_prefix, output_dir, iterations,
                                   '--geopm-trace-signals=' + ','.join(trace_sig)]
                 extra_cli_args += experiment_cli_args
                 # any arguments after run_args are passed directly to launcher
-                util.launch_run(agent_conf, app_conf, extra_cli_args,
+                util.launch_run(agent_conf, app_conf, output_dir, extra_cli_args,
                                 num_node=num_node, num_rank=num_rank)  # raw launcher factory args
 
                 # rest to cool off between runs

--- a/integration/experiment/trace_analysis/Makefile.mk
+++ b/integration/experiment/trace_analysis/Makefile.mk
@@ -29,12 +29,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-EXTRA_DIST += integration/experiment/common_args.py \
-              integration/experiment/__init__.py \
-              integration/experiment/machine.py \
-              integration/experiment/util.py \
+EXTRA_DIST += integration/experiment/trace_analysis/gen_rate_hist.py \
+              integration/experiment/trace_analysis/__init__.py \
+              integration/experiment/trace_analysis/README.md \
               # end
-
-include integration/experiment/monitor/Makefile.mk
-include integration/experiment/power_sweep/Makefile.mk
-include integration/experiment/trace_analysis/Makefile.mk

--- a/integration/experiment/trace_analysis/gen_rate_hist.py
+++ b/integration/experiment/trace_analysis/gen_rate_hist.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+'''
+Displays a historgram of the control loop sample intervals
+'''
+
+import pandas
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
+import numpy as np
+import sys
+import os
+
+
+def rate_hist(traces):
+    num_traces = len(traces)
+    all_delta_t = pandas.DataFrame()
+    for path in traces:
+        df = pandas.read_csv(path, delimiter='|', comment='#')
+        delta_t = df['TIME'].diff()[1:]
+        delta_t = delta_t.loc[delta_t != 0]
+        all_delta_t = all_delta_t.append(delta_t, ignore_index=True)
+
+    plt.hist(all_delta_t, 100)
+
+    dir_name = os.path.dirname(traces[0])
+    plt.title('Control Loop Duration {}'.format(dir_name))
+    plt.ylabel('count')
+    plt.xlabel('sample duration (sec)')
+    plt.savefig(os.path.join(dir_name, 'rate_hist.png'))
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        sys.stderr.write('Provide paths to trace file(s)')
+        sys.exit(1)
+    rate_hist(sys.argv[1:])

--- a/integration/experiment/util.py
+++ b/integration/experiment/util.py
@@ -39,7 +39,6 @@ import subprocess
 import io
 import yaml
 import shlex
-import json
 
 import geopmpy.launcher
 
@@ -132,20 +131,25 @@ def geopmread(read_str):
     return result
 
 
-def launch_run(agent_conf, app_conf, extra_cli_args, **launcher_factory_args):
+def launch_run(agent_conf, app_conf, output_dir, extra_cli_args, **launcher_factory_args):
     # TODO: why does launcher strip off first arg, rather than geopmlaunch main?
     argv = ['dummy', detect_launcher()]
 
-    if agent_conf.get_agent() != 'monitor':
+    if agent_conf is not None and agent_conf.get_agent() != 'monitor':
         argv.append('--geopm-agent=' + agent_conf.get_agent())
         argv.append('--geopm-policy=' + agent_conf.get_path())
 
     argv.extend(extra_cli_args)
 
     argv.extend(['--'])
+
+    # TODO: does it matter if these are string or list?
+    # throw if get_exec_args is not a list?
     # Use app config to get path and arguments
-    argv.append(app_conf.get_exec_path())
-    argv.extend(app_conf.get_exec_args())
+    # argv.append(app_conf.get_exec_path())
+    # argv.extend(app_conf.get_exec_args())
+    bash_path = app_conf.make_bash(output_dir)
+    argv.extend([bash_path])
 
     launcher = geopmpy.launcher.Factory().create(argv, **launcher_factory_args)
     launcher.run()

--- a/integration/experiment/util.py
+++ b/integration/experiment/util.py
@@ -131,7 +131,8 @@ def geopmread(read_str):
     return result
 
 
-def launch_run(agent_conf, app_conf, output_dir, extra_cli_args, **launcher_factory_args):
+def launch_run(agent_conf, app_conf, output_dir, extra_cli_args, log_path=None,
+               **launcher_factory_args):
     # TODO: why does launcher strip off first arg, rather than geopmlaunch main?
     argv = ['dummy', detect_launcher()]
 
@@ -143,13 +144,13 @@ def launch_run(agent_conf, app_conf, output_dir, extra_cli_args, **launcher_fact
 
     argv.extend(['--'])
 
-    # TODO: does it matter if these are string or list?
-    # throw if get_exec_args is not a list?
-    # Use app config to get path and arguments
-    # argv.append(app_conf.get_exec_path())
-    # argv.extend(app_conf.get_exec_args())
     bash_path = app_conf.make_bash(output_dir)
     argv.extend([bash_path])
 
     launcher = geopmpy.launcher.Factory().create(argv, **launcher_factory_args)
-    launcher.run()
+    if log_path is None:
+        launcher.run()
+    else:
+        with open(log_path, 'w') as outfile:
+            # TODO: some apps print to stderr..... use stderr=outfile
+            launcher.run(stdout=outfile)


### PR DESCRIPTION
- Initial version of AppConf interface
- Monitor experiment helpers and run script for DGEMM
- Achieved power analysis based on monitor output
- Script to plot control loop sample rate of a trace
- Lots of small changes for dealing with Python module locations: for now, adding $GEOPM/integration to the PYTHONPATH is required.
- Resolves #1223 