### PR TITLE
Add build function for geopm.  Also, increase interation count in AMG , and add more documentation

### DIFF
--- a/copying_headers/MANIFEST.EXEMPT
+++ b/copying_headers/MANIFEST.EXEMPT
@@ -30,6 +30,7 @@ geopm-ohpc.spec.in
 geopm-theta.spec.in
 integration/README.md
 integration/apps/README.md
+integration/apps/amg/README.md
 integration/apps/minife/README.md
 integration/apps/nasft/nasft/COPYING-NAS
 integration/apps/nasft/nasft/README

--- a/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
+++ b/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
@@ -1,4 +1,4 @@
-From 62708c3504cf9150e9fa39490fb36aaa3063f141 Mon Sep 17 00:00:00 2001
+From 461128cef50eb0d8436702ea1afc2f8e79470531 Mon Sep 17 00:00:00 2001
 From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
 Date: Mon, 5 Oct 2020 13:41:31 -0700
 Subject: [PATCH] Insert calls to geopm profile APIs in the AMG timing.c file
@@ -38,9 +38,9 @@ Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
 ---
  .gitignore         |  2 ++
  Makefile.include   |  4 ++++
- krylov/pcg.c       |  4 ++++
+ krylov/pcg.c       |  5 +++++
  utilities/timing.c | 21 +++++++++++++++++++++
- 4 files changed, 31 insertions(+)
+ 4 files changed, 32 insertions(+)
  create mode 100644 .gitignore
 
 diff --git a/.gitignore b/.gitignore
@@ -65,10 +65,18 @@ index b73ccce..f911dc9 100644
 +INCLUDE_CFLAGS += -xCORE-AVX2 -I$(GEOPM_INSTALL)/include -DGEOPM
 +INCLUDE_LFLAGS += -L$(GEOPM_INSTALL)/lib -lgeopm
 diff --git a/krylov/pcg.c b/krylov/pcg.c
-index 2492dae..303e5b7 100644
+index 2492dae..56b0bac 100644
 --- a/krylov/pcg.c
 +++ b/krylov/pcg.c
-@@ -478,6 +478,10 @@ hypre_PCGSolve( void *pcg_vdata,
+@@ -32,6 +32,7 @@
+ 
+ #include "krylov.h"
+ #include "_hypre_utilities.h"
++#include <geopm.h>
+ 
+ /*--------------------------------------------------------------------------
+  * hypre_PCGFunctionsCreate
+@@ -478,6 +479,10 @@ hypre_PCGSolve( void *pcg_vdata,
  
     while ((i+1) <= max_iter)
     {

--- a/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
+++ b/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
@@ -63,17 +63,19 @@ index b73ccce..f911dc9 100644
  
 +# Add CFLAGS for geopm
 +GEOPM_INSTALL ?= $(HOME)/build/geopm
-+INCLUDE_CFLAGS += -xCORE-AVX2 -I$(GEOPM_INSTALL)/include -DGEOPM
-+INCLUDE_LFLAGS += -L$(GEOPM_INSTALL)/lib -lgeopm
++INCLUDE_CFLAGS += -xCORE-AVX2 $(GEOPM_CFLAGS) -DGEOPM
++INCLUDE_LFLAGS += $(GEOPM_LDFLAGS) $(GEOPM_LDLIBS)
 diff --git a/krylov/pcg.c b/krylov/pcg.c
 index 2492dae..56b0bac 100644
 --- a/krylov/pcg.c
 +++ b/krylov/pcg.c
-@@ -32,6 +32,7 @@
+@@ -32,6 +32,9 @@
  
  #include "krylov.h"
  #include "_hypre_utilities.h"
++#ifdef GEOPM
 +#include <geopm.h>
++#endif
  
  /*--------------------------------------------------------------------------
   * hypre_PCGFunctionsCreate

--- a/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
+++ b/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
@@ -1,4 +1,4 @@
-From b24d2ae1b7c96af22e2ef3d82340911219901b54 Mon Sep 17 00:00:00 2001
+From 62708c3504cf9150e9fa39490fb36aaa3063f141 Mon Sep 17 00:00:00 2001
 From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
 Date: Mon, 5 Oct 2020 13:41:31 -0700
 Subject: [PATCH] Insert calls to geopm profile APIs in the AMG timing.c file
@@ -38,8 +38,9 @@ Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
 ---
  .gitignore         |  2 ++
  Makefile.include   |  4 ++++
+ krylov/pcg.c       |  4 ++++
  utilities/timing.c | 21 +++++++++++++++++++++
- 3 files changed, 27 insertions(+)
+ 4 files changed, 31 insertions(+)
  create mode 100644 .gitignore
 
 diff --git a/.gitignore b/.gitignore
@@ -63,6 +64,21 @@ index b73ccce..f911dc9 100644
 +GEOPM_INSTALL ?= $(HOME)/build/geopm
 +INCLUDE_CFLAGS += -xCORE-AVX2 -I$(GEOPM_INSTALL)/include -DGEOPM
 +INCLUDE_LFLAGS += -L$(GEOPM_INSTALL)/lib -lgeopm
+diff --git a/krylov/pcg.c b/krylov/pcg.c
+index 2492dae..303e5b7 100644
+--- a/krylov/pcg.c
++++ b/krylov/pcg.c
+@@ -478,6 +478,10 @@ hypre_PCGSolve( void *pcg_vdata,
+ 
+    while ((i+1) <= max_iter)
+    {
++#ifdef GEOPM
++       geopm_prof_epoch();
++#endif
++
+       /*--------------------------------------------------------------------
+        * the core CG calculations...
+        *--------------------------------------------------------------------*/
 diff --git a/utilities/timing.c b/utilities/timing.c
 index 2ada3e4..c946211 100644
 --- a/utilities/timing.c

--- a/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
+++ b/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
@@ -1,7 +1,8 @@
-From 461128cef50eb0d8436702ea1afc2f8e79470531 Mon Sep 17 00:00:00 2001
+From d71f6dbf57fe7ea74beed704ed849f95e36c5fbc Mon Sep 17 00:00:00 2001
 From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
 Date: Mon, 5 Oct 2020 13:41:31 -0700
-Subject: [PATCH] Insert calls to geopm profile APIs in the AMG timing.c file
+Subject: [PATCH 1/2] Insert calls to geopm profile APIs in the AMG timing.c
+ file
 
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #

--- a/integration/apps/amg/0002-Increase-iteration-count-for-PCG-solve.patch
+++ b/integration/apps/amg/0002-Increase-iteration-count-for-PCG-solve.patch
@@ -1,3 +1,12 @@
+From 1b815dfb46002ab44064e26fea188cfbabe14ea0 Mon Sep 17 00:00:00 2001
+From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
+Date: Tue, 6 Oct 2020 17:08:13 -0700
+Subject: [PATCH 2/2] Increase iteration count for PCG solve
+
+- Increase mg_max_iter from 100 to 500
+- Decrease error tolerence to zero to avoid
+  leaving loop because of error convergence.
+
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -29,10 +38,33 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-EXTRA_DIST += integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch \
-              integration/apps/amg/0002-Increase-iteration-count-for-PCG-solve.patch \
-              integration/apps/amg/amg.py \
-              integration/apps/amg/build.sh \
-              integration/apps/amg/__init__.py \
-              integration/apps/amg/README.md \
-              # end
+Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
+---
+ test/amg.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test/amg.c b/test/amg.c
+index 18811ea..20cbb0b 100644
+--- a/test/amg.c
++++ b/test/amg.c
+@@ -72,7 +72,7 @@ main( hypre_int argc,
+    HYPRE_Int           max_levels = 25;
+    HYPRE_Int           num_iterations;
+    HYPRE_Int           max_iter = 1000;
+-   HYPRE_Int           mg_max_iter = 100;
++   HYPRE_Int           mg_max_iter = 500;
+    HYPRE_Int 	       cum_num_its=0;
+    HYPRE_Int           nodal = 0;
+    HYPRE_Real          final_res_norm;
+@@ -113,7 +113,7 @@ main( hypre_int argc,
+    HYPRE_Int    relax_type = 18;   
+    HYPRE_Int    rap2=1;
+    HYPRE_Int    keepTranspose = 0;
+-   HYPRE_Real   tol = 1.e-8, pc_tol = 0.;
++   HYPRE_Real   tol = 0., pc_tol = 0.;
+    HYPRE_Real   atol = 0.0;
+ 
+    HYPRE_Real   wall_time;
+-- 
+1.8.3.1
+

--- a/integration/apps/amg/Makefile.mk
+++ b/integration/apps/amg/Makefile.mk
@@ -33,4 +33,5 @@ EXTRA_DIST += integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-th
               integration/apps/amg/amg.py \
               integration/apps/amg/build.sh \
               integration/apps/amg/__init__.py \
+              integration/apps/amg/README.md \
               # end

--- a/integration/apps/amg/README.md
+++ b/integration/apps/amg/README.md
@@ -1,5 +1,10 @@
 # AMG: Algebraic Multi-Grid
 
+### Last update
+
+October 8, 2020
+Christopher Cantalupo <christopher.m.cantalupo@intel.com>
+
 ### Summary
 
 From the authors <https://proxyapps.exascaleproject.org/app/amg>:
@@ -15,20 +20,12 @@ From the authors <https://proxyapps.exascaleproject.org/app/amg>:
 This application may expose work imbalance across ranks, and appears
 to be capable of drawing near TDP on Xeon platforms.
 
-### Versions available:
+### Obtaining the Source Code
 
-- The version of posted to the CORAL-2 benchmark website is currently
-  one patch behind the github repository:
-  https://asc.llnl.gov/sites/asc/files/2020-09/amg-master-5.zip
-
-- The github repository has a correction for how "FOM_2" is
-  calculated:
-  https://github.com/LLNL/AMG/commit/3ada8a128e311543e84d9d66344ece77924127a8
-
-- This value is not printed in the configuration set up in amg.py (we
-  specify `-problem 1` on the CLI), rather "FOM_1" is printed at the
-  end of the log.
-
+Build script is written to download the latest from
+<https://github.com/LLNL/AMG.git>.  This version is currently one
+commit (3ada8a128e) ahead of the download posted to the CORAL-2
+benchmark webside.
 
 ### Parallelism
 
@@ -42,7 +39,7 @@ The command line arguments to the benchmark specify the type of
 problem to be solved, the size of the problem and distribution of the
 work across the ranks in a highly customizable way.  In the AmgAppConf
 "problem 1" is executed and the sizing of the problem was chosen so it
-would run for as long as possible without very large memory
+will run for as long as possible without very large memory
 requirements given the number of nodes requested.
 
 ### Modifications

--- a/integration/apps/amg/README.md
+++ b/integration/apps/amg/README.md
@@ -1,0 +1,42 @@
+# AMG: Algebraic Multi-Grid
+
+### Summary
+
+From the authors <https://proxyapps.exascaleproject.org/app/amg>:
+
+- "AMG is a parallel algebraic multigrid solver for linear systems
+  arising from problems on unstructured grids."
+
+- "The default problem is a Laplace type problem on an unstructured
+  domain with various jumps and an anisotropy in one part."
+
+
+### Versions available:
+
+- The version of posted to the CORAL-2 benchmark website is curently
+  one patch behind the github repository:
+  https://asc.llnl.gov/sites/asc/files/2020-09/amg-master-5.zip
+
+- The github repository has a correction for how "FOM_2" is
+  calculated:
+  https://github.com/LLNL/AMG/commit/3ada8a128e311543e84d9d66344ece77924127a8
+
+- This value is not printed in the configuration set up in amg.py (we
+  specify `-problem 1` on the CLI), rather "FOM_1" is printed at the
+  end of the log.
+
+
+### Parallelism
+
+This benchmark is a hybrid MPI/OpenMP application. Unclear which
+process / thread balance works best, but the app config sets the
+number of MPI ranks per node to 16.  Performance and scaling
+characteristics depend significantly on AVX compiler flags provided.
+The `build.sh` script specifies -xAVX2.
+
+The command line arguments to the benchmark specify the type of
+problem to be solved, the size of the problem and distribution of the
+work across the ranks in a highly customizable way.  In the AmgAppConf
+"problem 1" is executed and the sizing of the problem was chosen so it
+would run for as long as possible without very large memory
+requirements given the number of nodes requested.

--- a/integration/apps/amg/amg.py
+++ b/integration/apps/amg/amg.py
@@ -63,7 +63,7 @@ class AmgAppConf(apps.AppConf):
 
         self.app_params = problem + ' ' + size_per_proc + ' ' + process_config
         benchmark_dir = os.path.dirname(os.path.abspath(__file__))
-        self.exe_path = os.path.join(benchmark_dir, 'AMG-master/test/amg')
+        self.exe_path = os.path.join(benchmark_dir, 'AMG/test/amg')
 
     def get_rank_per_node(self):
         return self.ranks_per_node

--- a/integration/apps/amg/build.sh
+++ b/integration/apps/amg/build.sh
@@ -36,15 +36,11 @@ set -e
 # Get helper functions
 source ../build_func.sh
 
-DIRNAME=AMG-master
-ARCHIVE=amg-master-5.zip
-URL=https://asc.llnl.gov/sites/asc/files/2020-09
+DIRNAME=AMG
 
 clean_source ${DIRNAME}
-get_archive ${ARCHIVE} ${URL}
-unpack_archive ${ARCHIVE}
-setup_source_git ${DIRNAME}
-
-# build
+git clone https://github.com/LLNL/AMG.git ${DIRNAME}
 cd ${DIRNAME}
+git am ../*.patch
+# build
 make

--- a/integration/apps/build_func.sh
+++ b/integration/apps/build_func.sh
@@ -43,10 +43,10 @@ clean_source() {
         echo "WARNING: Previous source directory detected at ./${DIRNAME}"
         read -p "OK to delete and rebuild? (y/n) " -n 1 -r
         echo
-        if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+        if [[ "${REPLY}" =~ ^[Yy]$ ]]; then
             rm -rf ${DIRNAME}
         else
-            echo "Not OK.  Stopping."
+            echo "Not OK.  Stopping." 1>&2
             exit 1
         fi
     fi
@@ -103,9 +103,11 @@ clean_geopm() {
         echo "WARNING: Previous build of geopm or other data found at ${BUILD_DIR}"
         read -p "OK to delete all object files and recompile? (y/n) " -n 1 -r
         echo
-        if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+        if [[ "${REPLY}" =~ ^[Yy]$ ]]; then
             rm -rf ${BUILD_DIR}
-        elif [[ ! ${REPLY} =~ ^[Nn]$ ]]; then
+        elif [[ "${REPLY}" =~ ^[Nn]$ ]]; then
+            echo "WARNING: Executing incremental build"
+        else
             echo "Error: Did not understand reply: ${REPLY}" 1>&2
             return 1
         fi
@@ -123,8 +125,10 @@ clean_geopm() {
     fi
 }
 
-# Build geopm in a subdirectory and install
+# Build geopm in a subdirectory and install into GEOPM build
+# All arguments are forwarded to the configure command
 install_geopm() {
+    local CONFIG_EXT="$@"
     local BASE_DIR=${PWD}
     local BUILD_DIR=${GEOPM_SOURCE}/integration/build
     clean_geopm ${BUILD_DIR} && \
@@ -132,7 +136,7 @@ install_geopm() {
     ./autogen.sh && \
     mkdir -p ${BUILD_DIR} && \
     cd ${BUILD_DIR} && \
-    ${GEOPM_SOURCE}/configure --prefix=${GEOPM_INSTALL} --with-python=python3 && \
+    ${GEOPM_SOURCE}/configure --prefix=${GEOPM_INSTALL} ${CONFIG_EXT} && \
     make -j10 && \
     make install
     local ERR=$?


### PR DESCRIPTION
This is really three features and can be split into multiple PRs if that is easier to review.

- Introduces a build_geopm() function to build_func.sh while modifying build_func.sh to source build_env.sh.
- Modifies AMG to use the build_env.sh environment
- Modifies the AMG benchmark to run for more iterations and adds a lot of documentation about why that is okay.