### PR TITLE
Helper refactor

### DIFF
--- a/src/Helper.cpp
+++ b/src/Helper.cpp
@@ -184,9 +184,7 @@ namespace geopm
 
     bool string_ends_with(const std::string &str, const std::string &key)
     {
-        std::reverse(str.begin(), str.end());
-        std::reverse(key.begin(), key.end());
-        return string_begins_with(str, key);
+        return (str.rfind(key.c_str(), str.length() - key.length(), key.length()) != std::string::npos);
     }
 
     std::string string_format_double(double signal)

--- a/src/Helper.cpp
+++ b/src/Helper.cpp
@@ -182,7 +182,7 @@ namespace geopm
         return (str.find(key) == 0);
     }
 
-    bool string_ends_with(std::string str, std::string key)
+    bool string_ends_with(const std::string &str, const std::string &key)
     {
         std::reverse(str.begin(), str.end());
         std::reverse(key.begin(), key.end());

--- a/src/Helper.hpp
+++ b/src/Helper.hpp
@@ -97,7 +97,7 @@ namespace geopm
     bool string_begins_with(const std::string &str, const std::string &key);
 
     /// @brief Returns whether one string ends with another.
-    bool string_ends_with(std::string str, std::string key);
+    bool string_ends_with(const std::string &str, const std::string &key);
 
     /// @brief Format a string to best represent a signal encoding a
     ///        double precision floating point number.


### PR DESCRIPTION
As mentioned in https://github.com/geopm/geopm/pull/1382, pulling out the `Helper` pass by const ref. changes here.
And refactoring `string_ends_with` to use `rfind`.

Related to #1348