### PR TITLE
Add Git repo support to integration infrastructure; Update AMG

### DIFF
--- a/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
+++ b/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
@@ -1,4 +1,4 @@
-From d71f6dbf57fe7ea74beed704ed849f95e36c5fbc Mon Sep 17 00:00:00 2001
+From 312bdfcb681608d26b6b8a9824c4665144356647 Mon Sep 17 00:00:00 2001
 From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
 Date: Mon, 5 Oct 2020 13:41:31 -0700
 Subject: [PATCH 1/2] Insert calls to geopm profile APIs in the AMG timing.c
@@ -38,10 +38,10 @@ Subject: [PATCH 1/2] Insert calls to geopm profile APIs in the AMG timing.c
 Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
 ---
  .gitignore         |  2 ++
- Makefile.include   |  4 ++++
- krylov/pcg.c       |  5 +++++
+ Makefile.include   |  6 +++++-
+ krylov/pcg.c       |  7 +++++++
  utilities/timing.c | 21 +++++++++++++++++++++
- 4 files changed, 32 insertions(+)
+ 4 files changed, 35 insertions(+), 1 deletion(-)
  create mode 100644 .gitignore
 
 diff --git a/.gitignore b/.gitignore
@@ -54,9 +54,18 @@ index 0000000..151a620
 +*.a
 \ No newline at end of file
 diff --git a/Makefile.include b/Makefile.include
-index b73ccce..f911dc9 100644
+index b73ccce..1397d5b 100644
 --- a/Makefile.include
 +++ b/Makefile.include
+@@ -23,7 +23,7 @@
+ 
+ # set the compiler here
+ #CC = gcc
+-CC = mpicc
++CC = ${MPICC}
+ #CC = mpixlc_r
+ 
+ # set compile flags here
 @@ -51,3 +51,7 @@ INCLUDE_CFLAGS = -O2 -DTIMER_USE_MPI -DHYPRE_USING_OPENMP -fopenmp -DHYPRE_HOPSC
  INCLUDE_LFLAGS = -lm -fopenmp
  #INCLUDE_LFLAGS = -lm 
@@ -66,7 +75,7 @@ index b73ccce..f911dc9 100644
 +INCLUDE_CFLAGS += -xCORE-AVX2 $(GEOPM_CFLAGS) -DGEOPM
 +INCLUDE_LFLAGS += $(GEOPM_LDFLAGS) $(GEOPM_LDLIBS)
 diff --git a/krylov/pcg.c b/krylov/pcg.c
-index 2492dae..56b0bac 100644
+index 2492dae..3d1bc42 100644
 --- a/krylov/pcg.c
 +++ b/krylov/pcg.c
 @@ -32,6 +32,9 @@
@@ -79,7 +88,7 @@ index 2492dae..56b0bac 100644
  
  /*--------------------------------------------------------------------------
   * hypre_PCGFunctionsCreate
-@@ -478,6 +479,10 @@ hypre_PCGSolve( void *pcg_vdata,
+@@ -478,6 +481,10 @@ hypre_PCGSolve( void *pcg_vdata,
  
     while ((i+1) <= max_iter)
     {

--- a/integration/apps/amg/0002-Increase-iteration-count-for-PCG-solve.patch
+++ b/integration/apps/amg/0002-Increase-iteration-count-for-PCG-solve.patch
@@ -1,4 +1,4 @@
-From 1b815dfb46002ab44064e26fea188cfbabe14ea0 Mon Sep 17 00:00:00 2001
+From 6d49442a0cae9020c019bc43af63053b79b98534 Mon Sep 17 00:00:00 2001
 From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
 Date: Tue, 6 Oct 2020 17:08:13 -0700
 Subject: [PATCH 2/2] Increase iteration count for PCG solve
@@ -44,7 +44,7 @@ Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/test/amg.c b/test/amg.c
-index 18811ea..20cbb0b 100644
+index 18811ea..842f636 100644
 --- a/test/amg.c
 +++ b/test/amg.c
 @@ -72,7 +72,7 @@ main( hypre_int argc,

--- a/integration/apps/amg/build.sh
+++ b/integration/apps/amg/build.sh
@@ -37,10 +37,19 @@ set -e
 source ../build_func.sh
 
 DIRNAME=AMG
+GITREPO=https://github.com/LLNL/AMG.git
+TOPHASH=3ada8a1
+ARCHIVE=${DIRNAME}_${TOPHASH}.tgz
 
 clean_source ${DIRNAME}
-git clone https://github.com/LLNL/AMG.git ${DIRNAME}
-cd ${DIRNAME}
-git am ../*.patch
+get_archive ${ARCHIVE}
+if [ -f ${ARCHIVE} ]; then
+    unpack_archive ${ARCHIVE}
+else
+    clone_repo_git ${GITREPO} ${DIRNAME} ${TOPHASH}
+fi
+setup_source_git ${DIRNAME}
+
 # build
+cd ${DIRNAME}
 make

--- a/integration/apps/build_func.sh
+++ b/integration/apps/build_func.sh
@@ -66,7 +66,11 @@ setup_source_git() {
     git init
     git checkout -b main
     git add -A
-    git commit --no-edit -sm "Initial commit"
+
+    # The "|| true" is required if ${DIRNAME} is already a Git repo.
+    # In this case, no commit will be added.
+    git commit --no-edit -sm "Initial commit" || true
+
     if [ ! -z  "${PATCH_LIST}" ]; then
         git am ${PATCH_LIST}
     fi

--- a/integration/apps/build_func.sh
+++ b/integration/apps/build_func.sh
@@ -52,6 +52,36 @@ clean_source() {
     fi
 }
 
+# Clone a git reposutory
+clone_repo_git(){
+    local REPOURL=$1
+    local DIRNAME=$2
+    local TOPHASH=$3
+    local ARCHIVE=${DIRNAME}_${TOPHASH}.tgz
+
+    git clone ${REPOURL} ${DIRNAME}
+    if [ ! -d ${DIRNAME} ]; then
+        echo "Error: Unable to clone ${DIRNAME} source."
+        return 1
+    fi
+
+    cd ${DIRNAME}
+    local HASH=$(git rev-parse --short HEAD)
+    cd -
+    if [ "${TOPHASH}" != "${HASH}" ]; then
+        echo "Error: Current source hash (${HASH}) is different than expected hash (${TOPHASH})."
+        return 1
+    fi
+
+    # If the user set the cache dir, pack up the source for next time
+    if [ -d ${GEOPM_APPS_SOURCES} ]; then
+        tar czvf ${ARCHIVE} ${DIRNAME}
+        cp ${ARCHIVE} ${GEOPM_APPS_SOURCES}
+    else
+        echo "Warning: Please set GEOPM_APPS_SOURCES in your environment to enable the local source code cache."
+    fi
+}
+
 # Setup a git repository and apply patches
 setup_source_git() {
     local BASEDIR=${PWD}

--- a/integration/apps/build_func.sh
+++ b/integration/apps/build_func.sh
@@ -75,8 +75,7 @@ clone_repo_git(){
 
     # If the user set the cache dir, pack up the source for next time
     if [ -d ${GEOPM_APPS_SOURCES} ]; then
-        tar czvf ${ARCHIVE} ${DIRNAME}
-        cp ${ARCHIVE} ${GEOPM_APPS_SOURCES}
+        tar czvf ${GEOPM_APPS_SOURCES}/${ARCHIVE} ${DIRNAME}
     else
         echo "Warning: Please set GEOPM_APPS_SOURCES in your environment to enable the local source code cache."
     fi
@@ -93,13 +92,12 @@ setup_source_git() {
     fi
     cd ${DIRNAME}
     # Create a git repo for the app source
-    git init
-    git checkout -b main
-    git add -A
-
-    # The "|| true" is required if ${DIRNAME} is already a Git repo.
-    # In this case, no commit will be added.
-    git commit --no-edit -sm "Initial commit" || true
+    if [ ! -d .git ]; then
+        git init
+        git checkout -b main
+        git add -A
+        git commit --no-edit -sm "Initial commit"
+    fi
 
     if [ ! -z  "${PATCH_LIST}" ]; then
         git am ${PATCH_LIST}
@@ -116,6 +114,9 @@ get_archive() {
         elif [ $# -eq 2 ]; then
             local URL=$2
             wget ${URL}/${ARCHIVE}
+            if [ -d ${GEOPM_APPS_SOURCES} ]; then
+                cp ${ARCHIVE} ${GEOPM_APPS_SOURCES}
+            fi
         fi
     fi
 }


### PR DESCRIPTION
- Fix bug in setup_source_git() that prevented the git am logic from executing if the source being examined was already a git repo.
- Add clone_repo_git() to build_func.sh.  This will try to git clone the requested repo, and if successful package up the cloned source in the app cache.
- Update AMG to use the functions in build_func.sh and use the build env var for MPICC.

