### PR TITLE
Remove geopm_prof_progress()

### DIFF
--- a/examples/synthetic_benchmark.cpp
+++ b/examples/synthetic_benchmark.cpp
@@ -345,6 +345,7 @@ void synthetic_benchmark_main(int nranks, int rank)
 
     geopm_prof_region("loop_one", GEOPM_REGION_HINT_UNKNOWN, &region_id[0]);
     geopm_prof_enter(region_id[0]);
+    geopm_tprof_init(syntheticcfg.rank_iters(rank));
     geopm_time(&start);
 
     GET_TIME(tStart);
@@ -357,7 +358,7 @@ void synthetic_benchmark_main(int nranks, int rank)
         }
 
         x += do_work(i);
-        geopm_prof_progress(region_id[0], i*syntheticcfg.rank_norm(rank));
+        geopm_tprof_post();
     }
     GET_TIME(tEnd);
     fprintf(stderr, "%.2fs: Rank %d finished\n", tEnd-tStart, rank);

--- a/examples/timed_region.cpp
+++ b/examples/timed_region.cpp
@@ -38,40 +38,40 @@
 int main(int argc, char**argv)
 {
     uint64_t region_id[3];
-    struct geopm_time_s start, curr;
-    double timeout = 0;
     int rank;
+    int iterations, total_iterations;
 
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     geopm_prof_region("loop_one", GEOPM_REGION_HINT_UNKNOWN, &region_id[0]);
     geopm_prof_enter(region_id[0]);
-    geopm_time(&start);
-    while (timeout < 1.0) {
-        geopm_time(&curr);
-        timeout = geopm_time_diff(&start, &curr);
-        geopm_prof_progress(region_id[2], timeout/1.0);
+    total_iterations = 1000;
+    geopm_tprof_init(total_iterations);
+    iterations = 0;
+    while (iterations < total_iterations) {
+        geopm_tprof_post();
+        ++iterations;
     }
     geopm_prof_exit(region_id[0]);
 
     geopm_prof_region("loop_two", GEOPM_REGION_HINT_UNKNOWN, &region_id[1]);
     geopm_prof_enter(region_id[1]);
-    geopm_time(&start);
-    while (timeout < 2.0) {
-        geopm_time(&curr);
-        timeout = geopm_time_diff(&start, &curr);
-        geopm_prof_progress(region_id[2], timeout/2.0);
+    total_iterations = 2000;
+    geopm_tprof_init(total_iterations);
+    iterations = 0;
+    while (iterations < total_iterations) {
+        geopm_tprof_post();
     }
     geopm_prof_exit(region_id[1]);
 
     geopm_prof_region("loop_three", GEOPM_REGION_HINT_UNKNOWN, &region_id[2]);
     geopm_prof_enter(region_id[2]);
-    geopm_time(&start);
-    while (timeout < 3.0) {
-        geopm_time(&curr);
-        timeout = geopm_time_diff(&start, &curr);
-        geopm_prof_progress(region_id[2], timeout/3.0);
+    total_iterations = 1000;
+    geopm_tprof_init(total_iterations);
+    iterations = 0;
+    while (iterations < total_iterations) {
+        geopm_tprof_post();
     }
     geopm_prof_exit(region_id[2]);
 

--- a/ronn/geopm_fortran.3.ronn
+++ b/ronn/geopm_fortran.3.ronn
@@ -75,11 +75,6 @@ geopm_fortran(3) -- geopm fortran interface
    `type(c_ptr), value, intent(in) ::` _prof_ <br>
    `integer(kind=c_int64_t), value, intent(in) ::` _region_id_
 
- * `integer(kind=c_int) function geopm_prof_progress(`_prof_`,` _region_id_`,` _fraction_`)`:
-   `type(c_ptr), value, intent(in) ::` _prof_ <br>
-   `integer(kind=c_int64_t), value, intent(in) ::` _region_id_ <br>
-   `real(kind=c_double), value, intent(in) ::` _fraction_
-
  * `integer(kind=c_int) function geopm_prof_epoch(`_prof_`)`:
    `type(c_ptr), value, intent(in) ::` _prof_
 

--- a/ronn/geopm_prof_c.3.ronn
+++ b/ronn/geopm_prof_c.3.ronn
@@ -48,10 +48,6 @@ geopm_prof_c(3) -- application profiling interfaces
   * `int geopm_prof_exit(`:
     `uint64_t` _region_id_`);`
 
-  * `int geopm_prof_progress(`:
-    `uint64_t` _region_id_, <br>
-    `double` _fraction_`);`
-
   * `int geopm_prof_epoch(`:
     `void);`
 
@@ -95,15 +91,15 @@ initialized.
   * `geopm_prof_region`():
     registers an application region.  The _region_name_ and _hint_ are
     input parameters, and the _region_id_ is output.  The _region_id_
-    can be used with `geopm_prof_enter`(), `geopm_prof_exit`(), and
-    `geopm_prof_progress`() to reference the region.  If the region
-    name has been previously registered, a call to this function will
-    set the _region_id_ but the state associated with the region is
-    unmodified.  The _region_name_ is used to determine the output
-    _region_id_ and is also displayed in the profiling report to
-    identify the region.  The _hint_ is one of the values given by the
-    geopm_region_hint_e enum defined in _geopm.h_ which determines the
-    initial control settings.  The following hints are supported:
+    can be used with `geopm_prof_enter`() and `geopm_prof_exit`() to
+    reference the region.  If the region name has been previously
+    registered, a call to this function will set the _region_id_ but
+    the state associated with the region is unmodified.  The
+    _region_name_ is used to determine the output _region_id_ and is
+    also displayed in the profiling report to identify the region.
+    The _hint_ is one of the values given by the geopm_region_hint_e
+    enum defined in _geopm.h_ which determines the initial control
+    settings.  The following hints are supported:
 
     `GEOPM_REGION_HINT_UNKNOWN`: <br>
     Default value, provides no hint to the runtime.
@@ -149,14 +145,6 @@ initialized.
     region.  If this region is nested then the call is ignored and an
     error code is returned.
 
-  * `geopm_prof_progress`():
-    is called by the compute application in a single threaded context
-    to signal the proportion of work completed for a region,
-    _fraction_, where _fraction_ is between 0 and 1.  If the
-    _region_id_ does not match the _region_id_ of the last call to
-    geopm_prof_prof_enter() that was not nested, then this call is
-    ignored and an error code is returned.
-
   * `geopm_prof_epoch`():
     is called once for each pass through a computational loop
     containing inter-node synchronization events.  This call acts as a
@@ -170,22 +158,19 @@ initialized.
     the `GEOPM_REGION_HINT_IGNORE` hint bit set will be ignored.
 
   * `geopm_tprof_init`():
-    resets the thread profile table, which extends the functionality
-    of the profiling interface to report progress within threaded
-    regions.  Along with `geopm_tprof_post()`, it provides an
-    alternative to the `geopm_prof_progress()` method.  This should be
-    called by all threads to set up the table after entering a thread
-    parallel region.  This interface enables each thread to set
-    the total number work units that the thread will be executing.
-    This corresponds to the number of times that the
-    `geopm_tprof_post`() interface will be called by the thread to
-    report progress within the region.
+    resets the thread progress and updates the total work for a
+    threaded region.  Along with `geopm_tprof_post()`, it provides a
+    way for threads to report progress within a region.  This should
+    be called by all threads with _num_work_unit_, the total number of
+    work units to be completed by all threads after entering a thread
+    parallel region.  The total work units corresponds to the number
+    of times that the `geopm_tprof_post`() interface will be called by
+    any thread to report progress within the region.
 
   * `geopm_tprof_post`():
     is called after a thread has completed each work unit to report
-    progress.  Rather than a user-provided percentage of work complete,
-    this method signals the completion of one work unit out of the total
-    passed to `geopm_tprof_init()`.
+    progress.  This method signals the completion of one work unit out
+    of the total passed to `geopm_tprof_init()`.
 
 ## EXAMPLE
 

--- a/ronn/geopmbench.1.ronn
+++ b/ronn/geopmbench.1.ronn
@@ -119,7 +119,7 @@ the dgemm region.
 
 If "-progress" is appended to any region name in the
 configuration, then progress for the region will be
-reported through the geopm_prof_progress API.
+reported through the geopm_tprof_* API.
 
 ## COPYRIGHT
 Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation. All rights reserved.

--- a/src/DefaultProfile.cpp
+++ b/src/DefaultProfile.cpp
@@ -147,23 +147,6 @@ extern "C"
         return err;
     }
 
-    int geopm_prof_progress(uint64_t region_id, double fraction)
-    {
-        int err = 0;
-        if (g_pmpi_prof_enabled) {
-            try {
-                geopm::Profile::default_profile().progress(region_id, fraction);
-            }
-            catch (...) {
-                err = geopm::exception_handler(std::current_exception());
-            }
-        }
-        else {
-            err = GEOPM_ERROR_RUNTIME;
-        }
-        return err;
-    }
-
     int geopm_prof_epoch(void)
     {
         int err = 0;

--- a/src/ModelRegion.cpp
+++ b/src/ModelRegion.cpp
@@ -153,7 +153,7 @@ namespace geopm
         else {
             m_num_progress_updates = 100;
         }
-        m_norm = 1.0 / m_num_progress_updates;
+        (void)geopm_tprof_init(m_num_progress_updates);
     }
 
     int ModelRegion::region(uint64_t hint)
@@ -187,7 +187,7 @@ namespace geopm
     void ModelRegion::loop_enter(uint64_t iteration)
     {
         if (m_do_progress) {
-            (void)geopm_prof_progress(m_region_id, iteration * m_norm);
+            (void)geopm_tprof_post();
         }
         if (m_do_imbalance) {
             (void)geopm_imbalancer_enter();

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -489,31 +489,6 @@ namespace geopm
 
     }
 
-    void ProfileImp::progress(uint64_t region_id, double fraction)
-    {
-        if (!m_is_enabled) {
-            return;
-        }
-
-#ifdef GEOPM_OVERHEAD
-        struct geopm_time_s overhead_entry;
-        geopm_time(&overhead_entry);
-#endif
-
-        if (m_num_enter == 1 && m_curr_region_id == region_id &&
-            fraction > 0.0 && fraction < 1.0 &&
-            m_scheduler->do_sample()) {
-            m_progress = fraction;
-            sample();
-            m_scheduler->record_exit();
-        }
-
-#ifdef GEOPM_OVERHEAD
-        m_overhead_time += geopm_time_since(&overhead_entry);
-#endif
-
-    }
-
     void ProfileImp::epoch(void)
     {
         if (!m_is_enabled ||

--- a/src/Profile.hpp
+++ b/src/Profile.hpp
@@ -59,9 +59,9 @@ namespace geopm
     /// from tuning within previous occurrences of the region.  There
     /// are two competing motivations for defining a region within the
     /// application.  The first is to identify a section of code that
-    /// has distinct compute, memory or network characteristics.  The
+    /// has distinct compute, memory, or network characteristics.  The
     /// second is to avoid defining these regions such that they are
-    /// nested within each other, as nested regions are ignored, and
+    /// nested within each other, as nested regions are ignored and
     /// only the outer most region is used for tuning when nesting
     /// occurs.  Identifying progress within a region can be used to
     /// alleviate load imbalance in the application under the
@@ -110,9 +110,8 @@ namespace geopm
             ///
             /// @return Returns the region_id which is a unique
             ///         identifier derived from the region_name.  This
-            ///         value is passed to Profile::enter(),
-            ///         Profile::exit(), Profile::progress and
-            ///         Profile::sample() to associate these calls with
+            ///         value is passed to Profile::enter() and
+            ///         Profile::exit() to associate these calls with
             ///         the registered region.
             virtual uint64_t region(const std::string &region_name, long hint) = 0;
             /// @brief Mark a region entry point.
@@ -140,23 +139,6 @@ namespace geopm
             ///        Profile::region() when the region was
             ///        registered.
             virtual void exit(uint64_t region_id) = 0;
-            /// @brief Signal fractional progress through a region.
-            ///
-            /// Signals the fractional amount of work completed within
-            /// the phase.  This normalized progress reporting is used
-            /// to identify processes that are closer or further away
-            /// from completion, and resources can be shifted to those
-            /// processes which are further behind.  Calls to this
-            /// method from within a nested region are ignored.
-            ///
-            /// @param [in] region_id The identifier returned by
-            ///        Profile::region() when the region was
-            ///        registered.
-            ///
-            /// @param [in] fraction The fractional progress
-            ///        normalized to be between 0.0 and 1.0 (zero on
-            ///        entry one on completion).
-            virtual void progress(uint64_t region_id, double fraction) = 0;
             /// @brief Signal pass through outer loop.
             ///
             /// Called once for each pass through the outer most
@@ -257,7 +239,6 @@ namespace geopm
             uint64_t region(const std::string &region_name, long hint) override;
             void enter(uint64_t region_id) override;
             void exit(uint64_t region_id) override;
-            void progress(uint64_t region_id, double fraction) override;
             void epoch(void) override;
             void shutdown(void) override;
             void thread_init(int cpu, uint32_t num_work_unit) override;
@@ -282,7 +263,6 @@ namespace geopm
             enum m_profile_const_e {
                 M_PROF_SAMPLE_PERIOD = 1,
             };
-
             /// @brief Post profile sample.
             ///
             /// Called to derive a sample based on the profiling

--- a/src/geopm.f90
+++ b/src/geopm.f90
@@ -118,15 +118,6 @@ module geopm
             integer(kind=c_int64_t), value, intent(in) :: region_id
         end function geopm_prof_exit
 
-        !> @brief Fortran interface to @link geopm.h geopm_prof_progress @endlink C function.
-        !> @ingroup fortran
-        integer(kind=c_int) function geopm_prof_progress(region_id, fraction) bind(C)
-            import
-            implicit none
-            integer(kind=c_int64_t), value, intent(in) :: region_id
-            real(kind=c_double), value, intent(in) :: fraction
-        end function geopm_prof_progress
-
         !> @brief Fortran interface to @link geopm.h geopm_prof_epoch @endlink C function.
         !> @ingroup fortran
         integer(kind=c_int) function geopm_prof_epoch() bind(C)

--- a/src/geopm.h
+++ b/src/geopm.h
@@ -95,9 +95,6 @@ int geopm_prof_enter(uint64_t region_id);
 
 int geopm_prof_exit(uint64_t region_id);
 
-int geopm_prof_progress(uint64_t region_id,
-                        double fraction);
-
 int geopm_prof_epoch(void);
 
 int geopm_prof_shutdown(void);

--- a/src/geopmbench_main.cpp
+++ b/src/geopmbench_main.cpp
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
 "\n"
 "                 If \"-progress\" is appended to any region name in the\n"
 "                 configuration, then progress for the region will be\n"
-"                 reported through the geopm_prof_progress API.\n"
+"                 reported through the geopm_tprof_* API.\n"
 "\n"
 "\n";
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -180,8 +180,8 @@ arbitrarily by a race if the configuration file is not present.
 
 5. Using the progress interface
 -------------------------------
-A computational application may make use of the geopm_prof_progress()
-or the geopm_tprof_post() interfaces to report fractional progress
+A computational application may make use of the geopm_tprof_init()
+and geopm_tprof_post() interfaces to report fractional progress
 through a region to the controller.  These interfaces are documented
 in the geopm_prof_c(3) man page.  In tutorial 5 we modify the stream
 region to send progress updates though either the threaded or

--- a/tutorial/tutorial_region_prof.c
+++ b/tutorial/tutorial_region_prof.c
@@ -83,13 +83,13 @@ static int stream_profiled_serial(uint64_t region_id, size_t num_stream, double 
     const size_t block = 256;
     const size_t num_block = num_stream / block;
     const size_t num_remain = num_stream % block;
-    const double norm = 1.0 / num_block;
 
+    geopm_tprof_init(num_block);
     for (size_t i = 0; i < num_block; ++i) {
         for (size_t j = 0; j < block; ++j) {
             a[i * block + j] = b[i * block + j] + scalar * c[i * block + j];
         }
-        geopm_prof_progress(region_id, i * norm);
+        geopm_tprof_post();
     }
     for (size_t j = 0; j < num_remain; ++j) {
         a[num_block * block + j] = b[num_block * block + j] + scalar * c[num_block * block + j];


### PR DESCRIPTION
- Updated examples and ModelRegion to use geopm_tprof_init() and
  geopm_tprof_post()
- Updated geopm_prof_c man page.
- Changes to integration tests will come after full runtime is enabled
  with the new code path.
