### PR TITLE
Add configuration file for endeavor

### DIFF
--- a/integration/config/build_env.sh
+++ b/integration/config/build_env.sh
@@ -53,12 +53,15 @@ export GEOPM_APPS_SOURCES=${GEOPM_APPS_SOURCES:?Please set GEOPM_APPS_SOURCES in
 # The MPI compiler wrappers are supported by Intel, but are not Intel specific.
 export CC=${CC:-icc}
 export CXX=${CXX:-icpc}
-export MPICC=${MPICC:-mpicc}
-export MPICXX=${MPICXX:-mpicxx}
 export FC=${FC:-ifort}
 export F77=${F77:-ifort}
+export F90=${F90:-ifort}
+export MPICC=${MPICC:-mpicc}
+export MPICXX=${MPICXX:-mpicxx}
+export MPIFORT=${MPIFORT:-mpifort}
 export MPIFC=${MPIFC:-mpifort}
 export MPIF77=${MPIF77:-mpifort}
+export MPIF90=${MPIF90:-mpifort}
 
 COMPILER_LIST="CC CXX MPICC MPICXX FC F77 MPIFC MPIF77"
 for compiler in ${COMPILER_LIST}; do
@@ -83,4 +86,3 @@ export GEOPM_FFLAGS="-I${GEOPM_LIB}/${FC}/modules/geopm-x86_64"
 export GEOPM_LDFLAGS="-L${GEOPM_LIB}"
 export GEOPM_LDLIBS="-lgeopm"
 export GEOPM_FORTRAN_LDLIBS="${GEOPM_LDLIBS} -lgeopmfort"
-

--- a/integration/config/endeavor_env.sh
+++ b/integration/config/endeavor_env.sh
@@ -41,13 +41,8 @@ source /opt/intel/compiler/latest/bin/compilervars.sh intel64
 source /opt/intel/impi/latest/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh
 
 export GEOPM_LAUNCHER=impi
-export CC=icc
-export CXX=icpc
 export MPICC=mpiicc
 export MPICXX=mpiicpc
-export FC=ifort
-export F77=ifort
-export F90=ifort
 export MPIFORT=mpiifort
 export MPIFC=mpiifort
 export MPIF77=mpiifort

--- a/integration/config/endeavor_env.sh
+++ b/integration/config/endeavor_env.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -29,15 +31,24 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+# ENDEAVOR BUILD ENVIRONMENT
+#
+# This script is intended to be sourced within an existing script or shell ONLY.
+# It is NOT intended to be ./ executed.
 
-EXTRA_DIST += integration/README.md \
-              integration/config/build_env.sh \
-              integration/config/run_env.sh \
-              integration/config/dudley_env.sh \
-              integration/config/endeavor_env.sh \
-              # end
 
-include integration/apps/Makefile.mk
-include integration/experiment/Makefile.mk
-include integration/test/Makefile.mk
-include integration/smoke/Makefile.mk
+source /opt/intel/compiler/latest/bin/compilervars.sh intel64
+source /opt/intel/impi/latest/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh
+
+export GEOPM_LAUNCHER=impi
+export CC=icc
+export CXX=icpc
+export MPICC=mpiicc
+export MPICXX=mpiicpc
+export FC=ifort
+export F77=ifort
+export F90=ifort
+export MPIFORT=mpiifort
+export MPIFC=mpiifort
+export MPIF77=mpiifort
+export MPIF90=mpiifort


### PR DESCRIPTION
- Do not specify FI_PROVIDER in endeavor config
  since the system has multiple fabrics.
- One work around is to see which lustre file systems
  are loaded but this inference is not very direct.

Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
