### PR TITLE
Added 0x1B0 - Energy Perf Bias MSR register

### DIFF
--- a/src/msr_data_arch.cpp
+++ b/src/msr_data_arch.cpp
@@ -966,7 +966,7 @@ namespace geopm
                 }
             }
         },
-        "IA32_ENERGY_PERF_BIAS": {
+        "ENERGY_PERF_BIAS": {
             "offset": "0x1B0",
             "domain": "cpu",
             "fields": {

--- a/src/msr_data_arch.cpp
+++ b/src/msr_data_arch.cpp
@@ -966,6 +966,20 @@ namespace geopm
                 }
             }
         },
+        "IA32_ENERGY_PERF_BIAS": {
+            "offset": "0x1B0",
+            "domain": "cpu",
+            "fields": {
+                "POWER_POLICY_PREFERENCE": {
+                    "begin_bit": 0,
+                    "end_bit":   3,
+                    "function":  "scale",
+                    "units":     "none",
+                    "scalar":    1.0,
+                    "writeable": true
+                }
+            }
+        },
         "PERF_GLOBAL_OVF_CTRL": {
             "offset": "0x390",
             "domain": "cpu",


### PR DESCRIPTION
Signed-off-by: Lowren Lawson <lowren.h.lawson@intel.com>

Addition of Performance Energy Bias Hint IA32_ENERGY_PERF_BIAS MSR for testing.

This may be coupled with a check of CPUID.6H:EXC[3] = 1 to confirm the MSR is valid for a system if used on a mixture of systems that do and do not support EPB.  See SDM IA-32 Architectural MSRs documentation for more information.