### PR TITLE
Add support to the experiment infrastructure for studying barriers before collectives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@
 /googletest-release-1.8.1.tar.gz
 /gtest-all.o
 /install-sh
+/integration/apps/nekbone/nekbone/
 /integration/test/*.config
 /integration/test/geopm_test_integration
 /integration/test/geopm_test_integration.pyc

--- a/integration/apps/nekbone/0001-Fix-whitespace-issues.patch
+++ b/integration/apps/nekbone/0001-Fix-whitespace-issues.patch
@@ -1,7 +1,7 @@
-From 5be7a6dcc0afb70e23b53f282dd430269d297cbf Mon Sep 17 00:00:00 2001
+From 15af3e8216c38204c9b84a2be8553d042f7f6989 Mon Sep 17 00:00:00 2001
 From: Brad Geltz <brad.geltz@intel.com>
 Date: Wed, 5 Aug 2020 13:33:08 -0700
-Subject: [PATCH 1/7] Fix whitespace issues
+Subject: [PATCH 1/8] Fix whitespace issues
 #
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
@@ -33,12 +33,14 @@ Subject: [PATCH 1/7] Fix whitespace issues
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
 Signed-off-by: Brad Geltz <brad.geltz@intel.com>
 ---
- src/cg.f                    |  8 ++++----
- src/driver.f                | 50 ++++++++++++++++++++++-----------------------
- test/example1/makenek-intel |  6 +++---
- 3 files changed, 32 insertions(+), 32 deletions(-)
+ src/cg.f                    |  8 +++---
+ src/comm_mpi.f              | 56 ++++++++++++++++++-------------------
+ src/driver.f                | 50 ++++++++++++++++-----------------
+ test/example1/makenek-intel |  6 ++--
+ 4 files changed, 60 insertions(+), 60 deletions(-)
 
 diff --git a/src/cg.f b/src/cg.f
 index b4214dd..f9c4f6d 100644
@@ -67,6 +69,216 @@ index b4214dd..f9c4f6d 100644
        do i = 2,n-1
           w(i)=h2i*(2*u(i)-u(i-1)-u(i+1))
        enddo
+diff --git a/src/comm_mpi.f b/src/comm_mpi.f
+index 26f1bc0..11df316 100644
+--- a/src/comm_mpi.f
++++ b/src/comm_mpi.f
+@@ -13,7 +13,7 @@ c-----------------------------------------------------------------------
+       if ( mpi_is_initialized .eq. 0 ) then
+ #ifdef MPITHREADS
+         call mpi_init_thread (MPI_THREAD_MULTIPLE,provided,ierr)
+-#else 
++#else
+         call mpi_init (ierr)
+ #endif
+       endif
+@@ -33,11 +33,11 @@ c        call exitt
+       endif
+ 
+       IF (NP.GT.LP) THEN
+-         WRITE(6,*) 
++         WRITE(6,*)
+      $   'ERROR: Code compiled for a max of',LP,' processors.'
+-         WRITE(6,*) 
++         WRITE(6,*)
+      $   'Recompile with LP =',NP,' or run with fewer processors.'
+-         WRITE(6,*) 
++         WRITE(6,*)
+      $   'Aborting in routine INIPROC.'
+          call exitt
+       endif
+@@ -49,7 +49,7 @@ c        call exitt
+       if (oneeps.ne.1.0) then
+          wdsize=8
+       else
+-         if(nid.eq.0) 
++         if(nid.eq.0)
+      &     write(6,*) 'ABORT: single precision mode not supported!'
+          call exitt
+       endif
+@@ -74,7 +74,7 @@ c
+       NODE0=0
+       NODE= NID+1
+ 
+-      if (nid.eq.0) then 
++      if (nid.eq.0) then
+          write(6,*) 'Number of processors:',np
+          WRITE(6,*) 'REAL    wdsize      :',WDSIZE
+          WRITE(6,*) 'INTEGER wdsize      :',ISIZE
+@@ -203,7 +203,7 @@ C
+       call mpi_recv (buf,len,mpi_byte
+      $              ,jnid,mtype,nekcomm,status,ierr)
+ c
+-      if (len.gt.lenm) then 
++      if (len.gt.lenm) then
+           write(6,*) nid,'long message in mpi_crecv:',len,lenm
+           call exitt
+       endif
+@@ -224,7 +224,7 @@ C
+      $            ,jnid,mtype,nekcomm,status,ierr)
+       call mpi_get_count (status,mpi_byte,len,ierr)
+ c
+-      if (len.gt.lenm) then 
++      if (len.gt.lenm) then
+           write(6,*) nid,'long message in mpi_crecv:',len,lenm
+           call exitt
+       endif
+@@ -266,7 +266,7 @@ c-----------------------------------------------------------------------
+       double precision fclock_gettime
+       external fclock_gettime
+       dnekclock = fclock_gettime()
+-#else 
++#else
+       integer*8 countval, countrate, countmax
+       double precision countd
+       call system_clock(countval, countrate, countmax)
+@@ -443,7 +443,7 @@ c-----------------------------------------------------------------------
+       include 'TOTAL'
+ 
+       ierr = iglsum(ierr,1)
+-      if(ierr.eq.0) return 
++      if(ierr.eq.0) return
+ 
+       len = indx1(string,'$',1)
+       call blank(ostring,132)
+@@ -504,7 +504,7 @@ c
+       ttotal = tstop-etimes
+       nxyz   = nx1*ny1*nz1
+ 
+-      if (nid.eq.0) then 
++      if (nid.eq.0) then
+          dtmp1 = 0
+          dtmp2 = 0
+          dtmp3 = 0
+@@ -514,23 +514,23 @@ c
+            dtmp1 = np*ttime/(dgp*max(istep,1))
+            dtmp2 = ttime/max(istep,1)
+            dtmp3 = 1.*papi_flops/1e6
+-         endif 
++         endif
+          write(6,*) ' '
+          write(6,'(A)') 'call exitt: dying ...'
+          write(6,*) ' '
+ c        call print_stack()
+          write(6,*) ' '
+-         write(6,'(4(A,1p1e13.5,A,/))') 
++         write(6,'(4(A,1p1e13.5,A,/))')
+      &       'total elapsed time             : ',ttotal, ' sec'
+      &      ,'total solver time incl. I/O    : ',ttime , ' sec'
+      &      ,'time/timestep                  : ',dtmp2 , ' sec'
+      &      ,'CPU seconds/timestep/gridpt    : ',dtmp1 , ' sec'
+ #ifdef PAPI
+-         write(6,'(2(A,1g13.5,/))') 
++         write(6,'(2(A,1g13.5,/))')
+      &       'Gflops                         : ',dtmp3/1000.
+      &      ,'Gflops/s                       : ',papi_mflops/1000.
+ #endif
+-      endif 
++      endif
+ 
+       nz1 = 1/(nx1-ny1)
+ 
+@@ -644,7 +644,7 @@ c-----------------------------------------------------------------------
+          nloop = max(nloop,1)
+ 
+          len   = 8*nwds
+-     
++
+          call ping_loop(t1,t0,len,nloop,nodea,nodeb,nid,x,y,x,y)
+ 
+          if (nid.eq.nodea) then
+@@ -792,7 +792,7 @@ c-----------------------------------------------------------------------
+ 
+       nwds  = min(1000,lt)
+       nloop = 50
+- 
++
+       tmsg = 0.
+       call gop(tmsg,t1,'+  ',1)
+ 
+@@ -890,7 +890,7 @@ c-----------------------------------------------------------------------
+       if (nid.eq.0) then
+          nwds = 1
+          do itest=1,500
+-            if (ivb.gt.0.or.itest.eq.1) 
++            if (ivb.gt.0.or.itest.eq.1)
+      $         write(6,1) np,nwds,(times(k,itest),k=1,2)
+     1       format(i9,i12,1p2e16.8,' gop')
+             nwds = (nwds+1)*1.016
+@@ -943,7 +943,7 @@ c-----------------------------------------------------------------------
+       if (nid.eq.0) then
+          nwds = 1
+          do itest=1,500
+-            if (ivb.gt.0.or.itest.eq.1) 
++            if (ivb.gt.0.or.itest.eq.1)
+      $         write(6,1) np,nwds,(times(k,itest),k=1,2)
+     1       format(i9,i12,1p2e16.8,' gp2')
+             nwds = (nwds+1)*1.016
+@@ -992,7 +992,7 @@ c     Std. fan-in/fan-out
+       real x(n), w(n)
+       character*3 op
+ 
+-      integer bit, bytes, cnt, diff, spsize, i, 
++      integer bit, bytes, cnt, diff, spsize, i,
+      *   parent, troot, xor, root, lnp, log2
+       logical ifgot
+ 
+@@ -1168,17 +1168,17 @@ c     Double Buffer : does 2*nloop timings
+ 
+       itag=1
+       if (nid.eq.nodea) then
+-         call mpi_irecv(y1,len,mpi_byte,nodeb,itag,nekcomm,msg1,ierr)   ! 1b 
++         call mpi_irecv(y1,len,mpi_byte,nodeb,itag,nekcomm,msg1,ierr)   ! 1b
+          call nekgsync
+ 
+ 
+          t0 = mpi_wtime ()
+          do i=1,nloop
+-            call mpi_send (x1,len,mpi_byte,nodeb,itag,nekcomm,ierr)     ! 1a 
+-            call mpi_irecv(y2,len,mpi_byte,nodeb,itag,nekcomm,msg2,ierr)! 2b 
++            call mpi_send (x1,len,mpi_byte,nodeb,itag,nekcomm,ierr)     ! 1a
++            call mpi_irecv(y2,len,mpi_byte,nodeb,itag,nekcomm,msg2,ierr)! 2b
+             call mpi_wait (msg1,status,ierr)                            ! 1b
+-            call mpi_send (x2,len,mpi_byte,nodeb,itag,nekcomm,ierr)     ! 2a 
+-            call mpi_irecv(y1,len,mpi_byte,nodeb,itag,nekcomm,msg1,ierr)! 3b 
++            call mpi_send (x2,len,mpi_byte,nodeb,itag,nekcomm,ierr)     ! 2a
++            call mpi_irecv(y1,len,mpi_byte,nodeb,itag,nekcomm,msg1,ierr)! 3b
+             call mpi_wait (msg2,status,ierr)                            ! 2b
+          enddo
+          t1 = mpi_wtime ()
+@@ -1187,7 +1187,7 @@ c     Double Buffer : does 2*nloop timings
+ 
+       elseif (nid.eq.nodeb) then
+ 
+-         call mpi_irecv(y1,len,mpi_byte,nodea,itag,nekcomm,msg1,ierr)   ! nb 
++         call mpi_irecv(y1,len,mpi_byte,nodea,itag,nekcomm,msg1,ierr)   ! nb
+          call nekgsync
+ 
+ 
+@@ -1195,11 +1195,11 @@ c     Double Buffer : does 2*nloop timings
+             call mpi_wait (msg1,status,ierr)                            ! 1a
+             call mpi_send (x1,len,mpi_byte,nodea,itag,nekcomm,ierr)     ! 1b
+             call mpi_irecv(y2,len,mpi_byte,nodea,itag,nekcomm,msg2,ierr)! 2a
+-            call mpi_wait (msg2,status,ierr)                            ! 2a 
++            call mpi_wait (msg2,status,ierr)                            ! 2a
+             call mpi_send (x2,len,mpi_byte,nodea,itag,nekcomm,ierr)     ! 2b
+             call mpi_irecv(y1,len,mpi_byte,nodea,itag,nekcomm,msg1,ierr)! 3a
+          enddo
+-         call mpi_wait (msg1,status,ierr)                            ! 2a 
++         call mpi_wait (msg1,status,ierr)                            ! 2a
+          call mpi_send (x1,len,mpi_byte,nodea,itag,nekcomm,ierr)        ! nb
+ 
+       else
 diff --git a/src/driver.f b/src/driver.f
 index f45aa50..cb4421f 100644
 --- a/src/driver.f
@@ -274,5 +486,5 @@ index 209dfc3..fa6e4f3 100755
  
  # linking flags
 -- 
-1.8.3.1
+2.23.0
 

--- a/integration/apps/nekbone/0002-Use-AVX2.patch
+++ b/integration/apps/nekbone/0002-Use-AVX2.patch
@@ -1,7 +1,7 @@
-From 684454d80044c89ac714ded78bb83898faa240eb Mon Sep 17 00:00:00 2001
+From ebf7b3c74f53fb32aeba6d1be24511dc96465a5b Mon Sep 17 00:00:00 2001
 From: Brad Geltz <brad.geltz@intel.com>
-Date: Wed, 5 Aug 2020 14:12:20 -0700
-Subject: [PATCH 3/7] Only run the 12th order polynomial
+Date: Mon, 24 Aug 2020 15:53:59 -0700
+Subject: [PATCH 2/8] Use AVX2
 #
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
@@ -33,22 +33,29 @@ Subject: [PATCH 3/7] Only run the 12th order polynomial
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
+- xHost could enable AVX-512.
+
 Signed-off-by: Brad Geltz <brad.geltz@intel.com>
 ---
- test/example1/data.rea | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ test/example1/makenek-intel | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/test/example1/data.rea b/test/example1/data.rea
-index 36077f4..cc1c6a7 100644
---- a/test/example1/data.rea
-+++ b/test/example1/data.rea
-@@ -1,5 +1,5 @@
- .true. = ifbrick               ! brick or linear geometry
- 512 512 1  = iel0,ielN,ielD (per processor)  ! range of number of elements per proc.
-- 9  12 3 = nx0,nxN,nxD         ! poly. order range for nx1
-+ 12 12 1 = nx0,nxN,nxD         ! poly. order range for nx1
-  1  1  1 = npx, npy, npz       ! processor distribution in x,y,z
-  1  1  1 = mx, my, mz          ! local element distribution in x,y,z
+diff --git a/test/example1/makenek-intel b/test/example1/makenek-intel
+index fa6e4f3..a5cce80 100755
+--- a/test/example1/makenek-intel
++++ b/test/example1/makenek-intel
+@@ -35,8 +35,8 @@ USR_LFLAGS="-qopenmp -mcmodel=medium -shared-intel"
+ #G="-g"
+ 
+ # optimization flags
+-OPT_FLAGS_STD="-qopenmp -O3 -g -xHost -mcmodel=medium -shared-intel"
+-OPT_FLAGS_MAG="-qopenmp -O3 -g -xHost -mcmodel=medium -shared-intel"
++OPT_FLAGS_STD="-qopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
++OPT_FLAGS_MAG="-qopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
+ 
+ ###############################################################################
+ # DONT'T TOUCH WHAT FOLLOWS !!!
 -- 
-1.8.3.1
+2.23.0
 

--- a/integration/apps/nekbone/0003-Link-w-GEOPM.patch
+++ b/integration/apps/nekbone/0003-Link-w-GEOPM.patch
@@ -1,7 +1,7 @@
-From a193a2176c9b2aa82bd28a3dd8d767c3c51b2407 Mon Sep 17 00:00:00 2001
+From 7ddb3453e08be80148a4e032abb9490d620ac795 Mon Sep 17 00:00:00 2001
 From: Brad Geltz <brad.geltz@intel.com>
-Date: Thu, 13 Aug 2020 17:00:11 -0700
-Subject: [PATCH 7/7] Update GEOPM_PREFIX
+Date: Wed, 5 Aug 2020 13:34:15 -0700
+Subject: [PATCH 3/8] Link w/GEOPM
 #
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
@@ -33,24 +33,47 @@ Subject: [PATCH 7/7] Update GEOPM_PREFIX
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
+- Also use default compilers (not Intel wrappers)
+
 Signed-off-by: Brad Geltz <brad.geltz@intel.com>
 ---
- test/example1/makenek-intel | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ test/example1/makenek-intel | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/test/example1/makenek-intel b/test/example1/makenek-intel
-index 6fb562f..5c4066e 100755
+index a5cce80..491621b 100755
 --- a/test/example1/makenek-intel
 +++ b/test/example1/makenek-intel
-@@ -4,7 +4,7 @@
+@@ -4,12 +4,13 @@
  
  # source path
  SOURCE_ROOT="../../src"
--GEOPM_ROOT="${GEOPM_PREFIX:?Please set GEOPM_PREFIX.}" # Defined in intelCRADA/env.sh
 +GEOPM_ROOT="${HOME}/build/geopm"
  
  # Fortran compiler
- F77="mpifort -I${GEOPM_ROOT}/lib/ifort/modules/geopm-x86_64/"
+-F77="mpiifort"
++F77="mpifort -I${GEOPM_ROOT}/lib/ifort/modules/geopm-x86_64/"
+ 
+ # C compiler
+-CC="mpiicc"
++CC="mpicc"
+ 
+ # pre-processor symbol list
+ # (set PPLIST=? to get a list of available symbols)
+@@ -29,10 +30,10 @@ PPLIST="TIMERS CGTIMERS"
+ #USR="foo.o"
+ 
+ # linking flags
+-USR_LFLAGS="-qopenmp -mcmodel=medium -shared-intel"
++USR_LFLAGS="-qopenmp -mcmodel=medium -shared-intel -L${GEOPM_ROOT}/lib -lgeopm -lgeopmfort"
+ 
+ # generic compiler flags
+-#G="-g"
++G="-DGEOPM -I${GEOPM_ROOT}/include"
+ 
+ # optimization flags
+ OPT_FLAGS_STD="-qopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
 -- 
-1.8.3.1
+2.23.0
 

--- a/integration/apps/nekbone/0004-Only-run-the-12th-order-polynomial.patch
+++ b/integration/apps/nekbone/0004-Only-run-the-12th-order-polynomial.patch
@@ -1,7 +1,7 @@
-From 467a0ab9cf78eb7e1635369c467312b923b7a409 Mon Sep 17 00:00:00 2001
+From 08b26f4a624c744a9742d6dfdf91c3e502fa7828 Mon Sep 17 00:00:00 2001
 From: Brad Geltz <brad.geltz@intel.com>
-Date: Wed, 5 Aug 2020 13:34:15 -0700
-Subject: [PATCH 2/7] Link w/GEOPM
+Date: Wed, 5 Aug 2020 14:12:20 -0700
+Subject: [PATCH 4/8] Only run the 12th order polynomial
 #
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
@@ -33,44 +33,23 @@ Subject: [PATCH 2/7] Link w/GEOPM
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
 Signed-off-by: Brad Geltz <brad.geltz@intel.com>
 ---
- test/example1/makenek-intel | 8 +++++---
- 1 file changed, 5 insertions(+), 3 deletions(-)
+ test/example1/data.rea | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/test/example1/makenek-intel b/test/example1/makenek-intel
-index fa6e4f3..15eab37 100755
---- a/test/example1/makenek-intel
-+++ b/test/example1/makenek-intel
-@@ -4,12 +4,13 @@
- 
- # source path
- SOURCE_ROOT="../../src"
-+GEOPM_ROOT="${GEOPM_PREFIX:?Please set GEOPM_PREFIX.}" # Defined in intelCRADA/env.sh
- 
- # Fortran compiler
--F77="mpiifort"
-+F77="mpifort -I${GEOPM_ROOT}/lib/ifort/modules/geopm-x86_64/"
- 
- # C compiler
--CC="mpiicc"
-+CC="mpicc"
- 
- # pre-processor symbol list
- # (set PPLIST=? to get a list of available symbols)
-@@ -29,10 +30,11 @@ PPLIST="TIMERS CGTIMERS"
- #USR="foo.o"
- 
- # linking flags
--USR_LFLAGS="-qopenmp -mcmodel=medium -shared-intel"
-+USR_LFLAGS="-qopenmp -mcmodel=medium -shared-intel -L${GEOPM_ROOT}/lib -lgeopm -lgeopmfort"
- 
- # generic compiler flags
- #G="-g"
-+G="-xCORE-AVX2 -DGEOPM -I${GEOPM_ROOT}/include"
- 
- # optimization flags
- OPT_FLAGS_STD="-qopenmp -O3 -g -xHost -mcmodel=medium -shared-intel"
+diff --git a/test/example1/data.rea b/test/example1/data.rea
+index 36077f4..cc1c6a7 100644
+--- a/test/example1/data.rea
++++ b/test/example1/data.rea
+@@ -1,5 +1,5 @@
+ .true. = ifbrick               ! brick or linear geometry
+ 512 512 1  = iel0,ielN,ielD (per processor)  ! range of number of elements per proc.
+- 9  12 3 = nx0,nxN,nxD         ! poly. order range for nx1
++ 12 12 1 = nx0,nxN,nxD         ! poly. order range for nx1
+  1  1  1 = npx, npy, npz       ! processor distribution in x,y,z
+  1  1  1 = mx, my, mz          ! local element distribution in x,y,z
 -- 
-1.8.3.1
+2.23.0
 

--- a/integration/apps/nekbone/0005-Increase-maximum-number-of-elements-to-32768.patch
+++ b/integration/apps/nekbone/0005-Increase-maximum-number-of-elements-to-32768.patch
@@ -1,7 +1,7 @@
-From 76fffeff937942938ba978e3311ede8678279ba7 Mon Sep 17 00:00:00 2001
+From f67fab85676273085f053af416780c3aeff0de1b Mon Sep 17 00:00:00 2001
 From: Brad Geltz <brad.geltz@intel.com>
 Date: Wed, 5 Aug 2020 14:47:02 -0700
-Subject: [PATCH 4/7] Increase maximum number of elements to 32768
+Subject: [PATCH 5/8] Increase maximum number of elements to 32768
 #
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
@@ -33,6 +33,7 @@ Subject: [PATCH 4/7] Increase maximum number of elements to 32768
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
 Signed-off-by: Brad Geltz <brad.geltz@intel.com>
 ---
  test/example1/SIZE | 2 +-
@@ -52,5 +53,5 @@ index 941aedc..fa4fb8c 100644
        parameter (lelg=lelt*lp)                ! max total elements in a test
        parameter (lelx=lelg,lely=1,lelz=1)     ! max elements in each direction
 -- 
-1.8.3.1
+2.23.0
 

--- a/integration/apps/nekbone/0006-Add-Epoch-markup.patch
+++ b/integration/apps/nekbone/0006-Add-Epoch-markup.patch
@@ -1,9 +1,7 @@
-From efaf688e7f87891e90134b24de26332fed006a4b Mon Sep 17 00:00:00 2001
+From 1462dea2ad94396d4a1af5f48753c243c33b9d02 Mon Sep 17 00:00:00 2001
 From: Brad Geltz <brad.geltz@intel.com>
 Date: Wed, 5 Aug 2020 15:18:29 -0700
-Subject: [PATCH 5/7] Add Epoch markup
-
-- Only time the second invocation of cg().
+Subject: [PATCH 6/8] Add Epoch markup
 #
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
@@ -35,6 +33,9 @@ Subject: [PATCH 5/7] Add Epoch markup
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
+- Only time the second invocation of cg().
+
 Signed-off-by: Brad Geltz <brad.geltz@intel.com>
 ---
  src/cg.f     | 14 ++++++++++++++
@@ -110,5 +111,5 @@ index cb4421f..4f2a224 100644
             call set_timer_flop_cnt(1)
  
 -- 
-1.8.3.1
+2.23.0
 

--- a/integration/apps/nekbone/0007-Increase-iterations-to-2000.patch
+++ b/integration/apps/nekbone/0007-Increase-iterations-to-2000.patch
@@ -1,3 +1,8 @@
+From 92492983175ebc59b4d14a4be412cef0538669bd Mon Sep 17 00:00:00 2001
+From: Brad Geltz <brad.geltz@intel.com>
+Date: Wed, 5 Aug 2020 15:42:57 -0700
+Subject: [PATCH 7/8] Increase iterations to 2000
+#
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -29,15 +34,24 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-EXTRA_DIST += integration/apps/nekbone/0001-Fix-whitespace-issues.patch \
-              integration/apps/nekbone/0002-Use-AVX2.patch \
-              integration/apps/nekbone/0003-Link-w-GEOPM.patch \
-              integration/apps/nekbone/0004-Only-run-the-12th-order-polynomial.patch \
-              integration/apps/nekbone/0005-Increase-maximum-number-of-elements-to-32768.patch \
-              integration/apps/nekbone/0006-Add-Epoch-markup.patch \
-              integration/apps/nekbone/0007-Increase-iterations-to-2000.patch \
-              integration/apps/nekbone/0008-Add-barriers-to-collective-calls.patch \
-              integration/apps/nekbone/__init__.py \
-              integration/apps/nekbone/download_and_build.sh \
-              integration/apps/nekbone/nekbone.py \
-              # end
+Signed-off-by: Brad Geltz <brad.geltz@intel.com>
+---
+ test/example1/makenek-intel | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/example1/makenek-intel b/test/example1/makenek-intel
+index 491621b..1a2733b 100755
+--- a/test/example1/makenek-intel
++++ b/test/example1/makenek-intel
+@@ -15,7 +15,7 @@ CC="mpicc"
+ # pre-processor symbol list
+ # (set PPLIST=? to get a list of available symbols)
+ #PPLSIT="BGQ BGP K10_MXM TIMERS MPITIMER BGQTIMER CGTTIMER NITER=20 LOG MPITHREADS XSMM MXMBASIC MKL BLAS_MXM XSMM_FIXED XSMM_DISPATCH NPOLY=8"
+-PPLIST="TIMERS CGTIMERS"
++PPLIST="TIMERS CGTIMERS NITER=2000"
+ 
+ 
+ # OPTIONAL SETTINGS
+-- 
+2.23.0
+

--- a/integration/apps/nekbone/0008-Add-barriers-to-collective-calls.patch
+++ b/integration/apps/nekbone/0008-Add-barriers-to-collective-calls.patch
@@ -1,7 +1,7 @@
-From 18c38bb08657814c2f5df214628a19d9a7d43012 Mon Sep 17 00:00:00 2001
+From 479c5ab17bdd9ae592f678f76638334778b7c3e1 Mon Sep 17 00:00:00 2001
 From: Brad Geltz <brad.geltz@intel.com>
-Date: Wed, 5 Aug 2020 15:42:57 -0700
-Subject: [PATCH 6/7] Increase iterations to 2000
+Date: Mon, 24 Aug 2020 17:14:19 -0700
+Subject: [PATCH 8/8] Add barriers to collective calls
 #
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
@@ -33,24 +33,64 @@ Subject: [PATCH 6/7] Increase iterations to 2000
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
+- Add special makefile to set build flag which enables
+  barrier usage before collectives.
+
 Signed-off-by: Brad Geltz <brad.geltz@intel.com>
 ---
- test/example1/makenek-intel | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ src/comm_mpi.f              | 9 +++++++++
+ test/example1/makenek-intel | 3 +++
+ 2 files changed, 12 insertions(+)
 
+diff --git a/src/comm_mpi.f b/src/comm_mpi.f
+index 11df316..bf3dc4b 100644
+--- a/src/comm_mpi.f
++++ b/src/comm_mpi.f
+@@ -107,6 +107,9 @@ c
+       real x(n), w(n)
+       character*3 op
+ c
++#ifdef GEOPM_BARRIER
++      call mpi_barrier(nekcomm, ierr)
++#endif
+       if (op.eq.'+  ') then
+          call mpi_allreduce (x,w,n,nekreal,mpi_sum ,nekcomm,ierr)
+       elseif (op.EQ.'M  ') then
+@@ -135,6 +138,9 @@ c
+       integer x(n), w(n)
+       character*3 op
+ 
++#ifdef GEOPM_BARRIER
++      call mpi_barrier(nekcomm, ierr)
++#endif
+       if     (op.eq.'+  ') then
+         call mpi_allreduce (x,w,n,mpi_integer,mpi_sum ,nekcomm,ierr)
+       elseif (op.EQ.'M  ') then
+@@ -163,6 +169,9 @@ c
+       integer*8 x(n), w(n)
+       character*3 op
+ 
++#ifdef GEOPM_BARRIER
++      call mpi_barrier(nekcomm, ierr)
++#endif
+       if     (op.eq.'+  ') then
+         call mpi_allreduce (x,w,n,mpi_integer8,mpi_sum ,nekcomm,ierr)
+       elseif (op.EQ.'M  ') then
 diff --git a/test/example1/makenek-intel b/test/example1/makenek-intel
-index 15eab37..6fb562f 100755
+index 1a2733b..affd0e7 100755
 --- a/test/example1/makenek-intel
 +++ b/test/example1/makenek-intel
-@@ -15,7 +15,7 @@ CC="mpicc"
- # pre-processor symbol list
- # (set PPLIST=? to get a list of available symbols)
- #PPLSIT="BGQ BGP K10_MXM TIMERS MPITIMER BGQTIMER CGTTIMER NITER=20 LOG MPITHREADS XSMM MXMBASIC MKL BLAS_MXM XSMM_FIXED XSMM_DISPATCH NPOLY=8"
--PPLIST="TIMERS CGTIMERS"
-+PPLIST="TIMERS CGTIMERS NITER=2000"
+@@ -34,6 +34,9 @@ USR_LFLAGS="-qopenmp -mcmodel=medium -shared-intel -L${GEOPM_ROOT}/lib -lgeopm -
  
+ # generic compiler flags
+ G="-DGEOPM -I${GEOPM_ROOT}/include"
++if [ ! -z "${GEOPM_BARRIER+x}" ]; then
++    G="-DGEOPM_BARRIER ${G}"
++fi
  
- # OPTIONAL SETTINGS
+ # optimization flags
+ OPT_FLAGS_STD="-qopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
 -- 
-1.8.3.1
+2.23.0
 

--- a/integration/apps/nekbone/download_and_build.sh
+++ b/integration/apps/nekbone/download_and_build.sh
@@ -45,20 +45,18 @@ fi
 
 # Acquire the source:
 svn checkout https://repocafe.cels.anl.gov/repos/nekbone
-base_dir=$PWD
+base_dir=${PWD}
 
 # Change directories to the unpacked files.
 cd nekbone/trunk/nekbone
 
-# Patch nekbone with the patch utility:
-patch -p1 < $base_dir/0001-Fix-whitespace-issues.patch
-patch -p1 < $base_dir/0002-Use-AVX2.patch
-patch -p1 < $base_dir/0003-Link-w-GEOPM.patch
-patch -p1 < $base_dir/0004-Only-run-the-12th-order-polynomial.patch
-patch -p1 < $base_dir/0005-Increase-maximum-number-of-elements-to-32768.patch
-patch -p1 < $base_dir/0006-Add-Epoch-markup.patch
-patch -p1 < $base_dir/0007-Increase-iterations-to-2000.patch
-patch -p1 < $base_dir/0008-Add-barriers-to-collective-calls.patch
+# Create a git repo for the app source
+git init
+git add -A
+git commit -sm "Initial commit"
+
+# Patch nekbone:
+git am ${base_dir}/*.patch
 
 # Build
 cd test/example1

--- a/integration/apps/nekbone/download_and_build.sh
+++ b/integration/apps/nekbone/download_and_build.sh
@@ -52,13 +52,18 @@ cd nekbone/trunk/nekbone
 
 # Patch nekbone with the patch utility:
 patch -p1 < $base_dir/0001-Fix-whitespace-issues.patch
-patch -p1 < $base_dir/0002-Link-w-GEOPM.patch
-patch -p1 < $base_dir/0003-Only-run-the-12th-order-polynomial.patch
-patch -p1 < $base_dir/0004-Increase-maximum-number-of-elements-to-32768.patch
-patch -p1 < $base_dir/0005-Add-Epoch-markup.patch
-patch -p1 < $base_dir/0006-Increase-iterations-to-2000.patch
-patch -p1 < $base_dir/0007-Update-GEOPM_PREFIX.patch
+patch -p1 < $base_dir/0002-Use-AVX2.patch
+patch -p1 < $base_dir/0003-Link-w-GEOPM.patch
+patch -p1 < $base_dir/0004-Only-run-the-12th-order-polynomial.patch
+patch -p1 < $base_dir/0005-Increase-maximum-number-of-elements-to-32768.patch
+patch -p1 < $base_dir/0006-Add-Epoch-markup.patch
+patch -p1 < $base_dir/0007-Increase-iterations-to-2000.patch
+patch -p1 < $base_dir/0008-Add-barriers-to-collective-calls.patch
 
 # Build
 cd test/example1
+GEOPM_BARRIER=yes ./makenek-intel
+mv nekbone nekbone-barrier
+make clean
 ./makenek-intel
+

--- a/integration/apps/nekbone/download_and_build.sh
+++ b/integration/apps/nekbone/download_and_build.sh
@@ -31,7 +31,17 @@
 #
 
 # Clear out old versions:
-rm -rf nekbone
+if [ -d "nekbone" ]; then
+    echo "WARNING: Previous nekbone checkout detected at ./nekbone"
+    read -p "OK to delete and rebuild? (y/n) " -n 1 -r
+    echo
+    if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+        rm -rf nekbone
+    else
+        echo "Not OK.  Stopping."
+        exit 1
+    fi
+fi
 
 # Acquire the source:
 svn checkout https://repocafe.cels.anl.gov/repos/nekbone

--- a/integration/apps/nekbone/nekbone.py
+++ b/integration/apps/nekbone/nekbone.py
@@ -41,7 +41,8 @@ class NekboneAppConf(apps.AppConf):
     def name():
         return 'nekbone'
 
-    def __init__(self):
+    def __init__(self, add_barriers=False):
+        self._add_barriers = add_barriers
         benchmark_dir = os.path.dirname(os.path.abspath(__file__))
         self._nekbone_path = os.path.join(benchmark_dir, 'nekbone/trunk/nekbone/test/example1/')
         # TODO: needed? is size in setup() related ?
@@ -68,7 +69,13 @@ class NekboneAppConf(apps.AppConf):
         return 'rm -f ./data.rea'
 
     def get_exec_path(self):
-        return os.path.join(self._nekbone_path, 'nekbone')
+        binary_name = ''
+        if self._add_barriers:
+            binary_name = 'nekbone-barrier'
+        else:
+            binary_name = 'nekbone'
+
+        return os.path.join(self._nekbone_path, binary_name)
 
     def get_exec_args(self):
         return ['ex1']

--- a/integration/experiment/launch_util.py
+++ b/integration/experiment/launch_util.py
@@ -34,6 +34,7 @@
 
 import os
 import time
+import sys
 
 import geopmpy.launcher
 from . import util
@@ -64,6 +65,8 @@ def launch_run(agent_conf, app_conf, run_id, output_dir, extra_cli_args,
     trace_path = '{}.trace'.format(uid)
     profile_name = uid
     log_path = '{}.log'.format(uid)
+    sys.stdout.write('Run commencing...\nLive job output will be written to: {}\n'
+                     .format(os.path.join(output_dir, log_path)))
 
     # TODO: these are not passed to launcher create()
     # some are generic enough they could be, though
@@ -141,6 +144,7 @@ def launch_all_runs(targets, num_nodes, iterations, extra_cli_args, output_dir, 
 
             # rest to cool off between runs
             time.sleep(cool_off_time)
+    sys.stdout.write('Run complete!\n')
 
 
 def geopm_signal_args(report_signals, trace_signals):


### PR DESCRIPTION
- Add special nekbone binary with injected barriers before MPI_Allreduce.
- Clean up nekbone patch files.
- Add safety check around ```rm -fr``` usage.
- Write messages to stdout on job step start and job completion.
- Use git to track app source changes.