### PR TITLE
Pennant GEOPM region markup

### DIFF
--- a/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
+++ b/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
@@ -1,7 +1,7 @@
-From f766708b5ef5b3dcd6af90ac01558fca037a6b3a Mon Sep 17 00:00:00 2001
+From e69786877b727a92f47bd0f39187f02e3cc52098 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Sat, 24 Oct 2020 15:04:43 -0700
-Subject: [PATCH 1/2] Fixed Makefile to GEOPM and Intel conventions.
+Subject: [PATCH 1/3] Fixed Makefile to GEOPM and Intel conventions.
 
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #

--- a/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
+++ b/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
@@ -1,4 +1,4 @@
-From 9b40a0edd8c0264d806b295ed6217c1879967c07 Mon Sep 17 00:00:00 2001
+From 6b135cbf482881e48d99da93adef0781316becc0 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Sat, 24 Oct 2020 15:04:43 -0700
 Subject: [PATCH 1/3] Fixed Makefile to GEOPM and Intel conventions.

--- a/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
+++ b/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
@@ -1,4 +1,4 @@
-From e69786877b727a92f47bd0f39187f02e3cc52098 Mon Sep 17 00:00:00 2001
+From 987f8750ef032b3b2208ed0cccb448d7ee939b38 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Sat, 24 Oct 2020 15:04:43 -0700
 Subject: [PATCH 1/3] Fixed Makefile to GEOPM and Intel conventions.

--- a/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
+++ b/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
@@ -1,4 +1,4 @@
-From 987f8750ef032b3b2208ed0cccb448d7ee939b38 Mon Sep 17 00:00:00 2001
+From 9b40a0edd8c0264d806b295ed6217c1879967c07 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Sat, 24 Oct 2020 15:04:43 -0700
 Subject: [PATCH 1/3] Fixed Makefile to GEOPM and Intel conventions.

--- a/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
+++ b/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
@@ -1,4 +1,4 @@
-From cca8ef800267db82f7616d3d770f616ffaf3dc2c Mon Sep 17 00:00:00 2001
+From bafca9f816af1ffab7813382181f152d5848e452 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Wed, 4 Nov 2020 06:55:51 -0800
 Subject: [PATCH 2/3] Added geopm epoch markup.

--- a/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
+++ b/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
@@ -1,4 +1,4 @@
-From bafca9f816af1ffab7813382181f152d5848e452 Mon Sep 17 00:00:00 2001
+From f14e22fd61448762fd6a5c399378b5f7aa4c841e Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Wed, 4 Nov 2020 06:55:51 -0800
 Subject: [PATCH 2/3] Added geopm epoch markup.

--- a/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
+++ b/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
@@ -1,4 +1,4 @@
-From f14e22fd61448762fd6a5c399378b5f7aa4c841e Mon Sep 17 00:00:00 2001
+From e09a1a5a6e14c075de2b91847cd51b9b251673cf Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Wed, 4 Nov 2020 06:55:51 -0800
 Subject: [PATCH 2/3] Added geopm epoch markup.

--- a/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
+++ b/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
@@ -1,7 +1,7 @@
-From 8918aa87cbb70ba7bffffea3d334210912159ddd Mon Sep 17 00:00:00 2001
+From cca8ef800267db82f7616d3d770f616ffaf3dc2c Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Wed, 4 Nov 2020 06:55:51 -0800
-Subject: [PATCH 2/2] Added geopm epoch markup.
+Subject: [PATCH 2/3] Added geopm epoch markup.
 
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #

--- a/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
+++ b/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
@@ -1,4 +1,4 @@
-From 31d5ec851755fb6a948b41bae9a3bacb3fd6f2ab Mon Sep 17 00:00:00 2001
+From 49a76ed325466f32036ae9f6344988108f1465f6 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Tue, 1 Dec 2020 17:44:13 -0800
 Subject: [PATCH 3/3] Added GEOPM region markup
@@ -36,35 +36,32 @@ Subject: [PATCH 3/3] Added GEOPM region markup
 
 Signed-off-by: Fuat Keceli <fuat.keceli@intel.com>
 ---
- Makefile            |  6 ++++
- src/Driver.cc       | 28 +++++++++++++++++-
+ Makefile            |  3 ++
+ src/Driver.cc       | 15 +++++++++-
  src/Hydro.cc        | 85 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
- src/PennantGeopm.cc | 56 +++++++++++++++++++++++++++++++++++
- src/PennantGeopm.hh | 33 +++++++++++++++++++++
+ src/PennantGeopm.cc | 46 +++++++++++++++++++++++++++++
+ src/PennantGeopm.hh | 28 ++++++++++++++++++
  src/main.cc         |  3 ++
- 6 files changed, 209 insertions(+), 2 deletions(-)
+ 6 files changed, 178 insertions(+), 2 deletions(-)
  create mode 100644 src/PennantGeopm.cc
  create mode 100644 src/PennantGeopm.hh
 
 diff --git a/Makefile b/Makefile
-index a0611ef..369d119 100644
+index a0611ef..ba33a1d 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -40,6 +40,12 @@ CXXFLAGS := $(CXXFLAGS_OPT)
+@@ -40,6 +40,9 @@ CXXFLAGS := $(CXXFLAGS_OPT)
  ifdef USEGEOPM
  	LDFLAGS += $(GEOPM_LDFLAGS) $(GEOPM_LDLIBS)
  	CXXFLAGS += $(GEOPM_CFLAGS) -DUSEGEOPM -DEPOCH_TO_OUTERLOOP=$(EPOCH_TO_OUTERLOOP)
 +ifdef USEGEOPMMARKUP
 +	CXXFLAGS += -DUSEGEOPMMARKUP
 +endif
-+ifdef USEGEOPMMARKUP_2
-+	CXXFLAGS += -DUSEGEOPMMARKUP_2
-+endif
  endif
  
  # add mpi to compile (comment out for serial build)
 diff --git a/src/Driver.cc b/src/Driver.cc
-index c75da82..9785995 100644
+index c75da82..6339f31 100644
 --- a/src/Driver.cc
 +++ b/src/Driver.cc
 @@ -31,9 +31,11 @@
@@ -87,7 +84,7 @@ index c75da82..9785995 100644
  }
  
  Driver::~Driver() {
-@@ -111,12 +112,37 @@ void Driver::run() {
+@@ -111,9 +112,21 @@ void Driver::run() {
  
          cycle += 1;
  
@@ -95,9 +92,6 @@ index c75da82..9785995 100644
 +#ifdef USEGEOPMMARKUP
 +        geopm_prof_enter(region_id_calcGlobalDt);
 +#endif // USEGEOPMMARKUP
-+#ifdef USEGEOPMMARKUP_2
-+        geopm_prof_enter(region_id_calcGlobalDt);
-+#endif // USEGEOPMMARKUP_2
 +#endif // USEGEOPM
 +
          // get timestep
@@ -107,24 +101,11 @@ index c75da82..9785995 100644
 +#ifdef USEGEOPMMARKUP
 +        geopm_prof_exit(region_id_calcGlobalDt);
 +#endif // USEGEOPMMARKUP
-+#ifdef USEGEOPMMARKUP_2
-+        geopm_prof_exit(region_id_calcGlobalDt);
-+        geopm_prof_enter(region_id_hydroDoCycle);
-+#endif // USEGEOPMMARKUP_2
 +#endif // USEGEOPM
 +
          // begin hydro cycle
          hydro->doCycle(dt);
  
-+#ifdef USEGEOPM
-+#ifdef USEGEOPMMARKUP_2
-+        geopm_prof_exit(region_id_hydroDoCycle);
-+#endif // USEGEOPMMARKUP_2
-+#endif // USEGEOPM
-+
-         time += dt;
- 
-         if (mype == 0 &&
 diff --git a/src/Hydro.cc b/src/Hydro.cc
 index 23fab68..4427352 100644
 --- a/src/Hydro.cc
@@ -278,10 +259,10 @@ index 23fab68..4427352 100644
          const double2* px0,
 diff --git a/src/PennantGeopm.cc b/src/PennantGeopm.cc
 new file mode 100644
-index 0000000..dbea3c0
+index 0000000..49d1af5
 --- /dev/null
 +++ b/src/PennantGeopm.cc
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,46 @@
 +#ifdef USEGEOPM
 +#include "geopm.h"
 +#include "PennantGeopm.hh"
@@ -305,11 +286,6 @@ index 0000000..dbea3c0
 +uint64_t region_id_doCycle_omp5;
 +#endif // USEGEOPMMARKUP
 +
-+#ifdef USEGEOPMMARKUP_2
-+uint64_t region_id_calcGlobalDt;
-+uint64_t region_id_hydroDoCycle;
-+#endif // USEGEOPMMARKUP
-+
 +#endif // USEGEOPM
 +
 +void init() {
@@ -329,11 +305,6 @@ index 0000000..dbea3c0
 +    geopm_prof_region("doCycle_omp5", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp5);
 +#endif // USEGEOPMMARKUP
 +
-+#ifdef USEGEOPMMARKUP_2
-+    geopm_prof_region("calcGlobalDt", GEOPM_REGION_HINT_UNKNOWN, &region_id_calcGlobalDt);
-+    geopm_prof_region("hydroDoCycle", GEOPM_REGION_HINT_UNKNOWN, &region_id_hydroDoCycle);
-+#endif // USEGEOPMMARKUP_2
-+
 +#endif // USEGEOPM
 +}  // init
 +
@@ -341,10 +312,10 @@ index 0000000..dbea3c0
 \ No newline at end of file
 diff --git a/src/PennantGeopm.hh b/src/PennantGeopm.hh
 new file mode 100644
-index 0000000..fce4d06
+index 0000000..31bbd87
 --- /dev/null
 +++ b/src/PennantGeopm.hh
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,28 @@
 +#ifndef PENNANT_GEOPM_HH_
 +#define PENNANT_GEOPM_HH_
 +
@@ -365,11 +336,6 @@ index 0000000..fce4d06
 +    extern uint64_t region_id_doCycle_checkBadSides2;
 +    extern uint64_t region_id_doCycle_omp5;
 +#endif // USEGEOPMMARKUP
-+
-+#ifdef USEGEOPMMARKUP_2
-+    extern uint64_t region_id_calcGlobalDt;
-+    extern uint64_t region_id_hydroDoCycle;
-+#endif // USEGEOPMMARKUP_2
 +
 +#endif // USEGEOPM
 +

--- a/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
+++ b/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
@@ -1,4 +1,4 @@
-From 3e46efb2c171ea249538cf6ed42f0fb023923426 Mon Sep 17 00:00:00 2001
+From 31d5ec851755fb6a948b41bae9a3bacb3fd6f2ab Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Tue, 1 Dec 2020 17:44:13 -0800
 Subject: [PATCH 3/3] Added GEOPM region markup
@@ -39,10 +39,10 @@ Signed-off-by: Fuat Keceli <fuat.keceli@intel.com>
  Makefile            |  6 ++++
  src/Driver.cc       | 28 +++++++++++++++++-
  src/Hydro.cc        | 85 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
- src/PennantGeopm.cc | 54 ++++++++++++++++++++++++++++++++++
- src/PennantGeopm.hh | 32 ++++++++++++++++++++
+ src/PennantGeopm.cc | 56 +++++++++++++++++++++++++++++++++++
+ src/PennantGeopm.hh | 33 +++++++++++++++++++++
  src/main.cc         |  3 ++
- 6 files changed, 206 insertions(+), 2 deletions(-)
+ 6 files changed, 209 insertions(+), 2 deletions(-)
  create mode 100644 src/PennantGeopm.cc
  create mode 100644 src/PennantGeopm.hh
 
@@ -126,7 +126,7 @@ index c75da82..9785995 100644
  
          if (mype == 0 &&
 diff --git a/src/Hydro.cc b/src/Hydro.cc
-index 23fab68..82fe633 100644
+index 23fab68..4427352 100644
 --- a/src/Hydro.cc
 +++ b/src/Hydro.cc
 @@ -30,8 +30,15 @@
@@ -254,7 +254,7 @@ index 23fab68..82fe633 100644
 +#ifdef USEGEOPM
 +#ifdef USEGEOPMMARKUP
 +    geopm_prof_exit(region_id_doCycle_checkBadSides2);
-+    geopm_prof_enter(region_id_doCycle_omp4);
++    geopm_prof_enter(region_id_doCycle_omp5);
 +#endif
 +#endif
 +
@@ -268,7 +268,7 @@ index 23fab68..82fe633 100644
 -}
 +#ifdef USEGEOPM
 +#ifdef USEGEOPMMARKUP
-+    geopm_prof_exit(region_id_doCycle_omp4);
++    geopm_prof_exit(region_id_doCycle_omp5);
 +#endif
 +#endif
  
@@ -278,10 +278,10 @@ index 23fab68..82fe633 100644
          const double2* px0,
 diff --git a/src/PennantGeopm.cc b/src/PennantGeopm.cc
 new file mode 100644
-index 0000000..f1e4230
+index 0000000..dbea3c0
 --- /dev/null
 +++ b/src/PennantGeopm.cc
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,56 @@
 +#ifdef USEGEOPM
 +#include "geopm.h"
 +#include "PennantGeopm.hh"
@@ -302,6 +302,7 @@ index 0000000..f1e4230
 +uint64_t region_id_doCycle_resetDtHydro;
 +uint64_t region_id_doCycle_omp4;
 +uint64_t region_id_doCycle_checkBadSides2;
++uint64_t region_id_doCycle_omp5;
 +#endif // USEGEOPMMARKUP
 +
 +#ifdef USEGEOPMMARKUP_2
@@ -325,6 +326,7 @@ index 0000000..f1e4230
 +    geopm_prof_region("doCycle_resetDtHydro", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_resetDtHydro);
 +    geopm_prof_region("doCycle_omp4", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp4);
 +    geopm_prof_region("doCycle_checkBadSides2", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_checkBadSides2);
++    geopm_prof_region("doCycle_omp5", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp5);
 +#endif // USEGEOPMMARKUP
 +
 +#ifdef USEGEOPMMARKUP_2
@@ -339,10 +341,10 @@ index 0000000..f1e4230
 \ No newline at end of file
 diff --git a/src/PennantGeopm.hh b/src/PennantGeopm.hh
 new file mode 100644
-index 0000000..b14724c
+index 0000000..fce4d06
 --- /dev/null
 +++ b/src/PennantGeopm.hh
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +#ifndef PENNANT_GEOPM_HH_
 +#define PENNANT_GEOPM_HH_
 +
@@ -361,6 +363,7 @@ index 0000000..b14724c
 +    extern uint64_t region_id_doCycle_resetDtHydro;
 +    extern uint64_t region_id_doCycle_omp4;
 +    extern uint64_t region_id_doCycle_checkBadSides2;
++    extern uint64_t region_id_doCycle_omp5;
 +#endif // USEGEOPMMARKUP
 +
 +#ifdef USEGEOPMMARKUP_2

--- a/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
+++ b/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
@@ -1,0 +1,392 @@
+From 57bfeefcf42a9ed32ffe112c2e881ec0fd6f23b8 Mon Sep 17 00:00:00 2001
+From: Fuat Keceli <fuat.keceli@intel.com>
+Date: Tue, 1 Dec 2020 17:44:13 -0800
+Subject: [PATCH 3/3] Added GEOPM region markup
+
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+Signed-off-by: Fuat Keceli <fuat.keceli@intel.com>
+---
+ Makefile            |  6 +++++
+ src/Driver.cc       | 28 ++++++++++++++++++-
+ src/Hydro.cc        | 78 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
+ src/PennantGeopm.cc | 54 +++++++++++++++++++++++++++++++++++++
+ src/PennantGeopm.hh | 32 ++++++++++++++++++++++
+ src/main.cc         |  3 +++
+ 6 files changed, 199 insertions(+), 2 deletions(-)
+ create mode 100644 src/PennantGeopm.cc
+ create mode 100644 src/PennantGeopm.hh
+
+diff --git a/Makefile b/Makefile
+index a0611ef..369d119 100644
+--- a/Makefile
++++ b/Makefile
+@@ -40,6 +40,12 @@ CXXFLAGS := $(CXXFLAGS_OPT)
+ ifdef USEGEOPM
+ 	LDFLAGS += $(GEOPM_LDFLAGS) $(GEOPM_LDLIBS)
+ 	CXXFLAGS += $(GEOPM_CFLAGS) -DUSEGEOPM -DEPOCH_TO_OUTERLOOP=$(EPOCH_TO_OUTERLOOP)
++ifdef USEGEOPMMARKUP
++	CXXFLAGS += -DUSEGEOPMMARKUP
++endif
++ifdef USEGEOPMMARKUP_2
++	CXXFLAGS += -DUSEGEOPMMARKUP_2
++endif
+ endif
+ 
+ # add mpi to compile (comment out for serial build)
+diff --git a/src/Driver.cc b/src/Driver.cc
+index c75da82..9785995 100644
+--- a/src/Driver.cc
++++ b/src/Driver.cc
+@@ -31,9 +31,11 @@
+ #ifdef USEGEOPM
+ #include "geopm.h"
+ #endif
++#include "PennantGeopm.hh"
+ 
+ using namespace std;
+ 
++using namespace PennantGeopm;
+ 
+ Driver::Driver(const InputFile* inp, const string& pname)
+         : probname(pname) {
+@@ -70,7 +72,6 @@ Driver::Driver(const InputFile* inp, const string& pname)
+     // initialize mesh, hydro
+     mesh = new Mesh(inp);
+     hydro = new Hydro(inp, mesh);
+-
+ }
+ 
+ Driver::~Driver() {
+@@ -111,12 +112,37 @@ void Driver::run() {
+ 
+         cycle += 1;
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++        geopm_prof_enter(region_id_calcGlobalDt);
++#endif // USEGEOPMMARKUP
++#ifdef USEGEOPMMARKUP_2
++        geopm_prof_enter(region_id_calcGlobalDt);
++#endif // USEGEOPMMARKUP_2
++#endif // USEGEOPM
++
+         // get timestep
+         calcGlobalDt();
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++        geopm_prof_exit(region_id_calcGlobalDt);
++#endif // USEGEOPMMARKUP
++#ifdef USEGEOPMMARKUP_2
++        geopm_prof_exit(region_id_calcGlobalDt);
++        geopm_prof_enter(region_id_hydroDoCycle);
++#endif // USEGEOPMMARKUP_2
++#endif // USEGEOPM
++
+         // begin hydro cycle
+         hydro->doCycle(dt);
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP_2
++        geopm_prof_exit(region_id_hydroDoCycle);
++#endif // USEGEOPMMARKUP_2
++#endif // USEGEOPM
++
+         time += dt;
+ 
+         if (mype == 0 &&
+diff --git a/src/Hydro.cc b/src/Hydro.cc
+index 23fab68..02a7190 100644
+--- a/src/Hydro.cc
++++ b/src/Hydro.cc
+@@ -30,8 +30,15 @@
+ #include "QCS.hh"
+ #include "HydroBC.hh"
+ 
++#ifdef USEGEOPM
++#include "geopm.h"
++#endif
++#include "PennantGeopm.hh"
++
+ using namespace std;
+ 
++using namespace PennantGeopm;
++
+ 
+ Hydro::Hydro(const InputFile* inp, Mesh* m) : mesh(m) {
+     cfl = inp->getDouble("cfl", 0.6);
+@@ -193,6 +200,12 @@ void Hydro::doCycle(
+     double* smf = mesh->smf;
+     double* zdl = mesh->zdl;
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_enter(region_id_doCycle_omp1);
++#endif
++#endif
++
+     // Begin hydro cycle
+     #pragma omp parallel for schedule(static)
+     for (int pch = 0; pch < numpch; ++pch) {
+@@ -208,6 +221,13 @@ void Hydro::doCycle(
+         advPosHalf(px0, pu0, dt, pxp, pfirst, plast);
+     } // for pch
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_omp1);
++    geopm_prof_enter(region_id_doCycle_omp2);
++#endif
++#endif
++
+     #pragma omp parallel for schedule(static)
+     for (int sch = 0; sch < numsch; ++sch) {
+         int sfirst = mesh->schsfirst[sch];
+@@ -241,12 +261,41 @@ void Hydro::doCycle(
+         qcs->calcForce(sfq, sfirst, slast);
+         sumCrnrForce(sfp, sfq, sft, cftot, sfirst, slast);
+     }  // for sch
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_omp2);
++    geopm_prof_enter(region_id_doCycle_checkBadSides1);
++#endif
++#endif
++
+     mesh->checkBadSides();
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_checkBadSides1);
++    geopm_prof_enter(region_id_doCycle_sumToPoints1);
++#endif
++#endif
++
+     // sum corner masses, forces to points
+     mesh->sumToPoints(cmaswt, pmaswt);
++
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_sumToPoints1);
++    geopm_prof_enter(region_id_doCycle_sumToPoints2);
++#endif
++#endif
++
+     mesh->sumToPoints(cftot, pf);
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_sumToPoints2);
++    geopm_prof_enter(region_id_doCycle_omp3);
++#endif
++#endif
++
+     #pragma omp parallel for schedule(static)
+     for (int pch = 0; pch < numpch; ++pch) {
+         int pfirst = mesh->pchpfirst[pch];
+@@ -267,8 +316,22 @@ void Hydro::doCycle(
+         advPosFull(px0, pu0, pap, dt, px, pu, pfirst, plast);
+     }  // for pch
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_omp3);
++    geopm_prof_enter(region_id_doCycle_resetDtHydro);
++#endif
++#endif
++
+     resetDtHydro();
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_resetDtHydro);
++    geopm_prof_enter(region_id_doCycle_omp4);
++#endif
++#endif
++
+     #pragma omp parallel for schedule(static)
+     for (int sch = 0; sch < numsch; ++sch) {
+         int sfirst = mesh->schsfirst[sch];
+@@ -286,6 +349,14 @@ void Hydro::doCycle(
+         calcWork(sfp, sfq, pu0, pu, pxp, dt, zw, zetot,
+                 sfirst, slast);
+     }  // for sch
++
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_omp4);
++    geopm_prof_enter(region_id_doCycle_checkBadSides2);
++#endif
++#endif
++
+     mesh->checkBadSides();
+ 
+     #pragma omp parallel for schedule(static)
+@@ -304,8 +375,13 @@ void Hydro::doCycle(
+         calcDtHydro(zdl, zvol, zvol0, dt, zfirst, zlast);
+     }  // for zch
+ 
+-}
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_checkBadSides2);
++#endif
++#endif
+ 
++}
+ 
+ void Hydro::advPosHalf(
+         const double2* px0,
+diff --git a/src/PennantGeopm.cc b/src/PennantGeopm.cc
+new file mode 100644
+index 0000000..f1e4230
+--- /dev/null
++++ b/src/PennantGeopm.cc
+@@ -0,0 +1,54 @@
++#ifdef USEGEOPM
++#include "geopm.h"
++#include "PennantGeopm.hh"
++#endif
++
++namespace PennantGeopm {
++
++#ifdef USEGEOPM
++
++#ifdef USEGEOPMMARKUP
++uint64_t region_id_calcGlobalDt;
++uint64_t region_id_doCycle_omp1;
++uint64_t region_id_doCycle_omp2;
++uint64_t region_id_doCycle_checkBadSides1;
++uint64_t region_id_doCycle_sumToPoints1;
++uint64_t region_id_doCycle_sumToPoints2;
++uint64_t region_id_doCycle_omp3;
++uint64_t region_id_doCycle_resetDtHydro;
++uint64_t region_id_doCycle_omp4;
++uint64_t region_id_doCycle_checkBadSides2;
++#endif // USEGEOPMMARKUP
++
++#ifdef USEGEOPMMARKUP_2
++uint64_t region_id_calcGlobalDt;
++uint64_t region_id_hydroDoCycle;
++#endif // USEGEOPMMARKUP
++
++#endif // USEGEOPM
++
++void init() {
++#ifdef USEGEOPM
++
++#ifdef USEGEOPMMARKUP
++    geopm_prof_region("calcGlobalDt", GEOPM_REGION_HINT_UNKNOWN, &region_id_calcGlobalDt);
++    geopm_prof_region("doCycle_omp1", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp1);
++    geopm_prof_region("doCycle_omp2", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp2);
++    geopm_prof_region("doCycle_checkBadSides1", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_checkBadSides1);
++    geopm_prof_region("doCycle_sumToPoints1", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_sumToPoints1);
++    geopm_prof_region("doCycle_sumToPoints2", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_sumToPoints2);
++    geopm_prof_region("doCycle_omp3", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp3);
++    geopm_prof_region("doCycle_resetDtHydro", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_resetDtHydro);
++    geopm_prof_region("doCycle_omp4", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp4);
++    geopm_prof_region("doCycle_checkBadSides2", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_checkBadSides2);
++#endif // USEGEOPMMARKUP
++
++#ifdef USEGEOPMMARKUP_2
++    geopm_prof_region("calcGlobalDt", GEOPM_REGION_HINT_UNKNOWN, &region_id_calcGlobalDt);
++    geopm_prof_region("hydroDoCycle", GEOPM_REGION_HINT_UNKNOWN, &region_id_hydroDoCycle);
++#endif // USEGEOPMMARKUP_2
++
++#endif // USEGEOPM
++}  // init
++
++}  // namespace PennantGeopm
+\ No newline at end of file
+diff --git a/src/PennantGeopm.hh b/src/PennantGeopm.hh
+new file mode 100644
+index 0000000..b14724c
+--- /dev/null
++++ b/src/PennantGeopm.hh
+@@ -0,0 +1,32 @@
++#ifndef PENNANT_GEOPM_HH_
++#define PENNANT_GEOPM_HH_
++
++namespace PennantGeopm {
++
++#ifdef USEGEOPM
++
++#ifdef USEGEOPMMARKUP
++    extern uint64_t region_id_calcGlobalDt;
++    extern uint64_t region_id_doCycle_omp1;
++    extern uint64_t region_id_doCycle_omp2;
++    extern uint64_t region_id_doCycle_checkBadSides1;
++    extern uint64_t region_id_doCycle_sumToPoints1;
++    extern uint64_t region_id_doCycle_sumToPoints2;
++    extern uint64_t region_id_doCycle_omp3;
++    extern uint64_t region_id_doCycle_resetDtHydro;
++    extern uint64_t region_id_doCycle_omp4;
++    extern uint64_t region_id_doCycle_checkBadSides2;
++#endif // USEGEOPMMARKUP
++
++#ifdef USEGEOPMMARKUP_2
++    extern uint64_t region_id_calcGlobalDt;
++    extern uint64_t region_id_hydroDoCycle;
++#endif // USEGEOPMMARKUP_2
++
++#endif // USEGEOPM
++
++void init();
++
++}  // namespace PennantGeopm
++
++#endif /* PENNANT_GEOPM_HH_ */
+\ No newline at end of file
+diff --git a/src/main.cc b/src/main.cc
+index 5c41673..c62b97f 100644
+--- a/src/main.cc
++++ b/src/main.cc
+@@ -18,12 +18,15 @@
+ #include "InputFile.hh"
+ #include "Driver.hh"
+ 
++#include "PennantGeopm.hh"
++
+ using namespace std;
+ 
+ 
+ int main(const int argc, const char** argv)
+ {
+     Parallel::init();
++    PennantGeopm::init();
+ 
+     if (argc != 2) {
+         if (Parallel::mype == 0)
+-- 
+1.8.3.1
+

--- a/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
+++ b/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
@@ -1,4 +1,4 @@
-From 57bfeefcf42a9ed32ffe112c2e881ec0fd6f23b8 Mon Sep 17 00:00:00 2001
+From 3e46efb2c171ea249538cf6ed42f0fb023923426 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Tue, 1 Dec 2020 17:44:13 -0800
 Subject: [PATCH 3/3] Added GEOPM region markup
@@ -36,13 +36,13 @@ Subject: [PATCH 3/3] Added GEOPM region markup
 
 Signed-off-by: Fuat Keceli <fuat.keceli@intel.com>
 ---
- Makefile            |  6 +++++
- src/Driver.cc       | 28 ++++++++++++++++++-
- src/Hydro.cc        | 78 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
- src/PennantGeopm.cc | 54 +++++++++++++++++++++++++++++++++++++
- src/PennantGeopm.hh | 32 ++++++++++++++++++++++
- src/main.cc         |  3 +++
- 6 files changed, 199 insertions(+), 2 deletions(-)
+ Makefile            |  6 ++++
+ src/Driver.cc       | 28 +++++++++++++++++-
+ src/Hydro.cc        | 85 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
+ src/PennantGeopm.cc | 54 ++++++++++++++++++++++++++++++++++
+ src/PennantGeopm.hh | 32 ++++++++++++++++++++
+ src/main.cc         |  3 ++
+ 6 files changed, 206 insertions(+), 2 deletions(-)
  create mode 100644 src/PennantGeopm.cc
  create mode 100644 src/PennantGeopm.hh
 
@@ -126,7 +126,7 @@ index c75da82..9785995 100644
  
          if (mype == 0 &&
 diff --git a/src/Hydro.cc b/src/Hydro.cc
-index 23fab68..02a7190 100644
+index 23fab68..82fe633 100644
 --- a/src/Hydro.cc
 +++ b/src/Hydro.cc
 @@ -30,8 +30,15 @@
@@ -237,7 +237,7 @@ index 23fab68..02a7190 100644
      #pragma omp parallel for schedule(static)
      for (int sch = 0; sch < numsch; ++sch) {
          int sfirst = mesh->schsfirst[sch];
-@@ -286,6 +349,14 @@ void Hydro::doCycle(
+@@ -286,8 +349,23 @@ void Hydro::doCycle(
          calcWork(sfp, sfq, pu0, pu, pxp, dt, zw, zetot,
                  sfirst, slast);
      }  // for sch
@@ -251,15 +251,24 @@ index 23fab68..02a7190 100644
 +
      mesh->checkBadSides();
  
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_checkBadSides2);
++    geopm_prof_enter(region_id_doCycle_omp4);
++#endif
++#endif
++
      #pragma omp parallel for schedule(static)
-@@ -304,8 +375,13 @@ void Hydro::doCycle(
+     for (int zch = 0; zch < mesh->numzch; ++zch) {
+         int zfirst = mesh->zchzfirst[zch];
+@@ -304,8 +382,13 @@ void Hydro::doCycle(
          calcDtHydro(zdl, zvol, zvol0, dt, zfirst, zlast);
      }  // for zch
  
 -}
 +#ifdef USEGEOPM
 +#ifdef USEGEOPMMARKUP
-+    geopm_prof_exit(region_id_doCycle_checkBadSides2);
++    geopm_prof_exit(region_id_doCycle_omp4);
 +#endif
 +#endif
  

--- a/integration/apps/pennant/Makefile.mk
+++ b/integration/apps/pennant/Makefile.mk
@@ -36,4 +36,5 @@ EXTRA_DIST += integration/apps/pennant/pennant.py \
               integration/apps/pennant/README.md \
               integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch \
               integration/apps/pennant/0002-Added-geopm-epoch-markup.patch \
+              integration/apps/pennant/0003-Added-GEOPM-region-markup.patch \
               # end

--- a/integration/apps/pennant/build.sh
+++ b/integration/apps/pennant/build.sh
@@ -49,10 +49,10 @@ setup_source_git ${DIRNAME}
 
 # Build application
 cd ${DIRNAME}
-make USEGEOPM=1 EPOCH_TO_OUTERLOOP=100
+make USEGEOPM=1 EPOCH_TO_OUTERLOOP=100 USEGEOPMMARKUP=1
 mv build build_geopm_epoch100
 make clean
-make USEGEOPM=1 EPOCH_TO_OUTERLOOP=1
+make USEGEOPM=1 EPOCH_TO_OUTERLOOP=1 USEGEOPMMARKUP=1
 mv build build_geopm_epoch1
 make clean
 make

--- a/integration/apps/pennant/pennant.py
+++ b/integration/apps/pennant/pennant.py
@@ -89,13 +89,13 @@ class PennantAppConf(apps.AppConf):
         # handle less outer loops per epoch since outer loop time seems to go up with
         # problem size.
         exec_dir = {
-            'PENNANT/test/leblancx4/leblancx4.pnt': 'PENNANT/build_geopm_epoch100/pennant',
-            'PENNANT/test/leblancx4/leblancx16.pnt': 'PENNANT/build_geopm_epoch1/pennant',
+            'leblancx4.pnt': 'PENNANT/build_geopm_epoch100/pennant',
+            'leblancx16.pnt': 'PENNANT/build_geopm_epoch1/pennant',
             'default': 'PENNANT/build/pennant'
         }
         if epoch_to_outerloop is None:
-            if problem_file in exec_dir:
-                self._exec_path = os.path.join(benchmark_dir, exec_dir[problem_file])
+            if os.path.basename(problem_file) in exec_dir:
+                self._exec_path = os.path.join(benchmark_dir, exec_dir[os.path.basename(problem_file)])
             else:
                 self._exec_path = os.path.join(benchmark_dir, exec_dir['default'])
         else:
@@ -105,7 +105,6 @@ class PennantAppConf(apps.AppConf):
             else:
                 raise RuntimeError('Epoch to outer loop count does not match any of the pennant builds: {}'.format(epoch_to_outerloop))
 
-        self._exec_path = os.path.join(benchmark_dir, 'PENNANT/build/pennant')
         if os.path.isfile(problem_file):
             self._exec_args = problem_file
         elif os.path.isfile(os.path.join(benchmark_dir, problem_file)):


### PR DESCRIPTION
- Added GEOPM markup to Pennant with two flavors: High level functions and lower level functions. The default is lower level functions and we can switch to the other flavor by editing the build.sh script in the future if needed for studies.
- Fixed a bug in pennant.py that was affecting the executable choice based on dataset.