### PR TITLE
Enable unit testing for out of source builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -339,6 +339,7 @@ EXTRA_DIST = $(TUTORIAL_DIST) \
              test_hw/rapl_pkg_limit_plot.py \
              test_hw/rapl_pkg_limit_sweep.sh \
              test_hw/rapl_pkg_limit_test.c \
+             test_license.sh \
              # end
 
 TUTORIAL_DIST = tutorial/Makefile \

--- a/Makefile.am
+++ b/Makefile.am
@@ -844,7 +844,7 @@ check_PROGRAMS =
 check_LTLIBRARIES =
 noinst_PROGRAMS =
 noinst_LTLIBRARIES =
-TESTS =
+TESTS = test_license.sh
 
 PHONY_TARGETS = clean-local \
                 clean-local-coverage \

--- a/scripts/Makefile.mk
+++ b/scripts/Makefile.mk
@@ -153,4 +153,8 @@ CLEAN_LOCAL_TARGETS += clean-local-pytest-script-links \
                        clean-local-python
 
 install-python: scripts/setup.py
+# Move version.py into source for out of place builds
+	if [ ! -f $(abs_srcdir)/scripts/geopmpy/version.py ]; then \
+	    cp scripts/geopmpy/version.py $(abs_srcdir)/scripts/geopmpy/version.py; \
+	fi
 	cd $(abs_srcdir)/scripts && $(PYTHON) ./setup.py install -O1 --root $(DESTDIR)/ --prefix $(prefix)

--- a/scripts/Makefile.mk
+++ b/scripts/Makefile.mk
@@ -141,7 +141,8 @@ PHONY_TARGETS += pytest-checkprogs
 
 $(PYTEST_TESTS): scripts/test/pytest_links/%:
 	mkdir -p scripts/test/pytest_links
-	ln -s ../geopmpy_test.sh $@
+	rm -f $@
+	ln -s $(abs_srcdir)/scripts/test/geopmpy_test.sh $@
 
 clean-local-pytest-script-links:
 	rm -f scripts/test/pytest_links/*

--- a/scripts/geopmpy/__init__.py
+++ b/scripts/geopmpy/__init__.py
@@ -37,7 +37,22 @@ topo, agent, and version.
 """
 
 from __future__ import absolute_import
+import os
 
 __all__ = ['agent', 'error', 'io', 'hash', 'launcher', 'pio', 'plotter', 'policy_store', 'topo', 'version']
 
-from geopmpy.version import __version__
+try:
+    from geopmpy.version import __version__
+except ImportError:
+    try:
+        # Look for VERSION file in git repository
+        file_path = os.path.abspath(__file__)
+        src_version_path = os.path.join(
+                           os.path.dirname(
+                           os.path.dirname(
+                           os.path.dirname(file_path))),
+                           'VERSION')
+        with open(src_version_path) as fid:
+            __version__ = fid.read().strip()
+    except IOError:
+        __version__='0.0.0'

--- a/scripts/geopmpy/__init__.py
+++ b/scripts/geopmpy/__init__.py
@@ -55,4 +55,4 @@ except ImportError:
         with open(src_version_path) as fid:
             __version__ = fid.read().strip()
     except IOError:
-        __version__='0.0.0'
+        __version__ = '0.0.0'

--- a/test/MSRIOGroupTest.cpp
+++ b/test/MSRIOGroupTest.cpp
@@ -41,6 +41,7 @@
 #include <fstream>
 #include <string>
 #include <map>
+#include <libgen.h>
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "contrib/json11/json11.hpp"
@@ -929,7 +930,8 @@ TEST_F(MSRIOGroupTest, write_control)
 
 TEST_F(MSRIOGroupTest, whitelist)
 {
-    std::ifstream file("test/legacy_whitelist.out");
+    char file_name[NAME_MAX] = __FILE__;
+    std::ifstream file(std::string(dirname(file_name)) + "/legacy_whitelist.out");
     std::string line;
     uint64_t offset;
     uint64_t mask;

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -515,7 +515,6 @@ endif
 TESTS_ENVIRONMENT = PYTHON='$(PYTHON)'
 
 TESTS += $(GTEST_TESTS) \
-         copying_headers/test-license \
          # end
 
 EXTRA_DIST += test/InternalProfile.cpp \
@@ -720,7 +719,8 @@ PHONY_TARGETS += gtest-checkprogs
 
 $(GTEST_TESTS): test/gtest_links/%:
 	mkdir -p test/gtest_links
-	ln -s ../geopm_test.sh $@
+	rm -f $@
+	ln -s $(abs_srcdir)/test/geopm_test.sh $@
 
 coverage: check
 	lcov --no-external --capture --directory src --output-file coverage.info --rc lcov_branch_coverage=1

--- a/test_license.sh
+++ b/test_license.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -30,19 +31,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-test_name=$(basename $0)
-test_dir=$(dirname $0)
-obj_dir=$(readlink -f $test_dir/../../..)
-lib_path=$obj_dir/.libs
-real_path=$(dirname $(readlink -f $0))
-top_dir=$(readlink -f $real_path/../..)
-
-test_class=$(echo $test_name | awk -F. '{print $1}')
-scripts_dir=$top_dir/scripts
-lib_dir=$obj_dir/.libs
-export PYTHONPATH=$scripts_dir:$PYTHONPATH
-export LD_LIBRARY_PATH=$lib_dir:$LD_LIBRARY_PATH
-
-# PYTHON is expected to be set when running make check. However, the default
-# value may be used when invoking this script directly from the command line.
-"${PYTHON-python3}" $scripts_dir/test/$test_class.py --verbose $test_name >& $test_dir/$test_name.log
+set -e
+dir_name=$(dirname $0)
+cd $dir_name
+./copying_headers/test-license


### PR DESCRIPTION
- Fixes a number of issues with unit tests when run out of the source tree.
- Fixes install issue: geopmpy/version.py was not being installed when built out of tree
- Fixes #3 
