### PR TITLE
Add set -e to download and build scripts

### DIFF
--- a/integration/apps/minife/download_and_build.sh
+++ b/integration/apps/minife/download_and_build.sh
@@ -30,6 +30,8 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+set -e
+
 # Acquire the source:
 wget https://asc.llnl.gov/CORAL-benchmarks/Throughput/MiniFE_ref_2.0-rc3.tar.gz
 

--- a/integration/apps/nekbone/download_and_build.sh
+++ b/integration/apps/nekbone/download_and_build.sh
@@ -30,6 +30,8 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+set -e
+
 # Clear out old versions:
 if [ -d "nekbone" ]; then
     echo "WARNING: Previous nekbone checkout detected at ./nekbone"
@@ -64,4 +66,3 @@ GEOPM_BARRIER=yes ./makenek-intel
 mv nekbone nekbone-barrier
 make clean
 ./makenek-intel
-


### PR DESCRIPTION
Avoid unclear error messages when building applications in integration directory
