### PR TITLE
Add an SSTIO object to communicate with the isst_interface driver

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -587,6 +587,9 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/SharedMemoryScopedLock.cpp \
                             src/SharedMemoryScopedLock.hpp \
                             src/Signal.hpp \
+                            src/SSTIO.cpp \
+                            src/SSTIOImp.hpp \
+                            src/SSTIO.hpp \
                             src/TimeIOGroup.cpp \
                             src/TimeIOGroup.hpp \
                             src/TimeSignal.cpp \

--- a/src/SSTIO.cpp
+++ b/src/SSTIO.cpp
@@ -1,0 +1,537 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "SSTIO.hpp"
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+#include <algorithm>
+#include <utility>
+
+#include "Exception.hpp"
+#include "SSTIOImp.hpp"
+
+#define GEOPM_IOC_SST_VERSION _IOR(0xfe, 0, struct geopm::SSTIOImp::sst_version_s *)
+#define GEOPM_IOC_SST_GET_CPU_ID _IOWR(0xfe, 1, struct geopm::SSTIOImp::sst_mbox_interface_batch_s *)
+#define GEOPM_IOC_SST_MMIO _IOW(0xfe, 2, struct geopm::SSTIOImp::sst_mmio_interface_batch_s *)
+#define GEOPM_IOC_SST_MBOX _IOWR(0xfe, 3, struct geopm::SSTIOImp::sst_mbox_interface_batch_s *)
+
+namespace geopm
+{
+    std::shared_ptr<SSTIO> SSTIO::make_shared(uint32_t max_cpus)
+    {
+        return std::make_shared<SSTIOImp>(max_cpus);
+    }
+
+    SSTIOImp::SSTIOImp(uint32_t max_cpus)
+        : m_path("/dev/isst_interface")
+        , m_fd(open(m_path.c_str(), O_RDWR))
+        , m_batch_command_limit(0)
+    {
+        if (m_fd < 0) {
+            throw Exception("SSTIOImp failed to open SST driver",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+
+        sst_version_s sst_version;
+        int err = ioctl(m_fd, GEOPM_IOC_SST_VERSION, &sst_version);
+        if (err == -1) {
+            throw Exception("SSTIOImp::SSTIOImp() failed to get the SST driver version information",
+                            errno, __FILE__, __LINE__);
+        }
+        if (!sst_version.is_mbox_supported) {
+            throw Exception("SSTIOImp::SSTIOImp() SST driver does not support MBOX messages",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        if (!sst_version.is_mmio_supported) {
+            throw Exception("SSTIOImp::SSTIOImp() SST driver does not support MMIO messages",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        if (sst_version.batch_command_limit == 0) {
+            throw Exception("SSTIOImp::SSTIOImp() SST driver reports 0-command batch size limit",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        m_batch_command_limit = sst_version.batch_command_limit;
+
+        std::vector<sst_cpu_map_interface_s> batch_read_data;
+        batch_read_data.reserve(max_cpus);
+        for (uint32_t i = 0; i < max_cpus; ++i) {
+            batch_read_data.emplace_back(sst_cpu_map_interface_s{ i, 0 });
+        }
+        auto batch_reads = ioctl_structs_from_vector<sst_cpu_map_interface_batch_s>(
+            batch_read_data);
+
+        for (auto &batch_read : batch_reads) {
+            err = ioctl(m_fd, GEOPM_IOC_SST_GET_CPU_ID, batch_read.get());
+            if (err == -1) {
+                throw Exception("SSTIOImp::SSTIOImp() failed to get CPU map",
+                                errno, __FILE__, __LINE__);
+            }
+
+            for (size_t i = 0; i < batch_read->num_entries; ++i) {
+                m_cpu_punit_core_map.emplace(batch_read->interfaces[i].cpu_index,
+                                             // LSB indicates which hyperthread
+                                             // is mapped. Right-shift once to
+                                             // drop the hyperthread bit
+                                             batch_read->interfaces[i].punit_cpu >> 1);
+            }
+        }
+    }
+
+    int SSTIOImp::add_mbox_read(uint32_t cpu_index, uint16_t command,
+                                uint16_t subcommand, uint32_t subcommand_arg,
+                                uint32_t interface_parameter)
+    {
+        // save the stuff in the list
+        struct sst_mbox_interface_s mbox {
+            .cpu_index = cpu_index,
+            .mbox_interface_param = interface_parameter,
+            .write_value = subcommand_arg,
+            .read_value = 0,
+            .command = command,
+            .subcommand = subcommand,
+            .reserved = 0
+        };
+
+        // Stage everything in a vector for now. It will be copied to the ioctl
+        // buffer later.
+        int mbox_idx = m_mbox_read_interfaces.size();
+        auto it = std::find_if(
+            m_mbox_read_interfaces.begin(), m_mbox_read_interfaces.end(),
+            [&mbox](const sst_mbox_interface_s &existing_mbox) {
+                return existing_mbox.cpu_index == mbox.cpu_index &&
+                       existing_mbox.mbox_interface_param == mbox.mbox_interface_param &&
+                       existing_mbox.command == mbox.command &&
+                       existing_mbox.subcommand == mbox.subcommand &&
+                       existing_mbox.write_value == mbox.write_value;
+            });
+
+        int idx = -1;
+        if (it == m_mbox_read_interfaces.end()) {
+            m_mbox_read_interfaces.push_back(mbox);
+
+            // Multiple ioctls with different data structures are used here,
+            // along with multiple ioctl buffers. This vector indicates how a
+            // signal ID maps to a buffer, and to which offset in that buffer.
+            idx = m_added_interfaces.size();
+            m_added_interfaces.emplace_back(MBOX, mbox_idx);
+        }
+        else {
+            // This reader has been added before. Return the previously-used
+            // signal index.
+            size_t read_interface_idx = std::distance(
+                m_mbox_read_interfaces.begin(), it);
+            auto index_it = std::find(m_added_interfaces.begin(),
+                                      m_added_interfaces.end(),
+                                      std::make_pair(MBOX, read_interface_idx));
+            if (index_it == m_added_interfaces.end()) {
+                throw Exception(
+                    "SSTIOImp::add_mbox_read(): Inserted an existing "
+                    "signal, but cannot find its signal index",
+                    GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+            }
+            idx = std::distance(m_added_interfaces.begin(), index_it);
+        }
+
+        return idx;
+    }
+
+    int SSTIOImp::add_mbox_write(uint32_t cpu_index, uint16_t command,
+                                 uint16_t subcommand, uint32_t interface_parameter,
+                                 uint16_t read_subcommand,
+                                 uint32_t read_interface_parameter, uint32_t read_mask)
+    {
+        struct sst_mbox_interface_s mbox {
+            .cpu_index = cpu_index,
+            .mbox_interface_param = interface_parameter,
+            .write_value = 0,
+            .read_value = 0,
+            .command = command,
+            .subcommand = subcommand,
+            .reserved = 0
+        };
+        int mbox_idx = m_mbox_write_interfaces.size();
+        auto it = std::find_if(
+            m_mbox_write_interfaces.begin(), m_mbox_write_interfaces.end(),
+            [&mbox](const sst_mbox_interface_s &existing_mbox) {
+                return existing_mbox.cpu_index == mbox.cpu_index &&
+                       existing_mbox.mbox_interface_param == mbox.mbox_interface_param &&
+                       existing_mbox.command == mbox.command &&
+                       existing_mbox.subcommand == mbox.subcommand;
+            });
+
+        int idx = -1;
+        if (it == m_mbox_write_interfaces.end()) {
+            // First time this write slot is being added. Track both the
+            // actual write parameters and the associated read parameters for
+            // read-modify-write.
+            m_mbox_write_interfaces.push_back(mbox);
+
+            mbox.mbox_interface_param = read_interface_parameter;
+            mbox.subcommand = read_subcommand;
+            m_mbox_rmw_interfaces.push_back(mbox);
+            m_mbox_rmw_read_masks.push_back(read_mask);
+            m_mbox_rmw_write_masks.push_back(0);
+
+            idx = m_added_interfaces.size();
+            m_added_interfaces.emplace_back(MBOX, mbox_idx);
+        }
+        else {
+            // This writer, or another in the same mailbox slot, has been
+            // added before. Return the previously used control index.
+            size_t write_interface_idx = std::distance(
+                m_mbox_write_interfaces.begin(), it);
+            auto index_it = std::find(m_added_interfaces.begin(),
+                                      m_added_interfaces.end(),
+                                      std::make_pair(MBOX, write_interface_idx));
+            if (index_it == m_added_interfaces.end()) {
+                throw Exception(
+                    "SSTIOImp::add_mbox_write(): Inserted an existing "
+                    "control, but cannot find its control index",
+                    GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+            }
+            idx = std::distance(m_added_interfaces.begin(), index_it);
+        }
+
+        // Report the control ID as a separate index that encodes both ioctl
+        // type and the offset within that ioctl's message buffer.
+        return idx;
+    }
+
+    int SSTIOImp::add_mmio_read(uint32_t cpu_index, uint16_t register_offset,
+                                uint32_t register_value)
+    {
+        struct sst_mmio_interface_s mmio {
+            .is_write = 0,
+            .cpu_index = cpu_index,
+            .register_offset = register_offset,
+            .value = register_value,
+        };
+        int mmio_idx = m_mmio_read_interfaces.size();
+        m_mmio_read_interfaces.push_back(mmio);
+
+        int idx = m_added_interfaces.size();
+        m_added_interfaces.emplace_back(MMIO, mmio_idx);
+        return idx;
+    }
+
+    int SSTIOImp::add_mmio_write(uint32_t cpu_index, uint16_t register_offset,
+                                 uint32_t register_value, uint32_t read_mask)
+    {
+        struct sst_mmio_interface_s mmio {
+            .is_write = 1,
+            .cpu_index = cpu_index,
+            .register_offset = register_offset,
+            .value = register_value,
+        };
+        int mmio_idx = m_mmio_write_interfaces.size();
+        m_mmio_write_interfaces.push_back(mmio);
+
+        mmio.is_write = 0;
+        m_mmio_rmw_interfaces.push_back(mmio);
+        m_mmio_rmw_read_masks.push_back(read_mask);
+        m_mmio_rmw_write_masks.push_back(0);
+
+        int idx = m_added_interfaces.size();
+        m_added_interfaces.emplace_back(MMIO, mmio_idx);
+        return idx;
+    }
+
+    void SSTIOImp::read_batch(void)
+    {
+        if (!m_mbox_read_interfaces.empty()) {
+            m_mbox_read_batch = ioctl_structs_from_vector<sst_mbox_interface_batch_s>(
+                m_mbox_read_interfaces);
+
+            for (auto &batch : m_mbox_read_batch) {
+                int err = ioctl(m_fd, GEOPM_IOC_SST_MBOX, batch.get());
+                if (err == -1) {
+                    throw Exception("SSTIOImp::read_batch() mbox read failed",
+                                    errno, __FILE__, __LINE__);
+                }
+            }
+        }
+        if (!m_mmio_read_interfaces.empty()) {
+            m_mmio_read_batch = ioctl_structs_from_vector<sst_mmio_interface_batch_s>(
+                m_mmio_read_interfaces);
+
+            for (auto &batch : m_mmio_read_batch) {
+                int err = ioctl(m_fd, GEOPM_IOC_SST_MMIO, batch.get());
+                if (err == -1) {
+                    throw Exception("SSTIOImp::read_batch() mmio read failed",
+                                    errno, __FILE__, __LINE__);
+                }
+            }
+        }
+    }
+
+    uint64_t SSTIOImp::sample(int batch_idx) const
+    {
+        const auto &interface = m_added_interfaces[batch_idx];
+        uint64_t sample_value = 0;
+        // All interfaces in the list are divided into groups limited by a
+        // system-defined maximum size per group of commands. We use division
+        // to determine which group contains the requested sample. The modulo
+        // operation determines which sample within that group is the one we
+        // need.
+        if (interface.first == MMIO) {
+            size_t mmio_batch_idx = interface.second / m_batch_command_limit;
+            size_t mmio_interface_idx = interface.second % m_batch_command_limit;
+            sample_value = m_mmio_read_batch[mmio_batch_idx]->interfaces[mmio_interface_idx].value;
+        }
+        else {
+            if (interface.first != MBOX) {
+                throw Exception("SSTIOImp::sample(): Unexpected interface type",
+                                GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+            }
+            size_t mbox_batch_idx = interface.second / m_batch_command_limit;
+            size_t mbox_interface_idx = interface.second % m_batch_command_limit;
+            sample_value = m_mbox_read_batch[mbox_batch_idx]->interfaces[mbox_interface_idx].read_value;
+        }
+        return sample_value;
+    }
+
+    void SSTIOImp::write_batch(void)
+    {
+        if (!m_mbox_write_interfaces.empty()) {
+            m_mbox_write_batch = ioctl_structs_from_vector<sst_mbox_interface_batch_s>(
+                m_mbox_rmw_interfaces);
+
+            for (auto &batch : m_mbox_write_batch) {
+                // Read existing value (TODO: only need if not whole mask write)
+                int err = ioctl(m_fd, GEOPM_IOC_SST_MBOX, batch.get());
+                if (err == -1) {
+                    throw Exception("sstioimp::write_batch() pre-write mbox read failed",
+                                    errno, __FILE__, __LINE__);
+                }
+
+                // Modify the existing values with the adjusted values, using
+                // the buffer that contains the mailbox write locations (which
+                // may be different from the read locations for some controls)
+                for (size_t i = 0; i < batch->num_entries; ++i) {
+                    // Mask the read so we only propagate the bits that we are
+                    // supposed to read. Mask the write so we only update the
+                    // adjusted bits.
+                    m_mbox_write_interfaces[i].write_value |=
+                        ~m_mbox_rmw_write_masks[i] &
+                        (batch->interfaces[i].read_value &
+                         m_mbox_rmw_read_masks[i]);
+                }
+            }
+
+            m_mbox_write_batch = ioctl_structs_from_vector<sst_mbox_interface_batch_s>(
+                m_mbox_write_interfaces);
+
+            for (auto &batch : m_mbox_write_batch) {
+                // Write the adjusted value
+                int err = ioctl(m_fd, GEOPM_IOC_SST_MBOX, batch.get());
+                if (err == -1) {
+                    throw Exception("sstioimp::write_batch() mbox write failed",
+                                    errno, __FILE__, __LINE__);
+                }
+            }
+        }
+
+        if (!m_mmio_write_interfaces.empty()) {
+            m_mmio_write_batch = ioctl_structs_from_vector<sst_mmio_interface_batch_s>(
+                m_mmio_rmw_interfaces);
+
+            for (auto &batch : m_mmio_write_batch) {
+                // Read existing value (TODO: only need if not whole mask write)
+                int err = ioctl(m_fd, GEOPM_IOC_SST_MMIO, batch.get());
+                if (err == -1) {
+                    throw Exception("sstioimp::write_batch() pre-write mmio read failed",
+                                    errno, __FILE__, __LINE__);
+                }
+
+                // Modify the existing values with the adjusted values, using
+                // the buffer that contains the mailbox write locations (which
+                // may be different from the read locations for some controls)
+                for (size_t i = 0; i < batch->num_entries; ++i) {
+                    // Mask the read so we only propagate the bits that we are
+                    // supposed to read. Mask the write so we only update the
+                    // adjusted bits.
+                    m_mmio_write_interfaces[i].value |=
+                        ~m_mmio_rmw_write_masks[i] &
+                        (batch->interfaces[i].value &
+                         m_mmio_rmw_read_masks[i]);
+                }
+            }
+
+            m_mmio_write_batch = ioctl_structs_from_vector<sst_mmio_interface_batch_s>(
+                m_mmio_write_interfaces);
+
+            for (auto &batch : m_mmio_write_batch) {
+                // Write the adjusted value
+                int err = ioctl(m_fd, GEOPM_IOC_SST_MMIO, batch.get());
+                if (err == -1) {
+                    throw Exception("sstioimp::write_batch() mmio write failed",
+                                    errno, __FILE__, __LINE__);
+                }
+            }
+        }
+    }
+
+    uint32_t SSTIOImp::read_mbox_once(uint32_t cpu_index, uint16_t command,
+                                      uint16_t subcommand, uint32_t subcommand_arg,
+                                      uint32_t interface_parameter)
+    {
+        sst_mbox_interface_batch_s read_batch{
+            .num_entries = 1,
+            .interfaces = { { .cpu_index = cpu_index,
+                              .mbox_interface_param = interface_parameter,
+                              .write_value = subcommand_arg,
+                              .read_value = 0,
+                              .command = command,
+                              .subcommand = subcommand } }
+        };
+
+        int err = ioctl(m_fd, GEOPM_IOC_SST_MBOX, &read_batch);
+        if (err == -1) {
+            throw Exception("sstioimp::read_mbox_once() mbox read failed",
+                            errno, __FILE__, __LINE__);
+        }
+
+        return read_batch.interfaces[0].read_value;
+    }
+
+    void SSTIOImp::write_mbox_once(uint32_t cpu_index, uint16_t command,
+                                   uint16_t subcommand, uint32_t interface_parameter,
+                                   uint16_t read_subcommand,
+                                   uint32_t read_interface_parameter, uint32_t read_mask,
+                                   uint64_t write_value, uint64_t write_mask)
+    {
+        sst_mbox_interface_batch_s batch{
+            .num_entries = 1,
+            .interfaces = { { .cpu_index = cpu_index,
+                              .mbox_interface_param = read_interface_parameter,
+                              .write_value = 0,
+                              .read_value = 0,
+                              .command = command,
+                              .subcommand = read_subcommand } }
+        };
+        int err = ioctl(m_fd, GEOPM_IOC_SST_MBOX, &batch);
+        if (err == -1) {
+            throw Exception("sstioimp::write_mbox_once() pre-write mbox read failed",
+                            errno, __FILE__, __LINE__);
+        }
+        batch.interfaces[0].write_value =
+            write_value |
+            (~write_mask & (batch.interfaces[0].read_value & read_mask));
+        batch.interfaces[0].mbox_interface_param = interface_parameter;
+        batch.interfaces[0].read_value = 0;
+        batch.interfaces[0].subcommand = subcommand;
+
+        err = ioctl(m_fd, GEOPM_IOC_SST_MBOX, &batch);
+        if (err == -1) {
+            throw Exception("sstioimp::write_mbox_once() mbox write failed",
+                            errno, __FILE__, __LINE__);
+        }
+    }
+
+    uint32_t SSTIOImp::read_mmio_once(uint32_t cpu_index, uint16_t register_offset,
+                                      uint32_t register_value)
+    {
+        sst_mmio_interface_batch_s read_batch{
+            .num_entries = 1,
+            .interfaces = { { .is_write = 0,
+                              .cpu_index = cpu_index,
+                              .register_offset = register_offset,
+                              .value = 0 } }
+        };
+
+        int err = ioctl(m_fd, GEOPM_IOC_SST_MMIO, &read_batch);
+        if (err == -1) {
+            throw Exception("sstioimp::read_mmio_once() mmio read failed",
+                            errno, __FILE__, __LINE__);
+        }
+
+        return read_batch.interfaces[0].value;
+    }
+
+    void SSTIOImp::write_mmio_once(uint32_t cpu_index, uint16_t register_offset,
+                                   uint32_t register_value, uint32_t read_mask,
+                                   uint64_t write_value, uint64_t write_mask)
+    {
+        sst_mmio_interface_batch_s batch{
+            .num_entries = 1,
+            .interfaces = { { .is_write = 0,
+                              .cpu_index = cpu_index,
+                              .register_offset = register_offset,
+                              .value = 0 } }
+        };
+
+        int err = ioctl(m_fd, GEOPM_IOC_SST_MMIO, &batch);
+        if (err == -1) {
+            throw Exception("sstioimp::write_mmio_once() pre-write mmio read failed",
+                            errno, __FILE__, __LINE__);
+        }
+
+        batch.interfaces[0].is_write = 1;
+        batch.interfaces[0].value =
+            write_value | (~write_mask & (batch.interfaces[0].value & read_mask));
+
+        err = ioctl(m_fd, GEOPM_IOC_SST_MMIO, &batch);
+        if (err == -1) {
+            throw Exception("sstioimp::write_mmio_once() mmio write failed",
+                            errno, __FILE__, __LINE__);
+        }
+    }
+
+    void SSTIOImp::adjust(int batch_idx, uint64_t write_value, uint64_t write_mask)
+    {
+        const auto &interface = m_added_interfaces[batch_idx];
+        auto &write_destination =
+            interface.first == MMIO
+                ? m_mmio_write_interfaces[interface.second].value
+                : m_mbox_write_interfaces[interface.second].write_value;
+        write_destination &= ~write_mask;
+        write_destination |= write_value;
+
+        // Update the write masks so we know which bits to use in the write
+        // phase of the ioctl RMW operations.
+        if (interface.first == MBOX) {
+            m_mbox_rmw_write_masks[interface.second] |= write_mask;
+        }
+        else {
+            m_mmio_rmw_write_masks[interface.second] |= write_mask;
+        }
+    }
+
+    uint32_t SSTIOImp::get_punit_from_cpu(uint32_t cpu_index)
+    {
+        return m_cpu_punit_core_map.at(cpu_index);
+    }
+}

--- a/src/SSTIO.hpp
+++ b/src/SSTIO.hpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SSTIO_HPP_INCLUDE
+#define SSTIO_HPP_INCLUDE
+
+#include <cstdint>
+
+#include <vector>
+#include <memory>
+
+namespace geopm
+{
+    class SSTIO
+    {
+        public:
+            /// @brief Interact with the mailbox on commands that are expected to return data
+            /// @param [in] cpu_index Index of the cpu to which the mailbox
+            ///             read is being issued
+            /// @param [in] command Which SST mailbox command to issue
+            /// @param [in] subcommand Which SST mailbox subcommand to issue
+            /// @param [in] subcommand_arg Which argument to use for the SST
+            ///             mailbox subcommand
+            /// @param [in] interface_parameter Which SST mailbox paramter to use
+            virtual int add_mbox_read(uint32_t cpu_index, uint16_t command,
+                                      uint16_t subcommand, uint32_t subcommand_arg,
+                                      uint32_t interface_parameter) = 0;
+
+            /// @brief Interact with the mailbox on commands that are not expected to return data
+            /// @param [in] cpu_index Index of the cpu to which the mailbox
+            ///             read is being issued
+            /// @param [in] command Which SST mailbox command to issue
+            /// @param [in] subcommand Which SST mailbox subcommand to issue
+            /// @param [in] interface_parameter Which SST mailbox parameter to use
+            /// @param [in] read_subcommand Which SST mailbox subcommand to issue
+            ///             when reading the current value prior to a write
+            /// @param [in] read_interface_parameter Which SST mailbox parameter to use
+            ///             when reading the current value prior to a write
+            /// @param [in] read_mask The mask to apply to values read from the
+            ///             mailbox prior to a write
+            virtual int add_mbox_write(uint32_t cpu_index, uint16_t command,
+                                       uint16_t subcommand, uint32_t interface_parameter,
+                                       uint16_t read_subcommand,
+                                       uint32_t read_interface_parameter,
+                                       uint32_t read_mask) = 0;
+
+            /// @brief Interact with the mmio interface on commands that are expected to return data
+            /// @param [in] cpu_index Index of the cpu to which the MMIO
+            ///             read is being issued
+            /// @param [in] register_offset Which SST MMIO register offset to use
+            /// @param [in] register_value Which SST MMIO register value to set
+            ///             prior to the read.
+            virtual int add_mmio_read(uint32_t cpu_index, uint16_t register_offset,
+                                      uint32_t register_value) = 0;
+
+            /// @brief Interact with the mmio interface on commands that are not expected to return data
+            /// @param [in] cpu_index Index of the cpu to which the MMIO
+            ///             write is being issued
+            /// @param [in] register_offset Which SST MMIO register offset to use
+            /// @param [in] register_value Which SST MMIO register value to set
+            ///             for the write.
+            /// @param [in] read_mask The mask to apply to values read from the
+            ///             register prior to a write
+            virtual int add_mmio_write(uint32_t cpu_index, uint16_t register_offset,
+                                       uint32_t register_value,
+                                       uint32_t read_mask) = 0;
+
+            /// @brief Issue a batch read
+            virtual void read_batch(void) = 0;
+
+            /// @brief Sample a value from the most recent batch read
+            /// @param [in] batch_idx An index returned from an add_*_read function
+            ///             prior to calling read_batch().
+            virtual uint64_t sample(int batch_idx) const = 0;
+
+            /// @brief Issue a batch write
+            virtual void write_batch(void) = 0;
+
+            /// @brief Immediately query the SST mailbox for a read operation.
+            /// @param [in] cpu_index Index of the cpu to which the mailbox
+            ///             read is being issued
+            /// @param [in] command Which SST mailbox command to issue
+            /// @param [in] subcommand Which SST mailbox subcommand to issue
+            /// @param [in] subcommand_arg Which argument to use for the SST
+            ///             mailbox subcommand
+            /// @param [in] interface_parameter Which SST mailbox paramter to use
+            virtual uint32_t read_mbox_once(uint32_t cpu_index, uint16_t command,
+                                            uint16_t subcommand, uint32_t subcommand_arg,
+                                            uint32_t interface_parameter) = 0;
+
+            /// @brief Immediately query the SST mailbox for a write operation.
+            /// @param [in] cpu_index Index of the cpu to which the mailbox
+            ///             read is being issued
+            /// @param [in] command Which SST mailbox command to issue
+            /// @param [in] subcommand Which SST mailbox subcommand to issue
+            /// @param [in] interface_parameter Which SST mailbox parameter to use
+            /// @param [in] read_subcommand Which SST mailbox subcommand to issue
+            ///             when reading the current value prior to a write
+            /// @param [in] read_interface_parameter Which SST mailbox parameter to use
+            ///             when reading the current value prior to a write
+            /// @param [in] read_mask The mask to apply to values read from the
+            ///             mailbox prior to a write
+            /// @param [in] write_value The value to write
+            /// @param [in] write_mask The mask to apply to the written value
+            virtual void write_mbox_once(uint32_t cpu_index, uint16_t command,
+                                         uint16_t subcommand,
+                                         uint32_t interface_parameter,
+                                         uint16_t read_subcommand,
+                                         uint32_t read_interface_parameter,
+                                         uint32_t read_mask, uint64_t write_value,
+                                         uint64_t write_mask) = 0;
+
+            /// @brief Immediately read a value from the SST MMIO interface.
+            /// @param [in] cpu_index Index of the cpu to which the MMIO
+            ///             read is being issued
+            /// @param [in] register_offset Which SST MMIO register offset to use
+            /// @param [in] register_value Which SST MMIO register value to set
+            ///             prior to the read.
+            virtual uint32_t read_mmio_once(uint32_t cpu_index, uint16_t register_offset,
+                                            uint32_t register_value) = 0;
+
+            /// @brief Immediately write a value to the SST MMIO interface.
+            /// @param [in] cpu_index Index of the cpu to which the MMIO
+            ///             write is being issued
+            /// @param [in] register_offset Which SST MMIO register offset to use
+            /// @param [in] register_value Which SST MMIO register value to set
+            ///             for the write.
+            /// @param [in] read_mask The mask to apply to values read from the
+            ///             register prior to a write
+            /// @param [in] write_value The value to write
+            /// @param [in] write_mask The mask to apply to the written value
+            virtual void write_mmio_once(uint32_t cpu_index, uint16_t register_offset,
+                                         uint32_t register_value,
+                                         uint32_t read_mask, uint64_t write_value,
+                                         uint64_t write_mask) = 0;
+
+            /// @brief Adjust a value for the next batch write
+            /// @param [in] batch_idx An index returned from an add_*_write function
+            /// @param [in] write_value The value to write in the next batch_write()
+            /// @param [in] write_mask The mask to apply when writing this value
+            virtual void adjust(int batch_idx, uint64_t write_value, uint64_t write_mask) = 0;
+
+            /// @brief Get the punit index assocaited with a CPU index
+            /// @param [in] cpu_index Index of the CPU
+            virtual uint32_t get_punit_from_cpu(uint32_t cpu_index) = 0;
+
+            /// @brief Create an SSTIO object
+            /// @param [in] max_cpus The number of CPUs to attempt to map
+            ///             to punit cores.
+            static std::shared_ptr<SSTIO> make_shared(uint32_t max_cpus);
+    };
+
+}
+
+#endif

--- a/src/SSTIOImp.hpp
+++ b/src/SSTIOImp.hpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SSTIOIMP_HPP_INCLUDE
+#define SSTIOIMP_HPP_INCLUDE
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include "SSTIO.hpp"
+
+namespace geopm
+{
+    class SSTIOImp : public SSTIO
+    {
+        public:
+            SSTIOImp(uint32_t max_cpus);
+            virtual ~SSTIOImp() = default;
+
+            /// Interact with the mailbox on commands that are expected to return data
+            int add_mbox_read(uint32_t cpu_index, uint16_t command,
+                              uint16_t subcommand, uint32_t subcommand_arg,
+                              uint32_t interface_parameter) override;
+            int add_mbox_write(uint32_t cpu_index, uint16_t command,
+                               uint16_t subcommand, uint32_t interface_parameter,
+                               uint16_t read_subcommand,
+                               uint32_t read_interface_parameter,
+                               uint32_t read_mask) override;
+            int add_mmio_read(uint32_t cpu_index, uint16_t register_offset,
+                              uint32_t register_value) override;
+            int add_mmio_write(uint32_t cpu_index, uint16_t register_offset,
+                               uint32_t register_value, uint32_t read_mask) override;
+            // call ioctl() for both mbox list and mmio list,
+            // unless we end up splitting this class
+            void read_batch(void) override;
+
+            uint64_t sample(int batch_idx) const override;
+            void write_batch(void) override;
+            uint32_t read_mbox_once(uint32_t cpu_index, uint16_t command,
+                                    uint16_t subcommand, uint32_t subcommand_arg,
+                                    uint32_t interface_parameter) override;
+            void write_mbox_once(uint32_t cpu_index, uint16_t command,
+                                 uint16_t subcommand, uint32_t interface_parameter,
+                                 uint16_t read_subcommand,
+                                 uint32_t read_interface_parameter,
+                                 uint32_t read_mask, uint64_t write_value,
+                                 uint64_t write_mask) override;
+            uint32_t read_mmio_once(uint32_t cpu_index, uint16_t register_offset,
+                                    uint32_t register_value) override;
+            void write_mmio_once(uint32_t cpu_index, uint16_t register_offset,
+                                 uint32_t register_value, uint32_t read_mask,
+                                 uint64_t write_value, uint64_t write_mask) override;
+            void adjust(int batch_idx, uint64_t write_value, uint64_t write_mask) override;
+            uint32_t get_punit_from_cpu(uint32_t cpu_index) override;
+
+        private:
+            enum message_type_e
+            {
+                MBOX,
+                MMIO
+            };
+
+            struct sst_version_s
+            {
+                uint16_t interface_version;
+                uint16_t driver_version;
+                uint16_t batch_command_limit;
+                uint8_t is_mbox_supported;
+                uint8_t is_mmio_supported;
+            };
+
+            struct sst_cpu_map_interface_s
+            {
+                uint32_t cpu_index;
+                uint32_t punit_cpu;
+            };
+
+            struct sst_cpu_map_interface_batch_s
+            {
+                uint32_t num_entries;
+                sst_cpu_map_interface_s interfaces[1];
+            };
+
+            struct sst_mmio_interface_s
+            {
+                uint32_t is_write;
+                uint32_t cpu_index;
+                uint32_t register_offset;
+                uint32_t value;
+            };
+
+            struct sst_mmio_interface_batch_s
+            {
+                uint32_t num_entries;
+                sst_mmio_interface_s interfaces[1];
+            };
+
+            struct sst_mbox_interface_s
+            {
+                uint32_t cpu_index;
+                uint32_t mbox_interface_param; // Parameter to the mbox interface itself
+                uint32_t write_value; // Mailbox data, or input parameter for a read
+                uint32_t read_value; // Mailbox data (read-only)
+                uint16_t command;
+                uint16_t subcommand;
+                uint32_t reserved;
+            };
+
+            struct sst_mbox_interface_batch_s
+            {
+                uint32_t num_entries;
+                sst_mbox_interface_s interfaces[1];
+            };
+
+            template<typename OuterStruct>
+            using InnerStruct =
+                typename std::remove_all_extents<decltype(OuterStruct::interfaces)>::type;
+
+            // Given a single vector of messages to send to an ioctl, split it
+            // into multiple structs to send to that ioctl. Each InnerStruct
+            // contains a single message. Each OuterStruct contains multiple
+            // messages, with size upper-bounded by m_batch_command_limit.
+            template<typename OuterStruct>
+            std::vector<std::unique_ptr<OuterStruct> >
+                ioctl_structs_from_vector(const std::vector<InnerStruct<OuterStruct> >& commands)
+
+            {
+                std::vector<std::unique_ptr<OuterStruct> > outer_structs;
+
+                size_t handled_commands = 0;
+                while (handled_commands < commands.size())
+                {
+                    size_t batch_size = std::min(
+                        static_cast<size_t>(m_batch_command_limit),
+                        commands.size() - handled_commands);
+
+                    // The inner struct is embedded in the outer struct, and
+                    // the inner struct's size depends on how many entries it
+                    // can contain. That size is dynamically determined, so we
+                    // manually allocate the outer struct here.
+                    outer_structs.emplace_back(reinterpret_cast<OuterStruct *>(
+                        new char[sizeof(OuterStruct::num_entries) +
+                                 sizeof(InnerStruct<OuterStruct>) * commands.size()]));
+                    outer_structs.back()->num_entries = batch_size;
+                    std::copy(commands.data() + handled_commands,
+                              commands.data() + handled_commands + batch_size,
+                              outer_structs.back()->interfaces);
+
+                    handled_commands += batch_size;
+                }
+
+                return outer_structs;
+            }
+
+            std::string m_path;
+            int m_fd;
+            int m_batch_command_limit;
+            std::vector<struct sst_mbox_interface_s> m_mbox_read_interfaces;
+            std::vector<struct sst_mbox_interface_s> m_mbox_write_interfaces;
+            std::vector<struct sst_mbox_interface_s> m_mbox_rmw_interfaces;
+            std::vector<uint32_t> m_mbox_rmw_read_masks;
+            std::vector<uint32_t> m_mbox_rmw_write_masks;
+            std::vector<struct sst_mmio_interface_s> m_mmio_read_interfaces;
+            std::vector<struct sst_mmio_interface_s> m_mmio_write_interfaces;
+            std::vector<struct sst_mmio_interface_s> m_mmio_rmw_interfaces;
+            std::vector<uint32_t> m_mmio_rmw_read_masks;
+            std::vector<uint32_t> m_mmio_rmw_write_masks;
+            std::vector<std::pair<message_type_e, size_t> > m_added_interfaces;
+            std::vector<std::unique_ptr<sst_mbox_interface_batch_s> > m_mbox_read_batch;
+            std::vector<std::unique_ptr<sst_mbox_interface_batch_s> > m_mbox_write_batch;
+            std::vector<std::unique_ptr<sst_mmio_interface_batch_s> > m_mmio_read_batch;
+            std::vector<std::unique_ptr<sst_mmio_interface_batch_s> > m_mmio_write_batch;
+            std::map<uint32_t, uint32_t> m_cpu_punit_core_map;
+    };
+}
+
+#endif


### PR DESCRIPTION
This change introduces an object that interacts with isst_interface ioctls. The object is meant to provide the interface for an SSTIOGroup to use the mailbox and mmio SST controls and signals. Supporting ioctl calls enable functionality to build a map of Linux CPUs to punit cores, and to check how many messages can be bundled in a single isst_interface ioctl argument.

Co-authored-by: Diana Guttman <diana.r.guttman@intel.com>
Co-authored-by: Asma H Al-Rawi <asma.h.al-rawi@intel.com>