### PR TITLE
Fixes for cache alignment 

### DIFF
--- a/src/All2allModelRegion.cpp
+++ b/src/All2allModelRegion.cpp
@@ -39,7 +39,7 @@
 #include "geopm.h"
 #include "geopm_time.h"
 #include "Exception.hpp"
-
+#include "Helper.hpp"
 
 namespace geopm
 {
@@ -53,7 +53,7 @@ namespace geopm
         , m_recv_buffer(NULL)
         , m_num_send(0)
         , m_num_rank(0)
-        , m_align(64)
+        , m_align(geopm::hardware_destructive_interference_size)
         , m_rank(-1)
     {
         m_name = "all2all";

--- a/src/DGEMMModelRegion.cpp
+++ b/src/DGEMMModelRegion.cpp
@@ -39,6 +39,7 @@
 #include "geopm.h"
 #include "Exception.hpp"
 #include "Profile.hpp"
+#include "Helper.hpp"
 
 #ifdef GEOPM_ENABLE_MKL
 #include <mkl.h>
@@ -76,7 +77,7 @@ namespace geopm
         , m_matrix_b(NULL)
         , m_matrix_c(NULL)
         , m_matrix_size(0)
-        , m_pad_size(64)
+        , m_pad_size(geopm::hardware_destructive_interference_size)
     {
         m_name = "dgemm";
         m_do_imbalance = do_imbalance;

--- a/src/Helper.hpp
+++ b/src/Helper.hpp
@@ -134,6 +134,11 @@ namespace geopm
     ///        byte-wise copied into the memory of signal.
     /// @return A well formatted string representation of the signal.
     std::string string_format_raw64(double signal);
+
+    /// @brief Cache line size used to properly align structs to avoid
+    ///        false sharing between threads.
+    /// @todo  Replace with C++17 standard library equivalent.
+    static constexpr int hardware_destructive_interference_size = 64;
 }
 
 #endif

--- a/src/SharedMemory.cpp
+++ b/src/SharedMemory.cpp
@@ -52,7 +52,8 @@
 namespace geopm
 {
     /// @brief Size of the lock in memory.
-    static constexpr size_t M_LOCK_SIZE = sizeof(pthread_mutex_t);
+    static constexpr size_t M_LOCK_SIZE = geopm::hardware_destructive_interference_size;
+    static_assert(sizeof(pthread_mutex_t) <= M_LOCK_SIZE, "M_LOCK_SIZE not large enough for mutex type");
 
     static void setup_mutex(pthread_mutex_t *lock)
     {

--- a/src/StreamModelRegion.cpp
+++ b/src/StreamModelRegion.cpp
@@ -38,6 +38,7 @@
 #include "geopm.h"
 #include "Exception.hpp"
 #include "Profile.hpp"
+#include "Helper.hpp"
 
 namespace geopm
 {
@@ -51,7 +52,7 @@ namespace geopm
         , m_array_b(NULL)
         , m_array_c(NULL)
         , m_array_len(0)
-        , m_align(64)
+        , m_align(geopm::hardware_destructive_interference_size)
     {
         m_name = "stream";
         m_do_imbalance = do_imbalance;

--- a/test/SharedMemoryTest.cpp
+++ b/test/SharedMemoryTest.cpp
@@ -36,6 +36,7 @@
 #include "geopm_error.h"
 #include "Exception.hpp"
 #include "SharedMemory.hpp"
+#include "Helper.hpp"
 #include "geopm_test.hpp"
 
 using geopm::SharedMemory;
@@ -147,7 +148,8 @@ TEST_F(SharedMemoryTest, lock_shmem)
     // normally, this mutex should not be accessed directly.  This test
     // checks that get_scoped_lock() has the expected side effects on the
     // mutex.
-    pthread_mutex_t *mutex = (pthread_mutex_t*)((char*)m_shmem->pointer() - sizeof(pthread_mutex_t));
+    pthread_mutex_t *mutex = (pthread_mutex_t*)((char*)m_shmem->pointer() -
+                                                geopm::hardware_destructive_interference_size);
 
     // mutex starts out lockable
     EXPECT_EQ(0, pthread_mutex_trylock(mutex));
@@ -176,7 +178,8 @@ TEST_F(SharedMemoryTest, lock_shmem_u)
     // normally, this mutex should not be accessed directly.  This test
     // checks that get_scoped_lock() has the expected side effects on the
     // mutex.
-    pthread_mutex_t *mutex = (pthread_mutex_t*)((char*)m_shmem_u->pointer() - sizeof(pthread_mutex_t));
+    pthread_mutex_t *mutex = (pthread_mutex_t*)((char*)m_shmem_u->pointer() -
+                                                geopm::hardware_destructive_interference_size);
 
     // mutex starts out lockable
     EXPECT_EQ(0, pthread_mutex_trylock(mutex));


### PR DESCRIPTION
- Add a constant for the cache line size to Helper.hpp
- Fix SharedMemory so that the visible memory region (after the lock) is cache aligned