### PR TITLE
Update the way run scripts populate the argument parser

### DIFF
--- a/integration/experiment/common_args.py
+++ b/integration/experiment/common_args.py
@@ -44,84 +44,84 @@ def setup_run_args(parser):
     add_cool_off_time(parser)
 
 
-def add_output_dir(parser, default='.'):
+def add_output_dir(parser):
     parser.add_argument('--output-dir', dest='output_dir',
-                        action='store', default=default,
+                        action='store', default='.',
                         help='location for reports and other output files')
 
 
-def add_trial_count(parser, default=2):
+def add_trial_count(parser):
     parser.add_argument('--trial-count', dest='trial_count',
-                        action='store', type=int, default=default,
+                        action='store', type=int, default=2,
                         help='number of experiment trials to launch')
 
 
-def add_node_count(parser, default=1):
+def add_node_count(parser):
     parser.add_argument('--node-count', dest='node_count',
-                        default=default, type=int,
+                        default=1, type=int,
                         help='number of nodes to use for launch')
 
 
-def add_show_details(parser, default=False):
+def add_show_details(parser):
         parser.add_argument('--show-details', dest='show_details',
-                            action='store_true', default=default,
+                            action='store_true', default=False,
                             help='print additional data analysis details')
 
 
-def add_min_power(parser, default=None):
+def add_min_power(parser):
     parser.add_argument('--min-power', dest='min_power',
-                        action='store', type=float, default=default,
+                        action='store', type=float, default=None,
                         help='bottom power limit for the sweep')
 
 
-def add_max_power(parser, default=None):
+def add_max_power(parser):
     parser.add_argument('--max-power', dest='max_power',
-                        action='store', type=float, default=default,
+                        action='store', type=float, default=None,
                         help='top power limit for the sweep')
 
 
-def add_step_power(parser, default=10):
+def add_step_power(parser):
     parser.add_argument('--step-power', dest='step_power',
-                        action='store', type=float, default=default,
+                        action='store', type=float, default=10,
                         help='increment between power steps for sweep')
 
 
-def add_label(parser, default="APP"):
-    parser.add_argument('--label', action='store', default=default,
+def add_label(parser):
+    parser.add_argument('--label', action='store', default="APP",
                         help='name of the application to use for plot titles')
 
 
-def add_min_frequency(parser, default=None):
+def add_min_frequency(parser):
     parser.add_argument('--min-frequency', dest='min_frequency',
-                        action='store', type=float, default=default,
+                        action='store', type=float, default=None,
                         help='bottom frequency limit for the sweep')
 
 
-def add_max_frequency(parser, default=None):
+def add_max_frequency(parser):
     parser.add_argument('--max-frequency', dest='max_frequency',
-                        action='store', type=float, default=default,
+                        action='store', type=float, default=None,
                         help='top frequency limit for the sweep')
 
 
-def add_step_frequency(parser, default=None):
+def add_step_frequency(parser):
     parser.add_argument('--step-frequency', dest='step_frequency',
-                        action='store', type=float, default=default,
+                        action='store', type=float, default=None,
                         help='increment between frequency steps for sweep')
 
 
-def add_use_stdev(parser, default=False):
+def add_use_stdev(parser):
     parser.add_argument('--use-stdev', dest='use_stdev',
-                        action='store_true', default=default,
+                        action='store_true', default=False,
                         help='use standard deviation instead of min-max spread for error bars')
 
 
-def add_cool_off_time(parser, default=60):
+def add_cool_off_time(parser):
     parser.add_argument('--cool-off-time', dest='cool_off_time',
-                        action='store', type=float, default=default,
+                        action='store', type=float, default=60,
                         help='wait time between workload execution for cool down')
 
 
-def add_agent_list(parser, default=None):
+def add_agent_list(parser):
     parser.add_argument('--agent-list', dest='agent_list',
-                        action='store', type=str, default=default,
+                        action='store', type=str, default=None,
                         help='comma separated list of agents to be compared')

--- a/integration/experiment/common_args.py
+++ b/integration/experiment/common_args.py
@@ -34,61 +34,94 @@
 Common command line arguments for experiments.
 '''
 
+def setup_run_args(parser):
+    """Add common arguments for all run scripts:
+       --output-dir --node-count --trial-count --cool-off-time
+    """
+    add_output_dir(parser)
+    add_node_count(parser)
+    add_trial_count(parser)
+    add_cool_off_time(parser)
 
-def add_output_dir(parser):
-    parser.add_argument('-o', '--output-dir', dest='output_dir',
-                        action='store', default='.',
+
+def add_output_dir(parser, default='.'):
+    parser.add_argument('--output-dir', dest='output_dir',
+                        action='store', default=default,
                         help='location for reports and other output files')
 
 
-def add_nodes(parser):
-    parser.add_argument('--nodes', dest='nodes',
-                        default=1, type=int,
+def add_trial_count(parser, default=2):
+    parser.add_argument('--trial-count', dest='trial_count',
+                        action='store', type=int, default=default,
+                        help='number of experiment trials to launch')
+
+
+def add_node_count(parser, default=1):
+    parser.add_argument('--node-count', dest='node_count',
+                        default=default, type=int,
                         help='number of nodes to use for launch')
 
 
-def add_show_details(parser):
+def add_show_details(parser, default=False):
         parser.add_argument('--show-details', dest='show_details',
-                            action='store_true', default=False,
+                            action='store_true', default=default,
                             help='print additional data analysis details')
 
 
-def add_min_power(parser):
+def add_min_power(parser, default=None):
     parser.add_argument('--min-power', dest='min_power',
-                        action='store', type=float, default=None,
+                        action='store', type=float, default=default,
                         help='bottom power limit for the sweep')
 
 
-def add_max_power(parser):
+def add_max_power(parser, default=None):
     parser.add_argument('--max-power', dest='max_power',
-                        action='store', type=float, default=None,
+                        action='store', type=float, default=default,
                         help='top power limit for the sweep')
 
 
-def add_label(parser):
-    parser.add_argument('--label', action='store', default="APP",
+def add_step_power(parser, default=10):
+    parser.add_argument('--step-power', dest='step_power',
+                        action='store', type=float, default=default,
+                        help='increment between power steps for sweep')
+
+
+def add_label(parser, default="APP"):
+    parser.add_argument('--label', action='store', default=default,
                         help='name of the application to use for plot titles')
 
 
-def add_min_frequency(parser):
+def add_min_frequency(parser, default=None):
     parser.add_argument('--min-frequency', dest='min_frequency',
-                        action='store', type=float, default=None,
+                        action='store', type=float, default=default,
                         help='bottom frequency limit for the sweep')
 
 
-def add_max_frequency(parser):
+def add_max_frequency(parser, default=None):
     parser.add_argument('--max-frequency', dest='max_frequency',
-                        action='store', type=float, default=None,
+                        action='store', type=float, default=default,
                         help='top frequency limit for the sweep')
 
 
-def add_iterations(parser):
-    parser.add_argument('--iterations', dest='iterations',
-                        action='store', type=int, default=2,
-                        help='number of iterations to launch')
+def add_step_frequency(parser, default=None):
+    parser.add_argument('--step-frequency', dest='step_frequency',
+                        action='store', type=float, default=default,
+                        help='increment between frequency steps for sweep')
 
 
-def add_use_stdev(parser):
+def add_use_stdev(parser, default=False):
     parser.add_argument('--use-stdev', dest='use_stdev',
-                        action='store_true', default=False,
+                        action='store_true', default=default,
                         help='use standard deviation instead of min-max spread for error bars')
+
+
+def add_cool_off_time(parser, default=60):
+    parser.add_argument('--cool-off-time', dest='cool_off_time',
+                        action='store', type=float, default=default,
+                        help='wait time between workload execution for cool down')
+
+
+def add_agent_list(parser, default=None):
+    parser.add_argument('--agent-list', dest='agent_list',
+                        action='store', type=str, default=default,
+                        help='comma separated list of agents to be compared')

--- a/integration/experiment/energy_efficiency/barrier_frequency_sweep.py
+++ b/integration/experiment/energy_efficiency/barrier_frequency_sweep.py
@@ -89,7 +89,7 @@ def trace_signals():
     return ["MSR::UNCORE_PERF_STATUS:FREQ@package"]
 
 
-def launch(app_conf_init, args, experiment_cli_args):
+def launch(app_conf_ref, app_conf, args, experiment_cli_args):
     mach = machine.init_output_dir(args.output_dir)
     freq_range = frequency_sweep.setup_frequency_bounds(mach,
                                                         args.min_frequency,
@@ -98,8 +98,8 @@ def launch(app_conf_init, args, experiment_cli_args):
                                                         add_turbo_step=True)
     barrier_hash = geopmpy.hash.crc32_str('MPI_Barrier')
     default_freq = max(freq_range)
-    targets = launch_configs(app_conf_ref=app_conf_init(add_barriers=False),
-                             app_conf=app_conf_init(add_barriers=True),
+    targets = launch_configs(app_conf_ref=app_conf_ref,
+                             app_conf=app_conf,
                              default_freq=max(freq_range),
                              sweep_freqs=freq_range,
                              barrier_hash=geopmpy.hash.crc32_str('MPI_Barrier'))
@@ -115,11 +115,13 @@ def launch(app_conf_init, args, experiment_cli_args):
                                 cool_off_time=args.cool_off_time)
 
 
-def main(app_conf_init, **defaults):
+def main(app_conf_ref, app_conf, **defaults):
     parser = argparse.ArgumentParser()
     # Use frequency sweep's run args
     frequency_sweep.setup_run_args(parser)
     parser.set_defaults(**defaults)
     args, extra_cli_args = parser.parse_known_args()
-    launch(app_conf_init=app_conf_init, args=args,
+    launch(app_conf_ref=app_conf_ref,
+           app_conf=app_conf,
+           args=args,
            experiment_cli_args=extra_cli_args)

--- a/integration/experiment/energy_efficiency/power_balancer_energy.py
+++ b/integration/experiment/energy_efficiency/power_balancer_energy.py
@@ -31,7 +31,11 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+import argparse
+
 from experiment import launch_util
+from experiment import common_args
+from experiment import machine
 from experiment.power_sweep import power_sweep
 from experiment.monitor import monitor
 
@@ -60,19 +64,30 @@ def trace_signals():
     return power_sweep.trace_signals()
 
 
-def launch(output_dir, iterations,
-           min_power, max_power, step_power,
-           num_nodes, app_conf_ref, app_conf,
-           experiment_cli_args, cool_off_time=60):
-
+def launch(app_conf, args, experiment_cli_args):
+    agent_types = args.agent_list.split(',')
+    mach = machine.init_output_dir(args.output_dir)
+    min_power, max_power = setup_power_bounds(mach, args.min_power,
+                                              args.max_power, args.step_power)
+    targets = launch_configs(app_conf, agent_types, min_power, max_power, args.step_power)
     extra_cli_args = list(experiment_cli_args)
     extra_cli_args += launch_util.geopm_signal_args(report_signals=report_signals(),
                                                     trace_signals=trace_signals())
-    targets = launch_configs(app_conf_ref, app_conf, min_power, max_power, step_power)
-
     launch_util.launch_all_runs(targets=targets,
-                                num_nodes=num_nodes,
-                                iterations=iterations,
+                                num_nodes=args.node_count,
+                                iterations=args.trial_count,
                                 extra_cli_args=extra_cli_args,
-                                output_dir=output_dir,
-                                cool_off_time=cool_off_time)
+                                output_dir=args.output_dir,
+                                cool_off_time=args.cool_off_time)
+
+
+def main(app_conf, **defaults):
+    parser = argparse.ArgumentParser()
+    # Use power sweep's run args
+    power_sweep.setup_run_args(parser)
+    parser.set_defaults(**defaults)
+    # Change default agent_list (power_sweep runs the governor also)
+    parser.set_defaults(agent_list='power_balancer')
+    args, extra_cli_args = parser.parse_known_args()
+    launch(app_conf=app_conf, args=args,
+           experiment_cli_args=extra_cli_args)

--- a/integration/experiment/energy_efficiency/run_barrier_frequency_sweep_nekbone.py
+++ b/integration/experiment/energy_efficiency/run_barrier_frequency_sweep_nekbone.py
@@ -42,5 +42,6 @@ from apps.nekbone import nekbone
 
 if __name__ == '__main__':
 
-    app_conf_init = nekbone.NekboneAppConf
-    barrier_frequency_sweep.main(app_conf_init)
+    app_conf_ref = nekbone.NekboneAppConf(add_barriers=False)
+    app_conf = nekbone.NekboneAppConf(add_barriers=True)
+    barrier_frequency_sweep.main(app_conf_ref, app_conf)

--- a/integration/experiment/energy_efficiency/run_barrier_frequency_sweep_nekbone.py
+++ b/integration/experiment/energy_efficiency/run_barrier_frequency_sweep_nekbone.py
@@ -36,52 +36,11 @@ Frequency map experiment comparing nekbone with added barriers run
 at a lower frequency to the baseline with no added barriers.
 '''
 
-import argparse
-
-import geopmpy.hash
-from experiment import common_args
-from experiment import machine
-from experiment.frequency_sweep import frequency_sweep
 from experiment.energy_efficiency import barrier_frequency_sweep
 from apps.nekbone import nekbone
 
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_frequency(parser)
-    common_args.add_max_frequency(parser)
-    common_args.add_iterations(parser)
-    # TODO: option for add turbo step
-
-    args, extra_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-
-    # application parameters
-    baseline_app = nekbone.NekboneAppConf(add_barriers=False)
-    target_app = nekbone.NekboneAppConf(add_barriers=True)
-    barrier_hash = geopmpy.hash.crc32_str('MPI_Barrier')
-
-    # experiment parameters
-    mach = machine.init_output_dir(output_dir)
-    min_freq = args.min_frequency
-    max_freq = args.max_frequency
-    step_freq = None
-    freqs = frequency_sweep.setup_frequency_bounds(mach, min_freq, max_freq, step_freq,
-                                                   add_turbo_step=True)
-    default_freq = max(freqs)
-    iterations = args.iterations
-
-    barrier_frequency_sweep.launch(output_dir=output_dir,
-                                   iterations=iterations,
-                                   default_freq=default_freq,
-                                   sweep_freqs=freqs,
-                                   barrier_hash=barrier_hash,
-                                   num_nodes=num_nodes,
-                                   app_conf_ref=baseline_app,
-                                   app_conf=target_app,
-                                   experiment_cli_args=extra_cli_args)
+    app_conf_init = nekbone.NekboneAppConf
+    barrier_frequency_sweep.main(app_conf_init)

--- a/integration/experiment/energy_efficiency/run_power_balancer_energy_dgemm.py
+++ b/integration/experiment/energy_efficiency/run_power_balancer_energy_dgemm.py
@@ -31,46 +31,12 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-import argparse
 
-from experiment import common_args
-from experiment import machine
+from experiment.energy_efficiency import power_balancer_energy
 from apps import geopmbench
 
-from experiment.power_sweep import power_sweep
-from experiment.energy_efficiency import power_balancer_energy
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_power(parser)
-    common_args.add_max_power(parser)
-    common_args.add_iterations(parser)
-
-    args, extra_cli_args = parser.parse_known_args()
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
-
-    # application parameters
     app_conf = geopmbench.DgemmAppConf()
-
-    # experiment parameters
-    min_power = args.min_power
-    max_power = args.max_power
-    step_power = 10
-    min_power, max_power = power_sweep.setup_power_bounds(mach, min_power,
-                                                          max_power, step_power)
-    iterations = args.iterations
-
-    power_balancer_energy.launch(output_dir=output_dir,
-                                 iterations=iterations,
-                                 min_power=min_power,
-                                 max_power=max_power,
-                                 step_power=step_power,
-                                 num_nodes=num_nodes,
-                                 app_conf_ref=app_conf,
-                                 app_conf=app_conf,
-                                 experiment_cli_args=extra_cli_args)
+    power_balancer_energy.main(app_conf)

--- a/integration/experiment/energy_efficiency/run_power_balancer_energy_nekbone.py
+++ b/integration/experiment/energy_efficiency/run_power_balancer_energy_nekbone.py
@@ -31,47 +31,13 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-import argparse
 
-from experiment import common_args
-from experiment import machine
-from apps.nekbone import nekbone
-
-
-from experiment.power_sweep import power_sweep
 from experiment.energy_efficiency import power_balancer_energy
+from apps import nekbone
+
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_power(parser)
-    common_args.add_max_power(parser)
-    common_args.add_iterations(parser)
-
-    args, extra_cli_args = parser.parse_known_args()
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
-
-    # application parameters
     app_conf = nekbone.NekboneAppConf()
+    power_balancer_energy.main(app_conf)
 
-    # experiment parameters
-    min_power = args.min_power
-    max_power = args.max_power
-    iterations = args.iterations
-    step_power = 10
-    min_power, max_power = power_sweep.setup_power_bounds(mach, min_power,
-                                                          max_power, step_power)
-
-    power_balancer_energy.launch(output_dir=output_dir,
-                                 iterations=iterations,
-                                 min_power=min_power,
-                                 max_power=max_power,
-                                 step_power=step_power,
-                                 num_nodes=num_nodes,
-                                 app_conf_ref=app_conf,
-                                 app_conf=app_conf,
-                                 experiment_cli_args=extra_cli_args)

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_dgemm.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_dgemm.py
@@ -35,42 +35,12 @@
 Example frequency sweep experiment using geopmbench.
 '''
 
-import argparse
 
-from experiment import common_args
 from experiment.frequency_sweep import frequency_sweep
-from experiment import machine
 from apps import geopmbench
+
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_frequency(parser)
-    common_args.add_max_frequency(parser)
-    common_args.add_iterations(parser)
-
-    args, extra_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
-
-    # application parameters
     app_conf = geopmbench.DgemmAppConf()
-
-    # experiment parameters
-    min_freq = args.min_frequency
-    max_freq = args.max_frequency
-    step_freq = None
-    freqs = frequency_sweep.setup_frequency_bounds(mach, min_freq, max_freq, step_freq,
-                                                   add_turbo_step=True)
-    iterations = args.iterations
-    frequency_sweep.launch(output_dir=output_dir,
-                           iterations=iterations,
-                           freq_range=freqs,
-                           agent_types=['frequency_map'],
-                           num_node=num_nodes,
-                           app_conf=app_conf,
-                           experiment_cli_args=extra_cli_args)
+    frequency_sweep.main(app_conf)

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_dgemm_tiny.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_dgemm_tiny.py
@@ -35,43 +35,12 @@
 Example frequency sweep experiment using geopmbench.
 '''
 
-import argparse
 
-from experiment import common_args
 from experiment.frequency_sweep import frequency_sweep
-from experiment import machine
 from apps import geopmbench
+
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_frequency(parser)
-    common_args.add_max_frequency(parser)
-    common_args.add_iterations(parser)
-
-    args, extra_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
-
-    # application parameters
     app_conf = geopmbench.TinyAppConf()
-
-    # experiment parameters
-    min_freq = args.min_frequency
-    max_freq = args.max_frequency
-    step_freq = None
-    freqs = frequency_sweep.setup_frequency_bounds(mach, min_freq, max_freq, step_freq,
-                                                   add_turbo_step=True)
-    iterations = args.iterations
-    frequency_sweep.launch(output_dir=output_dir,
-                           iterations=iterations,
-                           freq_range=freqs,
-                           agent_types=['frequency_map'],
-                           num_node=num_nodes,
-                           app_conf=app_conf,
-                           experiment_cli_args=extra_cli_args,
-                           cool_off_time=0)
+    frequency_sweep.main(app_conf, cool_off_time=0)

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_minife.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_minife.py
@@ -38,13 +38,14 @@ Example frequency sweep experiment using miniFE.
 import argparse
 
 from experiment.frequency_sweep import frequency_sweep
-from apps import minife
+from apps.minife import minife
+
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     frequency_sweep.setup_run_args(parser)
     args, extra_cli_args = parser.parse_known_args()
-    app_conf = minife.MinifeAppConf(num_nodes)
+    app_conf = minife.MinifeAppConf(args.node_count)
     frequency_sweep.launch(app_conf=app_conf, args=args,
                            experiment_cli_args=extra_cli_args)

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_minife.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_minife.py
@@ -37,41 +37,14 @@ Example frequency sweep experiment using miniFE.
 
 import argparse
 
-from experiment import common_args
 from experiment.frequency_sweep import frequency_sweep
-from experiment import machine
-from apps.minife import minife
-
+from apps import minife
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_frequency(parser)
-    common_args.add_max_frequency(parser)
-    common_args.add_iterations(parser)
-
+    frequency_sweep.setup_run_args(parser)
     args, extra_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
-
-    # application parameters
     app_conf = minife.MinifeAppConf(num_nodes)
-
-    # experiment parameters
-    min_freq = args.min_frequency
-    max_freq = args.max_frequency
-    step_freq = None
-    freqs = frequency_sweep.setup_frequency_bounds(mach, min_freq, max_freq, step_freq,
-                                                   add_turbo_step=True)
-    iterations = args.iterations
-    frequency_sweep.launch(output_dir=output_dir,
-                           iterations=iterations,
-                           freq_range=freqs,
-                           agent_types=['frequency_map'],
-                           num_node=num_nodes,
-                           app_conf=app_conf,
+    frequency_sweep.launch(app_conf=app_conf, args=args,
                            experiment_cli_args=extra_cli_args)

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_nekbone.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_nekbone.py
@@ -37,7 +37,7 @@ Example frequency sweep experiment using Nekbone.
 
 
 from experiment.frequency_sweep import frequency_sweep
-from apps import nekbone
+from apps.nekbone import nekbone
 
 
 if __name__ == '__main__':

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_nekbone.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_nekbone.py
@@ -35,42 +35,12 @@
 Example frequency sweep experiment using Nekbone.
 '''
 
-import argparse
 
-from experiment import common_args
 from experiment.frequency_sweep import frequency_sweep
-from experiment import machine
-from apps.nekbone import nekbone
+from apps import nekbone
+
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_frequency(parser)
-    common_args.add_max_frequency(parser)
-    common_args.add_iterations(parser)
-
-    args, extra_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
-
-    # application parameters
     app_conf = nekbone.NekboneAppConf()
-
-    # experiment parameters
-    min_freq = args.min_frequency
-    max_freq = args.max_frequency
-    step_freq = None
-    freqs = frequency_sweep.setup_frequency_bounds(mach, min_freq, max_freq, step_freq,
-                                                   add_turbo_step=True)
-    iterations = args.iterations
-    frequency_sweep.launch(output_dir=output_dir,
-                           iterations=iterations,
-                           freq_range=freqs,
-                           agent_types=['frequency_map'],
-                           num_node=num_nodes,
-                           app_conf=app_conf,
-                           experiment_cli_args=extra_cli_args)
+    frequency_sweep.main(app_conf)

--- a/integration/experiment/monitor/monitor.py
+++ b/integration/experiment/monitor/monitor.py
@@ -33,7 +33,13 @@
 Helper functions for running the monitor agent.
 '''
 
+import argparse
+
 from experiment import launch_util
+from experiment import common_args
+
+def setup_run_args(parser):
+    common_args.setup_run_args(parser)
 
 
 def report_signals():
@@ -41,18 +47,25 @@ def report_signals():
             "TIME@package", "ENERGY_PACKAGE@package"]
 
 
-def launch(output_dir, iterations,
-           num_node, app_conf, experiment_cli_args, cool_off_time=60):
-
+def launch(app_conf, args, experiment_cli_args):
     extra_cli_args = launch_util.geopm_signal_args(report_signals(), None)
     extra_cli_args += experiment_cli_args
 
     targets = [launch_util.LaunchConfig(app_conf=app_conf,
                                         agent_conf=None,
                                         name="")]
+
     launch_util.launch_all_runs(targets=targets,
-                                num_nodes=num_node,
-                                iterations=iterations,
+                                num_nodes=args.node_count,
+                                iterations=args.trial_count,
                                 extra_cli_args=extra_cli_args,
-                                output_dir=output_dir,
-                                cool_off_time=cool_off_time)
+                                output_dir=args.output_dir,
+                                cool_off_time=args.cool_off_time)
+
+def main(app_conf, **defaults):
+    parser = argparse.ArgumentParser()
+    setup_run_args(parser)
+    parser.set_defaults(**defaults)
+    args, extra_args = parser.parse_known_args()
+    launch(app_conf=app_conf, args=args,
+           experiment_cli_args=extra_args)

--- a/integration/experiment/monitor/run_monitor_dgemm.py
+++ b/integration/experiment/monitor/run_monitor_dgemm.py
@@ -35,33 +35,11 @@
 Run DGEMM with the monitor agent.
 '''
 
-import argparse
-
-from experiment import common_args
 from experiment.monitor import monitor
 from apps import geopmbench
 
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_iterations(parser)
-
-    args, experiment_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_node = args.nodes
-
-    # application parameters
     app_conf = geopmbench.DgemmAppConf()
-
-    # experiment parameters
-    iterations = args.iterations
-
-    monitor.launch(output_dir=output_dir,
-                   iterations=iterations,
-                   num_node=num_node,
-                   app_conf=app_conf,
-                   experiment_cli_args=experiment_cli_args)
+    monitor.main(app_conf)

--- a/integration/experiment/monitor/run_monitor_dgemm_tiny.py
+++ b/integration/experiment/monitor/run_monitor_dgemm_tiny.py
@@ -35,34 +35,12 @@
 Run a small DGEMM with the monitor agent.
 '''
 
-import argparse
 
-from experiment import common_args
 from experiment.monitor import monitor
 from apps import geopmbench
 
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_iterations(parser)
-
-    args, experiment_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_node = args.nodes
-
-    # application parameters
     app_conf = geopmbench.TinyAppConf()
-
-    # experiment parameters
-    iterations = args.iterations
-
-    monitor.launch(output_dir=output_dir,
-                   iterations=iterations,
-                   num_node=num_node,
-                   app_conf=app_conf,
-                   experiment_cli_args=experiment_cli_args,
-                   cool_off_time=0)
+    monitor.main(app_conf, cool_off_time=0)

--- a/integration/experiment/monitor/run_monitor_minife.py
+++ b/integration/experiment/monitor/run_monitor_minife.py
@@ -37,30 +37,14 @@ Run MiniFE with the monitor agent.
 
 import argparse
 
-from experiment import common_args
 from experiment.monitor import monitor
 from apps.minife import minife
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_iterations(parser)
-
-    args, experiment_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_node = args.nodes
-
-    # application parameters
-    app_conf = minife.MinifeAppConf(num_node)
-
-    # experiment parameters
-    iterations = args.iterations
-
-    monitor.launch(output_dir=output_dir,
-                   iterations=iterations,
-                   num_node=num_node,
-                   app_conf=app_conf,
-                   experiment_cli_args=experiment_cli_args)
+    monitor.setup_run_args(parser)
+    args, extra_args = parser.parse_known_args()
+    app_conf = minife.MinifeAppConf(args.node_count)
+    monitor.launch(app_conf=app_conf, args=args,
+                   experiment_cli_args=extra_args)

--- a/integration/experiment/monitor/run_monitor_nekbone.py
+++ b/integration/experiment/monitor/run_monitor_nekbone.py
@@ -35,32 +35,12 @@
 Run Nekbone with the monitor agent.
 '''
 
-import argparse
 
-from experiment import common_args
 from experiment.monitor import monitor
 from apps.nekbone import nekbone
 
+
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_iterations(parser)
-
-    args, experiment_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_node = args.nodes
-
-    # application parameters
     app_conf = nekbone.NekboneAppConf()
-
-    # experiment parameters
-    iterations = args.iterations
-
-    monitor.launch(output_dir=output_dir,
-                   iterations=iterations,
-                   num_node=num_node,
-                   app_conf=app_conf,
-                   experiment_cli_args=experiment_cli_args)
+    monitor.main(app_conf)

--- a/integration/experiment/power_sweep/power_sweep.py
+++ b/integration/experiment/power_sweep/power_sweep.py
@@ -50,7 +50,8 @@ def setup_run_args(parser):
     common_args.add_min_power(parser)
     common_args.add_max_power(parser)
     common_args.add_step_power(parser)
-    common_args.add_agent_list(parser, 'power_governor,power_balancer')
+    common_args.add_agent_list(parser)
+    parser.set_defaults(agent_list='power_governor,power_balancer')
 
 
 def setup_power_bounds(mach, min_power, max_power, step_power):
@@ -108,7 +109,6 @@ def launch_configs(app_conf, agent_types, min_power, max_power, step_power):
 
 
 def launch(app_conf, args, experiment_cli_args):
-
     agent_types = args.agent_list.split(',')
     mach = machine.init_output_dir(args.output_dir)
     min_power, max_power = setup_power_bounds(mach, args.min_power,

--- a/integration/experiment/power_sweep/run_power_sweep_dgemm.py
+++ b/integration/experiment/power_sweep/run_power_sweep_dgemm.py
@@ -35,44 +35,12 @@
 Example power sweep experiment using geopmbench.
 '''
 
-import argparse
 
-from experiment import common_args
 from experiment.power_sweep import power_sweep
-from experiment import machine
 from apps import geopmbench
 
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_power(parser)
-    common_args.add_max_power(parser)
-    common_args.add_iterations(parser)
-
-    args, extra_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
-
-    # application parameters
     app_conf = geopmbench.DgemmAppConf()
-
-    # experiment parameters
-    min_power = args.min_power
-    max_power = args.max_power
-    step_power = 10
-    min_power, max_power = power_sweep.setup_power_bounds(mach, min_power, max_power, step_power)
-    iterations = args.iterations
-    power_sweep.launch(output_dir=output_dir,
-                       iterations=iterations,
-                       min_power=min_power,
-                       max_power=max_power,
-                       step_power=step_power,
-                       agent_types=['power_governor', 'power_balancer'],
-                       num_node=num_nodes,
-                       app_conf=app_conf,
-                       experiment_cli_args=extra_cli_args)
+    power_sweep.main(app_conf)

--- a/integration/experiment/power_sweep/run_power_sweep_dgemm_tiny.py
+++ b/integration/experiment/power_sweep/run_power_sweep_dgemm_tiny.py
@@ -35,46 +35,12 @@
 Example power sweep experiment using geopmbench.
 '''
 
-import argparse
 
-from experiment import common_args
 from experiment.power_sweep import power_sweep
-from experiment import machine
 from apps import geopmbench
 
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_power(parser)
-    common_args.add_max_power(parser)
-    common_args.add_iterations(parser)
-
-    args, extra_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
-
-    # application parameters
     app_conf = geopmbench.TinyAppConf()
-
-    # experiment parameters
-    min_power = args.min_power
-    max_power = args.max_power
-    step_power = 10
-    min_power, max_power = power_sweep.setup_power_bounds(mach, min_power, max_power, step_power)
-    iterations = args.iterations
-
-    power_sweep.launch(output_dir=output_dir,
-                       iterations=iterations,
-                       min_power=min_power,
-                       max_power=max_power,
-                       step_power=step_power,
-                       agent_types=['power_governor', 'power_balancer'],
-                       num_node=num_nodes,
-                       app_conf=app_conf,
-                       experiment_cli_args=extra_cli_args,
-                       cool_off_time=0)
+    power_sweep.main(app_conf, cool_off_time=0)

--- a/integration/experiment/power_sweep/run_power_sweep_minife.py
+++ b/integration/experiment/power_sweep/run_power_sweep_minife.py
@@ -37,44 +37,15 @@ Example power sweep experiment using miniFE.
 
 import argparse
 
-from experiment import common_args
 from experiment.power_sweep import power_sweep
-from experiment import machine
 from apps.minife import minife
 
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_power(parser)
-    common_args.add_max_power(parser)
-    common_args.add_iterations(parser)
-
+    power_sweep.setup_run_args(parser)
     args, extra_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
-
-    # application parameters
-    app_conf = minife.MinifeAppConf(num_nodes)
-    num_rank = num_nodes * app_conf.get_rank_per_node()
-
-    # experiment parameters
-    min_power = args.min_power
-    max_power = args.max_power
-    step_power = 10
-    min_power, max_power = power_sweep.setup_power_bounds(mach, min_power, max_power, step_power)
-    iterations = args.iterations
-
-    power_sweep.launch(output_dir=output_dir,
-                       iterations=iterations,
-                       min_power=min_power,
-                       max_power=max_power,
-                       step_power=step_power,
-                       agent_types=['power_governor', 'power_balancer'],
-                       num_node=num_nodes,
-                       app_conf=app_conf,
+    app_conf = minife.MinifeAppConf(args.node_count)
+    power_sweep.launch(app_conf=app_conf, args=args,
                        experiment_cli_args=extra_cli_args)

--- a/integration/experiment/power_sweep/run_power_sweep_nekbone.py
+++ b/integration/experiment/power_sweep/run_power_sweep_nekbone.py
@@ -35,45 +35,11 @@
 Run a power sweep with nekbone
 '''
 
-import argparse
-
-from experiment import common_args
 from experiment.power_sweep import power_sweep
-from experiment import machine
 from apps.nekbone import nekbone
 
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    common_args.add_output_dir(parser)
-    common_args.add_nodes(parser)
-    common_args.add_min_power(parser)
-    common_args.add_max_power(parser)
-    common_args.add_iterations(parser)
-
-    args, extra_cli_args = parser.parse_known_args()
-
-    output_dir = args.output_dir
-    num_nodes = args.nodes
-    mach = machine.init_output_dir(output_dir)
-
-    # application parameters
     app_conf = nekbone.NekboneAppConf()
-
-    # experiment parameters
-    min_power = args.min_power
-    max_power = args.max_power
-    step_power = 10
-    min_power, max_power = power_sweep.setup_power_bounds(mach, min_power, max_power, step_power)
-    iterations = args.iterations
-
-    power_sweep.launch(output_dir=output_dir,
-                       iterations=iterations,
-                       min_power=min_power,
-                       max_power=max_power,
-                       step_power=step_power,
-                       agent_types=['power_governor', 'power_balancer'],
-                       num_node=num_nodes,
-                       app_conf=app_conf,
-                       experiment_cli_args=extra_cli_args)
+    power_sweep.main(app_conf)


### PR DESCRIPTION
There is a lot of repreated code in the run scripts for adding command line arguments.   This change puts this code in a common place in common_args.py.  Another change is to pass the args object directly to the launch functions rather than breaking out the members.  Finally, a basic main() function has been added for experiments to use which takes an app config as input.