### PR TITLE
Use ApplicationRecordLog in ApplicationSampler

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -457,6 +457,8 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/ApplicationSampler.cpp \
                             src/ApplicationSampler.hpp \
                             src/ApplicationSamplerImp.hpp \
+                            src/ApplicationStatus.cpp \
+                            src/ApplicationStatus.hpp \
                             src/CircularBuffer.hpp \
                             src/CNLIOGroup.cpp \
                             src/CNLIOGroup.hpp \

--- a/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
+++ b/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
@@ -1,7 +1,7 @@
-From f766708b5ef5b3dcd6af90ac01558fca037a6b3a Mon Sep 17 00:00:00 2001
+From e69786877b727a92f47bd0f39187f02e3cc52098 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Sat, 24 Oct 2020 15:04:43 -0700
-Subject: [PATCH 1/2] Fixed Makefile to GEOPM and Intel conventions.
+Subject: [PATCH 1/3] Fixed Makefile to GEOPM and Intel conventions.
 
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #

--- a/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
+++ b/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
@@ -1,4 +1,4 @@
-From 9b40a0edd8c0264d806b295ed6217c1879967c07 Mon Sep 17 00:00:00 2001
+From 6b135cbf482881e48d99da93adef0781316becc0 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Sat, 24 Oct 2020 15:04:43 -0700
 Subject: [PATCH 1/3] Fixed Makefile to GEOPM and Intel conventions.

--- a/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
+++ b/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
@@ -1,4 +1,4 @@
-From e69786877b727a92f47bd0f39187f02e3cc52098 Mon Sep 17 00:00:00 2001
+From 987f8750ef032b3b2208ed0cccb448d7ee939b38 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Sat, 24 Oct 2020 15:04:43 -0700
 Subject: [PATCH 1/3] Fixed Makefile to GEOPM and Intel conventions.

--- a/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
+++ b/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
@@ -1,4 +1,4 @@
-From 987f8750ef032b3b2208ed0cccb448d7ee939b38 Mon Sep 17 00:00:00 2001
+From 9b40a0edd8c0264d806b295ed6217c1879967c07 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Sat, 24 Oct 2020 15:04:43 -0700
 Subject: [PATCH 1/3] Fixed Makefile to GEOPM and Intel conventions.

--- a/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
+++ b/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
@@ -1,4 +1,4 @@
-From cca8ef800267db82f7616d3d770f616ffaf3dc2c Mon Sep 17 00:00:00 2001
+From bafca9f816af1ffab7813382181f152d5848e452 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Wed, 4 Nov 2020 06:55:51 -0800
 Subject: [PATCH 2/3] Added geopm epoch markup.

--- a/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
+++ b/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
@@ -1,4 +1,4 @@
-From bafca9f816af1ffab7813382181f152d5848e452 Mon Sep 17 00:00:00 2001
+From f14e22fd61448762fd6a5c399378b5f7aa4c841e Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Wed, 4 Nov 2020 06:55:51 -0800
 Subject: [PATCH 2/3] Added geopm epoch markup.

--- a/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
+++ b/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
@@ -1,4 +1,4 @@
-From f14e22fd61448762fd6a5c399378b5f7aa4c841e Mon Sep 17 00:00:00 2001
+From e09a1a5a6e14c075de2b91847cd51b9b251673cf Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Wed, 4 Nov 2020 06:55:51 -0800
 Subject: [PATCH 2/3] Added geopm epoch markup.

--- a/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
+++ b/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
@@ -1,7 +1,7 @@
-From 8918aa87cbb70ba7bffffea3d334210912159ddd Mon Sep 17 00:00:00 2001
+From cca8ef800267db82f7616d3d770f616ffaf3dc2c Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Wed, 4 Nov 2020 06:55:51 -0800
-Subject: [PATCH 2/2] Added geopm epoch markup.
+Subject: [PATCH 2/3] Added geopm epoch markup.
 
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #

--- a/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
+++ b/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
@@ -1,4 +1,4 @@
-From 31d5ec851755fb6a948b41bae9a3bacb3fd6f2ab Mon Sep 17 00:00:00 2001
+From 49a76ed325466f32036ae9f6344988108f1465f6 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Tue, 1 Dec 2020 17:44:13 -0800
 Subject: [PATCH 3/3] Added GEOPM region markup
@@ -36,35 +36,32 @@ Subject: [PATCH 3/3] Added GEOPM region markup
 
 Signed-off-by: Fuat Keceli <fuat.keceli@intel.com>
 ---
- Makefile            |  6 ++++
- src/Driver.cc       | 28 +++++++++++++++++-
+ Makefile            |  3 ++
+ src/Driver.cc       | 15 +++++++++-
  src/Hydro.cc        | 85 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
- src/PennantGeopm.cc | 56 +++++++++++++++++++++++++++++++++++
- src/PennantGeopm.hh | 33 +++++++++++++++++++++
+ src/PennantGeopm.cc | 46 +++++++++++++++++++++++++++++
+ src/PennantGeopm.hh | 28 ++++++++++++++++++
  src/main.cc         |  3 ++
- 6 files changed, 209 insertions(+), 2 deletions(-)
+ 6 files changed, 178 insertions(+), 2 deletions(-)
  create mode 100644 src/PennantGeopm.cc
  create mode 100644 src/PennantGeopm.hh
 
 diff --git a/Makefile b/Makefile
-index a0611ef..369d119 100644
+index a0611ef..ba33a1d 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -40,6 +40,12 @@ CXXFLAGS := $(CXXFLAGS_OPT)
+@@ -40,6 +40,9 @@ CXXFLAGS := $(CXXFLAGS_OPT)
  ifdef USEGEOPM
  	LDFLAGS += $(GEOPM_LDFLAGS) $(GEOPM_LDLIBS)
  	CXXFLAGS += $(GEOPM_CFLAGS) -DUSEGEOPM -DEPOCH_TO_OUTERLOOP=$(EPOCH_TO_OUTERLOOP)
 +ifdef USEGEOPMMARKUP
 +	CXXFLAGS += -DUSEGEOPMMARKUP
 +endif
-+ifdef USEGEOPMMARKUP_2
-+	CXXFLAGS += -DUSEGEOPMMARKUP_2
-+endif
  endif
  
  # add mpi to compile (comment out for serial build)
 diff --git a/src/Driver.cc b/src/Driver.cc
-index c75da82..9785995 100644
+index c75da82..6339f31 100644
 --- a/src/Driver.cc
 +++ b/src/Driver.cc
 @@ -31,9 +31,11 @@
@@ -87,7 +84,7 @@ index c75da82..9785995 100644
  }
  
  Driver::~Driver() {
-@@ -111,12 +112,37 @@ void Driver::run() {
+@@ -111,9 +112,21 @@ void Driver::run() {
  
          cycle += 1;
  
@@ -95,9 +92,6 @@ index c75da82..9785995 100644
 +#ifdef USEGEOPMMARKUP
 +        geopm_prof_enter(region_id_calcGlobalDt);
 +#endif // USEGEOPMMARKUP
-+#ifdef USEGEOPMMARKUP_2
-+        geopm_prof_enter(region_id_calcGlobalDt);
-+#endif // USEGEOPMMARKUP_2
 +#endif // USEGEOPM
 +
          // get timestep
@@ -107,24 +101,11 @@ index c75da82..9785995 100644
 +#ifdef USEGEOPMMARKUP
 +        geopm_prof_exit(region_id_calcGlobalDt);
 +#endif // USEGEOPMMARKUP
-+#ifdef USEGEOPMMARKUP_2
-+        geopm_prof_exit(region_id_calcGlobalDt);
-+        geopm_prof_enter(region_id_hydroDoCycle);
-+#endif // USEGEOPMMARKUP_2
 +#endif // USEGEOPM
 +
          // begin hydro cycle
          hydro->doCycle(dt);
  
-+#ifdef USEGEOPM
-+#ifdef USEGEOPMMARKUP_2
-+        geopm_prof_exit(region_id_hydroDoCycle);
-+#endif // USEGEOPMMARKUP_2
-+#endif // USEGEOPM
-+
-         time += dt;
- 
-         if (mype == 0 &&
 diff --git a/src/Hydro.cc b/src/Hydro.cc
 index 23fab68..4427352 100644
 --- a/src/Hydro.cc
@@ -278,10 +259,10 @@ index 23fab68..4427352 100644
          const double2* px0,
 diff --git a/src/PennantGeopm.cc b/src/PennantGeopm.cc
 new file mode 100644
-index 0000000..dbea3c0
+index 0000000..49d1af5
 --- /dev/null
 +++ b/src/PennantGeopm.cc
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,46 @@
 +#ifdef USEGEOPM
 +#include "geopm.h"
 +#include "PennantGeopm.hh"
@@ -305,11 +286,6 @@ index 0000000..dbea3c0
 +uint64_t region_id_doCycle_omp5;
 +#endif // USEGEOPMMARKUP
 +
-+#ifdef USEGEOPMMARKUP_2
-+uint64_t region_id_calcGlobalDt;
-+uint64_t region_id_hydroDoCycle;
-+#endif // USEGEOPMMARKUP
-+
 +#endif // USEGEOPM
 +
 +void init() {
@@ -329,11 +305,6 @@ index 0000000..dbea3c0
 +    geopm_prof_region("doCycle_omp5", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp5);
 +#endif // USEGEOPMMARKUP
 +
-+#ifdef USEGEOPMMARKUP_2
-+    geopm_prof_region("calcGlobalDt", GEOPM_REGION_HINT_UNKNOWN, &region_id_calcGlobalDt);
-+    geopm_prof_region("hydroDoCycle", GEOPM_REGION_HINT_UNKNOWN, &region_id_hydroDoCycle);
-+#endif // USEGEOPMMARKUP_2
-+
 +#endif // USEGEOPM
 +}  // init
 +
@@ -341,10 +312,10 @@ index 0000000..dbea3c0
 \ No newline at end of file
 diff --git a/src/PennantGeopm.hh b/src/PennantGeopm.hh
 new file mode 100644
-index 0000000..fce4d06
+index 0000000..31bbd87
 --- /dev/null
 +++ b/src/PennantGeopm.hh
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,28 @@
 +#ifndef PENNANT_GEOPM_HH_
 +#define PENNANT_GEOPM_HH_
 +
@@ -365,11 +336,6 @@ index 0000000..fce4d06
 +    extern uint64_t region_id_doCycle_checkBadSides2;
 +    extern uint64_t region_id_doCycle_omp5;
 +#endif // USEGEOPMMARKUP
-+
-+#ifdef USEGEOPMMARKUP_2
-+    extern uint64_t region_id_calcGlobalDt;
-+    extern uint64_t region_id_hydroDoCycle;
-+#endif // USEGEOPMMARKUP_2
 +
 +#endif // USEGEOPM
 +

--- a/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
+++ b/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
@@ -1,4 +1,4 @@
-From 3e46efb2c171ea249538cf6ed42f0fb023923426 Mon Sep 17 00:00:00 2001
+From 31d5ec851755fb6a948b41bae9a3bacb3fd6f2ab Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Tue, 1 Dec 2020 17:44:13 -0800
 Subject: [PATCH 3/3] Added GEOPM region markup
@@ -39,10 +39,10 @@ Signed-off-by: Fuat Keceli <fuat.keceli@intel.com>
  Makefile            |  6 ++++
  src/Driver.cc       | 28 +++++++++++++++++-
  src/Hydro.cc        | 85 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
- src/PennantGeopm.cc | 54 ++++++++++++++++++++++++++++++++++
- src/PennantGeopm.hh | 32 ++++++++++++++++++++
+ src/PennantGeopm.cc | 56 +++++++++++++++++++++++++++++++++++
+ src/PennantGeopm.hh | 33 +++++++++++++++++++++
  src/main.cc         |  3 ++
- 6 files changed, 206 insertions(+), 2 deletions(-)
+ 6 files changed, 209 insertions(+), 2 deletions(-)
  create mode 100644 src/PennantGeopm.cc
  create mode 100644 src/PennantGeopm.hh
 
@@ -126,7 +126,7 @@ index c75da82..9785995 100644
  
          if (mype == 0 &&
 diff --git a/src/Hydro.cc b/src/Hydro.cc
-index 23fab68..82fe633 100644
+index 23fab68..4427352 100644
 --- a/src/Hydro.cc
 +++ b/src/Hydro.cc
 @@ -30,8 +30,15 @@
@@ -254,7 +254,7 @@ index 23fab68..82fe633 100644
 +#ifdef USEGEOPM
 +#ifdef USEGEOPMMARKUP
 +    geopm_prof_exit(region_id_doCycle_checkBadSides2);
-+    geopm_prof_enter(region_id_doCycle_omp4);
++    geopm_prof_enter(region_id_doCycle_omp5);
 +#endif
 +#endif
 +
@@ -268,7 +268,7 @@ index 23fab68..82fe633 100644
 -}
 +#ifdef USEGEOPM
 +#ifdef USEGEOPMMARKUP
-+    geopm_prof_exit(region_id_doCycle_omp4);
++    geopm_prof_exit(region_id_doCycle_omp5);
 +#endif
 +#endif
  
@@ -278,10 +278,10 @@ index 23fab68..82fe633 100644
          const double2* px0,
 diff --git a/src/PennantGeopm.cc b/src/PennantGeopm.cc
 new file mode 100644
-index 0000000..f1e4230
+index 0000000..dbea3c0
 --- /dev/null
 +++ b/src/PennantGeopm.cc
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,56 @@
 +#ifdef USEGEOPM
 +#include "geopm.h"
 +#include "PennantGeopm.hh"
@@ -302,6 +302,7 @@ index 0000000..f1e4230
 +uint64_t region_id_doCycle_resetDtHydro;
 +uint64_t region_id_doCycle_omp4;
 +uint64_t region_id_doCycle_checkBadSides2;
++uint64_t region_id_doCycle_omp5;
 +#endif // USEGEOPMMARKUP
 +
 +#ifdef USEGEOPMMARKUP_2
@@ -325,6 +326,7 @@ index 0000000..f1e4230
 +    geopm_prof_region("doCycle_resetDtHydro", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_resetDtHydro);
 +    geopm_prof_region("doCycle_omp4", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp4);
 +    geopm_prof_region("doCycle_checkBadSides2", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_checkBadSides2);
++    geopm_prof_region("doCycle_omp5", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp5);
 +#endif // USEGEOPMMARKUP
 +
 +#ifdef USEGEOPMMARKUP_2
@@ -339,10 +341,10 @@ index 0000000..f1e4230
 \ No newline at end of file
 diff --git a/src/PennantGeopm.hh b/src/PennantGeopm.hh
 new file mode 100644
-index 0000000..b14724c
+index 0000000..fce4d06
 --- /dev/null
 +++ b/src/PennantGeopm.hh
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +#ifndef PENNANT_GEOPM_HH_
 +#define PENNANT_GEOPM_HH_
 +
@@ -361,6 +363,7 @@ index 0000000..b14724c
 +    extern uint64_t region_id_doCycle_resetDtHydro;
 +    extern uint64_t region_id_doCycle_omp4;
 +    extern uint64_t region_id_doCycle_checkBadSides2;
++    extern uint64_t region_id_doCycle_omp5;
 +#endif // USEGEOPMMARKUP
 +
 +#ifdef USEGEOPMMARKUP_2

--- a/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
+++ b/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
@@ -1,0 +1,392 @@
+From 57bfeefcf42a9ed32ffe112c2e881ec0fd6f23b8 Mon Sep 17 00:00:00 2001
+From: Fuat Keceli <fuat.keceli@intel.com>
+Date: Tue, 1 Dec 2020 17:44:13 -0800
+Subject: [PATCH 3/3] Added GEOPM region markup
+
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+Signed-off-by: Fuat Keceli <fuat.keceli@intel.com>
+---
+ Makefile            |  6 +++++
+ src/Driver.cc       | 28 ++++++++++++++++++-
+ src/Hydro.cc        | 78 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
+ src/PennantGeopm.cc | 54 +++++++++++++++++++++++++++++++++++++
+ src/PennantGeopm.hh | 32 ++++++++++++++++++++++
+ src/main.cc         |  3 +++
+ 6 files changed, 199 insertions(+), 2 deletions(-)
+ create mode 100644 src/PennantGeopm.cc
+ create mode 100644 src/PennantGeopm.hh
+
+diff --git a/Makefile b/Makefile
+index a0611ef..369d119 100644
+--- a/Makefile
++++ b/Makefile
+@@ -40,6 +40,12 @@ CXXFLAGS := $(CXXFLAGS_OPT)
+ ifdef USEGEOPM
+ 	LDFLAGS += $(GEOPM_LDFLAGS) $(GEOPM_LDLIBS)
+ 	CXXFLAGS += $(GEOPM_CFLAGS) -DUSEGEOPM -DEPOCH_TO_OUTERLOOP=$(EPOCH_TO_OUTERLOOP)
++ifdef USEGEOPMMARKUP
++	CXXFLAGS += -DUSEGEOPMMARKUP
++endif
++ifdef USEGEOPMMARKUP_2
++	CXXFLAGS += -DUSEGEOPMMARKUP_2
++endif
+ endif
+ 
+ # add mpi to compile (comment out for serial build)
+diff --git a/src/Driver.cc b/src/Driver.cc
+index c75da82..9785995 100644
+--- a/src/Driver.cc
++++ b/src/Driver.cc
+@@ -31,9 +31,11 @@
+ #ifdef USEGEOPM
+ #include "geopm.h"
+ #endif
++#include "PennantGeopm.hh"
+ 
+ using namespace std;
+ 
++using namespace PennantGeopm;
+ 
+ Driver::Driver(const InputFile* inp, const string& pname)
+         : probname(pname) {
+@@ -70,7 +72,6 @@ Driver::Driver(const InputFile* inp, const string& pname)
+     // initialize mesh, hydro
+     mesh = new Mesh(inp);
+     hydro = new Hydro(inp, mesh);
+-
+ }
+ 
+ Driver::~Driver() {
+@@ -111,12 +112,37 @@ void Driver::run() {
+ 
+         cycle += 1;
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++        geopm_prof_enter(region_id_calcGlobalDt);
++#endif // USEGEOPMMARKUP
++#ifdef USEGEOPMMARKUP_2
++        geopm_prof_enter(region_id_calcGlobalDt);
++#endif // USEGEOPMMARKUP_2
++#endif // USEGEOPM
++
+         // get timestep
+         calcGlobalDt();
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++        geopm_prof_exit(region_id_calcGlobalDt);
++#endif // USEGEOPMMARKUP
++#ifdef USEGEOPMMARKUP_2
++        geopm_prof_exit(region_id_calcGlobalDt);
++        geopm_prof_enter(region_id_hydroDoCycle);
++#endif // USEGEOPMMARKUP_2
++#endif // USEGEOPM
++
+         // begin hydro cycle
+         hydro->doCycle(dt);
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP_2
++        geopm_prof_exit(region_id_hydroDoCycle);
++#endif // USEGEOPMMARKUP_2
++#endif // USEGEOPM
++
+         time += dt;
+ 
+         if (mype == 0 &&
+diff --git a/src/Hydro.cc b/src/Hydro.cc
+index 23fab68..02a7190 100644
+--- a/src/Hydro.cc
++++ b/src/Hydro.cc
+@@ -30,8 +30,15 @@
+ #include "QCS.hh"
+ #include "HydroBC.hh"
+ 
++#ifdef USEGEOPM
++#include "geopm.h"
++#endif
++#include "PennantGeopm.hh"
++
+ using namespace std;
+ 
++using namespace PennantGeopm;
++
+ 
+ Hydro::Hydro(const InputFile* inp, Mesh* m) : mesh(m) {
+     cfl = inp->getDouble("cfl", 0.6);
+@@ -193,6 +200,12 @@ void Hydro::doCycle(
+     double* smf = mesh->smf;
+     double* zdl = mesh->zdl;
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_enter(region_id_doCycle_omp1);
++#endif
++#endif
++
+     // Begin hydro cycle
+     #pragma omp parallel for schedule(static)
+     for (int pch = 0; pch < numpch; ++pch) {
+@@ -208,6 +221,13 @@ void Hydro::doCycle(
+         advPosHalf(px0, pu0, dt, pxp, pfirst, plast);
+     } // for pch
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_omp1);
++    geopm_prof_enter(region_id_doCycle_omp2);
++#endif
++#endif
++
+     #pragma omp parallel for schedule(static)
+     for (int sch = 0; sch < numsch; ++sch) {
+         int sfirst = mesh->schsfirst[sch];
+@@ -241,12 +261,41 @@ void Hydro::doCycle(
+         qcs->calcForce(sfq, sfirst, slast);
+         sumCrnrForce(sfp, sfq, sft, cftot, sfirst, slast);
+     }  // for sch
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_omp2);
++    geopm_prof_enter(region_id_doCycle_checkBadSides1);
++#endif
++#endif
++
+     mesh->checkBadSides();
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_checkBadSides1);
++    geopm_prof_enter(region_id_doCycle_sumToPoints1);
++#endif
++#endif
++
+     // sum corner masses, forces to points
+     mesh->sumToPoints(cmaswt, pmaswt);
++
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_sumToPoints1);
++    geopm_prof_enter(region_id_doCycle_sumToPoints2);
++#endif
++#endif
++
+     mesh->sumToPoints(cftot, pf);
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_sumToPoints2);
++    geopm_prof_enter(region_id_doCycle_omp3);
++#endif
++#endif
++
+     #pragma omp parallel for schedule(static)
+     for (int pch = 0; pch < numpch; ++pch) {
+         int pfirst = mesh->pchpfirst[pch];
+@@ -267,8 +316,22 @@ void Hydro::doCycle(
+         advPosFull(px0, pu0, pap, dt, px, pu, pfirst, plast);
+     }  // for pch
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_omp3);
++    geopm_prof_enter(region_id_doCycle_resetDtHydro);
++#endif
++#endif
++
+     resetDtHydro();
+ 
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_resetDtHydro);
++    geopm_prof_enter(region_id_doCycle_omp4);
++#endif
++#endif
++
+     #pragma omp parallel for schedule(static)
+     for (int sch = 0; sch < numsch; ++sch) {
+         int sfirst = mesh->schsfirst[sch];
+@@ -286,6 +349,14 @@ void Hydro::doCycle(
+         calcWork(sfp, sfq, pu0, pu, pxp, dt, zw, zetot,
+                 sfirst, slast);
+     }  // for sch
++
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_omp4);
++    geopm_prof_enter(region_id_doCycle_checkBadSides2);
++#endif
++#endif
++
+     mesh->checkBadSides();
+ 
+     #pragma omp parallel for schedule(static)
+@@ -304,8 +375,13 @@ void Hydro::doCycle(
+         calcDtHydro(zdl, zvol, zvol0, dt, zfirst, zlast);
+     }  // for zch
+ 
+-}
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_checkBadSides2);
++#endif
++#endif
+ 
++}
+ 
+ void Hydro::advPosHalf(
+         const double2* px0,
+diff --git a/src/PennantGeopm.cc b/src/PennantGeopm.cc
+new file mode 100644
+index 0000000..f1e4230
+--- /dev/null
++++ b/src/PennantGeopm.cc
+@@ -0,0 +1,54 @@
++#ifdef USEGEOPM
++#include "geopm.h"
++#include "PennantGeopm.hh"
++#endif
++
++namespace PennantGeopm {
++
++#ifdef USEGEOPM
++
++#ifdef USEGEOPMMARKUP
++uint64_t region_id_calcGlobalDt;
++uint64_t region_id_doCycle_omp1;
++uint64_t region_id_doCycle_omp2;
++uint64_t region_id_doCycle_checkBadSides1;
++uint64_t region_id_doCycle_sumToPoints1;
++uint64_t region_id_doCycle_sumToPoints2;
++uint64_t region_id_doCycle_omp3;
++uint64_t region_id_doCycle_resetDtHydro;
++uint64_t region_id_doCycle_omp4;
++uint64_t region_id_doCycle_checkBadSides2;
++#endif // USEGEOPMMARKUP
++
++#ifdef USEGEOPMMARKUP_2
++uint64_t region_id_calcGlobalDt;
++uint64_t region_id_hydroDoCycle;
++#endif // USEGEOPMMARKUP
++
++#endif // USEGEOPM
++
++void init() {
++#ifdef USEGEOPM
++
++#ifdef USEGEOPMMARKUP
++    geopm_prof_region("calcGlobalDt", GEOPM_REGION_HINT_UNKNOWN, &region_id_calcGlobalDt);
++    geopm_prof_region("doCycle_omp1", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp1);
++    geopm_prof_region("doCycle_omp2", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp2);
++    geopm_prof_region("doCycle_checkBadSides1", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_checkBadSides1);
++    geopm_prof_region("doCycle_sumToPoints1", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_sumToPoints1);
++    geopm_prof_region("doCycle_sumToPoints2", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_sumToPoints2);
++    geopm_prof_region("doCycle_omp3", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp3);
++    geopm_prof_region("doCycle_resetDtHydro", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_resetDtHydro);
++    geopm_prof_region("doCycle_omp4", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_omp4);
++    geopm_prof_region("doCycle_checkBadSides2", GEOPM_REGION_HINT_UNKNOWN, &region_id_doCycle_checkBadSides2);
++#endif // USEGEOPMMARKUP
++
++#ifdef USEGEOPMMARKUP_2
++    geopm_prof_region("calcGlobalDt", GEOPM_REGION_HINT_UNKNOWN, &region_id_calcGlobalDt);
++    geopm_prof_region("hydroDoCycle", GEOPM_REGION_HINT_UNKNOWN, &region_id_hydroDoCycle);
++#endif // USEGEOPMMARKUP_2
++
++#endif // USEGEOPM
++}  // init
++
++}  // namespace PennantGeopm
+\ No newline at end of file
+diff --git a/src/PennantGeopm.hh b/src/PennantGeopm.hh
+new file mode 100644
+index 0000000..b14724c
+--- /dev/null
++++ b/src/PennantGeopm.hh
+@@ -0,0 +1,32 @@
++#ifndef PENNANT_GEOPM_HH_
++#define PENNANT_GEOPM_HH_
++
++namespace PennantGeopm {
++
++#ifdef USEGEOPM
++
++#ifdef USEGEOPMMARKUP
++    extern uint64_t region_id_calcGlobalDt;
++    extern uint64_t region_id_doCycle_omp1;
++    extern uint64_t region_id_doCycle_omp2;
++    extern uint64_t region_id_doCycle_checkBadSides1;
++    extern uint64_t region_id_doCycle_sumToPoints1;
++    extern uint64_t region_id_doCycle_sumToPoints2;
++    extern uint64_t region_id_doCycle_omp3;
++    extern uint64_t region_id_doCycle_resetDtHydro;
++    extern uint64_t region_id_doCycle_omp4;
++    extern uint64_t region_id_doCycle_checkBadSides2;
++#endif // USEGEOPMMARKUP
++
++#ifdef USEGEOPMMARKUP_2
++    extern uint64_t region_id_calcGlobalDt;
++    extern uint64_t region_id_hydroDoCycle;
++#endif // USEGEOPMMARKUP_2
++
++#endif // USEGEOPM
++
++void init();
++
++}  // namespace PennantGeopm
++
++#endif /* PENNANT_GEOPM_HH_ */
+\ No newline at end of file
+diff --git a/src/main.cc b/src/main.cc
+index 5c41673..c62b97f 100644
+--- a/src/main.cc
++++ b/src/main.cc
+@@ -18,12 +18,15 @@
+ #include "InputFile.hh"
+ #include "Driver.hh"
+ 
++#include "PennantGeopm.hh"
++
+ using namespace std;
+ 
+ 
+ int main(const int argc, const char** argv)
+ {
+     Parallel::init();
++    PennantGeopm::init();
+ 
+     if (argc != 2) {
+         if (Parallel::mype == 0)
+-- 
+1.8.3.1
+

--- a/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
+++ b/integration/apps/pennant/0003-Added-GEOPM-region-markup.patch
@@ -1,4 +1,4 @@
-From 57bfeefcf42a9ed32ffe112c2e881ec0fd6f23b8 Mon Sep 17 00:00:00 2001
+From 3e46efb2c171ea249538cf6ed42f0fb023923426 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Tue, 1 Dec 2020 17:44:13 -0800
 Subject: [PATCH 3/3] Added GEOPM region markup
@@ -36,13 +36,13 @@ Subject: [PATCH 3/3] Added GEOPM region markup
 
 Signed-off-by: Fuat Keceli <fuat.keceli@intel.com>
 ---
- Makefile            |  6 +++++
- src/Driver.cc       | 28 ++++++++++++++++++-
- src/Hydro.cc        | 78 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
- src/PennantGeopm.cc | 54 +++++++++++++++++++++++++++++++++++++
- src/PennantGeopm.hh | 32 ++++++++++++++++++++++
- src/main.cc         |  3 +++
- 6 files changed, 199 insertions(+), 2 deletions(-)
+ Makefile            |  6 ++++
+ src/Driver.cc       | 28 +++++++++++++++++-
+ src/Hydro.cc        | 85 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
+ src/PennantGeopm.cc | 54 ++++++++++++++++++++++++++++++++++
+ src/PennantGeopm.hh | 32 ++++++++++++++++++++
+ src/main.cc         |  3 ++
+ 6 files changed, 206 insertions(+), 2 deletions(-)
  create mode 100644 src/PennantGeopm.cc
  create mode 100644 src/PennantGeopm.hh
 
@@ -126,7 +126,7 @@ index c75da82..9785995 100644
  
          if (mype == 0 &&
 diff --git a/src/Hydro.cc b/src/Hydro.cc
-index 23fab68..02a7190 100644
+index 23fab68..82fe633 100644
 --- a/src/Hydro.cc
 +++ b/src/Hydro.cc
 @@ -30,8 +30,15 @@
@@ -237,7 +237,7 @@ index 23fab68..02a7190 100644
      #pragma omp parallel for schedule(static)
      for (int sch = 0; sch < numsch; ++sch) {
          int sfirst = mesh->schsfirst[sch];
-@@ -286,6 +349,14 @@ void Hydro::doCycle(
+@@ -286,8 +349,23 @@ void Hydro::doCycle(
          calcWork(sfp, sfq, pu0, pu, pxp, dt, zw, zetot,
                  sfirst, slast);
      }  // for sch
@@ -251,15 +251,24 @@ index 23fab68..02a7190 100644
 +
      mesh->checkBadSides();
  
++#ifdef USEGEOPM
++#ifdef USEGEOPMMARKUP
++    geopm_prof_exit(region_id_doCycle_checkBadSides2);
++    geopm_prof_enter(region_id_doCycle_omp4);
++#endif
++#endif
++
      #pragma omp parallel for schedule(static)
-@@ -304,8 +375,13 @@ void Hydro::doCycle(
+     for (int zch = 0; zch < mesh->numzch; ++zch) {
+         int zfirst = mesh->zchzfirst[zch];
+@@ -304,8 +382,13 @@ void Hydro::doCycle(
          calcDtHydro(zdl, zvol, zvol0, dt, zfirst, zlast);
      }  // for zch
  
 -}
 +#ifdef USEGEOPM
 +#ifdef USEGEOPMMARKUP
-+    geopm_prof_exit(region_id_doCycle_checkBadSides2);
++    geopm_prof_exit(region_id_doCycle_omp4);
 +#endif
 +#endif
  

--- a/integration/apps/pennant/Makefile.mk
+++ b/integration/apps/pennant/Makefile.mk
@@ -36,4 +36,5 @@ EXTRA_DIST += integration/apps/pennant/pennant.py \
               integration/apps/pennant/README.md \
               integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch \
               integration/apps/pennant/0002-Added-geopm-epoch-markup.patch \
+              integration/apps/pennant/0003-Added-GEOPM-region-markup.patch \
               # end

--- a/integration/apps/pennant/build.sh
+++ b/integration/apps/pennant/build.sh
@@ -49,10 +49,10 @@ setup_source_git ${DIRNAME}
 
 # Build application
 cd ${DIRNAME}
-make USEGEOPM=1 EPOCH_TO_OUTERLOOP=100
+make USEGEOPM=1 EPOCH_TO_OUTERLOOP=100 USEGEOPMMARKUP=1
 mv build build_geopm_epoch100
 make clean
-make USEGEOPM=1 EPOCH_TO_OUTERLOOP=1
+make USEGEOPM=1 EPOCH_TO_OUTERLOOP=1 USEGEOPMMARKUP=1
 mv build build_geopm_epoch1
 make clean
 make

--- a/integration/apps/pennant/pennant.py
+++ b/integration/apps/pennant/pennant.py
@@ -89,13 +89,13 @@ class PennantAppConf(apps.AppConf):
         # handle less outer loops per epoch since outer loop time seems to go up with
         # problem size.
         exec_dir = {
-            'PENNANT/test/leblancx4/leblancx4.pnt': 'PENNANT/build_geopm_epoch100/pennant',
-            'PENNANT/test/leblancx4/leblancx16.pnt': 'PENNANT/build_geopm_epoch1/pennant',
+            'leblancx4.pnt': 'PENNANT/build_geopm_epoch100/pennant',
+            'leblancx16.pnt': 'PENNANT/build_geopm_epoch1/pennant',
             'default': 'PENNANT/build/pennant'
         }
         if epoch_to_outerloop is None:
-            if problem_file in exec_dir:
-                self._exec_path = os.path.join(benchmark_dir, exec_dir[problem_file])
+            if os.path.basename(problem_file) in exec_dir:
+                self._exec_path = os.path.join(benchmark_dir, exec_dir[os.path.basename(problem_file)])
             else:
                 self._exec_path = os.path.join(benchmark_dir, exec_dir['default'])
         else:
@@ -105,7 +105,6 @@ class PennantAppConf(apps.AppConf):
             else:
                 raise RuntimeError('Epoch to outer loop count does not match any of the pennant builds: {}'.format(epoch_to_outerloop))
 
-        self._exec_path = os.path.join(benchmark_dir, 'PENNANT/build/pennant')
         if os.path.isfile(problem_file):
             self._exec_args = problem_file
         elif os.path.isfile(os.path.join(benchmark_dir, problem_file)):

--- a/src/ApplicationIO.cpp
+++ b/src/ApplicationIO.cpp
@@ -54,16 +54,14 @@ namespace geopm
 {
     constexpr size_t ApplicationIOImp::M_SHMEM_REGION_SIZE;
 
-    ApplicationIOImp::ApplicationIOImp(const std::string &shm_key)
-        : ApplicationIOImp(shm_key,
-                           ApplicationSampler::application_sampler(),
+    ApplicationIOImp::ApplicationIOImp()
+        : ApplicationIOImp(ApplicationSampler::application_sampler(),
                            platform_io(), platform_topo())
     {
 
     }
 
-    ApplicationIOImp::ApplicationIOImp(const std::string &shm_key,
-                                       ApplicationSampler &application_sampler,
+    ApplicationIOImp::ApplicationIOImp(ApplicationSampler &application_sampler,
                                        PlatformIO &platform_io,
                                        const PlatformTopo &platform_topo)
         : m_platform_io(platform_io)

--- a/src/ApplicationIO.hpp
+++ b/src/ApplicationIO.hpp
@@ -128,9 +128,8 @@ namespace geopm
     class ApplicationIOImp : public ApplicationIO
     {
         public:
-            ApplicationIOImp(const std::string &shm_key);
-            ApplicationIOImp(const std::string &shm_key,
-                             ApplicationSampler &application_sampler,
+            ApplicationIOImp();
+            ApplicationIOImp(ApplicationSampler &application_sampler,
                              PlatformIO &platform_io,
                              const PlatformTopo &platform_topo);
             virtual ~ApplicationIOImp();

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
  *
@@ -36,6 +37,7 @@
 #include <functional>
 
 #include "ApplicationSamplerImp.hpp"
+#include "ApplicationRecordLog.hpp"
 #include "ProfileSampler.hpp"
 #include "ProfileIOSample.hpp"
 #include "EpochRuntimeRegulator.hpp"
@@ -43,8 +45,10 @@
 #include "RecordFilter.hpp"
 #include "Environment.hpp"
 #include "ValidateRecord.hpp"
-#include "geopm_hash.h"
+#include "SharedMemory.hpp"
 #include "record.hpp"
+#include "geopm_debug.hpp"
+#include "geopm_hash.h"
 
 namespace geopm
 {
@@ -105,22 +109,20 @@ namespace geopm
     }
 
     ApplicationSamplerImp::ApplicationSamplerImp()
-        : ApplicationSamplerImp(environment().do_record_filter() ?
-                                // use record filter from environment
-                                [](void) {
-                                    return RecordFilter::make_unique(environment().record_filter());
-                                } :
-                                // otherwise, do not filter records
-                                std::function<std::unique_ptr<RecordFilter>()>()
-                                )
+        : ApplicationSamplerImp(std::map<int, m_process_s> {},
+                                environment().do_record_filter(),
+                                environment().record_filter())
     {
 
     }
 
-    ApplicationSamplerImp::ApplicationSamplerImp(std::function<std::unique_ptr<RecordFilter>()> filter_factory)
+    ApplicationSamplerImp::ApplicationSamplerImp(const std::map<int, m_process_s> &process_map,
+                                                 bool is_filtered,
+                                                 const std::string &filter_name)
         : m_time_zero(geopm::time_zero())
-        , m_filter_factory(filter_factory)
-        , m_is_filtered(filter_factory)
+        , m_process_map(process_map)
+        , m_is_filtered(is_filtered)
+        , m_filter_name(filter_name)
     {
 
     }
@@ -130,133 +132,57 @@ namespace geopm
         m_time_zero = start_time;
     }
 
-    void ApplicationSamplerImp::update_records_epoch(const geopm_prof_message_s &msg)
-    {
-        double time = geopm_time_diff(&m_time_zero, &(msg.timestamp));
-        int process = msg.rank;
-        int event = EVENT_EPOCH_COUNT;
-        m_process_s &proc_it = get_process(process);
-        ++(proc_it.epoch_count);
-        uint64_t epoch_count = proc_it.epoch_count;
-        m_record_buffer.emplace_back(record_s {
-            .time = time,
-            .process = process,
-            .event = event,
-            .signal = epoch_count,
-        });
-    }
-
-    void ApplicationSamplerImp::update_records_mpi(const geopm_prof_message_s &msg)
-    {
-        double time = geopm_time_diff(&m_time_zero, &(msg.timestamp));
-        int process = msg.rank;
-        int event = EVENT_HINT;
-        uint64_t hint = GEOPM_REGION_HINT_NETWORK;
-        if (msg.progress == 1.0) {
-            m_process_s &proc_it = get_process(process);
-            hint = proc_it.hint;
-        }
-        m_record_buffer.emplace_back(record_s {
-            .time = time,
-            .process = process,
-            .event = event,
-            .signal = hint,
-        });
-    }
-
-    void ApplicationSamplerImp::update_records_entry(const geopm_prof_message_s &msg)
-    {
-        double time = geopm_time_diff(&m_time_zero, &(msg.timestamp));
-        int process = msg.rank;
-        uint64_t hash = geopm_region_id_hash(msg.region_id);
-        int event = EVENT_REGION_ENTRY;
-        // Record event for change of region ID
-        m_record_buffer.emplace_back(record_s {
-              .time = time,
-              .process = process,
-              .event = event,
-              .signal = hash,
-        });
-        // Record event for change of hint
-        uint64_t hint = geopm_region_id_hint(msg.region_id);
-        m_process_s &proc_it = get_process(process);
-        proc_it.hint = hint;
-        m_record_buffer.emplace_back(record_s {
-            .time = time,
-            .process = process,
-            .event = EVENT_HINT,
-            .signal = hint,
-        });
-    }
-
-    void ApplicationSamplerImp::update_records_exit(const geopm_prof_message_s &msg)
-    {
-        // Set common values for all events
-        double time = geopm_time_diff(&m_time_zero, &(msg.timestamp));
-        int process = msg.rank;
-        /// Handle outer region entry and exit
-        uint64_t hash = geopm_region_id_hash(msg.region_id);
-        int event = EVENT_REGION_EXIT;
-        // Record event for change of region ID
-        m_record_buffer.emplace_back(record_s {
-            .time = time,
-            .process = process,
-            .event = event,
-            .signal = hash,
-        });
-        // Record event for change of hint
-        uint64_t hint = GEOPM_REGION_HINT_UNKNOWN;
-        m_process_s &proc_it = get_process(process);
-        proc_it.hint = hint;
-        m_record_buffer.emplace_back(record_s {
-            .time = time,
-            .process = process,
-            .event = EVENT_HINT,
-            .signal = hint,
-        });
-    }
-
-    void ApplicationSamplerImp::update_records_progress(const geopm_prof_message_s &msg)
-    {
-        /// @todo handle calls to progress
-    }
-
     void ApplicationSamplerImp::update_records(void)
     {
-        m_record_buffer.clear();
-        for (auto &cache_it : m_sampler->sample_cache()) {
-            if (geopm_region_id_is_epoch(cache_it.region_id)) {
-                update_records_epoch(cache_it);
-            }
-            else if (geopm_region_id_is_mpi(cache_it.region_id)) {
-                update_records_mpi(cache_it);
-            }
-            else if (cache_it.progress == 0.0) {
-                update_records_entry(cache_it);
-            }
-            else if (cache_it.progress == 1.0) {
-                update_records_exit(cache_it);
-            }
-            else {
-                update_records_progress(cache_it);
-            }
-        }
+        // Dump the record log from each process, filter the results,
+        // and reindex the short region event signals.
 
-        std::vector<record_s> tmp_buffer;
-        for (auto &record_it : m_record_buffer) {
-            auto &proc = get_process(record_it.process);
+        // Clear the buffers that we will be building.
+        m_record_buffer.clear();
+        m_short_region_buffer.clear();
+        // Itereate over the record log for each process
+        for (auto &proc_map_it : m_process_map) {
+            // Record the location in the record buffer where this
+            // process' data begins for updating the short region
+            // event signals.
+            size_t record_offset = m_record_buffer.size();
+            // Get data from the record log
+            auto &proc_it = proc_map_it.second;
+            proc_it.record_log->dump(proc_it.records, proc_it.short_regions);
             if (m_is_filtered) {
-                for (auto &filtered_it : proc.filter->filter(record_it)) {
-                    proc.valid.check(filtered_it);
-                    tmp_buffer.push_back(filtered_it);
+                // Filter and check the records and push them onto
+                // m_record_buffer
+                for (const auto &record_it : proc_it.records) {
+                    for (auto &filtered_it : proc_it.filter->filter(record_it)) {
+                        proc_it.valid.check(filtered_it);
+                        m_record_buffer.push_back(filtered_it);
+                    }
                 }
             }
             else {
-                proc.valid.check(record_it);
+                // Check the records and push them onto m_record_buffer
+                for (const auto &record : proc_it.records) {
+                    proc_it.valid.check(record);
+                }
+                m_record_buffer.insert(m_record_buffer.end(),
+                                       proc_it.records.begin(),
+                                       proc_it.records.end());
             }
-        }
-        if (m_is_filtered) {
-            m_record_buffer = tmp_buffer;
+            // Update the "signal" field for all of the short region
+            // events to have the right offset.
+            size_t short_region_remain = proc_it.short_regions.size();
+            for (auto record_it = m_record_buffer.begin() + record_offset;
+                 short_region_remain > 0 &&
+                 record_it != m_record_buffer.end();
+                 ++record_it) {
+                if (record_it->event == EVENT_SHORT_REGION) {
+                    record_it->signal += m_short_region_buffer.size();
+                    --short_region_remain;
+                }
+            }
+            m_short_region_buffer.insert(m_short_region_buffer.end(),
+                                         proc_it.short_regions.begin(),
+                                         proc_it.short_regions.end());
         }
     }
 
@@ -265,6 +191,14 @@ namespace geopm
         return m_record_buffer;
     }
 
+    short_region_s ApplicationSamplerImp::get_short_region(uint64_t event_signal) const
+    {
+        if (event_signal >= m_short_region_buffer.size()) {
+            throw Exception("ApplicationSampler::get_short_region(), event_signal does not match any short region handle",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return m_short_region_buffer.at(event_signal);
+    }
 
     std::map<uint64_t, std::string> ApplicationSamplerImp::get_name_map(uint64_t name_key) const
     {
@@ -292,11 +226,36 @@ namespace geopm
         return m_sampler->cpu_rank();
     }
 
+    void ApplicationSamplerImp::connect(const std::string &shm_key)
+    {
+        if (m_process_map.empty()) {
+            // Convert per-cpu process to a set of the unique process id's
+            std::set<int> proc_set;
+            for (const auto &proc_it : per_cpu_process()) {
+                proc_set.insert(proc_it);
+            }
+            // For each unique process id create a record log and
+            // insert it into map indexed by process id
+            for (const auto &proc_it : proc_set) {
+                std::string shmem_name = shm_key + "-record-log-" + std::to_string(proc_it);
+                std::shared_ptr<SharedMemory> record_log_shmem =
+                    SharedMemory::make_unique_owner(shmem_name,
+                                                    ApplicationRecordLog::buffer_size());
+                auto emplace_ret = m_process_map.emplace(proc_it, m_process_s {});
+                auto &process = emplace_ret.first->second;
+                if (m_is_filtered) {
+                    process.filter = RecordFilter::make_unique(m_filter_name);
+                }
+                process.record_log = ApplicationRecordLog::make_unique(record_log_shmem);
+                process.records.reserve(ApplicationRecordLog::max_record());
+                process.short_regions.reserve(ApplicationRecordLog::max_region());
+            }
+        }
+    }
+
     void ApplicationSamplerImp::set_sampler(std::shared_ptr<ProfileSampler> sampler)
     {
         m_sampler = sampler;
-        // Each message can create two records
-        m_record_buffer.reserve(2 * m_sampler->capacity());
     }
 
     std::shared_ptr<ProfileSampler> ApplicationSamplerImp::get_sampler(void)
@@ -322,18 +281,5 @@ namespace geopm
     std::shared_ptr<ProfileIOSample> ApplicationSamplerImp::get_io_sample(void)
     {
         return m_io_sample;
-    }
-
-    ApplicationSamplerImp::m_process_s &ApplicationSamplerImp::get_process(int process)
-    {
-        auto emp_it = m_process_map.emplace(process, m_process_s {
-            .epoch_count = 0LL,
-            .hint = GEOPM_REGION_HINT_UNKNOWN,
-            .filter = nullptr,
-        });
-        if (emp_it.second && m_is_filtered) {
-            emp_it.first->second.filter = m_filter_factory();
-        }
-        return emp_it.first->second;
     }
 }

--- a/src/ApplicationSampler.hpp
+++ b/src/ApplicationSampler.hpp
@@ -45,10 +45,12 @@
 
 namespace geopm
 {
+    class ApplicationRecordLog;
     class ProfileSampler;
     class ProfileIOSample;
     class EpochRuntimeRegulator;
     struct record_s;
+    struct short_region_s;
 
     class ApplicationSampler
     {
@@ -72,6 +74,7 @@ namespace geopm
             ///        update_records().
             /// @return Vector of application event records.
             virtual std::vector<record_s> get_records(void) const = 0;
+            virtual short_region_s get_short_region(uint64_t event_signal) const = 0;
             /// @brief Called after observing a EVENT_NAME_KEY event
             ///        to get a map from any hash returned in a previous
             ///        record to the string that generated the hash.
@@ -93,7 +96,7 @@ namespace geopm
             /// @brief Return a per-cpu vector of the process mapped
             ///        to each cpu.
             virtual std::vector<int> per_cpu_process(void) const = 0;
-
+            virtual void connect(const std::string &shm_key) = 0;
             // Deprecated API's below for access to legacy objects
             virtual void set_sampler(std::shared_ptr<ProfileSampler> sampler) = 0;
             virtual std::shared_ptr<ProfileSampler> get_sampler(void) = 0;

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -164,10 +164,10 @@ namespace geopm
         m_buffer[cpu_idx].completed_work += 1;
     }
 
-    double ApplicationStatusImp::get_work_progress(int cpu_idx) const
+    double ApplicationStatusImp::get_progress_cpu(int cpu_idx) const
     {
         if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
-            throw Exception("ApplicationStatusImp::get_work_progress(): invalid CPU index: " + std::to_string(cpu_idx),
+            throw Exception("ApplicationStatusImp::get_progress_cpu(): invalid CPU index: " + std::to_string(cpu_idx),
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -129,9 +129,8 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
 
         }
-
-        m_buffer[cpu_idx].total_work = work_units;
         m_buffer[cpu_idx].completed_work = 0;
+        m_buffer[cpu_idx].total_work = work_units;
     }
 
     void ApplicationStatusImp::increment_work_unit(int cpu_idx)
@@ -158,12 +157,12 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        double result = NAN;
         int total_work = m_buffer[cpu_idx].total_work;
-        if (total_work <= 0) {
-            return NAN;
+        if (total_work > 0) {
+            result = (double)m_buffer[cpu_idx].completed_work / total_work;
         }
-        int completed = m_buffer[cpu_idx].completed_work;
-        return (double)completed / total_work;
+        return result;
     }
 
     std::vector<double> ApplicationStatusImp::get_work_progress(void) const

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ApplicationStatus.hpp"
+
+#include <cmath>
+
+#include "geopm.h"
+#include "SharedMemory.hpp"
+#include "Helper.hpp"
+#include "Exception.hpp"
+#include "PlatformTopo.hpp"
+#include "geopm_debug.hpp"
+
+namespace geopm
+{
+
+    std::unique_ptr<ApplicationStatus> ApplicationStatus::make_unique(const PlatformTopo& topo,
+                                                                      std::shared_ptr<SharedMemory> shmem)
+    {
+        return geopm::make_unique<ApplicationStatusImp>(topo, shmem);
+    }
+
+    size_t ApplicationStatus::buffer_size(int num_cpu)
+    {
+        return M_STATUS_SIZE * num_cpu;
+    }
+
+    ApplicationStatusImp::ApplicationStatusImp(const PlatformTopo& topo,
+                                               std::shared_ptr<SharedMemory> shmem)
+        : m_topo(topo)
+        , m_num_cpu(m_topo.num_domain(GEOPM_DOMAIN_CPU))
+        , m_shmem(shmem)
+    {
+        if (m_shmem == nullptr) {
+            throw Exception("ApplicationStatus: shared memory pointer cannot be null",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (m_shmem->size() != buffer_size(m_num_cpu)) {
+            throw Exception("ApplicationStatus: shared memory incorrectly sized",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        // Note: no lock
+        m_buffer = (m_app_status_s *)m_shmem->pointer();
+
+        // initialize shmem if all zero is not appropriate
+        for (int ii = 0; ii < m_num_cpu; ++ii) {
+            m_buffer[ii].total_work = -1;
+            m_buffer[ii].process = -1;
+        }
+    }
+
+    void ApplicationStatusImp::set_hint(int cpu_idx, uint64_t hints)
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::set_hint(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if ((hints & ~GEOPM_MASK_REGION_HINT) != 0ULL) {
+            throw Exception("ApplicationStatusImp::set_hint(): invalid hint",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        // pack hints into 32 bits for atomic write
+        m_buffer[cpu_idx].hints = (uint32_t)(hints >> 32);
+    }
+
+    uint64_t ApplicationStatusImp::get_hint(int cpu_idx)
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::get_hint(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        return (uint64_t)m_buffer[cpu_idx].hints << 32;
+    }
+
+    std::vector<uint64_t> ApplicationStatusImp::get_hint(void)
+    {
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        std::vector<uint64_t> result(m_num_cpu);
+        for (int ii = 0; ii < m_num_cpu; ++ii) {
+            result[ii] = get_hint(ii);
+        }
+        return result;
+    }
+
+    void ApplicationStatusImp::set_hash(int cpu_idx, uint64_t hash)
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::set_hash(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (((~0ULL << 32) & hash) != 0) {
+            throw Exception("ApplicationStatusImp::set_hash(): invalid region hash: " + std::to_string(hash),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        m_buffer[cpu_idx].hash = (uint32_t)hash;
+    }
+
+    uint64_t ApplicationStatusImp::get_hash(int cpu_idx)
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::get_hash(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        return m_buffer[cpu_idx].hash;
+    }
+
+    std::vector<uint64_t> ApplicationStatusImp::get_hash(void)
+    {
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        std::vector<uint64_t> result(m_num_cpu);
+        // TODO: optimize by storing all hashes adjacent
+        for (int ii = 0; ii < m_num_cpu; ++ii) {
+            result[ii] = get_hash(ii);
+        }
+        return result;
+    }
+
+    void ApplicationStatusImp::set_total_work_units(int cpu_idx, int work_units)
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::set_total_work_units(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+
+        if (work_units < 0) {
+            throw Exception("ApplicationStatusImp::set_total_work_units(): invalid number of work units: " + std::to_string(work_units),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+
+        }
+
+        m_buffer[cpu_idx].total_work = work_units;
+        m_buffer[cpu_idx].completed_work = 0;
+    }
+
+    void ApplicationStatusImp::increment_work_unit(int cpu_idx)
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::increment_work_unit(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+
+        // only this thread is writing, so don't need to lock
+        if (m_buffer[cpu_idx].completed_work >= m_buffer[cpu_idx].total_work) {
+            throw Exception("ApplicationStatusImp::increment_work_unit(): more increments than total work",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+
+        }
+        m_buffer[cpu_idx].completed_work += 1;
+    }
+
+    double ApplicationStatusImp::get_work_progress(int cpu_idx)
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::get_work_progress(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        int total_work = m_buffer[cpu_idx].total_work;
+        if (total_work <= 0) {
+            return NAN;
+        }
+        int completed = m_buffer[cpu_idx].completed_work;
+        return (double)completed / total_work;
+    }
+
+    std::vector<double> ApplicationStatusImp::get_work_progress(void)
+    {
+        std::vector<double> result(m_num_cpu);
+        for (int ii = 0; ii < m_num_cpu; ++ii) {
+            result[ii] = get_work_progress(ii);
+        }
+        return result;
+    }
+
+    void ApplicationStatusImp::set_process(std::set<int> cpu_idx, int process)
+    {
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        for (auto cpu : cpu_idx) {
+            if (cpu < 0 || cpu >= m_num_cpu) {
+                throw Exception("ApplicationStatusImp::set_process(): invalid CPU index: " + std::to_string(cpu),
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            m_buffer[cpu].process = process;
+        }
+    }
+
+    int ApplicationStatusImp::get_process(int cpu_idx)
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::get_process(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+
+        return m_buffer[cpu_idx].process;
+    }
+
+    std::vector<int> ApplicationStatusImp::get_process(void)
+    {
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        std::vector<int> result(m_num_cpu);
+        for (int ii = 0; ii < m_num_cpu; ++ii) {
+            result[ii] = get_process(ii);
+        }
+        return result;
+    }
+}

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -116,40 +116,6 @@ namespace geopm
         return result;
     }
 
-    void ApplicationStatusImp::set_hash(int cpu_idx, uint64_t hash)
-    {
-        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
-            throw Exception("ApplicationStatusImp::set_hash(): invalid CPU index: " + std::to_string(cpu_idx),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-        if (((~0ULL << 32) & hash) != 0) {
-            throw Exception("ApplicationStatusImp::set_hash(): invalid region hash: " + std::to_string(hash),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
-        m_buffer[cpu_idx].hash = (uint32_t)hash;
-    }
-
-    uint64_t ApplicationStatusImp::get_hash(int cpu_idx) const
-    {
-        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
-            throw Exception("ApplicationStatusImp::get_hash(): invalid CPU index: " + std::to_string(cpu_idx),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
-        return m_buffer[cpu_idx].hash;
-    }
-
-    std::vector<uint64_t> ApplicationStatusImp::get_hash(void) const
-    {
-        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
-        std::vector<uint64_t> result(m_num_cpu);
-        for (int ii = 0; ii < m_num_cpu; ++ii) {
-            result[ii] = get_hash(ii);
-        }
-        return result;
-    }
-
     void ApplicationStatusImp::set_total_work_units(int cpu_idx, int work_units)
     {
         if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -70,7 +70,8 @@ namespace geopm
             throw Exception("ApplicationStatus: shared memory incorrectly sized",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        // Note: no lock
+        // Note: no lock; all members of the struct are 32-bits and will be
+        // accessed atomically by hardware.
         m_buffer = (m_app_status_s *)m_shmem->pointer();
 
         // initialize shmem if all zero is not appropriate
@@ -95,7 +96,7 @@ namespace geopm
         m_buffer[cpu_idx].hints = (uint32_t)(hints >> 32);
     }
 
-    uint64_t ApplicationStatusImp::get_hint(int cpu_idx)
+    uint64_t ApplicationStatusImp::get_hint(int cpu_idx) const
     {
         if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
             throw Exception("ApplicationStatusImp::get_hint(): invalid CPU index: " + std::to_string(cpu_idx),
@@ -105,7 +106,7 @@ namespace geopm
         return (uint64_t)m_buffer[cpu_idx].hints << 32;
     }
 
-    std::vector<uint64_t> ApplicationStatusImp::get_hint(void)
+    std::vector<uint64_t> ApplicationStatusImp::get_hint(void) const
     {
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
         std::vector<uint64_t> result(m_num_cpu);
@@ -129,7 +130,7 @@ namespace geopm
         m_buffer[cpu_idx].hash = (uint32_t)hash;
     }
 
-    uint64_t ApplicationStatusImp::get_hash(int cpu_idx)
+    uint64_t ApplicationStatusImp::get_hash(int cpu_idx) const
     {
         if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
             throw Exception("ApplicationStatusImp::get_hash(): invalid CPU index: " + std::to_string(cpu_idx),
@@ -139,11 +140,10 @@ namespace geopm
         return m_buffer[cpu_idx].hash;
     }
 
-    std::vector<uint64_t> ApplicationStatusImp::get_hash(void)
+    std::vector<uint64_t> ApplicationStatusImp::get_hash(void) const
     {
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
         std::vector<uint64_t> result(m_num_cpu);
-        // TODO: optimize by storing all hashes adjacent
         for (int ii = 0; ii < m_num_cpu; ++ii) {
             result[ii] = get_hash(ii);
         }
@@ -185,7 +185,7 @@ namespace geopm
         m_buffer[cpu_idx].completed_work += 1;
     }
 
-    double ApplicationStatusImp::get_work_progress(int cpu_idx)
+    double ApplicationStatusImp::get_work_progress(int cpu_idx) const
     {
         if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
             throw Exception("ApplicationStatusImp::get_work_progress(): invalid CPU index: " + std::to_string(cpu_idx),
@@ -200,7 +200,7 @@ namespace geopm
         return (double)completed / total_work;
     }
 
-    std::vector<double> ApplicationStatusImp::get_work_progress(void)
+    std::vector<double> ApplicationStatusImp::get_work_progress(void) const
     {
         std::vector<double> result(m_num_cpu);
         for (int ii = 0; ii < m_num_cpu; ++ii) {
@@ -209,7 +209,7 @@ namespace geopm
         return result;
     }
 
-    void ApplicationStatusImp::set_process(std::set<int> cpu_idx, int process)
+    void ApplicationStatusImp::set_process(const std::set<int> &cpu_idx, int process)
     {
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
         for (auto cpu : cpu_idx) {
@@ -221,7 +221,7 @@ namespace geopm
         }
     }
 
-    int ApplicationStatusImp::get_process(int cpu_idx)
+    int ApplicationStatusImp::get_process(int cpu_idx) const
     {
         if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
             throw Exception("ApplicationStatusImp::get_process(): invalid CPU index: " + std::to_string(cpu_idx),
@@ -232,7 +232,7 @@ namespace geopm
         return m_buffer[cpu_idx].process;
     }
 
-    std::vector<int> ApplicationStatusImp::get_process(void)
+    std::vector<int> ApplicationStatusImp::get_process(void) const
     {
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
         std::vector<int> result(m_num_cpu);

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -116,6 +116,40 @@ namespace geopm
         return result;
     }
 
+    void ApplicationStatusImp::set_hash(int cpu_idx, uint64_t hash)
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::set_hash(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (((~0ULL << 32) & hash) != 0) {
+            throw Exception("ApplicationStatusImp::set_hash(): invalid region hash: " + std::to_string(hash),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        m_buffer[cpu_idx].hash = (uint32_t)hash;
+    }
+
+    uint64_t ApplicationStatusImp::get_hash(int cpu_idx) const
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::get_hash(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        return m_buffer[cpu_idx].hash;
+    }
+
+    std::vector<uint64_t> ApplicationStatusImp::get_hash(void) const
+    {
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        std::vector<uint64_t> result(m_num_cpu);
+        for (int ii = 0; ii < m_num_cpu; ++ii) {
+            result[ii] = get_hash(ii);
+        }
+        return result;
+    }
+
     void ApplicationStatusImp::set_total_work_units(int cpu_idx, int work_units)
     {
         if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -106,16 +106,6 @@ namespace geopm
         return (uint64_t)m_buffer[cpu_idx].hints << 32;
     }
 
-    std::vector<uint64_t> ApplicationStatusImp::get_hint(void) const
-    {
-        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
-        std::vector<uint64_t> result(m_num_cpu);
-        for (int ii = 0; ii < m_num_cpu; ++ii) {
-            result[ii] = get_hint(ii);
-        }
-        return result;
-    }
-
     void ApplicationStatusImp::set_hash(int cpu_idx, uint64_t hash)
     {
         if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
@@ -138,16 +128,6 @@ namespace geopm
         }
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
         return m_buffer[cpu_idx].hash;
-    }
-
-    std::vector<uint64_t> ApplicationStatusImp::get_hash(void) const
-    {
-        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
-        std::vector<uint64_t> result(m_num_cpu);
-        for (int ii = 0; ii < m_num_cpu; ++ii) {
-            result[ii] = get_hash(ii);
-        }
-        return result;
     }
 
     void ApplicationStatusImp::set_total_work_units(int cpu_idx, int work_units)
@@ -199,15 +179,6 @@ namespace geopm
         return result;
     }
 
-    std::vector<double> ApplicationStatusImp::get_work_progress(void) const
-    {
-        std::vector<double> result(m_num_cpu);
-        for (int ii = 0; ii < m_num_cpu; ++ii) {
-            result[ii] = get_work_progress(ii);
-        }
-        return result;
-    }
-
     void ApplicationStatusImp::set_process(const std::set<int> &cpu_idx, int process)
     {
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
@@ -229,15 +200,5 @@ namespace geopm
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
 
         return m_buffer[cpu_idx].process;
-    }
-
-    std::vector<int> ApplicationStatusImp::get_process(void) const
-    {
-        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
-        std::vector<int> result(m_num_cpu);
-        for (int ii = 0; ii < m_num_cpu; ++ii) {
-            result[ii] = get_process(ii);
-        }
-        return result;
     }
 }

--- a/src/ApplicationStatus.hpp
+++ b/src/ApplicationStatus.hpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef APPLICATIONSTATUS_HPP_INCLUDE
+#define APPLICATIONSTATUS_HPP_INCLUDE
+
+#include <cstdint>
+
+#include <memory>
+#include <vector>
+#include <set>
+
+namespace geopm
+{
+    class SharedMemory;
+    class PlatformTopo;
+
+    class ApplicationStatus
+    {
+            /// TODO: check for num CPU
+            // TODO: const for getters
+            /// TODO: make sure everything stored in memory is 32 bits
+        public:
+            virtual ~ApplicationStatus() = default;
+
+            virtual void set_hint(int cpu_idx, uint64_t hints) = 0;  // may need to shift to get 32bit int
+            virtual uint64_t get_hint(int cpu_idx) = 0;
+            virtual std::vector<uint64_t> get_hint(void) = 0;
+
+            virtual void set_hash(int cpu_idx, uint64_t hash) = 0;
+            virtual uint64_t get_hash(int cpu_idx) = 0;
+            virtual std::vector<uint64_t> get_hash(void) = 0;
+
+            virtual void set_total_work_units(int cpu_idx, int work_units) = 0;  // each cpu gets a fraction of what was passed to tprof_init()
+            virtual void increment_work_unit(int cpu_idx) = 0;  // complete a work unit for this cpu
+            virtual double get_work_progress(int cpu_idx) = 0;
+            virtual std::vector<double> get_work_progress(void) = 0;
+            // unique id of a process with its own memory being managed by
+            // the geopm controller
+            // this may be:
+            // - COMM_WORLD MPI rank
+            // - local MPI rank
+            // - Linux parent process id for whole app
+            // unique id for things being coordinated within a job
+            // there will be one-to-one mapping of Profile object (AppRecordLog etc) per process
+            // this is not *necessarily* a linux process id, but it could be
+            // it just has to be self consistent and unique within a job
+            // more notes:
+            // there is one AppRecordLog per process on each side of the shmem
+            // there is one ApplicationStatus per node (board) on each side of the shmem
+            virtual void set_process(std::set<int> cpu_idx, int process) = 0;
+            virtual int get_process(int cpu_idx) = 0;
+            virtual std::vector<int> get_process(void) = 0;
+
+            // ID of a thread within a process
+            // - Linux child process id
+            // this should be something that linux understands0
+            //void set_thread_id(int cpu_idx, int thread_id);
+            //int get_thread_id(int cpu_idx);
+            //std::vector<int> get_thread_id(void);
+
+            static std::unique_ptr<ApplicationStatus> make_unique(const PlatformTopo& topo,
+                                                                  std::shared_ptr<SharedMemory> shmem);
+            static size_t buffer_size(int num_cpu);
+
+        protected:
+            static constexpr size_t M_STATUS_SIZE = 64;
+    };
+
+    class ApplicationStatusImp : public ApplicationStatus
+    {
+        public:
+            ApplicationStatusImp(const PlatformTopo& topo,
+                                 std::shared_ptr<SharedMemory> shmem);
+            virtual ~ApplicationStatusImp() = default;
+            void set_hint(int cpu_idx, uint64_t hints) override;
+            uint64_t get_hint(int cpu_idx) override;
+            std::vector<uint64_t> get_hint(void) override;
+            void set_hash(int cpu_idx, uint64_t hash) override;
+            uint64_t get_hash(int cpu_idx) override;
+            std::vector<uint64_t> get_hash(void) override;
+            void set_total_work_units(int cpu_idx, int work_units) override;
+            void increment_work_unit(int cpu_idx) override;
+            double get_work_progress(int cpu_idx) override;
+            std::vector<double> get_work_progress(void) override;
+            void set_process(std::set<int> cpu_idx, int process) override;
+            int get_process(int cpu_idx) override;
+            std::vector<int> get_process(void) override;
+        private:
+            // These fields must all be 32-bit int
+            struct m_app_status_s
+            {
+                uint32_t hints;
+                uint32_t hash;
+                int32_t process; // can be negative
+                uint32_t total_work;
+                uint32_t completed_work;
+                char padding[44];
+            };
+            static_assert((sizeof(ApplicationStatusImp::m_app_status_s) % 64) == 0,
+                          "m_app_status_s not aligned to cache lines");
+            static_assert(sizeof(ApplicationStatusImp::m_app_status_s) == ApplicationStatus::M_STATUS_SIZE,
+                          "M_STATUS_SIZE does not match size of m_app_status_s");
+
+            const PlatformTopo &m_topo;
+            int m_num_cpu;
+            std::shared_ptr<SharedMemory> m_shmem;
+            // TODO: this is an array; better way to handle?
+            // TODO: want all hints, etc. next to each other since
+            // we will frequently use the vector return
+            m_app_status_s *m_buffer;
+    };
+}
+
+#endif

--- a/src/ApplicationStatus.hpp
+++ b/src/ApplicationStatus.hpp
@@ -87,7 +87,7 @@ namespace geopm
             /// @param [in] cpu_idx Index of the Linux logical CPU.
             /// @return Fraction of the total work completed by this
             ///         CPU.
-            virtual double get_work_progress(int cpu_idx) const = 0;
+            virtual double get_progress_cpu(int cpu_idx) const = 0;
             /// @brief Assign a set of CPUs to a unique ID for a
             ///        process being coordinated within a job by the
             ///        GEOPM controller.  This may be: a COMM_WORLD or
@@ -138,7 +138,7 @@ namespace geopm
             uint64_t get_hash(int cpu_idx) const override;
             void set_total_work_units(int cpu_idx, int work_units) override;
             void increment_work_unit(int cpu_idx) override;
-            double get_work_progress(int cpu_idx) const override;
+            double get_progress_cpu(int cpu_idx) const override;
             void set_process(const std::set<int> &cpu_idx, int process) override;
             int get_process(int cpu_idx) const override;
         private:

--- a/src/ApplicationStatus.hpp
+++ b/src/ApplicationStatus.hpp
@@ -47,10 +47,9 @@ namespace geopm
     class PlatformTopo;
 
     /// @brief Object that encapsulates application process
-    ///        information such as the process ID, region hash, or
-    ///        region hint.  There will be one ApplicationStatus for
-    ///        the node (board domain) on each side of the shared
-    ///        memory.
+    ///        information such as the process ID or region hint.
+    ///        There will be one ApplicationStatus for the node (board
+    ///        domain) on each side of the shared memory.
     class ApplicationStatus
     {
         public:
@@ -62,16 +61,6 @@ namespace geopm
             virtual uint64_t get_hint(int cpu_idx) const = 0;
             /// @brief Get the current hint bits for every CPU.
             virtual std::vector<uint64_t> get_hint(void) const = 0;
-            /// @brief Set the hash of the region currently running on
-            ///        a CPU.
-            virtual void set_hash(int cpu_idx, uint64_t hash) = 0;
-            /// @brief Get the hash of the region currently running on
-            ///        a CPU.
-            virtual uint64_t get_hash(int cpu_idx) const = 0;
-            /// @brief Set the hashes of the regions currently running
-            ///        on each CPU.
-            virtual std::vector<uint64_t> get_hash(void) const = 0;
-
             /// @brief Reset the total work units for a single CPU to
             ///        be completed as part of a parallel region.
             ///        Calling this method also resets the work
@@ -129,9 +118,6 @@ namespace geopm
             void set_hint(int cpu_idx, uint64_t hints) override;
             uint64_t get_hint(int cpu_idx) const override;
             std::vector<uint64_t> get_hint(void) const override;
-            void set_hash(int cpu_idx, uint64_t hash) override;
-            uint64_t get_hash(int cpu_idx) const override;
-            std::vector<uint64_t> get_hash(void) const override;
             void set_total_work_units(int cpu_idx, int work_units) override;
             void increment_work_unit(int cpu_idx) override;
             double get_work_progress(int cpu_idx) const override;
@@ -144,11 +130,10 @@ namespace geopm
             struct m_app_status_s
             {
                 uint32_t hints;
-                uint32_t hash;
                 int32_t process; // can be negative
                 uint32_t total_work;
                 uint32_t completed_work;
-                char padding[44];
+                char padding[48];
             };
             static_assert((sizeof(ApplicationStatusImp::m_app_status_s) % geopm::hardware_destructive_interference_size) == 0,
                           "m_app_status_s not aligned to cache lines");

--- a/src/ApplicationStatus.hpp
+++ b/src/ApplicationStatus.hpp
@@ -66,19 +66,12 @@ namespace geopm
             /// @param [in] cpu_idx Index of the Linux logical CPU.
             /// @return The current hints for the given CPU.
             virtual uint64_t get_hint(int cpu_idx) const = 0;
-            /// @brief Get the current hint bits for every CPU.
-            /// @return Vector over Linux logical CPU of the current
-            ///         hints.
-            virtual std::vector<uint64_t> get_hint(void) const = 0;
             /// @brief Set the hash of the region currently running on
             ///        a CPU.
             virtual void set_hash(int cpu_idx, uint64_t hash) = 0;
             /// @brief Get the hash of the region currently running on
             ///        a CPU.
             virtual uint64_t get_hash(int cpu_idx) const = 0;
-            /// @brief Set the hashes of the regions currently running
-            ///        on each CPU.
-            virtual std::vector<uint64_t> get_hash(void) const = 0;
             /// @brief Reset the total work units for all threads to
             ///        be completed as part of a parallel region.
             ///        Calling this method also resets the work
@@ -95,12 +88,6 @@ namespace geopm
             /// @return Fraction of the total work completed by this
             ///         CPU.
             virtual double get_work_progress(int cpu_idx) const = 0;
-            /// @brief Get the current progress of every CPU.
-            ///        Progress is the fraction of the total work
-            ///        units that have been completed.
-            /// @return Vector over Linux logical CPU of the work
-            ///         progress values.
-            virtual std::vector<double> get_work_progress(void) const = 0;
             /// @brief Assign a set of CPUs to a unique ID for a
             ///        process being coordinated within a job by the
             ///        GEOPM controller.  This may be: a COMM_WORLD or
@@ -118,10 +105,6 @@ namespace geopm
             /// @param [in] cpu_idx Index of the Linux logical CPU
             /// @return ID of the process running on the given CPU.
             virtual int get_process(int cpu_idx) const = 0;
-            /// @brief Get the process IDs for every CPU.
-            /// @return Vector over Linux logical CPU of the process
-            ///         IDs.
-            virtual std::vector<int> get_process(void) const = 0;
             /// @brief Create an ApplicationStatus object using the
             ///        given SharedMemory.  The caller is responsible
             ///        for calling `buffer_size()` when creating the
@@ -151,17 +134,13 @@ namespace geopm
             virtual ~ApplicationStatusImp() = default;
             void set_hint(int cpu_idx, uint64_t hints) override;
             uint64_t get_hint(int cpu_idx) const override;
-            std::vector<uint64_t> get_hint(void) const override;
             void set_hash(int cpu_idx, uint64_t hash) override;
             uint64_t get_hash(int cpu_idx) const override;
-            std::vector<uint64_t> get_hash(void) const override;
             void set_total_work_units(int cpu_idx, int work_units) override;
             void increment_work_unit(int cpu_idx) override;
             double get_work_progress(int cpu_idx) const override;
-            std::vector<double> get_work_progress(void) const override;
             void set_process(const std::set<int> &cpu_idx, int process) override;
             int get_process(int cpu_idx) const override;
-            std::vector<int> get_process(void) const override;
         private:
             // These fields must all be 32-bit int
             struct m_app_status_s

--- a/src/ApplicationStatus.hpp
+++ b/src/ApplicationStatus.hpp
@@ -56,25 +56,40 @@ namespace geopm
             virtual ~ApplicationStatus() = default;
 
             /// @brief Set the current hint bits for a CPU.
+            /// @param [in] cpu_idx Index of the Linux logical CPU
+            /// @param [in] hints Bitfield of hints to set for the
+            ///             CPU.  Any existing hints will be
+            ///             overwritten.
             virtual void set_hint(int cpu_idx, uint64_t hints) = 0;
             /// @brief Get the current hint bits for a CPU.
+            /// @param [in] cpu_idx Index of the Linux logical CPU.
+            /// @return The current hints for the given CPU.
             virtual uint64_t get_hint(int cpu_idx) const = 0;
             /// @brief Get the current hint bits for every CPU.
+            /// @return Vector over Linux logical CPU of the current
+            ///         hints.
             virtual std::vector<uint64_t> get_hint(void) const = 0;
-            /// @brief Reset the total work units for a single CPU to
+            /// @brief Reset the total work units for all threads to
             ///        be completed as part of a parallel region.
             ///        Calling this method also resets the work
             ///        completed for the CPU.
+            /// @param [in] cpu_idx Index of the Linux logical CPU
             virtual void set_total_work_units(int cpu_idx, int work_units) = 0;
             /// @brief Mark a unit of work completed for this CPU.
+            /// @param [in] cpu_idx Index of the Linux logical CPU
             virtual void increment_work_unit(int cpu_idx) = 0;
             /// @brief Get the current progress for this CPU.
             ///        Progress is the fraction of the total work
             ///        units that have been completed.
+            /// @param [in] cpu_idx Index of the Linux logical CPU.
+            /// @return Fraction of the total work completed by this
+            ///         CPU.
             virtual double get_work_progress(int cpu_idx) const = 0;
             /// @brief Get the current progress of every CPU.
             ///        Progress is the fraction of the total work
             ///        units that have been completed.
+            /// @return Vector over Linux logical CPU of the work
+            ///         progress values.
             virtual std::vector<double> get_work_progress(void) const = 0;
             /// @brief Assign a set of CPUs to a unique ID for a
             ///        process being coordinated within a job by the
@@ -86,11 +101,16 @@ namespace geopm
             ///        will be one Profile object per process on the
             ///        application side, and one ApplicationRecordLog
             ///        per process on each side of the shared memory.
+            /// @param [in] cpu_idx Set of Linux logical CPUs for the process
             virtual void set_process(const std::set<int> &cpu_idx, int process) = 0;
             /// @brief Get the process ID for the process the CPU is
             ///        currently assigned to.
+            /// @param [in] cpu_idx Index of the Linux logical CPU
+            /// @return ID of the process running on the given CPU.
             virtual int get_process(int cpu_idx) const = 0;
             /// @brief Get the process IDs for every CPU.
+            /// @return Vector over Linux logical CPU of the process
+            ///         IDs.
             virtual std::vector<int> get_process(void) const = 0;
             /// @brief Create an ApplicationStatus object using the
             ///        given SharedMemory.  The caller is responsible
@@ -98,11 +118,15 @@ namespace geopm
             ///        shared memory, or attaching to an existing
             ///        shared memory region before passing the object
             ///        to this method.
+            /// @return A unique_ptr to the new ApplicationStatus
+            ///         object.
             static std::unique_ptr<ApplicationStatus> make_unique(const PlatformTopo& topo,
                                                                   std::shared_ptr<SharedMemory> shmem);
             /// @brief Return the required size of the shared memory
             ///        region used by the ApplicationStatus for the
             ///        given number of CPUs.
+            /// @return Minimum buffer size required for the
+            ///         SharedMemory used by ApplicationStatus.
             static size_t buffer_size(int num_cpu);
 
         protected:
@@ -129,8 +153,8 @@ namespace geopm
             // These fields must all be 32-bit int
             struct m_app_status_s
             {
+                int32_t process; // can be negative, indicating unset process
                 uint32_t hints;
-                int32_t process; // can be negative
                 uint32_t total_work;
                 uint32_t completed_work;
                 char padding[48];

--- a/src/ApplicationStatus.hpp
+++ b/src/ApplicationStatus.hpp
@@ -47,9 +47,10 @@ namespace geopm
     class PlatformTopo;
 
     /// @brief Object that encapsulates application process
-    ///        information such as the process ID or region hint.
-    ///        There will be one ApplicationStatus for the node (board
-    ///        domain) on each side of the shared memory.
+    ///        information such as the process ID, region hash, or
+    ///        region hint.  There will be one ApplicationStatus for
+    ///        the node (board domain) on each side of the shared
+    ///        memory.
     class ApplicationStatus
     {
         public:
@@ -69,6 +70,15 @@ namespace geopm
             /// @return Vector over Linux logical CPU of the current
             ///         hints.
             virtual std::vector<uint64_t> get_hint(void) const = 0;
+            /// @brief Set the hash of the region currently running on
+            ///        a CPU.
+            virtual void set_hash(int cpu_idx, uint64_t hash) = 0;
+            /// @brief Get the hash of the region currently running on
+            ///        a CPU.
+            virtual uint64_t get_hash(int cpu_idx) const = 0;
+            /// @brief Set the hashes of the regions currently running
+            ///        on each CPU.
+            virtual std::vector<uint64_t> get_hash(void) const = 0;
             /// @brief Reset the total work units for all threads to
             ///        be completed as part of a parallel region.
             ///        Calling this method also resets the work
@@ -142,6 +152,9 @@ namespace geopm
             void set_hint(int cpu_idx, uint64_t hints) override;
             uint64_t get_hint(int cpu_idx) const override;
             std::vector<uint64_t> get_hint(void) const override;
+            void set_hash(int cpu_idx, uint64_t hash) override;
+            uint64_t get_hash(int cpu_idx) const override;
+            std::vector<uint64_t> get_hash(void) const override;
             void set_total_work_units(int cpu_idx, int work_units) override;
             void increment_work_unit(int cpu_idx) override;
             double get_work_progress(int cpu_idx) const override;
@@ -155,9 +168,10 @@ namespace geopm
             {
                 int32_t process; // can be negative, indicating unset process
                 uint32_t hints;
+                uint32_t hash;
                 uint32_t total_work;
                 uint32_t completed_work;
-                char padding[48];
+                char padding[44];
             };
             static_assert((sizeof(ApplicationStatusImp::m_app_status_s) % geopm::hardware_destructive_interference_size) == 0,
                           "m_app_status_s not aligned to cache lines");

--- a/src/ApplicationStatus.hpp
+++ b/src/ApplicationStatus.hpp
@@ -39,6 +39,8 @@
 #include <vector>
 #include <set>
 
+#include "Helper.hpp"
+
 namespace geopm
 {
     class SharedMemory;
@@ -93,7 +95,7 @@ namespace geopm
             static size_t buffer_size(int num_cpu);
 
         protected:
-            static constexpr size_t M_STATUS_SIZE = 64;
+            static constexpr size_t M_STATUS_SIZE = geopm::hardware_destructive_interference_size;
     };
 
     class ApplicationStatusImp : public ApplicationStatus
@@ -126,7 +128,7 @@ namespace geopm
                 uint32_t completed_work;
                 char padding[44];
             };
-            static_assert((sizeof(ApplicationStatusImp::m_app_status_s) % 64) == 0,
+            static_assert((sizeof(ApplicationStatusImp::m_app_status_s) % geopm::hardware_destructive_interference_size) == 0,
                           "m_app_status_s not aligned to cache lines");
             static_assert(sizeof(ApplicationStatusImp::m_app_status_s) == ApplicationStatus::M_STATUS_SIZE,
                           "M_STATUS_SIZE does not match size of m_app_status_s");

--- a/src/Controller.hpp
+++ b/src/Controller.hpp
@@ -73,7 +73,7 @@ namespace geopm
                        int num_send_up,
                        int num_send_down,
                        std::unique_ptr<TreeComm> tree_comm,
-                       const ApplicationSampler &application_sampler,
+                       ApplicationSampler &application_sampler,
                        std::shared_ptr<ApplicationIO> application_io,
                        std::unique_ptr<Reporter> reporter,
                        std::unique_ptr<Tracer> tracer,
@@ -85,7 +85,8 @@ namespace geopm
                        bool do_policy,
                        std::unique_ptr<EndpointUser> endpoint,
                        const std::string &endpoint_path,
-                       bool do_endpoint);
+                       bool do_endpoint,
+                       const std::string &shm_key);
             virtual ~Controller();
             /// @brief Run control algorithm.
             ///
@@ -166,7 +167,7 @@ namespace geopm
             const int m_num_level_ctl;
             const int m_max_level;
             const int m_root_level;
-            const ApplicationSampler &m_application_sampler;
+            ApplicationSampler &m_application_sampler;
             std::shared_ptr<ApplicationIO> m_application_io;
             std::unique_ptr<Reporter> m_reporter;
             std::unique_ptr<Tracer> m_tracer;
@@ -188,6 +189,7 @@ namespace geopm
 
             std::vector<std::string> m_agent_policy_names;
             std::vector<std::string> m_agent_sample_names;
+            std::string m_shm_key;
     };
 }
 #endif

--- a/test/ApplicationIOTest.cpp
+++ b/test/ApplicationIOTest.cpp
@@ -95,8 +95,9 @@ void ApplicationIOTest::SetUp()
         .WillOnce(Return(m_num_cpu_domain));
     std::vector<int> ranks {1, 2, 3, 4};
     EXPECT_CALL(*m_sampler, cpu_rank()).WillOnce(Return(ranks));
-    m_app_io = geopm::make_unique<ApplicationIOImp>(m_shm_key,
-                                                    tmp_app_sampler, m_platform_io, m_platform_topo);
+    m_app_io = geopm::make_unique<ApplicationIOImp>(tmp_app_sampler,
+                                                    m_platform_io,
+                                                    m_platform_topo);
     m_app_io->connect();
 }
 

--- a/test/ApplicationSamplerTest.cpp
+++ b/test/ApplicationSamplerTest.cpp
@@ -178,36 +178,47 @@ TEST_F(ApplicationSamplerTest, one_enter_exit_two_ranks)
 
 TEST_F(ApplicationSamplerTest, with_epoch)
 {
-    uint64_t region_hash = 0xabcdULL;
-    std::vector<record_s> message_buffer {
+    uint64_t region_hash_0 = 0xabcdULL;
+    uint64_t region_hash_1 = 0x1234ULL;
+
+    std::vector<record_s> message_buffer_0 {
     //   time      process      event                      signal
-        {10.0,     0,           geopm::EVENT_REGION_ENTRY, region_hash},
+        {10.0,     0,           geopm::EVENT_REGION_ENTRY, region_hash_0},
         {11.0,     0,           geopm::EVENT_EPOCH_COUNT,  1},
-        {12.0,     0,           geopm::EVENT_REGION_EXIT, region_hash},
-        {13.0,     0,           geopm::EVENT_REGION_ENTRY, region_hash},
+        {12.0,     0,           geopm::EVENT_REGION_EXIT, region_hash_0},
+        {13.0,     0,           geopm::EVENT_REGION_ENTRY, region_hash_1},
         {14.0,     0,           geopm::EVENT_EPOCH_COUNT, 2},
-        {15.0,     0,           geopm::EVENT_REGION_EXIT, region_hash},
+        {15.0,     0,           geopm::EVENT_REGION_EXIT, region_hash_1},
     };
 
-    std::vector<record_s> empty_message_buffer;
+    std::vector<record_s> message_buffer_1 {
+    //   time      process      event                      signal
+        {10.5,     234,         geopm::EVENT_REGION_ENTRY, region_hash_0},
+        {11.5,     234,         geopm::EVENT_EPOCH_COUNT,  1},
+        {12.5,     234,         geopm::EVENT_REGION_EXIT, region_hash_0},
+        {13.5,     234,         geopm::EVENT_REGION_ENTRY, region_hash_1},
+        {14.5,     234,         geopm::EVENT_EPOCH_COUNT, 2},
+        {15.5,     234,         geopm::EVENT_REGION_EXIT, region_hash_1},
+    };
+
     std::vector<short_region_s> empty_short_region_buffer;
     EXPECT_CALL(*m_record_log_0, dump(_, _))
-        .WillOnce(DoAll(SetArgReferee<0>(message_buffer),
+        .WillOnce(DoAll(SetArgReferee<0>(message_buffer_0),
                         SetArgReferee<1>(empty_short_region_buffer)));
     EXPECT_CALL(*m_record_log_1, dump(_, _))
-        .WillOnce(DoAll(SetArgReferee<0>(empty_message_buffer),
+        .WillOnce(DoAll(SetArgReferee<0>(message_buffer_1),
                         SetArgReferee<1>(empty_short_region_buffer)));
     m_app_sampler->update_records();
     std::vector<struct record_s> result {
          m_app_sampler->get_records()
     };
 
-    ASSERT_EQ(6U, result.size());
+    ASSERT_EQ(12U, result.size());
 
     EXPECT_EQ(10.0, result[0].time);
     EXPECT_EQ(0, result[0].process);
     EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[0].event);
-    EXPECT_EQ(region_hash, result[0].signal);
+    EXPECT_EQ(region_hash_0, result[0].signal);
 
     EXPECT_EQ(11.0, result[1].time);
     EXPECT_EQ(0, result[1].process);
@@ -217,12 +228,12 @@ TEST_F(ApplicationSamplerTest, with_epoch)
     EXPECT_EQ(12.0, result[2].time);
     EXPECT_EQ(0, result[2].process);
     EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[2].event);
-    EXPECT_EQ(region_hash, result[2].signal);
+    EXPECT_EQ(region_hash_0, result[2].signal);
 
     EXPECT_EQ(13.0, result[3].time);
     EXPECT_EQ(0, result[3].process);
     EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[3].event);
-    EXPECT_EQ(region_hash, result[3].signal);
+    EXPECT_EQ(region_hash_1, result[3].signal);
 
     EXPECT_EQ(14.0, result[4].time);
     EXPECT_EQ(0, result[4].process);
@@ -232,7 +243,37 @@ TEST_F(ApplicationSamplerTest, with_epoch)
     EXPECT_EQ(15.0, result[5].time);
     EXPECT_EQ(0, result[5].process);
     EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[5].event);
-    EXPECT_EQ(region_hash, result[5].signal);
+    EXPECT_EQ(region_hash_1, result[5].signal);
+
+    EXPECT_EQ(10.5, result[6].time);
+    EXPECT_EQ(234, result[6].process);
+    EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[6].event);
+    EXPECT_EQ(region_hash_0, result[6].signal);
+
+    EXPECT_EQ(11.5, result[7].time);
+    EXPECT_EQ(234, result[7].process);
+    EXPECT_EQ(geopm::EVENT_EPOCH_COUNT, result[7].event);
+    EXPECT_EQ(1U, result[7].signal);
+
+    EXPECT_EQ(12.5, result[8].time);
+    EXPECT_EQ(234, result[8].process);
+    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[8].event);
+    EXPECT_EQ(region_hash_0, result[8].signal);
+
+    EXPECT_EQ(13.5, result[9].time);
+    EXPECT_EQ(234, result[9].process);
+    EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[9].event);
+    EXPECT_EQ(region_hash_1, result[9].signal);
+
+    EXPECT_EQ(14.5, result[10].time);
+    EXPECT_EQ(234, result[10].process);
+    EXPECT_EQ(geopm::EVENT_EPOCH_COUNT, result[10].event);
+    EXPECT_EQ(2U, result[10].signal);
+
+    EXPECT_EQ(15.5, result[11].time);
+    EXPECT_EQ(234, result[11].process);
+    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[11].event);
+    EXPECT_EQ(region_hash_1, result[11].signal);
 }
 
 TEST_F(ApplicationSamplerTest, string_conversion)

--- a/test/ApplicationSamplerTest.cpp
+++ b/test/ApplicationSamplerTest.cpp
@@ -35,19 +35,28 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
-#include "ApplicationSampler.hpp"
+#include "ApplicationSamplerImp.hpp"
 #include "MockProfileSampler.hpp"
 #include "MockEpochRuntimeRegulator.hpp"
+#include "MockApplicationRecordLog.hpp"
+#include "MockRecordFilter.hpp"
 #include "record.hpp"
 #include "geopm.h"
 #include "geopm_internal.h"
+#include "geopm_test.hpp"
 
 using testing::_;
 using testing::Return;
+using testing::SetArgReferee;
+using testing::DoAll;
 using geopm::ApplicationSampler;
+using geopm::ApplicationSamplerImp;
 using geopm::ProfileSampler;
 using geopm::EpochRuntimeRegulator;
 using geopm::record_s;
+using geopm::short_region_s;
+using geopm::RecordFilter;
+using geopm::ApplicationRecordLog;
 
 
 class ApplicationSamplerTest : public ::testing::Test
@@ -56,32 +65,92 @@ class ApplicationSamplerTest : public ::testing::Test
         void SetUp();
         std::shared_ptr<MockProfileSampler> m_mock_profile_sampler;
         std::shared_ptr<MockEpochRuntimeRegulator> m_mock_regulator;
+        std::shared_ptr<ApplicationSampler> m_app_sampler;
+        std::map<int, ApplicationSamplerImp::m_process_s> m_process_map;
+        std::shared_ptr<MockRecordFilter> m_filter_0;
+        std::shared_ptr<MockRecordFilter> m_filter_1;
+        std::shared_ptr<MockApplicationRecordLog> m_record_log_0;
+        std::shared_ptr<MockApplicationRecordLog> m_record_log_1;
 };
 
 void ApplicationSamplerTest::SetUp()
 {
     m_mock_profile_sampler = std::make_shared<MockProfileSampler>();
     m_mock_regulator = std::make_shared<MockEpochRuntimeRegulator>();
-    EXPECT_CALL(*m_mock_profile_sampler, capacity())
-        .WillOnce(Return(4096));
-    ApplicationSampler::application_sampler().set_sampler(m_mock_profile_sampler);
-    ApplicationSampler::application_sampler().set_regulator(m_mock_regulator);
-    ApplicationSampler::application_sampler().time_zero(geopm_time_s {{0,0}});
+    m_filter_0 = std::make_shared<MockRecordFilter>();
+    m_filter_1 = std::make_shared<MockRecordFilter>();
+    m_record_log_0 = std::make_shared<MockApplicationRecordLog>();
+    m_record_log_1 = std::make_shared<MockApplicationRecordLog>();
+
+    m_process_map[0].filter = m_filter_0;
+    m_process_map[0].record_log = m_record_log_0;
+    m_process_map[234].filter = m_filter_1;
+    m_process_map[234].record_log = m_record_log_1;
+
+    m_app_sampler = std::make_shared<ApplicationSamplerImp>(m_process_map, false, "");
+    m_app_sampler->set_sampler(m_mock_profile_sampler);
+    m_app_sampler->set_regulator(m_mock_regulator);
+    m_app_sampler->time_zero(geopm_time_s {{0,0}});
 }
 
 TEST_F(ApplicationSamplerTest, one_enter_exit)
 {
-    uint64_t region_id = 0xabcdULL | GEOPM_REGION_HINT_COMPUTE;
-    std::vector<struct geopm_prof_message_s> message_buffer {
-    //   rank     region_id     timestamp     progress
-        {0,       region_id,    {{10,0}},     0.0},
-        {0,       region_id,    {{11,0}},     1.0},
+    uint64_t region_hash = 0xabcdULL;
+    std::vector<record_s> message_buffer {
+    //   time    process    event                      signal
+        {10,     0,         geopm::EVENT_REGION_ENTRY, region_hash},
+        {11,     0,         geopm::EVENT_REGION_EXIT,  region_hash},
     };
-    EXPECT_CALL(*m_mock_profile_sampler, sample_cache())
-        .WillOnce(Return(message_buffer));
-    ApplicationSampler::application_sampler().update_records();
+    std::vector<record_s> empty_message_buffer;
+    std::vector<short_region_s> empty_short_region_buffer;
+    EXPECT_CALL(*m_record_log_0, dump(_, _))
+        .WillOnce(DoAll(SetArgReferee<0>(message_buffer),
+                        SetArgReferee<1>(empty_short_region_buffer)));
+    EXPECT_CALL(*m_record_log_1, dump(_, _))
+        .WillOnce(DoAll(SetArgReferee<0>(empty_message_buffer),
+                        SetArgReferee<1>(empty_short_region_buffer)));
+    m_app_sampler->update_records();
     std::vector<struct record_s> result {
-        ApplicationSampler::application_sampler().get_records()
+         m_app_sampler->get_records()
+    };
+
+    ASSERT_EQ(2U, result.size());
+
+    EXPECT_EQ(10.0, result[0].time);
+    EXPECT_EQ(0, result[0].process);
+    EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[0].event);
+    EXPECT_EQ(region_hash, result[0].signal);
+
+    EXPECT_EQ(11.0, result[1].time);
+    EXPECT_EQ(0, result[1].process);
+    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[1].event);
+    EXPECT_EQ(region_hash, result[1].signal);
+}
+
+TEST_F(ApplicationSamplerTest, one_enter_exit_two_ranks)
+{
+    uint64_t region_hash = 0xabcdULL;
+    std::vector<record_s> message_buffer_0 {
+    //   time    process    event                      signal
+        {10,     0,         geopm::EVENT_REGION_ENTRY, region_hash},
+        {11,     0,         geopm::EVENT_REGION_EXIT,  region_hash},
+    };
+    std::vector<record_s> message_buffer_1 {
+    //   time      process      event                      signal
+        {10.5,     234,         geopm::EVENT_REGION_ENTRY, region_hash},
+        {11.5,     234,         geopm::EVENT_REGION_EXIT,  region_hash},
+    };
+
+    std::vector<short_region_s> empty_short_region_buffer;
+    EXPECT_CALL(*m_record_log_0, dump(_, _))
+        .WillOnce(DoAll(SetArgReferee<0>(message_buffer_0),
+                        SetArgReferee<1>(empty_short_region_buffer)));
+    EXPECT_CALL(*m_record_log_1, dump(_, _))
+        .WillOnce(DoAll(SetArgReferee<0>(message_buffer_1),
+                        SetArgReferee<1>(empty_short_region_buffer)));
+    m_app_sampler->update_records();
+    std::vector<struct record_s> result {
+         m_app_sampler->get_records()
     };
 
     ASSERT_EQ(4U, result.size());
@@ -89,146 +158,81 @@ TEST_F(ApplicationSamplerTest, one_enter_exit)
     EXPECT_EQ(10.0, result[0].time);
     EXPECT_EQ(0, result[0].process);
     EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[0].event);
-    EXPECT_EQ(0xabcdULL, result[0].signal);
+    EXPECT_EQ(region_hash, result[0].signal);
 
-    EXPECT_EQ(10.0, result[1].time);
+    EXPECT_EQ(11.0, result[1].time);
     EXPECT_EQ(0, result[1].process);
-    EXPECT_EQ(geopm::EVENT_HINT, result[1].event);
-    EXPECT_EQ(GEOPM_REGION_HINT_COMPUTE, result[1].signal);
+    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[1].event);
+    EXPECT_EQ(region_hash, result[1].signal);
 
-    EXPECT_EQ(11.0, result[2].time);
-    EXPECT_EQ(0, result[2].process);
-    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[2].event);
-    EXPECT_EQ(0xabcdULL, result[2].signal);
+    EXPECT_EQ(10.5, result[2].time);
+    EXPECT_EQ(234, result[2].process);
+    EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[2].event);
+    EXPECT_EQ(region_hash, result[2].signal);
 
-    EXPECT_EQ(11.0, result[3].time);
-    EXPECT_EQ(0, result[3].process);
-    EXPECT_EQ(geopm::EVENT_HINT, result[3].event);
-    EXPECT_EQ(GEOPM_REGION_HINT_UNKNOWN, result[3].signal);
+    EXPECT_EQ(11.5, result[3].time);
+    EXPECT_EQ(234, result[3].process);
+    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[3].event);
+    EXPECT_EQ(region_hash, result[3].signal);
 }
 
-TEST_F(ApplicationSamplerTest, with_mpi)
+TEST_F(ApplicationSamplerTest, with_epoch)
 {
-    uint64_t region_id = 0xabcdULL | GEOPM_REGION_HINT_COMPUTE;
-    uint64_t mpi_id = geopm_region_id_set_mpi(region_id);
-    std::vector<struct geopm_prof_message_s> message_buffer {
-    //   rank     region_id     timestamp     progress
-        {234,     region_id,    {{10,0}},     0.0},
-        {234,     mpi_id,       {{11,0}},     0.0},
-        {234,     mpi_id,       {{12,0}},     1.0},
-        {234,     region_id,    {{13,0}},     1.0},
+    uint64_t region_hash = 0xabcdULL;
+    std::vector<record_s> message_buffer {
+    //   time      process      event                      signal
+        {10.0,     0,           geopm::EVENT_REGION_ENTRY, region_hash},
+        {11.0,     0,           geopm::EVENT_EPOCH_COUNT,  1},
+        {12.0,     0,           geopm::EVENT_REGION_EXIT, region_hash},
+        {13.0,     0,           geopm::EVENT_REGION_ENTRY, region_hash},
+        {14.0,     0,           geopm::EVENT_EPOCH_COUNT, 2},
+        {15.0,     0,           geopm::EVENT_REGION_EXIT, region_hash},
     };
-    EXPECT_CALL(*m_mock_profile_sampler, sample_cache())
-        .WillOnce(Return(message_buffer));
-    ApplicationSampler::application_sampler().update_records();
+
+    std::vector<record_s> empty_message_buffer;
+    std::vector<short_region_s> empty_short_region_buffer;
+    EXPECT_CALL(*m_record_log_0, dump(_, _))
+        .WillOnce(DoAll(SetArgReferee<0>(message_buffer),
+                        SetArgReferee<1>(empty_short_region_buffer)));
+    EXPECT_CALL(*m_record_log_1, dump(_, _))
+        .WillOnce(DoAll(SetArgReferee<0>(empty_message_buffer),
+                        SetArgReferee<1>(empty_short_region_buffer)));
+    m_app_sampler->update_records();
     std::vector<struct record_s> result {
-        ApplicationSampler::application_sampler().get_records()
+         m_app_sampler->get_records()
     };
 
     ASSERT_EQ(6U, result.size());
 
     EXPECT_EQ(10.0, result[0].time);
-    EXPECT_EQ(234, result[0].process);
-    EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[0].event);
-    EXPECT_EQ(0xabcdULL, result[0].signal);
-
-    EXPECT_EQ(10.0, result[1].time);
-    EXPECT_EQ(234, result[1].process);
-    EXPECT_EQ(geopm::EVENT_HINT, result[1].event);
-    EXPECT_EQ(GEOPM_REGION_HINT_COMPUTE, result[1].signal);
-
-    EXPECT_EQ(11.0, result[2].time);
-    EXPECT_EQ(234, result[2].process);
-    EXPECT_EQ(geopm::EVENT_HINT, result[2].event);
-    EXPECT_EQ(GEOPM_REGION_HINT_NETWORK, result[2].signal);
-
-    EXPECT_EQ(12.0, result[3].time);
-    EXPECT_EQ(234, result[3].process);
-    EXPECT_EQ(geopm::EVENT_HINT, result[3].event);
-    EXPECT_EQ(GEOPM_REGION_HINT_COMPUTE, result[3].signal);
-
-    EXPECT_EQ(13.0, result[4].time);
-    EXPECT_EQ(234, result[4].process);
-    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[4].event);
-    EXPECT_EQ(0xabcdULL, result[4].signal);
-
-    EXPECT_EQ(13.0, result[5].time);
-    EXPECT_EQ(234, result[5].process);
-    EXPECT_EQ(geopm::EVENT_HINT, result[5].event);
-    EXPECT_EQ(GEOPM_REGION_HINT_UNKNOWN, result[5].signal);
-}
-
-TEST_F(ApplicationSamplerTest, with_epoch)
-{
-    uint64_t region_id = 0xabcdULL | GEOPM_REGION_HINT_COMPUTE;
-    uint64_t epoch_id = GEOPM_REGION_ID_EPOCH;
-    std::vector<struct geopm_prof_message_s> message_buffer {
-    //   rank     region_id     timestamp     progress
-        {0,       region_id,    {{10,0}},     0.0},
-        {0,       epoch_id,     {{11,0}},     0.0},
-        {0,       region_id,    {{12,0}},     1.0},
-        {0,       region_id,    {{13,0}},     0.0},
-        {0,       epoch_id,     {{14,0}},     0.0},
-        {0,       region_id,    {{15,0}},     1.0},
-    };
-    EXPECT_CALL(*m_mock_profile_sampler, sample_cache())
-        .WillOnce(Return(message_buffer));
-    ApplicationSampler::application_sampler().update_records();
-    std::vector<struct record_s> result {
-        ApplicationSampler::application_sampler().get_records()
-    };
-
-    ASSERT_EQ(10U, result.size());
-
-    EXPECT_EQ(10.0, result[0].time);
     EXPECT_EQ(0, result[0].process);
     EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[0].event);
-    EXPECT_EQ(0xabcdULL, result[0].signal);
+    EXPECT_EQ(region_hash, result[0].signal);
 
-    EXPECT_EQ(10.0, result[1].time);
+    EXPECT_EQ(11.0, result[1].time);
     EXPECT_EQ(0, result[1].process);
-    EXPECT_EQ(geopm::EVENT_HINT, result[1].event);
-    EXPECT_EQ(GEOPM_REGION_HINT_COMPUTE, result[1].signal);
+    EXPECT_EQ(geopm::EVENT_EPOCH_COUNT, result[1].event);
+    EXPECT_EQ(1U, result[1].signal);
 
-    EXPECT_EQ(11.0, result[2].time);
+    EXPECT_EQ(12.0, result[2].time);
     EXPECT_EQ(0, result[2].process);
-    EXPECT_EQ(geopm::EVENT_EPOCH_COUNT, result[2].event);
-    EXPECT_EQ(1ULL, result[2].signal);
+    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[2].event);
+    EXPECT_EQ(region_hash, result[2].signal);
 
-    EXPECT_EQ(12.0, result[3].time);
+    EXPECT_EQ(13.0, result[3].time);
     EXPECT_EQ(0, result[3].process);
-    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[3].event);
-    EXPECT_EQ(0xabcdULL, result[3].signal);
+    EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[3].event);
+    EXPECT_EQ(region_hash, result[3].signal);
 
-    EXPECT_EQ(12.0, result[4].time);
+    EXPECT_EQ(14.0, result[4].time);
     EXPECT_EQ(0, result[4].process);
-    EXPECT_EQ(geopm::EVENT_HINT, result[4].event);
-    EXPECT_EQ(GEOPM_REGION_HINT_UNKNOWN, result[4].signal);
+    EXPECT_EQ(geopm::EVENT_EPOCH_COUNT, result[4].event);
+    EXPECT_EQ(2U, result[4].signal);
 
-    EXPECT_EQ(13.0, result[5].time);
+    EXPECT_EQ(15.0, result[5].time);
     EXPECT_EQ(0, result[5].process);
-    EXPECT_EQ(geopm::EVENT_REGION_ENTRY, result[5].event);
-    EXPECT_EQ(0xabcdULL, result[5].signal);
-
-    EXPECT_EQ(13.0, result[6].time);
-    EXPECT_EQ(0, result[6].process);
-    EXPECT_EQ(geopm::EVENT_HINT, result[6].event);
-    EXPECT_EQ(GEOPM_REGION_HINT_COMPUTE, result[6].signal);
-
-    EXPECT_EQ(14.0, result[7].time);
-    EXPECT_EQ(0, result[7].process);
-    EXPECT_EQ(geopm::EVENT_EPOCH_COUNT, result[7].event);
-    EXPECT_EQ(2ULL, result[7].signal);
-
-    EXPECT_EQ(15.0, result[8].time);
-    EXPECT_EQ(0, result[8].process);
-    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[8].event);
-    EXPECT_EQ(0xabcdULL, result[8].signal);
-
-    EXPECT_EQ(15.0, result[9].time);
-    EXPECT_EQ(0, result[9].process);
-    EXPECT_EQ(geopm::EVENT_HINT, result[9].event);
-    EXPECT_EQ(GEOPM_REGION_HINT_UNKNOWN, result[9].signal);
+    EXPECT_EQ(geopm::EVENT_REGION_EXIT, result[5].event);
+    EXPECT_EQ(region_hash, result[5].signal);
 }
 
 TEST_F(ApplicationSamplerTest, string_conversion)
@@ -252,6 +256,65 @@ TEST_F(ApplicationSamplerTest, process_mapping)
     std::vector<int> expected { 4, 5, 77, 32 };
     EXPECT_CALL(*m_mock_profile_sampler, cpu_rank())
         .WillOnce(Return(expected));
-    std::vector<int> result = ApplicationSampler::application_sampler().per_cpu_process();
+    std::vector<int> result = m_app_sampler->per_cpu_process();
     EXPECT_EQ(expected, result);
+}
+
+TEST_F(ApplicationSamplerTest, short_regions)
+{
+    uint64_t region_hash_0 = 0xabcdULL;
+    uint64_t region_hash_1 = 0x1234ULL;
+    std::vector<record_s> message_buffer_0 {
+    //   time    process    event                      signal
+        {10,     0,         geopm::EVENT_SHORT_REGION, 0},
+    };
+    std::vector<record_s> message_buffer_1 {
+        {11,     234,       geopm::EVENT_SHORT_REGION, 0},
+    };
+    std::vector<short_region_s> short_region_buffer_0 {
+    //   hash           num_complete, total_time
+        {region_hash_0, 3,             1.0}
+    };
+    std::vector<short_region_s> short_region_buffer_1 {
+    //   hash           num_complete, total_time
+        {region_hash_1, 4,            1.1}
+    };
+    EXPECT_CALL(*m_record_log_0, dump(_, _))
+        .WillOnce(DoAll(SetArgReferee<0>(message_buffer_0),
+                        SetArgReferee<1>(short_region_buffer_0)));
+    EXPECT_CALL(*m_record_log_1, dump(_, _))
+        .WillOnce(DoAll(SetArgReferee<0>(message_buffer_1),
+                        SetArgReferee<1>(short_region_buffer_1)));
+    m_app_sampler->update_records();
+    std::vector<struct record_s> records {
+        m_app_sampler->get_records()
+    };
+
+    ASSERT_EQ(2U, records.size());
+
+    EXPECT_EQ(10.0, records[0].time);
+    EXPECT_EQ(0, records[0].process);
+    EXPECT_EQ(geopm::EVENT_SHORT_REGION, records[0].event);
+    EXPECT_EQ(0ULL, records[0].signal);
+
+    EXPECT_EQ(11.0, records[1].time);
+    EXPECT_EQ(234, records[1].process);
+    EXPECT_EQ(geopm::EVENT_SHORT_REGION, records[1].event);
+    EXPECT_EQ(1ULL, records[1].signal);
+
+    std::vector<struct short_region_s> short_regions {
+        m_app_sampler->get_short_region(0),
+        m_app_sampler->get_short_region(1),
+    };
+
+    EXPECT_EQ(region_hash_0, short_regions[0].hash);
+    EXPECT_EQ(region_hash_1, short_regions[1].hash);
+    EXPECT_EQ(3, short_regions[0].num_complete);
+    EXPECT_EQ(4, short_regions[1].num_complete);
+    EXPECT_EQ(1.0, short_regions[0].total_time);
+    EXPECT_EQ(1.1, short_regions[1].total_time);
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_app_sampler->get_short_region(3),
+                               GEOPM_ERROR_INVALID,
+                               "event_signal does not match any short region handle");
 }

--- a/test/ApplicationStatusTest.cpp
+++ b/test/ApplicationStatusTest.cpp
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm_test.hpp"
+
+#include "geopm.h"
+#include "ApplicationStatus.hpp"
+#include "MockSharedMemory.hpp"
+#include "MockPlatformTopo.hpp"
+
+using geopm::ApplicationStatus;
+using testing::AtLeast;
+using testing::Return;
+
+class ApplicationStatusTest : public ::testing::Test
+{
+    protected:
+        void SetUp();
+        std::shared_ptr<MockSharedMemory> m_mock_shared_memory;
+        std::unique_ptr<ApplicationStatus> m_status;
+        MockPlatformTopo m_topo;
+        const int M_NUM_CPU = 4;
+};
+
+void ApplicationStatusTest::SetUp()
+{
+    ON_CALL(m_topo, num_domain(GEOPM_DOMAIN_CPU))
+        .WillByDefault(Return(M_NUM_CPU));
+
+    size_t buffer_size = ApplicationStatus::buffer_size(M_NUM_CPU);
+    m_mock_shared_memory = std::make_shared<MockSharedMemory>(buffer_size);
+
+    EXPECT_CALL(m_topo, num_domain(GEOPM_DOMAIN_CPU));
+    m_status = ApplicationStatus::make_unique(m_topo, m_mock_shared_memory);
+
+
+}
+
+TEST_F(ApplicationStatusTest, wrong_buffer_size)
+{
+    auto shmem = std::make_shared<MockSharedMemory>(7);
+    EXPECT_CALL(m_topo, num_domain(GEOPM_DOMAIN_CPU));
+    GEOPM_EXPECT_THROW_MESSAGE(ApplicationStatus::make_unique(m_topo, shmem),
+                               GEOPM_ERROR_INVALID, "shared memory incorrectly sized");
+}
+
+TEST_F(ApplicationStatusTest, bad_shmem)
+{
+    EXPECT_CALL(m_topo, num_domain(GEOPM_DOMAIN_CPU));
+    GEOPM_EXPECT_THROW_MESSAGE(ApplicationStatus::make_unique(m_topo, nullptr),
+                               GEOPM_ERROR_INVALID, "shared memory pointer cannot be null");
+}
+
+TEST_F(ApplicationStatusTest, hints)
+{
+    std::vector<uint64_t> expected(M_NUM_CPU, 0ULL);
+    uint64_t NOHINTS = 0ULL;
+    uint64_t NETWORK = GEOPM_REGION_HINT_NETWORK;
+    uint64_t COMPARA = GEOPM_REGION_HINT_COMPUTE | GEOPM_REGION_HINT_PARALLEL;
+
+    EXPECT_EQ(expected, m_status->get_hint());
+    EXPECT_EQ(NOHINTS, m_status->get_hint(0));
+    EXPECT_EQ(NOHINTS, m_status->get_hint(1));
+    EXPECT_EQ(NOHINTS, m_status->get_hint(2));
+    EXPECT_EQ(NOHINTS, m_status->get_hint(3));
+
+    m_status->set_hint(1, NETWORK);
+    m_status->set_hint(3, NETWORK);
+    expected[1] = NETWORK;
+    expected[3] = NETWORK;
+    EXPECT_EQ(expected, m_status->get_hint());
+    EXPECT_EQ(NOHINTS, m_status->get_hint(0));
+    EXPECT_EQ(NETWORK, m_status->get_hint(1));
+    EXPECT_EQ(NOHINTS, m_status->get_hint(2));
+    EXPECT_EQ(NETWORK, m_status->get_hint(3));
+
+    m_status->set_hint(2, COMPARA);
+    m_status->set_hint(3, COMPARA);
+    expected[2] = COMPARA;
+    expected[3] = COMPARA;
+    EXPECT_EQ(expected, m_status->get_hint());
+    EXPECT_EQ(NOHINTS, m_status->get_hint(0));
+    EXPECT_EQ(NETWORK, m_status->get_hint(1));
+    EXPECT_EQ(COMPARA, m_status->get_hint(2));
+    EXPECT_EQ(COMPARA, m_status->get_hint(3));
+
+    // clear hint
+    m_status->set_hint(1, 0ULL);
+    m_status->set_hint(2, 0ULL);
+    m_status->set_hint(3, 0ULL);
+    expected[1] = NOHINTS;
+    expected[2] = NOHINTS;
+    expected[3] = NOHINTS;
+    EXPECT_EQ(expected, m_status->get_hint());
+    EXPECT_EQ(NOHINTS, m_status->get_hint(0));
+    EXPECT_EQ(NOHINTS, m_status->get_hint(1));
+    EXPECT_EQ(NOHINTS, m_status->get_hint(2));
+    EXPECT_EQ(NOHINTS, m_status->get_hint(3));
+
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hint(-1, NETWORK),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hint(99, NETWORK),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hint(0, 2),
+                               GEOPM_ERROR_INVALID, "invalid hint");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_hint(-1),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_hint(99),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+}
+
+TEST_F(ApplicationStatusTest, hash)
+{
+    std::vector<uint64_t> expected(M_NUM_CPU, 0ULL);
+    ASSERT_EQ(0x0, GEOPM_REGION_HASH_INVALID);
+
+    EXPECT_EQ(expected, m_status->get_hash());
+    EXPECT_EQ(0x00, m_status->get_hash(0));
+    EXPECT_EQ(0x00, m_status->get_hash(1));
+    EXPECT_EQ(0x00, m_status->get_hash(2));
+    EXPECT_EQ(0x00, m_status->get_hash(3));
+
+    m_status->set_hash(0, 0xAA);
+    m_status->set_hash(1, 0xAA);
+    m_status->set_hash(2, 0xBB);
+    m_status->set_hash(3, 0xCC);
+    expected = {0xAA, 0xAA, 0xBB, 0xCC};
+    EXPECT_EQ(expected, m_status->get_hash());
+    EXPECT_EQ(0xAA, m_status->get_hash(0));
+    EXPECT_EQ(0xAA, m_status->get_hash(1));
+    EXPECT_EQ(0xBB, m_status->get_hash(2));
+    EXPECT_EQ(0xCC, m_status->get_hash(3));
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(-1, 0xDD),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(99, 0xDD),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(0, (0xFFULL << 32)),
+                               GEOPM_ERROR_INVALID, "invalid region hash");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_hash(-1),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_hash(99),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+}
+
+TEST_F(ApplicationStatusTest, work_progress)
+{
+
+    // CPUs 2 and 3 are inactive, 0 work units
+    m_status->set_total_work_units(0, 4);
+    m_status->set_total_work_units(1, 8);
+    EXPECT_DOUBLE_EQ(0.000, m_status->get_work_progress(0));
+    EXPECT_DOUBLE_EQ(0.000, m_status->get_work_progress(1));
+    EXPECT_TRUE(std::isnan(m_status->get_work_progress(2)));
+    EXPECT_TRUE(std::isnan(m_status->get_work_progress(3)));
+    m_status->increment_work_unit(0);
+    m_status->increment_work_unit(1);
+    EXPECT_DOUBLE_EQ(0.250, m_status->get_work_progress(0));
+    EXPECT_DOUBLE_EQ(0.125, m_status->get_work_progress(1));
+    m_status->increment_work_unit(0);
+    EXPECT_DOUBLE_EQ(0.500, m_status->get_work_progress(0));
+    EXPECT_DOUBLE_EQ(0.125, m_status->get_work_progress(1));
+    EXPECT_DOUBLE_EQ(0.125, m_status->get_work_progress(1));
+    m_status->increment_work_unit(0);
+    m_status->increment_work_unit(1);
+    EXPECT_DOUBLE_EQ(0.750, m_status->get_work_progress(0));
+    EXPECT_DOUBLE_EQ(0.250, m_status->get_work_progress(1));
+    auto result = m_status->get_work_progress();
+    EXPECT_DOUBLE_EQ(0.750, result[0]);
+    EXPECT_DOUBLE_EQ(0.250, result[1]);
+    EXPECT_TRUE(std::isnan(result[2]));
+    EXPECT_TRUE(std::isnan(result[3]));
+    m_status->increment_work_unit(0);
+    m_status->increment_work_unit(1);
+    m_status->increment_work_unit(1);
+    EXPECT_DOUBLE_EQ(1.000, m_status->get_work_progress(0));
+    EXPECT_DOUBLE_EQ(0.500, m_status->get_work_progress(1));
+
+    // TODO: throw in profile side?
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->increment_work_unit(0),
+                               GEOPM_ERROR_RUNTIME, "more increments than total work");
+
+    // reset progress
+    m_status->set_total_work_units(0, 8);
+    EXPECT_DOUBLE_EQ(0.00, m_status->get_work_progress(0));
+
+    // leave region
+    m_status->set_total_work_units(0, 0);
+    m_status->set_total_work_units(1, 0);
+    m_status->set_total_work_units(2, 0);
+    m_status->set_total_work_units(3, 0);
+    EXPECT_TRUE(std::isnan(m_status->get_work_progress(0)));
+    EXPECT_TRUE(std::isnan(m_status->get_work_progress(1)));
+    EXPECT_TRUE(std::isnan(m_status->get_work_progress(2)));
+    EXPECT_TRUE(std::isnan(m_status->get_work_progress(3)));
+
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_work_progress(-1),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_work_progress(99),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_total_work_units(-1, 100),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_total_work_units(99, 100),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->increment_work_unit(-1),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->increment_work_unit(99),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_total_work_units(0, -10),
+                               GEOPM_ERROR_INVALID, "invalid number of work units");
+}
+
+TEST_F(ApplicationStatusTest, process)
+{
+    std::vector<int> expected(M_NUM_CPU, -1);
+
+    EXPECT_EQ(expected, m_status->get_process());
+    EXPECT_EQ(-1, m_status->get_process(0));
+    EXPECT_EQ(-1, m_status->get_process(1));
+    EXPECT_EQ(-1, m_status->get_process(2));
+    EXPECT_EQ(-1, m_status->get_process(3));
+
+    m_status->set_process({0, 2}, 34);
+    m_status->set_process({1}, 56);
+    m_status->set_process({3}, 78);
+    expected = {34, 56, 34, 78};
+    EXPECT_EQ(expected, m_status->get_process());
+    EXPECT_EQ(34, m_status->get_process(0));
+    EXPECT_EQ(56, m_status->get_process(1));
+    EXPECT_EQ(34, m_status->get_process(2));
+    EXPECT_EQ(78, m_status->get_process(3));
+
+    // detach processes
+    m_status->set_process({0, 1, 2, 3}, -1);
+    expected = {-1, -1, -1, -1};
+    EXPECT_EQ(expected, m_status->get_process());
+    EXPECT_EQ(-1, m_status->get_process(0));
+    EXPECT_EQ(-1, m_status->get_process(1));
+    EXPECT_EQ(-1, m_status->get_process(2));
+    EXPECT_EQ(-1, m_status->get_process(3));
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_process({-1}, 2),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_process({99}, 2),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_process(-1),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_process(99),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+}

--- a/test/ApplicationStatusTest.cpp
+++ b/test/ApplicationStatusTest.cpp
@@ -141,6 +141,40 @@ TEST_F(ApplicationStatusTest, hints)
                                GEOPM_ERROR_INVALID, "invalid CPU index");
 }
 
+TEST_F(ApplicationStatusTest, hash)
+{
+    std::vector<uint64_t> expected(M_NUM_CPU, 0ULL);
+    ASSERT_EQ(0x0, GEOPM_REGION_HASH_INVALID);
+
+    EXPECT_EQ(expected, m_status->get_hash());
+    EXPECT_EQ(0x00, m_status->get_hash(0));
+    EXPECT_EQ(0x00, m_status->get_hash(1));
+    EXPECT_EQ(0x00, m_status->get_hash(2));
+    EXPECT_EQ(0x00, m_status->get_hash(3));
+
+    m_status->set_hash(0, 0xAA);
+    m_status->set_hash(1, 0xAA);
+    m_status->set_hash(2, 0xBB);
+    m_status->set_hash(3, 0xCC);
+    expected = {0xAA, 0xAA, 0xBB, 0xCC};
+    EXPECT_EQ(expected, m_status->get_hash());
+    EXPECT_EQ(0xAA, m_status->get_hash(0));
+    EXPECT_EQ(0xAA, m_status->get_hash(1));
+    EXPECT_EQ(0xBB, m_status->get_hash(2));
+    EXPECT_EQ(0xCC, m_status->get_hash(3));
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(-1, 0xDD),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(99, 0xDD),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(0, (0xFFULL << 32)),
+                               GEOPM_ERROR_INVALID, "invalid region hash");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_hash(-1),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_hash(99),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+}
+
 TEST_F(ApplicationStatusTest, work_progress)
 {
 

--- a/test/ApplicationStatusTest.cpp
+++ b/test/ApplicationStatusTest.cpp
@@ -131,21 +131,21 @@ TEST_F(ApplicationStatusTest, hints)
 
 TEST_F(ApplicationStatusTest, hash)
 {
-    ASSERT_EQ(0x0, GEOPM_REGION_HASH_INVALID);
+    ASSERT_EQ(0x00ULL, GEOPM_REGION_HASH_INVALID);
 
-    EXPECT_EQ(0x00, m_status->get_hash(0));
-    EXPECT_EQ(0x00, m_status->get_hash(1));
-    EXPECT_EQ(0x00, m_status->get_hash(2));
-    EXPECT_EQ(0x00, m_status->get_hash(3));
+    EXPECT_EQ(0x00ULL, m_status->get_hash(0));
+    EXPECT_EQ(0x00ULL, m_status->get_hash(1));
+    EXPECT_EQ(0x00ULL, m_status->get_hash(2));
+    EXPECT_EQ(0x00ULL, m_status->get_hash(3));
 
     m_status->set_hash(0, 0xAA);
     m_status->set_hash(1, 0xAA);
     m_status->set_hash(2, 0xBB);
     m_status->set_hash(3, 0xCC);
-    EXPECT_EQ(0xAA, m_status->get_hash(0));
-    EXPECT_EQ(0xAA, m_status->get_hash(1));
-    EXPECT_EQ(0xBB, m_status->get_hash(2));
-    EXPECT_EQ(0xCC, m_status->get_hash(3));
+    EXPECT_EQ(0xAAULL, m_status->get_hash(0));
+    EXPECT_EQ(0xAAULL, m_status->get_hash(1));
+    EXPECT_EQ(0xBBULL, m_status->get_hash(2));
+    EXPECT_EQ(0xCCULL, m_status->get_hash(3));
 
     GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(-1, 0xDD),
                                GEOPM_ERROR_INVALID, "invalid CPU index");

--- a/test/ApplicationStatusTest.cpp
+++ b/test/ApplicationStatusTest.cpp
@@ -84,12 +84,10 @@ TEST_F(ApplicationStatusTest, bad_shmem)
 
 TEST_F(ApplicationStatusTest, hints)
 {
-    std::vector<uint64_t> expected(M_NUM_CPU, 0ULL);
     uint64_t NOHINTS = 0ULL;
     uint64_t NETWORK = GEOPM_REGION_HINT_NETWORK;
     uint64_t COMPARA = GEOPM_REGION_HINT_COMPUTE | GEOPM_REGION_HINT_PARALLEL;
 
-    EXPECT_EQ(expected, m_status->get_hint());
     EXPECT_EQ(NOHINTS, m_status->get_hint(0));
     EXPECT_EQ(NOHINTS, m_status->get_hint(1));
     EXPECT_EQ(NOHINTS, m_status->get_hint(2));
@@ -97,9 +95,6 @@ TEST_F(ApplicationStatusTest, hints)
 
     m_status->set_hint(1, NETWORK);
     m_status->set_hint(3, NETWORK);
-    expected[1] = NETWORK;
-    expected[3] = NETWORK;
-    EXPECT_EQ(expected, m_status->get_hint());
     EXPECT_EQ(NOHINTS, m_status->get_hint(0));
     EXPECT_EQ(NETWORK, m_status->get_hint(1));
     EXPECT_EQ(NOHINTS, m_status->get_hint(2));
@@ -107,9 +102,6 @@ TEST_F(ApplicationStatusTest, hints)
 
     m_status->set_hint(2, COMPARA);
     m_status->set_hint(3, COMPARA);
-    expected[2] = COMPARA;
-    expected[3] = COMPARA;
-    EXPECT_EQ(expected, m_status->get_hint());
     EXPECT_EQ(NOHINTS, m_status->get_hint(0));
     EXPECT_EQ(NETWORK, m_status->get_hint(1));
     EXPECT_EQ(COMPARA, m_status->get_hint(2));
@@ -119,10 +111,6 @@ TEST_F(ApplicationStatusTest, hints)
     m_status->set_hint(1, 0ULL);
     m_status->set_hint(2, 0ULL);
     m_status->set_hint(3, 0ULL);
-    expected[1] = NOHINTS;
-    expected[2] = NOHINTS;
-    expected[3] = NOHINTS;
-    EXPECT_EQ(expected, m_status->get_hint());
     EXPECT_EQ(NOHINTS, m_status->get_hint(0));
     EXPECT_EQ(NOHINTS, m_status->get_hint(1));
     EXPECT_EQ(NOHINTS, m_status->get_hint(2));
@@ -143,10 +131,8 @@ TEST_F(ApplicationStatusTest, hints)
 
 TEST_F(ApplicationStatusTest, hash)
 {
-    std::vector<uint64_t> expected(M_NUM_CPU, 0ULL);
     ASSERT_EQ(0x0, GEOPM_REGION_HASH_INVALID);
 
-    EXPECT_EQ(expected, m_status->get_hash());
     EXPECT_EQ(0x00, m_status->get_hash(0));
     EXPECT_EQ(0x00, m_status->get_hash(1));
     EXPECT_EQ(0x00, m_status->get_hash(2));
@@ -156,8 +142,6 @@ TEST_F(ApplicationStatusTest, hash)
     m_status->set_hash(1, 0xAA);
     m_status->set_hash(2, 0xBB);
     m_status->set_hash(3, 0xCC);
-    expected = {0xAA, 0xAA, 0xBB, 0xCC};
-    EXPECT_EQ(expected, m_status->get_hash());
     EXPECT_EQ(0xAA, m_status->get_hash(0));
     EXPECT_EQ(0xAA, m_status->get_hash(1));
     EXPECT_EQ(0xBB, m_status->get_hash(2));
@@ -197,18 +181,14 @@ TEST_F(ApplicationStatusTest, work_progress)
     m_status->increment_work_unit(1);
     EXPECT_DOUBLE_EQ(0.750, m_status->get_work_progress(0));
     EXPECT_DOUBLE_EQ(0.250, m_status->get_work_progress(1));
-    auto result = m_status->get_work_progress();
-    EXPECT_DOUBLE_EQ(0.750, result[0]);
-    EXPECT_DOUBLE_EQ(0.250, result[1]);
-    EXPECT_TRUE(std::isnan(result[2]));
-    EXPECT_TRUE(std::isnan(result[3]));
+    EXPECT_TRUE(std::isnan(m_status->get_work_progress(2)));
+    EXPECT_TRUE(std::isnan(m_status->get_work_progress(3)));
     m_status->increment_work_unit(0);
     m_status->increment_work_unit(1);
     m_status->increment_work_unit(1);
     EXPECT_DOUBLE_EQ(1.000, m_status->get_work_progress(0));
     EXPECT_DOUBLE_EQ(0.500, m_status->get_work_progress(1));
 
-    // TODO: throw in profile side?
     GEOPM_EXPECT_THROW_MESSAGE(m_status->increment_work_unit(0),
                                GEOPM_ERROR_RUNTIME, "more increments than total work");
 
@@ -246,9 +226,6 @@ TEST_F(ApplicationStatusTest, work_progress)
 
 TEST_F(ApplicationStatusTest, process)
 {
-    std::vector<int> expected(M_NUM_CPU, -1);
-
-    EXPECT_EQ(expected, m_status->get_process());
     EXPECT_EQ(-1, m_status->get_process(0));
     EXPECT_EQ(-1, m_status->get_process(1));
     EXPECT_EQ(-1, m_status->get_process(2));
@@ -257,8 +234,6 @@ TEST_F(ApplicationStatusTest, process)
     m_status->set_process({0, 2}, 34);
     m_status->set_process({1}, 56);
     m_status->set_process({3}, 78);
-    expected = {34, 56, 34, 78};
-    EXPECT_EQ(expected, m_status->get_process());
     EXPECT_EQ(34, m_status->get_process(0));
     EXPECT_EQ(56, m_status->get_process(1));
     EXPECT_EQ(34, m_status->get_process(2));
@@ -266,8 +241,6 @@ TEST_F(ApplicationStatusTest, process)
 
     // detach processes
     m_status->set_process({0, 1, 2, 3}, -1);
-    expected = {-1, -1, -1, -1};
-    EXPECT_EQ(expected, m_status->get_process());
     EXPECT_EQ(-1, m_status->get_process(0));
     EXPECT_EQ(-1, m_status->get_process(1));
     EXPECT_EQ(-1, m_status->get_process(2));

--- a/test/ApplicationStatusTest.cpp
+++ b/test/ApplicationStatusTest.cpp
@@ -165,51 +165,51 @@ TEST_F(ApplicationStatusTest, work_progress)
     // CPUs 2 and 3 are inactive, 0 work units
     m_status->set_total_work_units(0, 4);
     m_status->set_total_work_units(1, 8);
-    EXPECT_DOUBLE_EQ(0.000, m_status->get_work_progress(0));
-    EXPECT_DOUBLE_EQ(0.000, m_status->get_work_progress(1));
-    EXPECT_TRUE(std::isnan(m_status->get_work_progress(2)));
-    EXPECT_TRUE(std::isnan(m_status->get_work_progress(3)));
+    EXPECT_DOUBLE_EQ(0.000, m_status->get_progress_cpu(0));
+    EXPECT_DOUBLE_EQ(0.000, m_status->get_progress_cpu(1));
+    EXPECT_TRUE(std::isnan(m_status->get_progress_cpu(2)));
+    EXPECT_TRUE(std::isnan(m_status->get_progress_cpu(3)));
     m_status->increment_work_unit(0);
     m_status->increment_work_unit(1);
-    EXPECT_DOUBLE_EQ(0.250, m_status->get_work_progress(0));
-    EXPECT_DOUBLE_EQ(0.125, m_status->get_work_progress(1));
+    EXPECT_DOUBLE_EQ(0.250, m_status->get_progress_cpu(0));
+    EXPECT_DOUBLE_EQ(0.125, m_status->get_progress_cpu(1));
     m_status->increment_work_unit(0);
-    EXPECT_DOUBLE_EQ(0.500, m_status->get_work_progress(0));
-    EXPECT_DOUBLE_EQ(0.125, m_status->get_work_progress(1));
-    EXPECT_DOUBLE_EQ(0.125, m_status->get_work_progress(1));
-    m_status->increment_work_unit(0);
-    m_status->increment_work_unit(1);
-    EXPECT_DOUBLE_EQ(0.750, m_status->get_work_progress(0));
-    EXPECT_DOUBLE_EQ(0.250, m_status->get_work_progress(1));
-    EXPECT_TRUE(std::isnan(m_status->get_work_progress(2)));
-    EXPECT_TRUE(std::isnan(m_status->get_work_progress(3)));
+    EXPECT_DOUBLE_EQ(0.500, m_status->get_progress_cpu(0));
+    EXPECT_DOUBLE_EQ(0.125, m_status->get_progress_cpu(1));
+    EXPECT_DOUBLE_EQ(0.125, m_status->get_progress_cpu(1));
     m_status->increment_work_unit(0);
     m_status->increment_work_unit(1);
+    EXPECT_DOUBLE_EQ(0.750, m_status->get_progress_cpu(0));
+    EXPECT_DOUBLE_EQ(0.250, m_status->get_progress_cpu(1));
+    EXPECT_TRUE(std::isnan(m_status->get_progress_cpu(2)));
+    EXPECT_TRUE(std::isnan(m_status->get_progress_cpu(3)));
+    m_status->increment_work_unit(0);
     m_status->increment_work_unit(1);
-    EXPECT_DOUBLE_EQ(1.000, m_status->get_work_progress(0));
-    EXPECT_DOUBLE_EQ(0.500, m_status->get_work_progress(1));
+    m_status->increment_work_unit(1);
+    EXPECT_DOUBLE_EQ(1.000, m_status->get_progress_cpu(0));
+    EXPECT_DOUBLE_EQ(0.500, m_status->get_progress_cpu(1));
 
     GEOPM_EXPECT_THROW_MESSAGE(m_status->increment_work_unit(0),
                                GEOPM_ERROR_RUNTIME, "more increments than total work");
 
     // reset progress
     m_status->set_total_work_units(0, 8);
-    EXPECT_DOUBLE_EQ(0.00, m_status->get_work_progress(0));
+    EXPECT_DOUBLE_EQ(0.00, m_status->get_progress_cpu(0));
 
     // leave region
     m_status->set_total_work_units(0, 0);
     m_status->set_total_work_units(1, 0);
     m_status->set_total_work_units(2, 0);
     m_status->set_total_work_units(3, 0);
-    EXPECT_TRUE(std::isnan(m_status->get_work_progress(0)));
-    EXPECT_TRUE(std::isnan(m_status->get_work_progress(1)));
-    EXPECT_TRUE(std::isnan(m_status->get_work_progress(2)));
-    EXPECT_TRUE(std::isnan(m_status->get_work_progress(3)));
+    EXPECT_TRUE(std::isnan(m_status->get_progress_cpu(0)));
+    EXPECT_TRUE(std::isnan(m_status->get_progress_cpu(1)));
+    EXPECT_TRUE(std::isnan(m_status->get_progress_cpu(2)));
+    EXPECT_TRUE(std::isnan(m_status->get_progress_cpu(3)));
 
 
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_work_progress(-1),
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_progress_cpu(-1),
                                GEOPM_ERROR_INVALID, "invalid CPU index");
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_work_progress(99),
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_progress_cpu(99),
                                GEOPM_ERROR_INVALID, "invalid CPU index");
     GEOPM_EXPECT_THROW_MESSAGE(m_status->set_total_work_units(-1, 100),
                                GEOPM_ERROR_INVALID, "invalid CPU index");

--- a/test/ApplicationStatusTest.cpp
+++ b/test/ApplicationStatusTest.cpp
@@ -141,40 +141,6 @@ TEST_F(ApplicationStatusTest, hints)
                                GEOPM_ERROR_INVALID, "invalid CPU index");
 }
 
-TEST_F(ApplicationStatusTest, hash)
-{
-    std::vector<uint64_t> expected(M_NUM_CPU, 0ULL);
-    ASSERT_EQ(0x0, GEOPM_REGION_HASH_INVALID);
-
-    EXPECT_EQ(expected, m_status->get_hash());
-    EXPECT_EQ(0x00, m_status->get_hash(0));
-    EXPECT_EQ(0x00, m_status->get_hash(1));
-    EXPECT_EQ(0x00, m_status->get_hash(2));
-    EXPECT_EQ(0x00, m_status->get_hash(3));
-
-    m_status->set_hash(0, 0xAA);
-    m_status->set_hash(1, 0xAA);
-    m_status->set_hash(2, 0xBB);
-    m_status->set_hash(3, 0xCC);
-    expected = {0xAA, 0xAA, 0xBB, 0xCC};
-    EXPECT_EQ(expected, m_status->get_hash());
-    EXPECT_EQ(0xAA, m_status->get_hash(0));
-    EXPECT_EQ(0xAA, m_status->get_hash(1));
-    EXPECT_EQ(0xBB, m_status->get_hash(2));
-    EXPECT_EQ(0xCC, m_status->get_hash(3));
-
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(-1, 0xDD),
-                               GEOPM_ERROR_INVALID, "invalid CPU index");
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(99, 0xDD),
-                               GEOPM_ERROR_INVALID, "invalid CPU index");
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(0, (0xFFULL << 32)),
-                               GEOPM_ERROR_INVALID, "invalid region hash");
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_hash(-1),
-                               GEOPM_ERROR_INVALID, "invalid CPU index");
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->get_hash(99),
-                               GEOPM_ERROR_INVALID, "invalid CPU index");
-}
-
 TEST_F(ApplicationStatusTest, work_progress)
 {
 

--- a/test/ControllerTest.cpp
+++ b/test/ControllerTest.cpp
@@ -163,6 +163,7 @@ class ControllerTest : public ::testing::Test
         std::string m_file_policy_path = "ControllerTest_policy.json";
         MockApplicationSampler m_application_sampler;
         std::shared_ptr<MockProfileTracer> m_profile_tracer;
+        std::string m_shm_key = "ControllerTest_shm_key";
 };
 
 void ControllerTest::SetUp()
@@ -230,8 +231,8 @@ TEST_F(ControllerTest, construct_with_file_policy)
                           std::move(m_agents),
                           {"A", "B"},
                           m_file_policy_path, true,
-                          nullptr, "", false // endpoint
-                          );
+                          nullptr, "", false, // endpoint
+                          m_shm_key);
 }
 
 TEST_F(ControllerTest, run_with_no_policy)
@@ -272,8 +273,8 @@ TEST_F(ControllerTest, run_with_no_policy)
                           std::move(m_agents),
                           {"A", "B"},
                           "", false,  // false
-                          nullptr, "", false // endpoint
-                          );
+                          nullptr, "", false, // endpoint
+                          m_shm_key);
 
 
     std::vector<std::string> trace_names = {"COL1", "COL2"};
@@ -381,8 +382,8 @@ TEST_F(ControllerTest, get_hostnames)
                           std::move(m_agents),
                           {}, "", false, // file policy
                           std::unique_ptr<MockEndpointUser>(m_endpoint),
-                          "", true  // endpoint
-                          );
+                          "", true,  // endpoint
+                          m_shm_key);
 
     EXPECT_CALL(*multi_node_comm, rank());
     std::set<std::string> result = controller.get_hostnames("node4");
@@ -414,8 +415,8 @@ TEST_F(ControllerTest, single_node)
                           std::move(m_agents),
                           {}, "", false,  // file policy
                           std::unique_ptr<MockEndpointUser>(m_endpoint),
-                          "", true  // endpoint
-                          );
+                          "", true,  // endpoint
+                          m_shm_key);
 
     // setup trace
     std::vector<std::string> trace_names = {"COL1", "COL2"};
@@ -497,8 +498,8 @@ TEST_F(ControllerTest, two_level_controller_1)
                           std::move(m_agents),
                           {}, "", false, // file policy
                           std::unique_ptr<MockEndpointUser>(m_endpoint),
-                          "", true  // endpoint
-                          );
+                          "", true,  // endpoint
+                          m_shm_key);
 
     std::vector<std::string> trace_names = {"COL1", "COL2"};
     std::vector<std::function<std::string(double)> > trace_formats = {
@@ -600,8 +601,8 @@ TEST_F(ControllerTest, two_level_controller_2)
                           std::move(m_agents),
                           {}, "", false, // file policy
                           std::unique_ptr<MockEndpointUser>(m_endpoint),
-                          "", true // endpoint
-                          );
+                          "", true, // endpoint
+                          m_shm_key);
 
     std::vector<std::string> trace_names = {"COL1", "COL2"};
     std::vector<std::function<std::string(double)> > trace_formats = {
@@ -712,8 +713,8 @@ TEST_F(ControllerTest, two_level_controller_0)
                           std::move(m_agents),
                           {}, "", false, // file policy
                           std::unique_ptr<MockEndpointUser>(m_endpoint),
-                          "", true // endpoint
-                          );
+                          "", true, // endpoint
+                          m_shm_key);
 
     std::vector<std::string> trace_names = {"COL1", "COL2"};
     std::vector<std::function<std::string(double)> > trace_formats = {

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -76,7 +76,6 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/ApplicationSamplerTest.with_mpi \
               test/gtest_links/ApplicationSamplerTest.with_epoch \
               test/gtest_links/ApplicationStatusTest.bad_shmem \
-              test/gtest_links/ApplicationStatusTest.hash \
               test/gtest_links/ApplicationStatusTest.hints \
               test/gtest_links/ApplicationStatusTest.process \
               test/gtest_links/ApplicationStatusTest.work_progress \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -75,7 +75,12 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/ApplicationSamplerTest.string_conversion \
               test/gtest_links/ApplicationSamplerTest.with_mpi \
               test/gtest_links/ApplicationSamplerTest.with_epoch \
-              test/gtest_links/ApplicationStatusTest.something \
+              test/gtest_links/ApplicationStatusTest.bad_shmem \
+              test/gtest_links/ApplicationStatusTest.hash \
+              test/gtest_links/ApplicationStatusTest.hints \
+              test/gtest_links/ApplicationStatusTest.process \
+              test/gtest_links/ApplicationStatusTest.work_progress \
+              test/gtest_links/ApplicationStatusTest.wrong_buffer_size \
               test/gtest_links/ApplicationIOTest.passthrough \
               test/gtest_links/CircularBufferTest.buffer_capacity \
               test/gtest_links/CircularBufferTest.buffer_size \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -75,6 +75,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/ApplicationSamplerTest.string_conversion \
               test/gtest_links/ApplicationSamplerTest.with_mpi \
               test/gtest_links/ApplicationSamplerTest.with_epoch \
+              test/gtest_links/ApplicationStatusTest.something \
               test/gtest_links/ApplicationIOTest.passthrough \
               test/gtest_links/CircularBufferTest.buffer_capacity \
               test/gtest_links/CircularBufferTest.buffer_size \
@@ -562,6 +563,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
                           test/ApplicationIOTest.cpp \
                           test/ApplicationRecordLogTest.cpp \
                           test/ApplicationSamplerTest.cpp \
+                          test/ApplicationStatusTest.cpp \
                           test/CircularBufferTest.cpp \
                           test/CNLIOGroupTest.cpp \
                           test/CombinedSignalTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -76,6 +76,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/ApplicationSamplerTest.with_mpi \
               test/gtest_links/ApplicationSamplerTest.with_epoch \
               test/gtest_links/ApplicationStatusTest.bad_shmem \
+              test/gtest_links/ApplicationStatusTest.hash \
               test/gtest_links/ApplicationStatusTest.hints \
               test/gtest_links/ApplicationStatusTest.process \
               test/gtest_links/ApplicationStatusTest.work_progress \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -71,9 +71,10 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/ApplicationRecordLogTest.overflow_record_table \
               test/gtest_links/ApplicationRecordLogTest.cannot_overflow_region_table \
               test/gtest_links/ApplicationSamplerTest.one_enter_exit \
+              test/gtest_links/ApplicationSamplerTest.one_enter_exit_two_ranks \
               test/gtest_links/ApplicationSamplerTest.process_mapping \
               test/gtest_links/ApplicationSamplerTest.string_conversion \
-              test/gtest_links/ApplicationSamplerTest.with_mpi \
+              test/gtest_links/ApplicationSamplerTest.short_regions \
               test/gtest_links/ApplicationSamplerTest.with_epoch \
               test/gtest_links/ApplicationStatusTest.bad_shmem \
               test/gtest_links/ApplicationStatusTest.hash \
@@ -605,6 +606,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
                           test/MockAcceleratorTopo.hpp \
                           test/MockAgent.hpp \
                           test/MockApplicationIO.hpp \
+                          test/MockApplicationRecordLog.hpp \
                           test/MockApplicationSampler.cpp \
                           test/MockApplicationSampler.hpp \
                           test/MockComm.hpp \
@@ -629,6 +631,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
                           test/MockProfileTable.hpp \
                           test/MockProfileTracer.hpp \
                           test/MockProfileThreadTable.hpp \
+                          test/MockRecordFilter.hpp \
                           test/MockRegionAggregator.hpp \
                           test/MockReporter.hpp \
                           test/MockRuntimeRegulator.hpp \

--- a/test/MockApplicationRecordLog.hpp
+++ b/test/MockApplicationRecordLog.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MOCKAPPLICATIONRECORDLOG_HPP_INCLUDE
+#define MOCKAPPLICATIONRECORDLOG_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "ApplicationRecordLog.hpp"
+
+class MockApplicationRecordLog : public geopm::ApplicationRecordLog
+{
+    public:
+        MOCK_METHOD1(set_process,
+                     void(int process));
+        MOCK_METHOD1(set_time_zero,
+                     void(const geopm_time_s &time));
+        MOCK_METHOD2(enter,
+                     void(uint64_t hash, const geopm_time_s &time));
+        MOCK_METHOD2(exit,
+                     void(uint64_t hash, const geopm_time_s &time));
+        MOCK_METHOD1(epoch,
+                     void(const geopm_time_s &time));
+        MOCK_METHOD2(dump,
+                     void(std::vector<geopm::record_s> &records, std::vector<geopm::short_region_s> &short_regions));
+};
+
+#endif

--- a/test/MockApplicationSampler.hpp
+++ b/test/MockApplicationSampler.hpp
@@ -51,6 +51,8 @@ class MockApplicationSampler : public geopm::ApplicationSampler
                            std::vector<double>(void));
         MOCK_CONST_METHOD0(per_cpu_process,
                            std::vector<int>(void));
+        MOCK_METHOD1(connect,
+                     void(const std::string &shm_key));
         MOCK_METHOD1(set_sampler,
                      void(std::shared_ptr<geopm::ProfileSampler> sampler));
         MOCK_METHOD0(get_sampler,
@@ -65,7 +67,8 @@ class MockApplicationSampler : public geopm::ApplicationSampler
                      std::shared_ptr<geopm::ProfileIOSample>(void));
         MOCK_CONST_METHOD1(get_name_map,
                            std::map<uint64_t, std::string>(uint64_t name_key));
-
+        MOCK_CONST_METHOD1(get_short_region,
+                           geopm::short_region_s(uint64_t event_signal));
         std::vector<geopm::record_s> get_records(void) const override;
         /// Inject records to be used by next call to get_records()
         /// @todo: figure out input type for this


### PR DESCRIPTION
    - Modify test constructor to take filter name and avoid
      environment() call in implementation.
    - Update ApplicationSampler unit tests to use ApplicationRecordLog mock
    - Removed checks for logic about hints related to regions.
    - Added a ApplicationSampler test with two ranks.
    - Add ApplicationSampler test for short region functionality
