### PR TITLE
Nekbone fixups and code style alignment

### DIFF
--- a/integration/apps/amg/build.sh
+++ b/integration/apps/amg/build.sh
@@ -36,16 +36,16 @@ set -e
 # Get helper functions
 source ../build_func.sh
 
-dirname=AMG-master
-archive=amg-master-5.zip
-url=https://asc.llnl.gov/sites/asc/files/2020-09
+DIRNAME=AMG-master
+ARCHIVE=amg-master-5.zip
+URL=https://asc.llnl.gov/sites/asc/files/2020-09
 
-clean_source $dirname
-get_archive $archive $url
-unpack_archive $archive
+clean_source ${DIRNAME}
+get_archive ${ARCHIVE} ${URL}
+unpack_archive ${ARCHIVE}
 # TODO: geopm markup patch needs to be fixed
-setup_source_git $dirname ''
+setup_source_git ${DIRNAME} ''
 
 # build
-cd $dirname
+cd ${DIRNAME}
 make

--- a/integration/apps/build_func.sh
+++ b/integration/apps/build_func.sh
@@ -32,14 +32,14 @@
 
 # Clean out old versions of application source and warn user
 clean_source() {
-    local dirname=$1
+    local DIRNAME=${1}
     # Clear out old versions:
-    if [ -d "$dirname" ]; then
-        echo "WARNING: Previous source directory detected at ./$dirname"
+    if [ -d "${DIRNAME}" ]; then
+        echo "WARNING: Previous source directory detected at ./${DIRNAME}"
         read -p "OK to delete and rebuild? (y/n) " -n 1 -r
         echo
         if [[ ${REPLY} =~ ^[Yy]$ ]]; then
-            rm -rf $dirname
+            rm -rf ${DIRNAME}
         else
             echo "Not OK.  Stopping."
             exit 1
@@ -49,44 +49,44 @@ clean_source() {
 
 # Setup a git repository and apply patches
 setup_source_git() {
-    local basedir=$PWD
-    local dirname=$1
+    local BASEDIR=${PWD}
+    local DIRNAME=${1}
     if [ $# == 2 ]; then
-        local patch_list=$2
+        local PATCH_LIST=${2}
     else
-        local patch_list="$(ls $basedir/*.patch 2> /dev/null || true)"
+        local PATCH_LIST="$(ls ${BASEDIR}/*.patch 2> /dev/null || true)"
     fi
-    cd $dirname
+    cd ${DIRNAME}
     # Create a git repo for the app source
     git init
     git checkout -b main
     git add -A
     git commit --no-edit -sm "Initial commit"
-    if [ ! -z  "$patch_list" ]; then
-        git am $patch_list
+    if [ ! -z  "${PATCH_LIST}" ]; then
+        git am ${PATCH_LIST}
     fi
     cd -
 }
 
 # Get the source archive from local cache or web page
 get_archive() {
-    local archive=$1
-    if [ ! -f $archive ]; then
-        if [ -f "$GEOPM_APPS_SRCDIR/$archive" ]; then
-            cp $"$GEOPM_APPS_SRCDIR/$archive" .
+    local ARCHIVE=$1
+    if [ ! -f ${ARCHIVE} ]; then
+        if [ -f "${GEOPM_APPS_SRCDIR}/${ARCHIVE}" ]; then
+            cp "${GEOPM_APPS_SRCDIR}/${ARCHIVE}" .
         elif [ $# -eq 2 ]; then
-            local url=$2
-            wget $url/$archive
+            local URL=$2
+            wget ${URL}/${ARCHIVE}
         fi
     fi
 }
 
 # Unpack an archive with tar or unzip
 unpack_archive() {
-    local archive=$1
-    if [ "${archive##*.}" == zip ]; then
-        unzip $archive
+    local ARCHIVE=$1
+    if [ "${ARCHIVE##*.}" == zip ]; then
+        unzip ${ARCHIVE}
     else
-        tar xvf $archive
+        tar xvf ${ARCHIVE}
     fi
 }

--- a/integration/apps/build_func.sh
+++ b/integration/apps/build_func.sh
@@ -59,6 +59,7 @@ function setup_source_git {
     cd $dirname
     # Create a git repo for the app source
     git init
+    git checkout -b main
     git add -A
     git commit --no-edit -sm "Initial commit"
     if [ ! -z  "$patch_list" ]; then

--- a/integration/apps/build_func.sh
+++ b/integration/apps/build_func.sh
@@ -31,7 +31,7 @@
 
 
 # Clean out old versions of application source and warn user
-function clean_source {
+clean_source() {
     local dirname=$1
     # Clear out old versions:
     if [ -d "$dirname" ]; then
@@ -48,7 +48,7 @@ function clean_source {
 }
 
 # Setup a git repository and apply patches
-function setup_source_git {
+setup_source_git() {
     local basedir=$PWD
     local dirname=$1
     if [ $# == 2 ]; then
@@ -69,7 +69,7 @@ function setup_source_git {
 }
 
 # Get the source archive from local cache or web page
-function get_archive {
+get_archive() {
     local archive=$1
     if [ ! -f $archive ]; then
         if [ -f "$GEOPM_APPS_SRCDIR/$archive" ]; then
@@ -82,7 +82,7 @@ function get_archive {
 }
 
 # Unpack an archive with tar or unzip
-function unpack_archive {
+unpack_archive() {
     local archive=$1
     if [ "${archive##*.}" == zip ]; then
         unzip $archive

--- a/integration/apps/hpcg/build.sh
+++ b/integration/apps/hpcg/build.sh
@@ -41,18 +41,18 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-target_arch=$1
+TARGET_ARCH=${1}
 
 # Supported targets
-if [ "$target_arch" = "mcfly" ]; then
+if [ "${TARGET_ARCH}" = "mcfly" ]; then
     BUILD_PATCHES=""
     TARGET=IMPI_IOMP_SKX
     BIN=xhpcg_skx
-elif [ "$target_arch" = "quartz" ]; then
+elif [ "${TARGET_ARCH}" = "quartz" ]; then
     BUILD_PATCHES="../0001-Change-MPI-compiler-to-mpicxx.patch"
     TARGET=IMPI_IOMP_AVX2
     BIN=xhpcg_avx2
-elif [ "$target_arch" = "xeon" ]; then
+elif [ "${TARGET_ARCH}" = "xeon" ]; then
     BUILD_PATCHES=""
     TARGET=IMPI_IOMP_AVX2
     BIN=xhpcg_avx2
@@ -61,15 +61,15 @@ else
     exit 1
 fi
 
-dirname=hpcg
-clean_source $dirname
+DIRNAME=hpcg
+clean_source ${DIRNAME}
 # Acquire the source:
-cp -r ${MKLROOT}/benchmarks/hpcg/ $dirname
+cp -r ${MKLROOT}/benchmarks/hpcg/ ${DIRNAME}
 # Get rid of prebuilt binaries
-rm $dirname/bin/xhpcg*
-setup_source_git "$dirname" "$BUILD_PATCHES"
+rm ${DIRNAME}/bin/xhpcg*
+setup_source_git "${DIRNAME}" "${BUILD_PATCHES}"
 # Build
-cd $dirname
+cd ${DIRNAME}
 ./configure ${TARGET}
 make
 # Use uniform binary name

--- a/integration/apps/minife/build.sh
+++ b/integration/apps/minife/build.sh
@@ -37,18 +37,18 @@ set -e
 source ../build_func.sh
 
 # Set variables for workload
-dirname=miniFE_openmp-2.0-rc3
-archive=$dirname.zip
-url=https://asc.llnl.gov/sites/asc/files/2020-09
+DIRNAME=miniFE_openmp-2.0-rc3
+ARCHIVE=${DIRNAME}.zip
+URL=https://asc.llnl.gov/sites/asc/files/2020-09
 
 # Run helper functions
-clean_source $dirname
+clean_source ${DIRNAME}
 rm -rf __MACOSX
-get_archive $archive $url
-unpack_archive $archive
+get_archive ${ARCHIVE} ${URL}
+unpack_archive ${ARCHIVE}
 rm -rf __MACOSX
-setup_source_git $dirname
+setup_source_git ${DIRNAME}
 
 # Build application
-cd $dirname/src
+cd ${DIRNAME}/src
 make

--- a/integration/apps/nekbone/build.sh
+++ b/integration/apps/nekbone/build.sh
@@ -32,7 +32,6 @@
 
 set -x
 set -e
-set -x
 
 # Get helper functions
 source ../build_func.sh

--- a/integration/apps/nekbone/build.sh
+++ b/integration/apps/nekbone/build.sh
@@ -37,8 +37,12 @@ set -e
 source ../build_func.sh
 
 get_nekbone_source() {
-    svn checkout https://repocafe.cels.anl.gov/repos/nekbone/trunk/nekbone ${1}
-    rm -fr ${1}/.svn
+    local DIRNAME=${1}
+    svn checkout https://repocafe.cels.anl.gov/repos/nekbone/trunk/nekbone ${DIRNAME}
+    cd ${DIRNAME}
+    svn log > svn.log
+    rm -fr .svn
+    cd -
 }
 
 # Set variables for workload

--- a/integration/apps/nekbone/build.sh
+++ b/integration/apps/nekbone/build.sh
@@ -36,7 +36,7 @@ set -e
 # Get helper functions
 source ../build_func.sh
 
-function get_nekbone_source {
+get_nekbone_source() {
     svn checkout https://repocafe.cels.anl.gov/repos/nekbone/trunk/nekbone ${1}
     rm -fr ${1}/.svn
 }

--- a/integration/apps/nekbone/build.sh
+++ b/integration/apps/nekbone/build.sh
@@ -42,14 +42,14 @@ get_nekbone_source() {
 }
 
 # Set variables for workload
-dirname=nekbone
-clean_source $dirname
+DIRNAME=nekbone
+clean_source ${DIRNAME}
 # Acquire the source:
-get_nekbone_source $dirname
-setup_source_git $dirname
+get_nekbone_source ${DIRNAME}
+setup_source_git ${DIRNAME}
 
 # Build
-cd $dirname/test/example1
+cd ${DIRNAME}/test/example1
 GEOPM_BARRIER=yes ./makenek-intel
 mv nekbone nekbone-barrier
 make clean

--- a/integration/apps/nekbone/build.sh
+++ b/integration/apps/nekbone/build.sh
@@ -38,14 +38,8 @@ set -x
 source ../build_func.sh
 
 function get_nekbone_source {
-    dirname=$1
-    basedir=$PWD
-    tmpdir=$(mktemp -d)
-    cd $tmpdir
-    svn checkout https://repocafe.cels.anl.gov/repos/nekbone
-    mv nekbone/trunk/nekbone $basedir/$dirname
-    cd -
-    rm -rf $tmpdir
+    svn checkout https://repocafe.cels.anl.gov/repos/nekbone/trunk/nekbone ${1}
+    rm -fr ${1}/.svn
 }
 
 # Set variables for workload


### PR DESCRIPTION
Incorporates Nekbone changes to only checkout the trunk branch and use the main branch.
Use POSIX compliant function declarations.
Align variable naming with other BASH scripts in the repo.
