### PR TITLE
Added inclusion of string header as required by gcc10

### DIFF
--- a/src/Agg.hpp
+++ b/src/Agg.hpp
@@ -34,6 +34,7 @@
 #define AGG_HPP_INCLUDE
 
 #include <vector>
+#include <string>
 #include <functional>
 
 namespace geopm


### PR DESCRIPTION
Signed-off-by: Lowren Lawson <lowren.h.lawson@intel.com>

Missing #include <string> in Agg.hpp caused build failure using icc version 19.1.2.254 (gcc version 10.2.1 compatibility).  Simple inclusion fix resolves this.