### PR TITLE
NVML Accelerator IO Group Addition

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -633,6 +633,8 @@ if ENABLE_NVML
                                  src/NVMLDevicePool.cpp \
                                  src/NVMLDevicePool.hpp \
                                  src/NVMLDevicePoolImp.hpp \
+                                 src/NVMLIOGroup.cpp \
+                                 src/NVMLIOGroup.hpp \
                                  #end
 endif
 

--- a/src/IOGroup.cpp
+++ b/src/IOGroup.cpp
@@ -46,6 +46,9 @@
 #ifdef GEOPM_CNL_IOGROUP
 #include "CNLIOGroup.hpp"
 #endif
+#ifdef GEOPM_ENABLE_NVML
+#include "NVMLIOGroup.hpp"
+#endif
 #ifdef GEOPM_DEBUG
 #include <iostream>
 #endif
@@ -92,6 +95,10 @@ namespace geopm
 #ifdef GEOPM_CNL_IOGROUP
         register_plugin(CNLIOGroup::plugin_name(),
                         CNLIOGroup::make_plugin);
+#endif
+#ifdef GEOPM_ENABLE_NVML
+        register_plugin(NVMLIOGroup::plugin_name(),
+                        NVMLIOGroup::make_plugin);
 #endif
     }
 

--- a/src/NVMLDevicePool.cpp
+++ b/src/NVMLDevicePool.cpp
@@ -174,6 +174,20 @@ namespace geopm
         return (uint64_t)result;
     }
 
+    uint64_t NVMLDevicePoolImp::power_limit(int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        unsigned int result;
+        nvmlReturn_t nvml_result;
+
+        nvml_result = nvmlDeviceGetPowerManagementLimit(m_nvml_device.at(accel_idx), &result);
+        check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
+                          ": NVML failed to get power limit for accelerator " +
+                          std::to_string(accel_idx) + ".", __LINE__);
+
+        return (uint64_t)result;
+    }
+
     uint64_t NVMLDevicePoolImp::frequency_status_mem(int accel_idx) const
     {
         check_accel_range(accel_idx);

--- a/src/NVMLDevicePool.cpp
+++ b/src/NVMLDevicePool.cpp
@@ -137,9 +137,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         unsigned int result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_SM, NVML_CLOCK_ID_CURRENT,
+        nvmlReturn_t nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_SM, NVML_CLOCK_ID_CURRENT,
                                          &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get SM Frequency for accelerator " +
@@ -151,9 +150,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         nvmlUtilization_t result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &result);
+        nvmlReturn_t nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get GPU Utilization for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -164,9 +162,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         unsigned int result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetPowerUsage(m_nvml_device.at(accel_idx), &result);
+        nvmlReturn_t nvml_result = nvmlDeviceGetPowerUsage(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get power for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -178,9 +175,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         unsigned int result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetPowerManagementLimit(m_nvml_device.at(accel_idx), &result);
+        nvmlReturn_t nvml_result = nvmlDeviceGetPowerManagementLimit(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get power limit for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -192,9 +188,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         unsigned int result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_MEM, NVML_CLOCK_ID_CURRENT, &result);
+        nvmlReturn_t nvml_result = nvmlDeviceGetClock(m_nvml_device.at(accel_idx), NVML_CLOCK_MEM, NVML_CLOCK_ID_CURRENT, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get Memory Frequency for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -206,9 +201,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         unsigned long long result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetCurrentClocksThrottleReasons(m_nvml_device.at(accel_idx), &result);
+        nvmlReturn_t nvml_result = nvmlDeviceGetCurrentClocksThrottleReasons(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get current clock throttle reasosn for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -220,9 +214,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         unsigned int result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result =  nvmlDeviceGetTemperature(m_nvml_device.at(accel_idx), NVML_TEMPERATURE_GPU, &result);
+        nvmlReturn_t nvml_result =  nvmlDeviceGetTemperature(m_nvml_device.at(accel_idx), NVML_TEMPERATURE_GPU, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get temperature for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -234,9 +227,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         unsigned long long result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result =  nvmlDeviceGetTotalEnergyConsumption(m_nvml_device.at(accel_idx), &result);
+        nvmlReturn_t nvml_result =  nvmlDeviceGetTotalEnergyConsumption(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get energy for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -248,9 +240,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         nvmlPstates_t result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetPerformanceState(m_nvml_device.at(accel_idx), &result);
+        nvmlReturn_t nvml_result = nvmlDeviceGetPerformanceState(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get performance state for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -262,9 +253,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         unsigned int result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_RX_BYTES, &result);
+        nvmlReturn_t nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_RX_BYTES, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get PCIE received throughput rate for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -276,9 +266,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         unsigned int result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_TX_BYTES, &result);
+        nvmlReturn_t nvml_result = nvmlDeviceGetPcieThroughput(m_nvml_device.at(accel_idx), NVML_PCIE_UTIL_TX_BYTES, &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get PCIE transmitted throughput rate for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -290,9 +279,8 @@ namespace geopm
     {
         check_accel_range(accel_idx);
         nvmlUtilization_t result;
-        nvmlReturn_t nvml_result;
 
-        nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &result);
+        nvmlReturn_t nvml_result =  nvmlDeviceGetUtilizationRates(m_nvml_device.at(accel_idx), &result);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get memory utilization for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -306,11 +294,10 @@ namespace geopm
         std::vector<int> result;
         unsigned int temp = M_MAX_CONTEXTS;
 
-        nvmlReturn_t nvml_result;
-        nvmlProcessInfo_t *process_info_list;
+                nvmlProcessInfo_t *process_info_list;
         process_info_list = new nvmlProcessInfo_t[temp];
 
-        nvml_result = nvmlDeviceGetComputeRunningProcesses(m_nvml_device[accel_idx], &temp, &process_info_list[0]);
+        nvmlReturn_t nvml_result = nvmlDeviceGetComputeRunningProcesses(m_nvml_device[accel_idx], &temp, &process_info_list[0]);
         if (nvml_result == NVML_SUCCESS) {
             for (int i = 0; i<temp; i++) {
                 result.push_back(process_info_list[i].pid);
@@ -349,9 +336,8 @@ namespace geopm
     void NVMLDevicePoolImp::frequency_control_sm(int accel_idx, int min_freq, int max_freq) const
     {
         check_accel_range(accel_idx);
-        nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceSetGpuLockedClocks(m_nvml_device[accel_idx], (unsigned int) min_freq, (unsigned int) max_freq);
+        nvmlReturn_t nvml_result = nvmlDeviceSetGpuLockedClocks(m_nvml_device[accel_idx], (unsigned int) min_freq, (unsigned int) max_freq);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to set sm frequency for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -360,9 +346,8 @@ namespace geopm
     void NVMLDevicePoolImp::frequency_reset_control(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        nvmlReturn_t nvml_result;
 
-        nvml_result =  nvmlDeviceResetGpuLockedClocks(m_nvml_device[accel_idx]);
+        nvmlReturn_t nvml_result =  nvmlDeviceResetGpuLockedClocks(m_nvml_device[accel_idx]);
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to reset sm frequency for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
@@ -371,9 +356,8 @@ namespace geopm
     void NVMLDevicePoolImp::power_control(int accel_idx, int setting) const
     {
         check_accel_range(accel_idx);
-        nvmlReturn_t nvml_result;
 
-        nvml_result = nvmlDeviceSetPowerManagementLimit(m_nvml_device.at(accel_idx), (unsigned int) (setting));
+        nvmlReturn_t nvml_result = nvmlDeviceSetPowerManagementLimit(m_nvml_device.at(accel_idx), (unsigned int) (setting));
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to set power limit for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);

--- a/src/NVMLDevicePool.hpp
+++ b/src/NVMLDevicePool.hpp
@@ -74,6 +74,11 @@ namespace geopm
             ///        accelerator.
             /// @return Accelerator power consumption in milliwatts.
             virtual uint64_t power (int accel_idx) const = 0;
+            /// @brief Get the NVML device power limit in milliwatts.
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator.
+            /// @return Accelerator power limit in milliwatts.
+            virtual uint64_t power_limit (int accel_idx) const = 0;
             /// @brief Get the NVML device memory subsystem frequency in MHz.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
@@ -82,7 +87,7 @@ namespace geopm
             /// @brief Get the current NVML device clock throttle reasons.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
-            /// @return Accelerator clock throttle reasons as defined 
+            /// @return Accelerator clock throttle reasons as defined
             //          in nvml.h.
             virtual uint64_t throttle_reasons(int accel_idx) const = 0;
             /// @brief Get the current NVML device temperature.
@@ -100,7 +105,7 @@ namespace geopm
             //         device.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
-            /// @return Accelerator performance state, defined by the 
+            /// @return Accelerator performance state, defined by the
             //          NVML API as 0 to 15, with 0 being maximum performance,
             //          15 being minimum performance, and 32 being unknown.
             virtual uint64_t performance_state(int accel_idx) const = 0;
@@ -119,7 +124,7 @@ namespace geopm
             /// @brief Get the NVML device memory Utilization metric
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
-            /// @return Accelerator memory utilization percentage 
+            /// @return Accelerator memory utilization percentage
             //          as a whole number from 0 to 100.
             virtual uint64_t utilization_mem(int accel_idx) const = 0;
             /// @brief Get the list of PIDs with an active context on an NVML

--- a/src/NVMLDevicePoolImp.hpp
+++ b/src/NVMLDevicePoolImp.hpp
@@ -48,6 +48,7 @@ namespace geopm
             virtual uint64_t frequency_status_sm(int accel_idx) const override;
             virtual uint64_t utilization(int accel_idx) const override;
             virtual uint64_t power(int accel_idx) const override;
+            virtual uint64_t power_limit(int accel_idx) const override;
             virtual uint64_t frequency_status_mem(int accel_idx) const override;
             virtual uint64_t throttle_reasons(int accel_idx) const override;
             virtual uint64_t temperature(int accel_idx) const override;

--- a/src/NVMLIOGroup.cpp
+++ b/src/NVMLIOGroup.cpp
@@ -1,0 +1,702 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "NVMLIOGroup.hpp"
+
+#include <cmath>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <sched.h>
+
+#include "IOGroup.hpp"
+#include "PlatformTopo.hpp"
+#include "Exception.hpp"
+#include "Agg.hpp"
+#include "Helper.hpp"
+
+namespace geopm
+{
+    NVMLIOGroup::NVMLIOGroup()
+        : NVMLIOGroup(platform_topo(), nvml_device_pool(platform_topo().num_domain(GEOPM_DOMAIN_CPU)))
+    {
+    }
+
+    // Set up mapping between signal and control names and corresponding indices
+    NVMLIOGroup::NVMLIOGroup(const PlatformTopo &platform_topo, const NVMLDevicePool &device_pool)
+        : m_platform_topo(platform_topo)
+        , m_nvml_device_pool(device_pool)
+        , m_is_batch_read(false)
+        , m_signal_available({{"NVML::FREQUENCY", {
+                                  "Streaming multiprocessor frequency in hertz",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"NVML::UTILIZATION_ACCELERATOR", {
+                                  "Percentage of time the accelerator operated on a kernel in the last set of driver samples",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"NVML::POWER", {
+                                  "Accelerator power usage in watts",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::sum,
+                                  string_format_double
+                                  }},
+                              {"NVML::POWER_LIMIT", {
+                                  "Accelerator power limit in watts",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::sum,
+                                  string_format_double
+                                  }},
+                              {"NVML::FREQUENCY_MEMORY", {
+                                  "Accelerator memory frequency in hertz",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"NVML::THROTTLE_REASONS", {
+                                  "Accelerator clock throttling reasons",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"NVML::TEMPERATURE", {
+                                  "Accelerator temperature",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"NVML::TOTAL_ENERGY_CONSUMPTION", {
+                                  "Accelerator energy consumption in joules since the driver was loaded",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::sum,
+                                  string_format_double
+                                  }},
+                              {"NVML::PERFORMANCE_STATE", {
+                                  "Accelerator performance state",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"NVML::PCIE_RX_THROUGHPUT", {
+                                  "Accelerator PCIE receive throughput in bytes per second over a 20 millisecond period",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"NVML::PCIE_TX_THROUGHPUT", {
+                                  "Accelerator PCIE transmit throughput in bytes per second over a 20 millisecond period",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"NVML::CPU_ACCELERATOR_ACTIVE_AFFINITIZATION", {
+                                  "Returns the associated accelerator for a given CPU as determined by running processes."
+                                  "\n  If no accelerators map to the CPU then NAN is returned"
+                                  "\n  If multiple accelerators map to the CPU -1 is returned",
+                                  {},
+                                  GEOPM_DOMAIN_CPU,
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"NVML::UTILIZATION_MEMORY", {
+                                  "Percentage of time the accelerator memory was accessed in the last set of driver samples",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::max,
+                                  string_format_double
+                                  }}
+						     })
+        , m_control_available({{"NVML::FREQUENCY", {
+                                    "Sets streaming multiprocessor frequency min and max to the same limit",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                    Agg::average,
+                                    string_format_double
+                                    }},
+                               {"NVML::FREQUENCY_RESET", {
+                                    "Resets streaming multiprocessor frequency min and max limits to default values",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                    Agg::average,
+                                    string_format_double
+                                    }},
+                               {"NVML::POWER_LIMIT", {
+                                    "Sets accelerator power limit",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                    Agg::average,
+                                    string_format_double
+                                    }}
+                              })
+    {
+        // populate signals for each domain
+        for (auto &sv : m_signal_available) {
+            std::vector<std::shared_ptr<signal_s> > result;
+            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(signal_domain_type(sv.first)); ++domain_idx) {
+                std::shared_ptr<signal_s> sgnl = std::make_shared<signal_s>(signal_s{0, false});
+                result.push_back(sgnl);
+            }
+            sv.second.signals = result;
+        }
+        register_signal_alias("POWER_ACCELERATOR", "NVML::POWER");
+        register_signal_alias("FREQUENCY_ACCELERATOR", "NVML::FREQUENCY");
+
+        // populate controls for each domain
+        for (auto &sv : m_control_available) {
+            std::vector<std::shared_ptr<control_s> > result;
+            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(control_domain_type(sv.first)); ++domain_idx) {
+                std::shared_ptr<control_s> ctrl = std::make_shared<control_s>(control_s{0, false});
+                result.push_back(ctrl);
+            }
+            sv.second.controls = result;
+        }
+        register_control_alias("POWER_ACCELERATOR_LIMIT", "NVML::POWER_LIMIT");
+        register_control_alias("FREQUENCY_ACCELERATOR_CONTROL", "NVML::FREQUENCY");
+    }
+
+    // Extract the set of all signal names from the index map
+    std::set<std::string> NVMLIOGroup::signal_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &sv : m_signal_available) {
+            result.insert(sv.first);
+        }
+        return result;
+    }
+
+    // Extract the set of all control names from the index map
+    std::set<std::string> NVMLIOGroup::control_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &sv : m_control_available) {
+            result.insert(sv.first);
+        }
+        return result;
+    }
+
+    // Check signal name using index map
+    bool NVMLIOGroup::is_valid_signal(const std::string &signal_name) const
+    {
+        return m_signal_available.find(signal_name) != m_signal_available.end();
+    }
+
+    // Check control name using index map
+    bool NVMLIOGroup::is_valid_control(const std::string &control_name) const
+    {
+        return m_control_available.find(control_name) != m_control_available.end();
+    }
+
+    // Return domain for all valid signals
+    int NVMLIOGroup::signal_domain_type(const std::string &signal_name) const
+    {
+        int result = GEOPM_DOMAIN_INVALID;
+        auto it = m_signal_available.find(signal_name);
+        if (it != m_signal_available.end()) {
+            result = it->second.domain;
+        }
+        return result;
+    }
+
+    // Return domain for all valid controls
+    int NVMLIOGroup::control_domain_type(const std::string &control_name) const
+    {
+        int result = GEOPM_DOMAIN_INVALID;
+        auto it = m_control_available.find(control_name);
+        if (it != m_control_available.end()) {
+            result = it->second.domain;
+        }
+        return result;
+    }
+
+    // Mark the given signal to be read by read_batch()
+    int NVMLIOGroup::push_signal(const std::string &signal_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": signal_name " + signal_name +
+                            " not valid for NVMLIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != signal_domain_type(signal_name)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": " + signal_name + ": domain_type must be " +
+                            std::to_string(signal_domain_type(signal_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(signal_domain_type(signal_name))) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (m_is_batch_read) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": cannot push signal after call to read_batch().",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        int result = -1;
+        bool is_found = false;
+        std::shared_ptr<signal_s> signal = m_signal_available.at(signal_name).signals.at(domain_idx);
+
+        // Check if signal was already pushed
+        for (size_t ii = 0; !is_found && ii < m_signal_pushed.size(); ++ii) {
+            // same location means this signal or its alias was already pushed
+            if (m_signal_pushed[ii].get() == signal.get()) {
+                result = ii;
+                is_found = true;
+            }
+        }
+        if (!is_found) {
+            // If not pushed, add to pushed signals and configure for batch reads
+            result = m_signal_pushed.size();
+            signal->m_do_read = true;
+            m_signal_pushed.push_back(signal);
+        }
+
+        return result;
+    }
+
+    // Mark the given control to be written by write_batch()
+    int NVMLIOGroup::push_control(const std::string &control_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": control_name " + control_name +
+                            " not valid for NVMLIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != control_domain_type(control_name)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": " + control_name + ": domain_type must be " +
+                            std::to_string(control_domain_type(control_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(domain_type)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        int result = -1;
+        bool is_found = false;
+        std::shared_ptr<control_s> control = m_control_available.at(control_name).controls.at(domain_idx);
+
+        // Check if control was already pushed
+        for (size_t ii = 0; !is_found && ii < m_control_pushed.size(); ++ii) {
+            // same location means this control or its alias was already pushed
+            if (m_control_pushed[ii] == control) {
+                result = ii;
+                is_found = true;
+            }
+        }
+        if (!is_found) {
+            // If not pushed, add to pushed control
+            result = m_control_pushed.size();
+            m_control_pushed.push_back(control);
+        }
+
+        return result;
+    }
+
+    // Parse and update saved values for signals
+    void NVMLIOGroup::read_batch(void)
+    {
+        m_is_batch_read = true;
+        for (auto &sv : m_signal_available) {
+            if (sv.first == "NVML::CPU_ACCELERATOR_ACTIVE_AFFINITIZATION") {
+                // clear previous values
+                for (int domain_idx = 0; domain_idx < sv.second.signals.size(); ++domain_idx) {
+                    if (sv.second.signals.at(domain_idx)->m_do_read) {
+                        sv.second.signals.at(domain_idx)->m_value = NAN;
+                    }
+                }
+
+                // The active process list NVML call can be costly, 0.5-2ms per call was seen in early testing on average,
+                // with a worst case of 8ms per call.  Because of this we want to cache the processes first, THEN
+                // associate them with a CPU & Accelerator pairing
+                std::vector<int> active_process_list;
+                std::map<pid_t,int> process_accelerator_map;
+
+                for (int accel_idx = 0; accel_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR); ++accel_idx) {
+                    active_process_list = m_nvml_device_pool.active_process_list(accel_idx);
+
+                    for (auto proc_itr : active_process_list) {
+                        // If a process is associated with multiple accelerators we have no good means of
+                        // signaling the user beyond providing an error value (-1).
+                        if (!process_accelerator_map.count((pid_t)proc_itr)) {
+                            process_accelerator_map[(pid_t)proc_itr] = accel_idx;
+                        }
+                        else {
+                            process_accelerator_map[(pid_t)proc_itr] = -1;
+                        }
+                    }
+                }
+
+                // Parse PID to CPU affinitzation and use process list --> accelerator mapping to get CPU --> accelerator
+                cpu_set_t *proc_cpuset = NULL;
+                proc_cpuset = CPU_ALLOC(m_platform_topo.num_domain(GEOPM_DOMAIN_CPU));
+                if (proc_cpuset != NULL) {
+                    for (auto &proc : process_accelerator_map) {
+                        for (int domain_idx = 0; domain_idx < sv.second.signals.size(); ++domain_idx) {
+                            if (sv.second.signals.at(domain_idx)->m_do_read) {
+                                if (sched_getaffinity(proc.first, CPU_ALLOC_SIZE(m_platform_topo.num_domain(GEOPM_DOMAIN_CPU)), proc_cpuset) == 0) {
+                                    if (CPU_ISSET(domain_idx, proc_cpuset)) {
+                                        sv.second.signals.at(domain_idx)->m_value = proc.second;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                else {
+                    throw Exception("NVMLIOGroup::" + std::string(__func__) + ": failed to allocate process CPU mask",
+                                    GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+                }
+            }
+            else {
+                for (int domain_idx = 0; domain_idx < sv.second.signals.size(); ++domain_idx) {
+                    if (sv.second.signals.at(domain_idx)->m_do_read) {
+                        sv.second.signals.at(domain_idx)->m_value = read_signal(sv.first, sv.second.domain, domain_idx);
+                    }
+                }
+            }
+        }
+
+    }
+
+    // Write all controls that have been pushed and adjusted
+    void NVMLIOGroup::write_batch(void)
+    {
+        for (auto &sv : m_control_available) {
+            for (int domain_idx = 0; domain_idx < sv.second.controls.size(); ++domain_idx) {
+                if (sv.second.controls.at(domain_idx)->m_do_write) {
+                    write_control(sv.first, sv.second.domain, domain_idx, sv.second.controls.at(domain_idx)->m_setting);
+                }
+            }
+        }
+    }
+
+    // Return the latest value read by read_batch()
+    double NVMLIOGroup::sample(int batch_idx)
+    {
+        // Do conversion of signal values stored in read batch
+        if (batch_idx < 0 || batch_idx >= (int)m_signal_pushed.size()) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": batch_idx " +std::to_string(batch_idx)+ " out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (!m_is_batch_read) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": signal has not been read.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_signal_pushed[batch_idx]->m_value;
+    }
+
+    // Save a setting to be written by a future write_batch()
+    void NVMLIOGroup::adjust(int batch_idx, double setting)
+    {
+        if (batch_idx < 0 || (unsigned)batch_idx >= m_control_pushed.size()) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + "(): batch_idx " +std::to_string(batch_idx)+ " out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        m_control_pushed.at(batch_idx)->m_setting = setting;
+        m_control_pushed.at(batch_idx)->m_do_write = true;
+    }
+
+    // Read the value of a signal immediately, bypassing read_batch().  Should not modify m_signal_value
+    double NVMLIOGroup::read_signal(const std::string &signal_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            " not valid for NVMLIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != signal_domain_type(signal_name)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": " + signal_name + ": domain_type must be " +
+                            std::to_string(signal_domain_type(signal_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(signal_domain_type(signal_name))) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        double result = NAN;
+        if (signal_name == "NVML::FREQUENCY" || signal_name == "FREQUENCY_ACCELERATOR") {
+            result = (double) m_nvml_device_pool.frequency_status_sm(domain_idx)*1e6;
+        }
+        else if (signal_name == "NVML::UTILIZATION_ACCELERATOR") {
+            result = (double) m_nvml_device_pool.utilization(domain_idx)/100;
+        }
+        else if (signal_name == "NVML::THROTTLE_REASONS") {
+            result = (double) m_nvml_device_pool.throttle_reasons(domain_idx);
+        }
+        else if (signal_name == "NVML::POWER" || signal_name == "POWER_ACCELERATOR") {
+            result = (double) m_nvml_device_pool.power(domain_idx)/1e3;
+        }
+        else if (signal_name == "NVML::POWER_LIMIT") {
+            result = (double) m_nvml_device_pool.power_limit(domain_idx)/1e3;
+        }
+        else if (signal_name == "NVML::FREQUENCY_MEMORY") {
+            result = (double) m_nvml_device_pool.frequency_status_mem(domain_idx)*1e6;
+        }
+        else if (signal_name == "NVML::TEMPERATURE") {
+            result = (double) m_nvml_device_pool.temperature(domain_idx);
+        }
+        else if (signal_name == "NVML::TOTAL_ENERGY_CONSUMPTION" ) {
+            result = (double) m_nvml_device_pool.energy(domain_idx)/1e3;
+        }
+        else if (signal_name == "NVML::PERFORMANCE_STATE") {
+            result = (double) m_nvml_device_pool.performance_state(domain_idx);
+        }
+        else if (signal_name == "NVML::PCIE_RX_THROUGHPUT") {
+            result = (double) m_nvml_device_pool.throughput_rx_pcie(domain_idx)*1024;
+        }
+        else if (signal_name == "NVML::PCIE_TX_THROUGHPUT") {
+            result = (double) m_nvml_device_pool.throughput_tx_pcie(domain_idx)*1024;
+        }
+        else if (signal_name == "NVML::UTILIZATION_MEMORY") {
+            result = (double) m_nvml_device_pool.utilization_mem(domain_idx)/100;
+        }
+        else if (signal_name == "NVML::CPU_ACCELERATOR_ACTIVE_AFFINITIZATION") {
+            std::vector<int> active_process_list;
+            std::map<pid_t,int> process_accelerator_map;
+
+            // Cache active process list --> accelerator
+            for (int accel_idx = 0; accel_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR); ++accel_idx) {
+                active_process_list = m_nvml_device_pool.active_process_list(accel_idx);
+
+                for (auto proc_itr : active_process_list) {
+                    process_accelerator_map[(pid_t) proc_itr] = accel_idx;
+                }
+            }
+
+            // Parse PID to CPU affinitzation and use process list --> accelerator map to get CPU --> accelerator
+            cpu_set_t *proc_cpuset = NULL;
+            proc_cpuset = CPU_ALLOC(m_platform_topo.num_domain(GEOPM_DOMAIN_CPU));
+            if (proc_cpuset != NULL) {
+                for (auto &proc : process_accelerator_map) {
+                    if (sched_getaffinity(proc.first, CPU_ALLOC_SIZE(m_platform_topo.num_domain(GEOPM_DOMAIN_CPU)), proc_cpuset) == 0) {
+                        if (CPU_ISSET(domain_idx, proc_cpuset)) {
+                            result = proc.second;
+                        }
+                    }
+                }
+            }
+            else {
+                throw Exception("NVMLIOGroup::" + std::string(__func__) + ": failed to allocate memory for cpuset",
+                                GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+            }
+        }
+        else {
+    #ifdef GEOPM_DEBUG
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": Handling not defined for " +
+                            signal_name, GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+
+    #endif
+        }
+        return result;
+    }
+
+    // Write to the control immediately, bypassing write_batch()
+    void NVMLIOGroup::write_control(const std::string &control_name, int domain_type, int domain_idx, double setting)
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": " + control_name +
+                            " not valid for NVMLIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": " + control_name + ": domain_type must be " +
+                            std::to_string(control_domain_type(control_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (control_name == "NVML::FREQUENCY" || control_name == "FREQUENCY_ACCELERATOR_CONTROL") {
+            m_nvml_device_pool.frequency_control_sm(domain_idx, setting/1e6, setting/1e6);
+        }
+        else if (control_name == "NVML::FREQUENCY_RESET") {
+            m_nvml_device_pool.frequency_reset_control(domain_idx);
+        }
+        else if (control_name == "NVML::POWER_LIMIT" || control_name == "POWER_ACCELERATOR_LIMIT") {
+            m_nvml_device_pool.power_control(domain_idx, setting*1e3);
+        }
+        else {
+    #ifdef GEOPM_DEBUG
+                throw Exception("NVMLIOGroup::" + std::string(__func__) + "Handling not defined for "
+                                + control_name, GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+    #endif
+        }
+    }
+
+    // Implemented to allow an IOGroup to save platform settings before starting
+    // to adjust them
+    void NVMLIOGroup::save_control(void)
+    {
+        // Read NVML Power Limit
+        for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR); ++domain_idx) {
+            m_initial_power_limit.push_back(m_nvml_device_pool.power_limit(domain_idx));
+        }
+    }
+
+    // Implemented to allow an IOGroup to restore previously saved
+    // platform settings
+    void NVMLIOGroup::restore_control(void)
+    {
+        /// @todo: Usage of the NVML API for setting frequency, power, etc requires root privileges.
+        ///        As such several unit tests will fail when calling restore_control.  Once a non-
+        ///        privileged solution is available this code may be restored
+        // for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR); ++domain_idx) {
+        //     // Write original NVML Power Limit
+        //     m_nvml_device_pool.power_control(domain_idx, m_initial_power_limit.at(domain_idx));
+
+        //     // Reset NVML Frequency Limit
+        //     m_nvml_device_pool.frequency_reset_control(domain_idx);
+        // }
+    }
+
+    // Hint to Agent about how to aggregate signals from this IOGroup
+    std::function<double(const std::vector<double> &)> NVMLIOGroup::agg_function(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            "not valid for NVMLIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return it->second.m_agg_function;
+    }
+
+    // Specifies how to print signals from this IOGroup
+    std::function<std::string(double)> NVMLIOGroup::format_function(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            "not valid for NVMLIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return it->second.m_format_function;
+    }
+
+    // A user-friendly description of each signal
+    std::string NVMLIOGroup::signal_description(const std::string &signal_name) const
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": signal_name " + signal_name +
+                            " not valid for NVMLIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        std::string result = "";
+        result = m_signal_available.at(signal_name).m_description;
+        return result;
+    }
+
+    // A user-friendly description of each control
+    std::string NVMLIOGroup::control_description(const std::string &control_name) const
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": " + control_name +
+                            "not valid for NVMLIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::string result = "";
+        result = m_control_available.at(control_name).m_description;
+        return result;
+    }
+
+    // Name used for registration with the IOGroup factory
+    std::string NVMLIOGroup::plugin_name(void)
+    {
+        return "nvml";
+    }
+
+    // Function used by the factory to create objects of this type
+    std::unique_ptr<IOGroup> NVMLIOGroup::make_plugin(void)
+    {
+        return std::unique_ptr<IOGroup>(new NVMLIOGroup);
+    }
+
+    void NVMLIOGroup::register_signal_alias(const std::string &alias_name,
+                                           const std::string &signal_name)
+    {
+        if (m_signal_available.find(alias_name) != m_signal_available.end()) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": signal_name " + alias_name +
+                            " was previously registered.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            // skip adding an alias if underlying signal is not found
+            return;
+        }
+        // copy signal info but append to description
+        m_signal_available[alias_name] = it->second;
+        m_signal_available[alias_name].m_description =
+            m_signal_available[signal_name].m_description + '\n' + "    alias_for: " + signal_name;
+    }
+
+    void NVMLIOGroup::register_control_alias(const std::string &alias_name,
+                                           const std::string &control_name)
+    {
+        if (m_control_available.find(alias_name) != m_control_available.end()) {
+            throw Exception("NVMLIOGroup::" + std::string(__func__) + ": contro1_name " + alias_name +
+                            " was previously registered.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto it = m_control_available.find(control_name);
+        if (it == m_control_available.end()) {
+            // skip adding an alias if underlying control is not found
+            return;
+        }
+        // copy control info but append to description
+        m_control_available[alias_name] = it->second;
+        m_control_available[alias_name].m_description =
+        m_control_available[control_name].m_description + '\n' + "    alias_for: " + control_name;
+    }
+}

--- a/src/NVMLIOGroup.hpp
+++ b/src/NVMLIOGroup.hpp
@@ -80,8 +80,8 @@ namespace geopm
             void register_signal_alias(const std::string &alias_name, const std::string &signal_name);
             void register_control_alias(const std::string &alias_name, const std::string &control_name);
 
-            std::map<pid_t, int> accelerator_process_map(void) const;
-            double cpu_accelerator_affinity(int cpu_idx, std::map<pid_t, int> process_map) const;
+            std::map<pid_t, double> accelerator_process_map(void) const;
+            double cpu_accelerator_affinity(int cpu_idx, std::map<pid_t, double> process_map) const;
 
             const PlatformTopo &m_platform_topo;
             const NVMLDevicePool &m_nvml_device_pool;

--- a/src/NVMLIOGroup.hpp
+++ b/src/NVMLIOGroup.hpp
@@ -38,15 +38,14 @@
 #include <string>
 #include <memory>
 
-#include "PluginFactory.hpp"
 #include "IOGroup.hpp"
-#include "NVMLDevicePool.hpp"
 
 #include <nvml.h>
 
 namespace geopm
 {
     class PlatformTopo;
+    class NVMLDevicePool;
 
     /// @brief IOGroup that provides signals and controls for NVML Accelerators
     class NVMLIOGroup : public IOGroup
@@ -81,6 +80,9 @@ namespace geopm
             void register_signal_alias(const std::string &alias_name, const std::string &signal_name);
             void register_control_alias(const std::string &alias_name, const std::string &control_name);
 
+            std::map<pid_t, int> accelerator_process_map(void) const;
+            double cpu_accelerator_affinity(int cpu_idx, std::map<pid_t, int> process_map) const;
+
             const PlatformTopo &m_platform_topo;
             const NVMLDevicePool &m_nvml_device_pool;
             bool m_is_batch_read;
@@ -95,7 +97,7 @@ namespace geopm
             struct control_s
             {
                 double m_setting;
-                bool m_do_write;
+                bool m_is_adjusted;
             };
 
             struct signal_info {

--- a/src/NVMLIOGroup.hpp
+++ b/src/NVMLIOGroup.hpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVMLIOGROUP_HPP_INCLUDE
+#define NVMLIOGROUP_HPP_INCLUDE
+
+#include <map>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "PluginFactory.hpp"
+#include "IOGroup.hpp"
+#include "NVMLDevicePool.hpp"
+
+#include <nvml.h>
+
+namespace geopm
+{
+    class PlatformTopo;
+
+    /// @brief IOGroup that provides signals and controls for NVML Accelerators
+    class NVMLIOGroup : public IOGroup
+    {
+        public:
+            NVMLIOGroup();
+            NVMLIOGroup(const PlatformTopo &platform_topo, const NVMLDevicePool &device_pool);
+            virtual ~NVMLIOGroup() = default;
+            std::set<std::string> signal_names(void) const override;
+            std::set<std::string> control_names(void) const override;
+            bool is_valid_signal(const std::string &signal_name) const override;
+            bool is_valid_control(const std::string &control_name) const override;
+            int signal_domain_type(const std::string &signal_name) const override;
+            int control_domain_type(const std::string &control_name) const override;
+            int push_signal(const std::string &signal_name, int domain_type, int domain_idx)  override;
+            int push_control(const std::string &control_name, int domain_type, int domain_idx) override;
+            void read_batch(void) override;
+            void write_batch(void) override;
+            double sample(int batch_idx) override;
+            void adjust(int batch_idx, double setting) override;
+            double read_signal(const std::string &signal_name, int domain_type, int domain_idx) override;
+            void write_control(const std::string &control_name, int domain_type, int domain_idx, double setting) override;
+            void save_control(void) override;
+            void restore_control(void) override;
+            std::function<double(const std::vector<double> &)> agg_function(const std::string &signal_name) const override;
+            std::function<std::string(double)> format_function(const std::string &signal_name) const override;
+            std::string signal_description(const std::string &signal_name) const;
+            std::string control_description(const std::string &control_name) const;
+            static std::string plugin_name(void);
+            static std::unique_ptr<geopm::IOGroup> make_plugin(void);
+        private:
+            void register_signal_alias(const std::string &alias_name, const std::string &signal_name);
+            void register_control_alias(const std::string &alias_name, const std::string &control_name);
+
+            const PlatformTopo &m_platform_topo;
+            const NVMLDevicePool &m_nvml_device_pool;
+            bool m_is_batch_read;
+            std::vector<uint64_t> m_initial_power_limit;
+
+            struct signal_s
+            {
+                double m_value;
+                bool m_do_read;
+            };
+
+            struct control_s
+            {
+                double m_setting;
+                bool m_do_write;
+            };
+
+            struct signal_info {
+                std::string m_description;
+                std::vector<std::shared_ptr<signal_s> > signals;
+                int domain;
+                std::function<double(const std::vector<double> &)> m_agg_function;
+                std::function<std::string(double)> m_format_function;
+            };
+
+            struct control_info {
+                std::string m_description;
+                std::vector<std::shared_ptr<control_s> > controls;
+                int domain;
+                std::function<double(const std::vector<double> &)> m_agg_function;
+                std::function<std::string(double)> m_format_function;
+            };
+
+            std::map<std::string, signal_info> m_signal_available;
+            std::map<std::string, control_info> m_control_available;
+            std::vector<std::shared_ptr<signal_s> > m_signal_pushed;
+            std::vector<std::shared_ptr<control_s> > m_control_pushed;
+    };
+}
+#endif

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -488,6 +488,11 @@ if ENABLE_NVML
                    test/gtest_links/NVMLAcceleratorTopoTest.uneven_affinitization_config \
                    test/gtest_links/NVMLAcceleratorTopoTest.high_cpu_count_config \
                    test/gtest_links/NVMLAcceleratorTopoTest.high_cpu_count_gaps_config \
+                   test/gtest_links/NVMLIOGroupTest.read_signal \
+                   test/gtest_links/NVMLIOGroupTest.read_signal_and_batch \
+                   test/gtest_links/NVMLIOGroupTest.write_control \
+                   test/gtest_links/NVMLIOGroupTest.push_control_adjust_write_batch \
+                   test/gtest_links/NVMLIOGroupTest.error_path \
                    # end
 endif
 
@@ -633,6 +638,7 @@ beta_test_sources = test/DaemonTest.cpp \
 
 nvml_test_sources = test/NVMLAcceleratorTopoTest.cpp \
                     test/MockNVMLDevicePool.hpp \
+                    test/NVMLIOGroupTest.cpp \
                     # end
 
 if ENABLE_BETA

--- a/test/MockNVMLDevicePool.hpp
+++ b/test/MockNVMLDevicePool.hpp
@@ -50,7 +50,9 @@ class MockNVMLDevicePool : public geopm::NVMLDevicePool
                            uint64_t(int));
         MOCK_CONST_METHOD1(utilization,
                            uint64_t(int));
-        MOCK_CONST_METHOD1(power ,
+        MOCK_CONST_METHOD1(power,
+                           uint64_t(int));
+        MOCK_CONST_METHOD1(power_limit,
                            uint64_t(int));
         MOCK_CONST_METHOD1(frequency_status_mem,
                            uint64_t(int));

--- a/test/NVMLIOGroupTest.cpp
+++ b/test/NVMLIOGroupTest.cpp
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <unistd.h>
+#include <limits.h>
+
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "config.h"
+#include "Helper.hpp"
+#include "Exception.hpp"
+#include "PlatformTopo.hpp"
+#include "PluginFactory.hpp"
+#include "NVMLIOGroup.hpp"
+#include "geopm_test.hpp"
+#include "MockNVMLDevicePool.hpp"
+#include "MockPlatformTopo.hpp"
+
+using geopm::NVMLIOGroup;
+using geopm::PlatformTopo;
+using geopm::Exception;
+using testing::Return;
+
+class NVMLIOGroupTest : public :: testing :: Test
+{
+    protected:
+        void SetUp();
+        void TearDown();
+        void write_affinitization(const std::string &affinitization_str);
+
+        std::shared_ptr<MockNVMLDevicePool> m_device_pool;
+        std::unique_ptr<MockPlatformTopo> m_platform_topo;
+};
+
+void NVMLIOGroupTest::SetUp()
+{
+    const int num_board = 1;
+    const int num_package = 2;
+    const int num_board_accelerator = 4;
+    const int num_core = 20;
+    const int num_cpu = 40;
+
+    m_device_pool = std::make_shared<MockNVMLDevicePool>();
+    m_platform_topo = geopm::make_unique<MockPlatformTopo>();
+
+    //Platform Topo prep
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD))
+        .WillByDefault(Return(num_board));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .WillByDefault(Return(num_package));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR))
+        .WillByDefault(Return(num_board_accelerator));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_CPU))
+        .WillByDefault(Return(num_cpu));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_CORE))
+        .WillByDefault(Return(num_core));
+
+    for (int cpu_idx = 0; cpu_idx < num_cpu; ++cpu_idx) {
+        if (cpu_idx < 10) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(0));
+        }
+        else if (cpu_idx < 20) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(1));
+        }
+        else if (cpu_idx < 30) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(2));
+        }
+        else {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(3));
+        }
+    }
+
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillRepeatedly(Return(num_board_accelerator));
+}
+
+void NVMLIOGroupTest::TearDown()
+{
+}
+
+TEST_F(NVMLIOGroupTest, push_control_adjust_write_batch)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+    std::vector<int> batch_idx;
+    NVMLIOGroup nvml_io(*m_platform_topo, *m_device_pool);
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        batch_idx.push_back(nvml_io.push_control("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+        batch_idx.push_back(nvml_io.push_control("FREQUENCY_ACCELERATOR_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+        batch_idx.push_back(nvml_io.push_control("NVML::FREQUENCY_RESET", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+        batch_idx.push_back(nvml_io.push_control("NVML::POWER_LIMIT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+        batch_idx.push_back(nvml_io.push_control("POWER_ACCELERATOR_LIMIT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+    }
+
+    for (int idx = 0; idx < batch_idx.size(); ++idx) {
+        // Given that we are mocking NVMLDevicePool the actual setting here doesn't matter
+        EXPECT_NO_THROW(nvml_io.adjust(batch_idx.at(idx), 12345.6));
+    }
+    EXPECT_NO_THROW(nvml_io.write_batch());
+}
+
+TEST_F(NVMLIOGroupTest, write_control)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+    NVMLIOGroup nvml_io(*m_platform_topo, *m_device_pool);
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_NO_THROW(nvml_io.write_control("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, 1530000000));
+        EXPECT_NO_THROW(nvml_io.write_control("FREQUENCY_ACCELERATOR_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, 1530000000));
+        EXPECT_NO_THROW(nvml_io.write_control("NVML::FREQUENCY_RESET", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, 12345));
+        EXPECT_NO_THROW(nvml_io.write_control("NVML::POWER_LIMIT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, 200));
+        EXPECT_NO_THROW(nvml_io.write_control("POWER_ACCELERATOR_LIMIT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, 200));
+    }
+}
+
+TEST_F(NVMLIOGroupTest, read_signal_and_batch)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+
+    std::vector<double> mock_freq = {1530, 1320, 420, 135};
+    std::vector<int> batch_idx;
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_status_sm(accel_idx)).WillRepeatedly(Return(mock_freq.at(accel_idx)));
+    }
+
+    NVMLIOGroup nvml_io(*m_platform_topo, *m_device_pool);
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        batch_idx.push_back(nvml_io.push_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+    }
+    nvml_io.read_batch();
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double frequency = nvml_io.read_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_batch = nvml_io.sample(batch_idx.at(accel_idx));
+
+        EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx)*1e6);
+        EXPECT_DOUBLE_EQ(frequency, frequency_batch);
+    }
+}
+
+TEST_F(NVMLIOGroupTest, read_signal)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+    const int num_cpu = m_platform_topo->num_domain(GEOPM_DOMAIN_CPU);
+
+    std::vector<double> mock_freq = {1530, 1320, 420, 135};
+    std::vector<double> mock_utilization_accelerator = {100, 90, 50, 0};
+    std::vector<double> mock_power = {153600, 70000, 300000, 50000};
+    std::vector<double> mock_power_limit = {300000, 270000, 300000, 250000};
+    std::vector<double> mock_freq_mem = {877, 877, 877, 877};
+    std::vector<double> mock_throttle_reasons = {0, 1, 3, 128};
+    std::vector<double> mock_temperature = {45, 60, 68, 92};
+    std::vector<double> mock_energy = {630000, 280000, 470000, 950000};
+    std::vector<double> mock_performance_state = {0, 2, 3, 5};
+    std::vector<double> mock_pcie_rx_throughput = {4000, 3000, 2000, 0};
+    std::vector<double> mock_pcie_tx_throughput = {2000, 3000, 4000, 100};
+    std::vector<double> mock_utilization_mem = {25, 50, 100, 75};
+
+    /// @todo: Read /proc/sys/kernel/pid_max to guarantee that we never hit an actual PID in testing?
+    std::vector<int> active_process_list = {40961, 40962, 40963};
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_status_sm(accel_idx)).WillRepeatedly(Return(mock_freq.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, utilization(accel_idx)).WillRepeatedly(Return(mock_utilization_accelerator.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power(accel_idx)).WillRepeatedly(Return(mock_power.at(accel_idx)));;
+        EXPECT_CALL(*m_device_pool, power_limit(accel_idx)).WillRepeatedly(Return(mock_power_limit.at(accel_idx)));;
+        EXPECT_CALL(*m_device_pool, frequency_status_mem(accel_idx)).WillRepeatedly(Return(mock_freq_mem.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, throttle_reasons(accel_idx)).WillRepeatedly(Return(mock_throttle_reasons.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, temperature(accel_idx)).WillRepeatedly(Return(mock_temperature.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, energy(accel_idx)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, performance_state(accel_idx)).WillRepeatedly(Return(mock_performance_state.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, throughput_rx_pcie(accel_idx)).WillRepeatedly(Return(mock_pcie_rx_throughput.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, throughput_tx_pcie(accel_idx)).WillRepeatedly(Return(mock_pcie_tx_throughput.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, utilization_mem(accel_idx)).WillRepeatedly(Return(mock_utilization_mem.at(accel_idx)));
+
+    }
+
+    for (int cpu_idx = 0; cpu_idx < num_cpu; ++cpu_idx) {
+        EXPECT_CALL(*m_device_pool, active_process_list(cpu_idx)).WillRepeatedly(Return(active_process_list));;
+    }
+
+    NVMLIOGroup nvml_io(*m_platform_topo, *m_device_pool);
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double frequency = nvml_io.read_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_alias = nvml_io.read_signal("FREQUENCY_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, frequency_alias);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx)*1e6);
+
+        double utilization_accelerator = nvml_io.read_signal("NVML::UTILIZATION_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(utilization_accelerator, mock_utilization_accelerator.at(accel_idx)/100);
+
+        double throttle_reasons = nvml_io.read_signal("NVML::THROTTLE_REASONS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(throttle_reasons, mock_throttle_reasons.at(accel_idx));
+
+        double power = nvml_io.read_signal("NVML::POWER", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double power_alias = nvml_io.read_signal("POWER_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power, power_alias);
+        EXPECT_DOUBLE_EQ(power, mock_power.at(accel_idx)/1e3);
+
+        double frequency_mem = nvml_io.read_signal("NVML::FREQUENCY_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency_mem, mock_freq_mem.at(accel_idx)*1e6);
+
+        double temperature = nvml_io.read_signal("NVML::TEMPERATURE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(temperature, mock_temperature.at(accel_idx));
+
+        double total_energy_consumption = nvml_io.read_signal("NVML::TOTAL_ENERGY_CONSUMPTION", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(total_energy_consumption, mock_energy.at(accel_idx)/1e3);
+
+        double performance_state = nvml_io.read_signal("NVML::PERFORMANCE_STATE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(performance_state, mock_performance_state.at(accel_idx));
+
+        double pcie_rx_throughput = nvml_io.read_signal("NVML::PCIE_RX_THROUGHPUT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(pcie_rx_throughput, mock_pcie_rx_throughput.at(accel_idx)*1024);
+
+        double pcie_tx_throughput = nvml_io.read_signal("NVML::PCIE_TX_THROUGHPUT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(pcie_tx_throughput, mock_pcie_tx_throughput.at(accel_idx)*1024);
+
+        double utilization_mem = nvml_io.read_signal("NVML::UTILIZATION_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(utilization_mem, mock_utilization_mem.at(accel_idx)/100);
+    }
+
+    for (int cpu_idx = 0; cpu_idx < num_cpu; ++cpu_idx) {
+        // FIXME: The most complex signal is the cpu accelerator active afifinitzation signal, which is currently
+        //        not fully testable due to needing a running process for get affinity.  For now using a no throw check
+        EXPECT_NO_THROW(nvml_io.read_signal("NVML::CPU_ACCELERATOR_ACTIVE_AFFINITIZATION", GEOPM_DOMAIN_CPU, cpu_idx));
+    }
+}
+
+//Test case: Error path testing including:
+//              - Attempt to push a signal at an invalid domain level
+//              - Attempt to push an invalid signal
+//              - Attempt to sample without a read_batch prior
+//              - Attempt to read a signal at an invalid domain level
+//              - Attempt to push a control at an invalid domain level
+//              - Attempt to adjust a non-existent batch index
+//              - Attempt to write a control at an invalid domain level
+TEST_F(NVMLIOGroupTest, error_path)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+
+    std::vector<int> batch_idx;
+
+    std::vector<double> mock_freq = {1530, 1320, 420, 135};
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_status_sm(accel_idx)).WillRepeatedly(Return(mock_freq.at(accel_idx)));
+    }
+    NVMLIOGroup nvml_io(*m_platform_topo, *m_device_pool);
+
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.sample(0),
+                               GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal("NVML::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "signal_name NVML::INVALID not valid for NVMLIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal("NVML::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "NVML::INVALID not valid for NVMLIOGroup");
+
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.adjust(0, 12345.6),
+                               GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD, 0, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control("NVML::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "control_name NVML::INVALID not valid for NVMLIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control("NVML::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0, 1530000000),
+                               GEOPM_ERROR_INVALID, "NVML::INVALID not valid for NVMLIOGroup");
+
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+}

--- a/test/NVMLIOGroupTest.cpp
+++ b/test/NVMLIOGroupTest.cpp
@@ -306,7 +306,9 @@ TEST_F(NVMLIOGroupTest, read_signal)
     for (int cpu_idx = 0; cpu_idx < num_cpu; ++cpu_idx) {
         // FIXME: The most complex signal is the cpu accelerator active afifinitzation signal, which is currently
         //        not fully testable due to needing a running process for get affinity.  For now using a no throw check
-        EXPECT_NO_THROW(nvml_io.read_signal("NVML::CPU_ACCELERATOR_ACTIVE_AFFINITIZATION", GEOPM_DOMAIN_CPU, cpu_idx));
+        double affin = NAN;
+        EXPECT_NO_THROW(affin = nvml_io.read_signal("NVML::CPU_ACCELERATOR_ACTIVE_AFFINITIZATION", GEOPM_DOMAIN_CPU, cpu_idx));
+        EXPECT_DOUBLE_EQ(affin, -1);
     }
 }
 


### PR DESCRIPTION
This PR is a follow on to [PR 1229](https://github.com/geopm/geopm/pull/1229#).  It is intended to provide basic monitoring and control of NVML devices through the addition of an NVMLIOGroup that uses the classes added in the previous PR  With the addition of this IOGroup users should be able to set NVML device power & frequency limits using geopmread/write and monitor workloads using the monitoring agent and trace signals launch option.  PR should also allow for the creation of NVML agents but such agents are not included at this time.  

Note that the NVML Driver may require root permissions by default for the controls added to the NVMLIOGroup.  

Summary of change.
- Addition of an NVMLIOGroup class to provide an interface to the NVMLDevicePool, description of signals, and parsing of NVMLDevicePool results into SI units where possible
- Modification of the IOGroup class to include the NVMLIOGroup when appropriate configure options are used (--enable-nvml introduced in PR 1229)
- Addition of NVMLIOGroupTest.cpp to test the NVMLIOGroup functionality.  

High level overview:
![image](https://user-images.githubusercontent.com/23505009/90475932-549a1600-e0dd-11ea-93a4-6793d1e2d6f5.png)
Gray items were introduced in PR 1229
