### PR TITLE
Commit for AED PDP, new AED knob and AED test fixes (new PR)

### DIFF
--- a/src/EditDistEpochRecordFilter.cpp
+++ b/src/EditDistEpochRecordFilter.cpp
@@ -47,11 +47,13 @@ namespace geopm
     {
         int history_buffer_size;
         int min_hysteresis_base_period;
+        int min_detectable_period;
         double stable_period_hysteresis;
         double unstable_period_hysteresis;
         EditDistEpochRecordFilter::parse_name(name,
                                               history_buffer_size,
                                               min_hysteresis_base_period,
+                                              min_detectable_period,
                                               stable_period_hysteresis,
                                               unstable_period_hysteresis);
         return history_buffer_size;
@@ -61,25 +63,45 @@ namespace geopm
     {
         int history_buffer_size;
         int min_hysteresis_base_period;
+        int min_detectable_period;
         double stable_period_hysteresis;
         double unstable_period_hysteresis;
         EditDistEpochRecordFilter::parse_name(name,
                                               history_buffer_size,
                                               min_hysteresis_base_period,
+                                              min_detectable_period,
                                               stable_period_hysteresis,
                                               unstable_period_hysteresis);
         return min_hysteresis_base_period;
+    }
+
+    static int parse_min_detectable_period(const std::string &name)
+    {
+        int history_buffer_size;
+        int min_hysteresis_base_period;
+        int min_detectable_period;
+        double stable_period_hysteresis;
+        double unstable_period_hysteresis;
+        EditDistEpochRecordFilter::parse_name(name,
+                                              history_buffer_size,
+                                              min_hysteresis_base_period,
+                                              min_detectable_period,
+                                              stable_period_hysteresis,
+                                              unstable_period_hysteresis);
+        return min_detectable_period;
     }
 
     static int parse_stable_period_hysteresis(const std::string &name)
     {
         int history_buffer_size;
         int min_hysteresis_base_period;
+        int min_detectable_period;
         double stable_period_hysteresis;
         double unstable_period_hysteresis;
         EditDistEpochRecordFilter::parse_name(name,
                                               history_buffer_size,
                                               min_hysteresis_base_period,
+                                              min_detectable_period,
                                               stable_period_hysteresis,
                                               unstable_period_hysteresis);
         return stable_period_hysteresis;
@@ -89,11 +111,13 @@ namespace geopm
     {
         int history_buffer_size;
         int min_hysteresis_base_period;
+        int min_detectable_period;
         double stable_period_hysteresis;
         double unstable_period_hysteresis;
         EditDistEpochRecordFilter::parse_name(name,
                                               history_buffer_size,
                                               min_hysteresis_base_period,
+                                              min_detectable_period,
                                               stable_period_hysteresis,
                                               unstable_period_hysteresis);
         return unstable_period_hysteresis;
@@ -102,6 +126,7 @@ namespace geopm
     EditDistEpochRecordFilter::EditDistEpochRecordFilter(const std::string &name)
         : EditDistEpochRecordFilter(parse_history_buffer_size(name),
                                     parse_min_hysteresis_base_period(name),
+                                    parse_min_detectable_period(name),
                                     parse_stable_period_hysteresis(name),
                                     parse_unstable_period_hysteresis(name))
     {
@@ -110,10 +135,12 @@ namespace geopm
 
     EditDistEpochRecordFilter::EditDistEpochRecordFilter(int history_buffer_size,
                                                          int min_hysteresis_base_period,
+                                                         int min_detectable_period,
                                                          double stable_period_hysteresis,
                                                          double unstable_period_hysteresis)
         : EditDistEpochRecordFilter(std::make_shared<EditDistPeriodicityDetector>(history_buffer_size),
                                     min_hysteresis_base_period,
+                                    min_detectable_period,
                                     stable_period_hysteresis,
                                     unstable_period_hysteresis)
     {
@@ -122,10 +149,12 @@ namespace geopm
 
     EditDistEpochRecordFilter::EditDistEpochRecordFilter(std::shared_ptr<EditDistPeriodicityDetector> edpd,
                                                          int min_hysteresis_base_period,
+                                                         int min_detectable_period,
                                                          double stable_period_hysteresis,
                                                          double unstable_period_hysteresis)
         : m_edpd(edpd)
         , m_min_hysteresis_base_period(min_hysteresis_base_period)
+        , m_min_detectable_period(min_detectable_period)
         , m_stable_period_hysteresis(stable_period_hysteresis)
         , m_unstable_period_hysteresis(unstable_period_hysteresis)
         , m_last_period(-1)
@@ -134,7 +163,6 @@ namespace geopm
         , m_is_period_detected(false)
         , m_last_epoch(-1)
         , m_epoch_count(0)
-        , m_record_count(0)
     {
 
     }
@@ -147,7 +175,6 @@ namespace geopm
             result.push_back(record);
             if (record.event == EVENT_REGION_ENTRY) {
                 m_edpd->update(record);
-                m_record_count++;
                 if (epoch_detected()) {
                     m_epoch_count++;
                     record_s epoch_event = record;
@@ -167,7 +194,7 @@ namespace geopm
         // (true means state PERIOD_DETECTED false means NO_PERIOD_DETECTED).
         //
         if (!m_is_period_detected) {
-            if (m_edpd->get_score() >= m_edpd->get_period()) {
+            if (m_edpd->get_score() >= m_edpd->get_period() || m_edpd->get_period() < m_min_detectable_period) {
                 // If the score is the same as the period or greater the detected period is really low quality.
                 // For example: A B C D ... will give period = 1 with score = 1.
                 // In that case, we reset the period detection, i.e., we don't even treat the
@@ -189,11 +216,11 @@ namespace geopm
             if ((m_edpd->get_period() <= m_min_hysteresis_base_period &&
                  (m_period_stable == m_stable_period_hysteresis * m_min_hysteresis_base_period)) ||
                 (m_edpd->get_period() > m_min_hysteresis_base_period &&
-                 (m_period_stable == m_stable_period_hysteresis * m_edpd->get_period()))) {
+                 (m_period_stable >= (int)(m_stable_period_hysteresis * m_edpd->get_period())))) {
                 // To understand this criteria read m_min_hysteresis_base_period and m_stable_period_hysteresis documentation.
 
                 m_is_period_detected = true;
-                m_last_epoch = m_record_count;
+                m_last_epoch = m_edpd->num_records();
                 // Reset for next use
                 m_period_stable = 0;
 
@@ -210,7 +237,7 @@ namespace geopm
                 m_period_unstable += 1;
             }
 
-            if (m_period_unstable == (int)(m_unstable_period_hysteresis * m_last_period)) {
+            if (m_period_unstable >= (int)(m_unstable_period_hysteresis * m_last_period)) {
                 m_is_period_detected = false;
                 // Reset for next use
                 m_period_unstable = 0;
@@ -219,7 +246,7 @@ namespace geopm
 
             // Note that the following statement may work even if there is insertions, but that should be tested.
             // @todo We need to evaluate the value of passing the following condition:
-            //       (m_record_count - m_last_epoch) > m_edpd->get_period()
+            //       (m_edpd->num_records() - m_last_epoch) > m_edpd->get_period()
 
             // We fail the following condition:
             //       m_edpd->get_period() < m_last_period
@@ -228,8 +255,8 @@ namespace geopm
             // An idea to be evaluated: What is get_period returns an array of string lengths with different scores
             // Definitely skip length=1 but can move on to another length with a slightly higher score.
 
-            if (m_edpd->get_period() >= m_last_period && (m_record_count - m_last_epoch) >= m_edpd->get_period()) {
-                m_last_epoch = m_record_count;
+            if (m_edpd->get_period() >= m_last_period && (m_edpd->num_records() - m_last_epoch) >= m_edpd->get_period()) {
+                m_last_epoch = m_edpd->num_records();
                 return true;
             }
         }
@@ -239,6 +266,7 @@ namespace geopm
     void EditDistEpochRecordFilter::parse_name(const std::string &name,
                                                int &history_buffer_size,
                                                int &min_hysteresis_base_period,
+                                               int &min_detectable_period,
                                                double &stable_period_hysteresis,
                                                double &unstable_period_hysteresis)
     {
@@ -246,8 +274,9 @@ namespace geopm
         GEOPM_DEBUG_ASSERT(pieces.size() > 0, "string_split() failed.");
 
         // empirically determined default values
-        history_buffer_size = 100;
+        history_buffer_size = 50;
         min_hysteresis_base_period = 4;
+        min_detectable_period = 3;
         stable_period_hysteresis = 1.0;
         unstable_period_hysteresis = 1.5;
 
@@ -269,29 +298,38 @@ namespace geopm
                 min_hysteresis_base_period = std::stoi(pieces[2]);
             }
             catch (const std::exception &ex) {
-                throw Exception("EditDistEpochRecordFilter::parse_name(): invalid stable period",
+                throw Exception("EditDistEpochRecordFilter::parse_name(): invalid hysteresis base period",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
         }
         if (pieces.size() > 3) {
             try {
-                stable_period_hysteresis = std::stod(pieces[3]);
+                min_detectable_period = std::stoi(pieces[3]);
+            }
+            catch (const std::exception &ex) {
+                throw Exception("EditDistEpochRecordFilter::parse_name(): invalid minimum detectable period",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+        }
+        if (pieces.size() > 4) {
+            try {
+                stable_period_hysteresis = std::stod(pieces[4]);
             }
             catch (const std::exception &ex) {
                 throw Exception("EditDistEpochRecordFilter::parse_name(): invalid stable hysteresis",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
         }
-        if (pieces.size() > 4) {
+        if (pieces.size() > 5) {
             try {
-                unstable_period_hysteresis = std::stod(pieces[4]);
+                unstable_period_hysteresis = std::stod(pieces[5]);
             }
             catch (const std::exception &ex) {
                 throw Exception("EditDistEpochRecordFilter::parse_name(): invalid unstable hysteresis",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
         }
-        if (pieces.size() > 5) {
+        if (pieces.size() > 6) {
             throw Exception("Too many commas in filter name", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
     }

--- a/src/EditDistEpochRecordFilter.hpp
+++ b/src/EditDistEpochRecordFilter.hpp
@@ -53,6 +53,10 @@ namespace geopm
             ///        stable in order to begin emitting epoch
             ///        records.  Suggested default is 4.
             ///
+            /// @param [in] min_detectable_period Minimum period length in
+            ///        number of records that is considered by the algorithm as
+            ///        potentially a period.  Suggested default is 3.
+            ///
             /// @param [in] stable_period_hysteresis Factor that along
             ///        with the period length that detemines when a
             ///        stable period has been detected.  Suggested
@@ -66,10 +70,12 @@ namespace geopm
             ///        is 1.5.
             EditDistEpochRecordFilter(int history_buffer_size,
                                       int min_hysteresis_base_period,
+                                      int min_detectable_period,
                                       double stable_period_hysteresis,
                                       double unstable_period_hysteresis);
             EditDistEpochRecordFilter(std::shared_ptr<EditDistPeriodicityDetector> edpd,
                                       int min_hysteresis_base_period,
+                                      int min_detectable_period,
                                       double stable_period_hysteresis,
                                       double unstable_period_hysteresis);
             EditDistEpochRecordFilter(const std::string &name);
@@ -83,6 +89,7 @@ namespace geopm
             static void parse_name(const std::string &name,
                                    int &history_buffer_size,
                                    int &min_hysteresis_base_period,
+                                   int &min_detectable_period,
                                    double &stable_period_hysteresis,
                                    double &unstable_period_hysteresis);
         private:
@@ -106,7 +113,8 @@ namespace geopm
             /// The conditions for NO_PERIOD_DETECTED -> PERIOD_DETECTED state transition:
             ///    * Stable period of N detected by String Edit Distance algorithm for
             ///      the last MAX(N, min_hysteresis_base_period) x STABLE_PERIOD_HYSTERESIS records.
-            ///    * Only periods >= MIN_DETECTABLE_PERIOD are considered as potentially stable.
+            ///    * Only periods >= MIN_DETECTABLE_PERIOD and score greater than the period are considered as
+            ///      potentially stable.
             ///
             /// The conditions for PERIOD_DETECTED -> NO_PERIOD_DETECTED state transition:
             ///    * Detected period deviated from N for the last UNSTABLE_PERIOD_HYSTERESIS x N records.
@@ -121,6 +129,9 @@ namespace geopm
             // Parameter for the epoch detection algorithm. See
             // EditDistEpochRecordFilter::epoch_detected().
             const int m_min_hysteresis_base_period;
+            // Parameter for the epoch detection algorithm. See
+            // EditDistEpochRecordFilter::epoch_detected().
+            const int m_min_detectable_period;
             // Parameter for the epoch detection algorithm. See
             // EditDistEpochRecordFilter::epoch_detected().
             const double m_stable_period_hysteresis;
@@ -139,9 +150,6 @@ namespace geopm
             int m_last_epoch;
             // Variable for the filter method.
             int m_epoch_count;
-            // Input to the stable period detector state machine.
-            // Set by the filter method.
-            int m_record_count;
     };
 }
 

--- a/src/EditDistPeriodicityDetector.cpp
+++ b/src/EditDistPeriodicityDetector.cpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <cmath>
 #include <algorithm>
+#include <limits>
 
 #include "record.hpp"
 #include "geopm_debug.hpp"
@@ -45,8 +46,11 @@ namespace geopm
 {
     EditDistPeriodicityDetector::EditDistPeriodicityDetector(int history_buffer_size)
         : m_history_buffer(history_buffer_size)
+        , m_history_buffer_size(history_buffer_size)
         , m_period(-1)
         , m_score(-1)
+        , m_record_count(0)
+        , m_DP(history_buffer_size * history_buffer_size * history_buffer_size)
     {
 
     }
@@ -55,60 +59,106 @@ namespace geopm
     {
         if (record.event == EVENT_REGION_ENTRY) {
             m_history_buffer.insert(record.signal);
+            ++m_record_count;
             calc_period();
         }
     }
 
-    void EditDistPeriodicityDetector::calc_period(void)
-    {
-        int buffer_size = m_history_buffer.size();
-        if (buffer_size < 2) {
+    size_t EditDistPeriodicityDetector::Didx(int ii, int jj, int mm) const {
+        return (ii % m_history_buffer_size) * m_history_buffer_size * m_history_buffer_size +
+               (jj % m_history_buffer_size) * m_history_buffer_size +
+               (mm % m_history_buffer_size);
+    }
+
+    void EditDistPeriodicityDetector::Dset(int ii, int jj, int mm, uint32_t val) {
+        m_DP[Didx(ii, jj, mm)] = val;
+    }
+
+    uint32_t EditDistPeriodicityDetector::Dget(int ii, int jj, int mm) const {
+        // This value is supposed to be INF but not so large that it gets wrapped around when
+        // a small value is added to it.
+        uint32_t result = std::numeric_limits<uint32_t>::max()/2;
+
+        // D[ii, jj, mm] is the string-edit distance between records [0..ii) and
+        // [mm..mm+jj). If ii is too short, the values will be truncated.
+        // Likewise, if mm is too small, this refers to data that has been lost.
+        // We want to truncate values of jj that are too *large*.
+        if (m_record_count - ii < m_history_buffer_size &&
+            jj < m_history_buffer_size &&
+            m_record_count - mm < m_history_buffer_size) {
+            result = m_DP[Didx(ii, jj, mm)];
+        }
+
+        return result;
+    }
+
+    void EditDistPeriodicityDetector::calc_period(void) {
+        if (m_record_count < 2) {
             return;
         }
 
-        size_t dim_i = m_history_buffer.size();
-        size_t dim_j = dim_i + 1;
-        size_t dim_m = dim_i + 1;
-        int DD[dim_i][dim_j][dim_m];
-        for (int mm = 0; mm < buffer_size + 1; ++mm) {
-            for (int ii = 0; ii < buffer_size; ++ii) {
-                DD[ii][0][mm] = 0;
-                DD[0][ii][mm] = ii;
-            }
+        int num_recs_in_hist = m_history_buffer.size();
+
+        for (int ii = std::max({0, m_record_count - m_history_buffer_size}); ii < m_record_count; ++ii) {
+            Dset(ii, 0, m_record_count-1, 0);
+        }
+        for (int mm = std::max({0, m_record_count - m_history_buffer_size}); mm < m_record_count; ++mm) {
+            Dset(0, m_record_count - mm, mm, m_record_count - mm);
         }
 
-        for (int mm = 1; mm < buffer_size + 1; ++mm) {
-            for (int ii = 1; ii < mm; ++ii) {
-                for (int jj = 1; jj < buffer_size - mm + 2; ++jj) {
-                    int term = (get_history_value(ii) !=
-                                get_history_value(mm + jj - 1)) ?
-                               2 : 0;
-                    DD[ii][jj][mm] = std::min({DD[ii - 1][jj    ][mm] + 1,
-                                               DD[ii    ][jj - 1][mm] + 1,
-                                               DD[ii - 1][jj - 1][mm] + term});
+        uint64_t last_rec_in_history = m_history_buffer.value(num_recs_in_hist - 1);
+        for (int mm = std::max({1, m_record_count - m_history_buffer_size}); mm < m_record_count; ++mm) {
+            for (int ii = std::max({1, m_record_count - m_history_buffer_size}); ii < mm + 1; ++ii) {
+                // If the record to be compared to the latest addition is not new enough to reside in the
+                // history buffer, by default it is not a match. If it is in the history buffer, the penalty
+                // term is 0 if they are equal.
+
+                // ii is the length of the first substring that we are comparing against. If there were
+                // no history truncation, we would be comparing entry ii - 1 (0-indexed) to the latest
+                // record, entry m_record_count - 1.
+
+                // entry_age is 1 for the most recent entry (it goes from 1 to m_record_count, inclusive)
+                int entry_age = m_record_count - (ii - 1);
+                // If entry_age is above num_recs_in_hist, it will no longer be in our buffer.
+                bool cond_newrec = entry_age <= num_recs_in_hist;
+                int term = 2;
+                if (cond_newrec) {
+                    // We still have the desired record, so we can compare it to the new one.
+                    uint64_t compared_rec = m_history_buffer.value(num_recs_in_hist - entry_age);
+                    if (compared_rec == last_rec_in_history) {
+                        term = 0;
+                    }
                 }
+                // The value that will go into the D matrix (i.e. penalty) is the minimum of the
+                // added penalties from all directions (add/subtract/replace).
+                uint32_t d_value = std::min({Dget(ii - 1, m_record_count - mm    , mm) + 1,
+                                             Dget(ii    , m_record_count - mm - 1, mm) + 1,
+                                             Dget(ii - 1, m_record_count - mm - 1, mm) + term});
+                Dset(ii, m_record_count - mm, mm, d_value);
             }
         }
 
-        int mm = 1 + (buffer_size / 2.0 + 0.5);
+        int mm = std::max({(int)(m_record_count / 2.0 + 0.5), m_record_count - m_history_buffer_size});
         int bestm = mm;
-        int bestval = DD[mm - 1][buffer_size - mm + 1][mm];
+        uint32_t bestval = Dget(mm, m_record_count - mm, mm);
         ++mm;
-        for(; mm != buffer_size + 1; ++mm) {
-            int val = DD[mm - 1][buffer_size - mm + 1][mm];
+        for(; mm < m_record_count; ++mm) {
+            uint32_t val = Dget(mm, m_record_count - mm, mm);
             if(val < bestval) {
                 bestval = val;
                 bestm = mm;
             }
         }
+
         m_score = bestval;
         // Originally this was:
         //      m_period = n - bestm + 1;
         // However since the algorithm find the bestm with the lowest index it will
         // return a string with a repeating pattern in it. For example:
         //     A B A B A B ...
-        // find_gcd will find the smallest repeating pattern in it: A B
-        m_period = find_smallest_repeating_pattern(bestm);
+        // find_min_match will find the smallest repeating pattern in it: A B
+        size_t bestm_reverse_index = m_record_count - bestm;
+        m_period = find_smallest_repeating_pattern(num_recs_in_hist - bestm_reverse_index);
     }
 
     int EditDistPeriodicityDetector::get_period(void) const
@@ -126,13 +176,19 @@ namespace geopm
         return m_history_buffer.value(index - 1);
     }
 
+    int EditDistPeriodicityDetector::num_records(void) const
+    {
+        return m_record_count;
+    }
+
     int EditDistPeriodicityDetector::find_smallest_repeating_pattern(int slice_start) const
     {
         if (m_history_buffer.size() == slice_start) {
             return 1;
         }
         std::vector<uint64_t> recs = m_history_buffer.make_vector(
-            slice_start - 1, m_history_buffer.size());
+            slice_start, m_history_buffer.size());
+
         int result = recs.size();
         bool perfect_match = false;
         int div_max = (recs.size() / 2) + 1;

--- a/src/EditDistPeriodicityDetector.hpp
+++ b/src/EditDistPeriodicityDetector.hpp
@@ -58,14 +58,23 @@ namespace geopm
             ///        detemine the period.  Until a stable period is
             ///        determined, returns -1.
             int get_score(void) const;
+            /// @brief Return the number of records that this object has
+            ///        received so far via update().
+            int num_records(void) const;
         private:
             void calc_period();
+            size_t Didx(int ii, int jj, int mm) const;
+            uint32_t Dget(int ii, int jj, int mm) const;
+            void Dset(int ii, int jj, int mm, uint32_t val);
             uint64_t get_history_value(int index) const;
             int find_smallest_repeating_pattern(int index) const;
 
             CircularBuffer<uint64_t> m_history_buffer;
+            const int m_history_buffer_size;
             int m_period;
             int m_score;
+            int m_record_count;
+            std::vector<uint32_t> m_DP;
     };
 }
 

--- a/test/EditDistEpochRecordFilterTest.cpp
+++ b/test/EditDistEpochRecordFilterTest.cpp
@@ -58,6 +58,7 @@ class EditDistEpochRecordFilterTest : public ::testing::Test
         std::vector<int> m_out_events;
         std::string m_trace_file_prefix;
         int m_min_hysteresis_base_period = 4;
+        int m_min_detectable_period = 1;
         double m_stable_hyst = 1;
         double m_unstable_hyst = 1.5;
 
@@ -104,6 +105,7 @@ TEST_F(EditDistEpochRecordFilterTest, one_region_repeated)
     int buffer_size = 16;
     geopm::EditDistEpochRecordFilter ederf(buffer_size,
                                            m_min_hysteresis_base_period,
+                                           m_min_detectable_period,
                                            m_stable_hyst,
                                            m_unstable_hyst);
     for (uint64_t count = 0; count <= 4; ++count) {
@@ -171,6 +173,7 @@ TEST_F(EditDistEpochRecordFilterTest, filter_in)
     int buffer_size = 16;
     geopm::EditDistEpochRecordFilter ederf(buffer_size,
                                            m_min_hysteresis_base_period,
+                                           m_min_detectable_period,
                                            m_stable_hyst,
                                            m_unstable_hyst);
     for (auto event : m_in_events) {
@@ -191,6 +194,7 @@ TEST_F(EditDistEpochRecordFilterTest, filter_out)
     int buffer_size = 16;
     geopm::EditDistEpochRecordFilter ederf(buffer_size,
                                            m_min_hysteresis_base_period,
+                                           m_min_detectable_period,
                                            m_stable_hyst,
                                            m_unstable_hyst);
     for (auto event : m_out_events) {
@@ -205,7 +209,7 @@ TEST_F(EditDistEpochRecordFilterTest, filter_out)
 /// Pattern 0: (A)x10
 TEST_F(EditDistEpochRecordFilterTest, pattern_a)
 {
-    int history_size = 100;
+    int history_size = 20;
 
     std::vector<record_s> testout = filter_file(m_trace_file_prefix + "0_pattern_a.trace", history_size);
     check_vals(testout, {5, 6, 7, 8, 9});
@@ -214,7 +218,7 @@ TEST_F(EditDistEpochRecordFilterTest, pattern_a)
 /// Pattern 1: (AB)x15
 TEST_F(EditDistEpochRecordFilterTest, pattern_ab)
 {
-    int history_size = 100;
+    int history_size = 20;
 
     std::vector<record_s> testout = filter_file(m_trace_file_prefix + "1_pattern_ab.trace", history_size);
     check_vals(testout, {7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29});
@@ -223,7 +227,7 @@ TEST_F(EditDistEpochRecordFilterTest, pattern_ab)
 /// Pattern 2: (ABB)x12
 TEST_F(EditDistEpochRecordFilterTest, pattern_abb)
 {
-    int history_size = 100;
+    int history_size = 20;
 
     std::vector<record_s> testout = filter_file(m_trace_file_prefix + "2_pattern_abb.trace",history_size);
     check_vals(testout, {9, 12, 15, 18, 21, 24, 27, 30, 33});
@@ -232,16 +236,16 @@ TEST_F(EditDistEpochRecordFilterTest, pattern_abb)
 /// Pattern 3: (ABCDABCDABCDC) (ABCDABCDABCDABCDC)x6 (ABCD)
 TEST_F(EditDistEpochRecordFilterTest, pattern_abcdc)
 {
-    int history_size = 100;
+    int history_size = 20;
 
     std::vector<record_s> testout = filter_file(m_trace_file_prefix + "3_pattern_abcdc.trace", history_size);
-    check_vals(testout, {11, 16, 20, 24, 28, 45, 71, 88, 105});
+    check_vals(testout, {11, 16, 24, 28, 52, 69, 86, 103});
 }
 
 /// Pattern 4: (AB) (ABABC)x3
 TEST_F(EditDistEpochRecordFilterTest, pattern_ababc)
 {
-    int history_size = 100;
+    int history_size = 20;
 
     std::vector<record_s> testout = filter_file(m_trace_file_prefix + "4_pattern_ababc.trace", history_size);
     check_vals(testout, {16, 21, 26, 31});
@@ -250,7 +254,7 @@ TEST_F(EditDistEpochRecordFilterTest, pattern_ababc)
 /// Pattern 5: (ABABABC)x6
 TEST_F(EditDistEpochRecordFilterTest, pattern_abababc)
 {
-    int history_size = 100;
+    int history_size = 20;
 
     std::vector<record_s> testout = filter_file(m_trace_file_prefix + "5_pattern_abababc.trace", history_size);
     check_vals(testout, {20, 27, 34, 41});
@@ -259,28 +263,28 @@ TEST_F(EditDistEpochRecordFilterTest, pattern_abababc)
 /// Pattern 6: (ABCD)x6 (E) (ABCD)x6
 TEST_F(EditDistEpochRecordFilterTest, pattern_add1)
 {
-    int history_size = 100;
+    int history_size = 20;
 
     std::vector<record_s> testout = filter_file(m_trace_file_prefix + "6_pattern_add1.trace", history_size);
-    check_vals(testout, {11, 15, 19, 23, 32, 36, 40, 44, 48});
+    check_vals(testout, {11, 15, 19, 23, 36, 40, 44, 48});
 }
 
 /// Pattern 7: (ABCD)x6 (EF) (ABCD)x9
 TEST_F(EditDistEpochRecordFilterTest, pattern_add2)
 {
-    int history_size = 100;
+    int history_size = 20;
 
     std::vector<record_s> testout = filter_file(m_trace_file_prefix + "7_pattern_add2.trace", history_size);
-    check_vals(testout, {11, 15, 19, 23, 32, 36, 40, 44, 48, 52, 56, 60});
+    check_vals(testout, {11, 15, 19, 23, 36, 40, 44, 48, 52, 56, 60});
 }
 
 /// Pattern 8: (ABCD)x6 (ABC) (ABCD)x12
 TEST_F(EditDistEpochRecordFilterTest, pattern_subtract1)
 {
-    int history_size = 100;
+    int history_size = 20;
 
     std::vector<record_s> testout = filter_file(m_trace_file_prefix + "8_pattern_subtract1.trace", history_size);
-    check_vals(testout, {11, 15, 19, 23, 33, 38, 42, 46, 50, 54, 58, 62, 66, 70, 74});
+    check_vals(testout, {11, 15, 19, 23, 46, 50, 54, 58, 62, 66, 70, 74});
 }
 
 TEST_F(EditDistEpochRecordFilterTest, parse_name)
@@ -288,82 +292,128 @@ TEST_F(EditDistEpochRecordFilterTest, parse_name)
     int buffer_size = -1;
     double stable_hyst = NAN;
     int min_hysteresis_base_period = -1;
+    int min_detectable_period = -1;
     double unstable_hyst = NAN;
 
     EditDistEpochRecordFilter::parse_name("edit_distance",
-                                          buffer_size, min_hysteresis_base_period,
-                                          stable_hyst, unstable_hyst);
+                                          buffer_size,
+                                          min_hysteresis_base_period,
+                                          min_detectable_period,
+                                          stable_hyst,
+                                          unstable_hyst);
     // default values
-    EXPECT_EQ(100, buffer_size);
+    EXPECT_EQ(50, buffer_size);
     EXPECT_EQ(1.0, stable_hyst);
     EXPECT_EQ(4, min_hysteresis_base_period);
+    EXPECT_EQ(3, min_detectable_period);
     EXPECT_EQ(1.5, unstable_hyst);
 
     EditDistEpochRecordFilter::parse_name("edit_distance,42",
-                                          buffer_size, min_hysteresis_base_period,
-                                          stable_hyst, unstable_hyst);
+                                          buffer_size,
+                                          min_hysteresis_base_period,
+                                          min_detectable_period,
+                                          stable_hyst,
+                                          unstable_hyst);
     EXPECT_EQ(42, buffer_size);
     EXPECT_EQ(4, min_hysteresis_base_period);
+    EXPECT_EQ(3, min_detectable_period);
     EXPECT_EQ(1.0, stable_hyst);
     EXPECT_EQ(1.5, unstable_hyst);
 
     EditDistEpochRecordFilter::parse_name("edit_distance,52,20",
-                                          buffer_size, min_hysteresis_base_period,
-                                          stable_hyst, unstable_hyst);
+                                          buffer_size,
+                                          min_hysteresis_base_period,
+                                          min_detectable_period,
+                                          stable_hyst,
+                                          unstable_hyst);
     EXPECT_EQ(52, buffer_size);
     EXPECT_EQ(20, min_hysteresis_base_period);
+    EXPECT_EQ(3, min_detectable_period);
     EXPECT_EQ(1.0, stable_hyst);
     EXPECT_EQ(1.5, unstable_hyst);
 
-    EditDistEpochRecordFilter::parse_name("edit_distance,62,30,5.0",
-                                          buffer_size, min_hysteresis_base_period,
-                                          stable_hyst, unstable_hyst);
+    EditDistEpochRecordFilter::parse_name("edit_distance,52,20,105",
+                                          buffer_size,
+                                          min_hysteresis_base_period,
+                                          min_detectable_period,
+                                          stable_hyst,
+                                          unstable_hyst);
+    EXPECT_EQ(52, buffer_size);
+    EXPECT_EQ(20, min_hysteresis_base_period);
+    EXPECT_EQ(105, min_detectable_period);
+    EXPECT_EQ(1.0, stable_hyst);
+    EXPECT_EQ(1.5, unstable_hyst);
+
+    EditDistEpochRecordFilter::parse_name("edit_distance,62,30,115,5.0",
+                                          buffer_size,
+                                          min_hysteresis_base_period,
+                                          min_detectable_period,
+                                          stable_hyst,
+                                          unstable_hyst);
     EXPECT_EQ(62, buffer_size);
     EXPECT_EQ(30, min_hysteresis_base_period);
+    EXPECT_EQ(115, min_detectable_period);
     EXPECT_EQ(5.0, stable_hyst);
     EXPECT_EQ(1.5, unstable_hyst);
 
-    EditDistEpochRecordFilter::parse_name("edit_distance,62,40,6.0,3.5",
-                                          buffer_size, min_hysteresis_base_period,
-                                          stable_hyst, unstable_hyst);
+    EditDistEpochRecordFilter::parse_name("edit_distance,62,40,125,6.0,3.5",
+                                          buffer_size,
+                                          min_hysteresis_base_period,
+                                          min_detectable_period,
+                                          stable_hyst,
+                                          unstable_hyst);
     EXPECT_EQ(62, buffer_size);
     EXPECT_EQ(40, min_hysteresis_base_period);
+    EXPECT_EQ(125, min_detectable_period);
     EXPECT_EQ(6.0, stable_hyst);
     EXPECT_EQ(3.5, unstable_hyst);
 
     GEOPM_EXPECT_THROW_MESSAGE(EditDistEpochRecordFilter::parse_name("not_edit_distance",
                                                                      buffer_size,
                                                                      min_hysteresis_base_period,
+                                                                     m_min_detectable_period,
                                                                      stable_hyst,
                                                                      unstable_hyst),
                                GEOPM_ERROR_INVALID, "Unknown filter name");
     GEOPM_EXPECT_THROW_MESSAGE(EditDistEpochRecordFilter::parse_name("edit_distance,invalid",
                                                                      buffer_size,
                                                                      min_hysteresis_base_period,
+                                                                     m_min_detectable_period,
                                                                      stable_hyst,
                                                                      unstable_hyst),
                                GEOPM_ERROR_INVALID, "invalid buffer size");
     GEOPM_EXPECT_THROW_MESSAGE(EditDistEpochRecordFilter::parse_name("edit_distance,1,invalid",
                                                                      buffer_size,
                                                                      min_hysteresis_base_period,
+                                                                     m_min_detectable_period,
                                                                      stable_hyst,
                                                                      unstable_hyst),
-                               GEOPM_ERROR_INVALID, "invalid stable period");
+                               GEOPM_ERROR_INVALID, "invalid hysteresis base period");
     GEOPM_EXPECT_THROW_MESSAGE(EditDistEpochRecordFilter::parse_name("edit_distance,1,1,invalid",
                                                                      buffer_size,
                                                                      min_hysteresis_base_period,
+                                                                     m_min_detectable_period,
                                                                      stable_hyst,
                                                                      unstable_hyst),
-                               GEOPM_ERROR_INVALID, "invalid stable hysteresis");
+                               GEOPM_ERROR_INVALID, "invalid minimum detectable period");
     GEOPM_EXPECT_THROW_MESSAGE(EditDistEpochRecordFilter::parse_name("edit_distance,1,1,1,invalid",
                                                                      buffer_size,
                                                                      min_hysteresis_base_period,
+                                                                     m_min_detectable_period,
+                                                                     stable_hyst,
+                                                                     unstable_hyst),
+                               GEOPM_ERROR_INVALID, "invalid stable hysteresis");
+    GEOPM_EXPECT_THROW_MESSAGE(EditDistEpochRecordFilter::parse_name("edit_distance,1,1,1,1,invalid",
+                                                                     buffer_size,
+                                                                     min_hysteresis_base_period,
+                                                                     m_min_detectable_period,
                                                                      stable_hyst,
                                                                      unstable_hyst),
                                GEOPM_ERROR_INVALID, "invalid unstable hysteresis");
     GEOPM_EXPECT_THROW_MESSAGE(EditDistEpochRecordFilter::parse_name("edit_distance,1,1,1,2,2,2",
                                                                      buffer_size,
                                                                      min_hysteresis_base_period,
+                                                                     m_min_detectable_period,
                                                                      stable_hyst,
                                                                      unstable_hyst),
                                GEOPM_ERROR_INVALID, "Too many commas");
@@ -377,6 +427,7 @@ std::vector<record_s> EditDistEpochRecordFilterTest::filter_file(std::string tra
 
     geopm::EditDistEpochRecordFilter ederf(buffer_size,
                                            m_min_hysteresis_base_period,
+                                           m_min_detectable_period,
                                            m_stable_hyst,
                                            m_unstable_hyst);
 

--- a/test/EditDistPeriodicityDetectorTest.cpp
+++ b/test/EditDistPeriodicityDetectorTest.cpp
@@ -57,9 +57,9 @@ void EditDistPeriodicityDetectorTest::SetUp()
     m_trace_file_prefix += "/test/EditDistPeriodicityDetectorTest.";
 }
 
-void check_vals(std::string trace_file_path, int warmup, int period, int history_size=100);
+void check_vals(std::string trace_file_path, int warmup, int period, int history_size=20);
 void check_vals(std::string trace_file_path, int start, int end, int period, int history_size);
-void check_vals(std::vector<record_s> recs, std::vector<std::vector<int> > expected, int history_size=100);
+void check_vals(std::vector<record_s> recs, std::vector<std::vector<int> > expected, int history_size=20);
 
 
 /// Pattern 0: (A)x10
@@ -67,7 +67,7 @@ TEST_F(EditDistPeriodicityDetectorTest, pattern_a)
 {
     int warmup = 1;
     int period = 1;
-    int history_size = 100;
+    int history_size = 20;
 
     check_vals(m_trace_file_prefix + "0_pattern_a.trace", warmup, period, history_size);
 }
@@ -77,7 +77,7 @@ TEST_F(EditDistPeriodicityDetectorTest, pattern_ab)
 {
     int warmup = 3;
     int period = 2;
-    int history_size = 100;
+    int history_size = 20;
 
     check_vals(m_trace_file_prefix + "1_pattern_ab.trace", warmup, period, history_size);
 }
@@ -87,7 +87,7 @@ TEST_F(EditDistPeriodicityDetectorTest, pattern_abb)
 {
     int warmup = 5;
     int period = 3;
-    int history_size = 100;
+    int history_size = 20;
 
     check_vals(m_trace_file_prefix + "2_pattern_abb.trace", warmup, period, history_size);
 }
@@ -97,7 +97,7 @@ TEST_F(EditDistPeriodicityDetectorTest, pattern_abcdc)
 {
     int warmup = 33;
     int period = 17;
-    int history_size = 100;
+    int history_size = 20;
 
     check_vals(m_trace_file_prefix + "3_pattern_abcdc.trace", warmup, period, history_size);
 }
@@ -117,7 +117,7 @@ TEST_F(EditDistPeriodicityDetectorTest, pattern_abababc)
 {
     int warmup = 13;
     int period = 7;
-    int history_size = 100;
+    int history_size = 20;
 
     check_vals(m_trace_file_prefix + "5_pattern_abababc.trace", warmup, period, history_size);
 }
@@ -126,7 +126,7 @@ TEST_F(EditDistPeriodicityDetectorTest, pattern_abababc)
 TEST_F(EditDistPeriodicityDetectorTest, pattern_add1)
 {
     int period = 4;
-    int history_size = 100;
+    int history_size = 20;
 
     check_vals(m_trace_file_prefix + "6_pattern_add1.trace", 7, 24, period, history_size);
     int warmup = 32;
@@ -137,7 +137,7 @@ TEST_F(EditDistPeriodicityDetectorTest, pattern_add1)
 TEST_F(EditDistPeriodicityDetectorTest, pattern_add2)
 {
     int period = 4;
-    int history_size = 100;
+    int history_size = 20;
 
     check_vals(m_trace_file_prefix + "7_pattern_add2.trace", 7, 24, period, history_size);
     check_vals(m_trace_file_prefix + "7_pattern_add2.trace", 33, period, history_size);
@@ -147,7 +147,7 @@ TEST_F(EditDistPeriodicityDetectorTest, pattern_add2)
 TEST_F(EditDistPeriodicityDetectorTest, pattern_subtract1)
 {
     int period = 4;
-    int history_size = 100;
+    int history_size = 20;
 
     check_vals(m_trace_file_prefix + "8_pattern_subtract1.trace", 7, 27, period, history_size);
     check_vals(m_trace_file_prefix + "8_pattern_subtract1.trace", 54, period, history_size);

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -143,9 +143,25 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/EditDistEpochRecordFilterTest.one_region_repeated \
               test/gtest_links/EditDistEpochRecordFilterTest.filter_in \
               test/gtest_links/EditDistEpochRecordFilterTest.filter_out \
+              test/gtest_links/EditDistEpochRecordFilterTest.pattern_a \
+              test/gtest_links/EditDistEpochRecordFilterTest.pattern_ab \
+              test/gtest_links/EditDistEpochRecordFilterTest.pattern_abb \
+              test/gtest_links/EditDistEpochRecordFilterTest.pattern_abcdc \
+              test/gtest_links/EditDistEpochRecordFilterTest.pattern_ababc \
+              test/gtest_links/EditDistEpochRecordFilterTest.pattern_abababc \
+              test/gtest_links/EditDistEpochRecordFilterTest.pattern_add1 \
+              test/gtest_links/EditDistEpochRecordFilterTest.pattern_add2 \
+              test/gtest_links/EditDistEpochRecordFilterTest.pattern_subtract1 \
+              test/gtest_links/EditDistEpochRecordFilterTest.parse_name \
               test/gtest_links/EditDistPeriodicityDetectorTest.pattern_a \
               test/gtest_links/EditDistPeriodicityDetectorTest.pattern_ab \
               test/gtest_links/EditDistPeriodicityDetectorTest.pattern_abb \
+              test/gtest_links/EditDistPeriodicityDetectorTest.pattern_abcdc \
+              test/gtest_links/EditDistPeriodicityDetectorTest.pattern_ababc \
+              test/gtest_links/EditDistPeriodicityDetectorTest.pattern_abababc \
+              test/gtest_links/EditDistPeriodicityDetectorTest.pattern_add1 \
+              test/gtest_links/EditDistPeriodicityDetectorTest.pattern_add2 \
+              test/gtest_links/EditDistPeriodicityDetectorTest.pattern_subtract1 \
               test/gtest_links/EndpointTest.attach_wait_loop_timeout_throws \
               test/gtest_links/EndpointTest.detach_wait_loop_timeout_throws \
               test/gtest_links/EndpointTest.get_hostnames \


### PR DESCRIPTION
- Implemented the AED progressive dynamic-programming table optimization implemented in StringEditPeriodicityDetector class which speeds up the algorithm without changing its output. (Formerly known as online AED)
- Added a new knob in the StringEditEpochRecordFilter class: min_detectable_period.
- Some AED related tests were not included in the test/Makefile. Adding these tests to the Makefile exposed broken tests, fixed those tests.