### PR TITLE
Pennant configuration changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@
 /integration/apps/nasft/nasft/nas_ft
 /integration/apps/nasft/nasft/*.o
 /integration/apps/pennant/PENNANT/
+/integration/apps/pennant/pennant_1_0_1.tgz
 /integration/test/*.config
 /integration/test/geopm_test_integration
 /integration/test/geopm_test_integration.pyc

--- a/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
+++ b/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
@@ -1,4 +1,4 @@
-From 6266626aefb0b8ddae0f838429a2c11a6414c4ac Mon Sep 17 00:00:00 2001
+From f766708b5ef5b3dcd6af90ac01558fca037a6b3a Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Sat, 24 Oct 2020 15:04:43 -0700
 Subject: [PATCH 1/2] Fixed Makefile to GEOPM and Intel conventions.

--- a/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
+++ b/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
@@ -1,4 +1,4 @@
-From 5eaba38677522f077091b549334efc0b0d614eb5 Mon Sep 17 00:00:00 2001
+From 8918aa87cbb70ba7bffffea3d334210912159ddd Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Wed, 4 Nov 2020 06:55:51 -0800
 Subject: [PATCH 2/2] Added geopm epoch markup.
@@ -41,7 +41,7 @@ Signed-off-by: Fuat Keceli <fuat.keceli@intel.com>
  2 files changed, 18 insertions(+)
 
 diff --git a/Makefile b/Makefile
-index e05e812..4f4dbdb 100644
+index e05e812..a0611ef 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -36,6 +36,12 @@ CXXFLAGS_OPENMP := -qopenmp
@@ -51,14 +51,14 @@ index e05e812..4f4dbdb 100644
 +# link against geopm
 +ifdef USEGEOPM
 +	LDFLAGS += $(GEOPM_LDFLAGS) $(GEOPM_LDLIBS)
-+	CXXFLAGS += $(GEOPM_CFLAGS) -DUSEGEOPM
++	CXXFLAGS += $(GEOPM_CFLAGS) -DUSEGEOPM -DEPOCH_TO_OUTERLOOP=$(EPOCH_TO_OUTERLOOP)
 +endif
 +
  # add mpi to compile (comment out for serial build)
  # the following assumes the existence of an mpi compiler
  # wrapper called mpicxx
 diff --git a/src/Driver.cc b/src/Driver.cc
-index 2b919df..dca6d4c 100644
+index 2b919df..c75da82 100644
 --- a/src/Driver.cc
 +++ b/src/Driver.cc
 @@ -28,6 +28,10 @@
@@ -79,7 +79,7 @@ index 2b919df..dca6d4c 100644
 +#ifdef USEGEOPM
 +        // Picking up an epoch every cycle end up in too many epochs
 +        // per second and increases the GEOPM control loop significantly.
-+        if (cycle % 100 == 0) {
++        if (cycle % EPOCH_TO_OUTERLOOP == 0) {
 +            geopm_prof_epoch();
 +        }
 +#endif

--- a/integration/apps/pennant/README.md
+++ b/integration/apps/pennant/README.md
@@ -1,5 +1,35 @@
+# What is Pennant?
+
 From https://asc.llnl.gov/coral-2-benchmarks:
 
     PENNANT is a mini-app for hydrodynamics on general unstructured
     meshes in 2D (arbitrary polygons). It makes heavy use of indirect
     addressing and irregular memory access patterns.
+
+A detailed description of the algorithm can be found in the Pennant
+repository (downloaded to integration/apps/pennant/PENNANT by the
+build.sh script) under doc/pennantdoc.pdf.
+
+# Number of Cores Reserved for Pennant
+
+Pennant AppConfig file (pennant.py) reserves N physical cores per node
+where N is the largest even number less than the total number of physical
+cores in the node. This way, at least one physical core is reserved for
+the OS and GEOPM.
+
+# GEOPM Epoch Selection
+
+Based on the problem size we choose a different build of pennant.
+The difference between these builds is how GEOPM epochs are marked:
+
+    epoch100: One epoch every 100 outer loops iterations.
+    epoch1: One epoch every 100 outer loops iterations.
+    default: No epoch markup.
+
+There is a known issue that epochs occuring too often causes GEOPM to hang due to
+epoch handling overwhelming GEOPM control loop. Larger problem sizes are expected to
+be able to handle a smaller number of outer loops per epoch since outer loop time
+seems to increase with problem size.
+
+The map of which dataset is run with which build is kept in the AppConfig file for
+Pennant (pennant.py).

--- a/integration/apps/pennant/README.md
+++ b/integration/apps/pennant/README.md
@@ -22,8 +22,8 @@ the OS and GEOPM.
 Based on the problem size we choose a different build of pennant.
 The difference between these builds is how GEOPM epochs are marked:
 
-    epoch100: One epoch every 100 outer loops iterations.
-    epoch1: One epoch every 100 outer loops iterations.
+    epoch100: One epoch every 100 outer loop iterations.
+    epoch1: One epoch every outer loop iteration.
     default: No epoch markup.
 
 There is a known issue that epochs occuring too often causes GEOPM to hang due to

--- a/integration/apps/pennant/build.sh
+++ b/integration/apps/pennant/build.sh
@@ -49,4 +49,10 @@ setup_source_git ${DIRNAME}
 
 # Build application
 cd ${DIRNAME}
-make USEGEOPM=1
+make USEGEOPM=1 EPOCH_TO_OUTERLOOP=100
+mv build build_geopm_epoch100
+make clean
+make USEGEOPM=1 EPOCH_TO_OUTERLOOP=1
+mv build build_geopm_epoch1
+make clean
+make

--- a/integration/apps/pennant/pennant.py
+++ b/integration/apps/pennant/pennant.py
@@ -81,8 +81,8 @@ class PennantAppConf(apps.AppConf):
 
         # Based on the problem size we choose a different build of pennant.
         # The difference between these builds is how GEOPM epochs are marked:
-        #    epoch100: One epoch every 100 outer loops iterations.
-        #    epoch1: One epoch every 100 outer loops iterations.
+        #    epoch100: One epoch every 100 outer loop iterations.
+        #    epoch1: One epoch every outer loop iteration.
         #    default: No epoch markup.
         # There is a known issue that epochs occuring too often causes GEOPM to hang due to
         # epoch handling overwhelming GEOPM control loop. Larger problem sizes are expected to

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_pennant.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_pennant.py
@@ -48,7 +48,6 @@ if __name__ == '__main__':
     pennant.setup_run_args(parser)
     args, extra_args = parser.parse_known_args()
     mach = machine.init_output_dir(args.output_dir)
-    app_conf = pennant.PennantAppConf(mach, args.pennant_input,
-                                      args.pennant_cores_per_node)
+    app_conf = pennant.create_appconf(mach, args)
     frequency_sweep.launch(app_conf=app_conf, args=args,
                            experiment_cli_args=extra_args)

--- a/integration/experiment/monitor/run_monitor_pennant.py
+++ b/integration/experiment/monitor/run_monitor_pennant.py
@@ -48,7 +48,6 @@ if __name__ == '__main__':
     pennant.setup_run_args(parser)
     args, extra_args = parser.parse_known_args()
     mach = machine.init_output_dir(args.output_dir)
-    app_conf = pennant.PennantAppConf(mach, args.pennant_input,
-                                      args.pennant_cores_per_node)
+    app_conf = pennant.create_appconf(mach, args)
     monitor.launch(app_conf=app_conf, args=args,
                    experiment_cli_args=extra_args)

--- a/integration/experiment/power_sweep/run_power_sweep_pennant.py
+++ b/integration/experiment/power_sweep/run_power_sweep_pennant.py
@@ -49,7 +49,6 @@ if __name__ == '__main__':
     pennant.setup_run_args(parser)
     args, extra_args = parser.parse_known_args()
     mach = machine.init_output_dir(args.output_dir)
-    app_conf = pennant.PennantAppConf(mach, args.pennant_input,
-                                      args.pennant_cores_per_node)
+    app_conf = pennant.create_appconf(mach, args)
     power_sweep.launch(app_conf=app_conf, args=args,
                        experiment_cli_args=extra_args)


### PR DESCRIPTION
1. Added alternative builds with different outer loop iterations to GEOPM epoch ratios. Different builds are chosen for different datasets.
2. Added more information to Pennant README.
3. Changed number of physical cores per node reserved for to be automatically deduced from the node configuration.
4. Added new command line options for Pennant run control.
5. New pennant.create_appconf(mach, args) function: Called from the run scripts to create the AppConfig. This way, we can add/remove command line options without having to change all the run scripts in the future.
6. Cleaned up Pennant constructor.
7. Added integration/apps/pennant/pennant_1_0_1.tgz to .gitignore.

