### PR TITLE
Merge power-balancer branch with socket support and update power balancer to to use ApplicationSampler

### DIFF
--- a/integration/test/test_power_balancer.cpp
+++ b/integration/test/test_power_balancer.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
     int cpu_idx = geopm_sched_get_cpu();
     int package_idx = geopm::platform_topo().domain_idx(GEOPM_DOMAIN_PACKAGE, cpu_idx);
     double big_o_base = 5.0;
-    double big_o = big_o_base * (1.0 + package_idx * 0.25);
+    double big_o = big_o_base * (1.0 + package_idx * 0.50);
 
     // Create a model region
     std::unique_ptr<geopm::ModelRegion> model(

--- a/integration/test/test_power_balancer.py
+++ b/integration/test/test_power_balancer.py
@@ -109,7 +109,6 @@ class TestIntegration_power_balancer(unittest.TestCase):
                     app_conf = geopmpy.io.BenchConf(cls._test_name + '_app.config')
                     cls._tmp_files.append(app_conf.get_path())
                     app_conf.append_region('dgemm-imbalance', 8.0)
-                    app_conf.append_region('all2all', 0.05)
                     app_conf.set_loop_count(loop_count)
                     # Update app config with imbalance
                     alloc_nodes = geopm_test_launcher.TestLauncher.get_alloc_nodes()

--- a/integration/test/test_power_balancer.py
+++ b/integration/test/test_power_balancer.py
@@ -135,7 +135,7 @@ class TestIntegration_power_balancer(unittest.TestCase):
                     launcher.set_num_node(cls._num_node)
                     launcher.set_num_rank(num_rank)
                     launcher.write_log(run_name, 'Power cap = {}W'.format(power_budget))
-                    launcher.run(run_name)
+                    launcher.run(run_name, add_geopm_args=['--geopm-trace-signals', 'MSR::PKG_POWER_LIMIT:PL1_POWER_LIMIT@package,EPOCH_RUNTIME@package,EPOCH_RUNTIME_NETWORK@package'])
                     time.sleep(60)
 
 
@@ -181,7 +181,7 @@ class TestIntegration_power_balancer(unittest.TestCase):
 
             # Get final power limit set on the node
             if agent == 'power_balancer':
-                power_limits.append(epoch_dropped_data['POWER_LIMIT'][-1])
+                power_limits.append(epoch_dropped_data['ENFORCED_POWER_LIMIT'][-1])
 
         # Check average limit for job is not exceeded
         if agent == 'power_balancer':

--- a/integration/test/test_power_balancer.py
+++ b/integration/test/test_power_balancer.py
@@ -98,7 +98,7 @@ class TestIntegration_power_balancer(unittest.TestCase):
                sys.stderr.write(err_fmt.format(num_node, cls._num_node))
                cls._num_node = num_node
             num_rank = 2 * cls._num_node
-            power_budget = 200
+            power_budget = 180
             if fam == 6 and mod == 87:
                 # budget for KNL
                 power_budget = 130

--- a/integration/test/test_power_balancer.py
+++ b/integration/test/test_power_balancer.py
@@ -89,9 +89,15 @@ class TestIntegration_power_balancer(unittest.TestCase):
         geopmpy.error.exc_clear()
 
         if not cls._skip_launch:
-            num_rank = 16
             loop_count = 500
             fam, mod = geopm_test_launcher.get_platform()
+            alloc_nodes = geopm_test_launcher.TestLauncher.get_alloc_nodes()
+            num_node = len(alloc_nodes)
+            if (len(alloc_nodes) != cls._num_node):
+               err_fmt = 'Warning: <test_power_balancer> Allocation size ({}) is different than expected ({})\n'
+               sys.stderr.write(err_fmt.format(num_node, cls._num_node))
+               cls._num_node = num_node
+            num_rank = 2 * cls._num_node
             power_budget = 200
             if fam == 6 and mod == 87:
                 # budget for KNL
@@ -111,7 +117,6 @@ class TestIntegration_power_balancer(unittest.TestCase):
                     app_conf.append_region('dgemm-imbalance', 8.0)
                     app_conf.set_loop_count(loop_count)
                     # Update app config with imbalance
-                    alloc_nodes = geopm_test_launcher.TestLauncher.get_alloc_nodes()
                     for nn in range(len(alloc_nodes) // 2):
                         app_conf.append_imbalance(alloc_nodes[nn], 0.5)
                 elif app_name == 'socket_imbalance':

--- a/src/PowerBalancer.cpp
+++ b/src/PowerBalancer.cpp
@@ -53,7 +53,7 @@ namespace geopm
     }
 
     PowerBalancerImp::PowerBalancerImp(double ctl_latency)
-        : PowerBalancerImp(ctl_latency, 0.125, 5, 0.25)
+        : PowerBalancerImp(ctl_latency, 0.125, 9, 0.25)
     {
 
     }

--- a/src/PowerBalancerAgent.cpp
+++ b/src/PowerBalancerAgent.cpp
@@ -642,7 +642,7 @@ namespace geopm
 
     PowerBalancerAgent::~PowerBalancerAgent() = default;
 
-    void PowerBalancerAgent::init(int level, const std::vector<int> &fan_in, bool is_root)
+    void PowerBalancerAgent::init(int level, const std::vector<int> &fan_in, bool is_level_root)
     {
         bool is_tree_root = (level == (int)fan_in.size());
         if (level == 0) {
@@ -654,6 +654,8 @@ namespace geopm
                                                 M_TIME_WINDOW,
                                                 is_tree_root,
                                                 calc_num_node(fan_in));
+            m_platform_io.write_control("POWER_PACKAGE_TIME_WINDOW",
+                                        GEOPM_DOMAIN_BOARD, 0, M_TIME_WINDOW);
         }
         else if (is_tree_root) {
             m_role = std::make_shared<RootRole>(level,
@@ -664,8 +666,6 @@ namespace geopm
         else {
             m_role = std::make_shared<TreeRole>(level, fan_in);
         }
-        m_platform_io.write_control("POWER_PACKAGE_TIME_WINDOW",
-                                    GEOPM_DOMAIN_BOARD, 0, M_TIME_WINDOW);
     }
 
     void PowerBalancerAgent::split_policy(const std::vector<double> &in_policy,

--- a/src/PowerBalancerAgent.hpp
+++ b/src/PowerBalancerAgent.hpp
@@ -45,6 +45,7 @@ namespace geopm
     class PlatformTopo;
     class PowerBalancer;
     class PowerGovernor;
+    class SampleAggregator;
 
     class PowerBalancerAgent : public Agent
     {
@@ -113,14 +114,6 @@ namespace geopm
                 M_NUM_SAMPLE,
             };
 
-            enum m_plat_signal_e {
-                M_PLAT_SIGNAL_EPOCH_RUNTIME,
-                M_PLAT_SIGNAL_EPOCH_COUNT,
-                M_PLAT_SIGNAL_EPOCH_RUNTIME_NETWORK,
-                M_PLAT_SIGNAL_EPOCH_RUNTIME_IGNORE,
-                M_PLAT_NUM_SIGNAL,
-            };
-
             enum m_trace_sample_e {
                 M_TRACE_SAMPLE_POLICY_POWER_PACKAGE_LIMIT_TOTAL,
                 M_TRACE_SAMPLE_POLICY_STEP_COUNT,
@@ -155,6 +148,7 @@ namespace geopm
 
             PowerBalancerAgent(PlatformIO &platform_io,
                                const PlatformTopo &platform_topo,
+                               std::shared_ptr<SampleAggregator> sample_agg,
                                std::vector<std::shared_ptr<PowerBalancer> > power_balancer,
                                double min_power,
                                double max_power);
@@ -223,6 +217,7 @@ namespace geopm
 
             PlatformIO &m_platform_io;
             const PlatformTopo &m_platform_topo;
+            std::shared_ptr<SampleAggregator> m_sample_agg;
             std::shared_ptr<Role> m_role;
             std::vector<std::shared_ptr<PowerBalancer> > m_power_balancer;
             struct geopm_time_s m_last_wait;
@@ -316,6 +311,7 @@ namespace geopm
                 public:
                     LeafRole(PlatformIO &platform_io,
                              const PlatformTopo &platform_topo,
+                             std::shared_ptr<SampleAggregator> sample_agg,
                              std::vector<std::shared_ptr<PowerBalancer> > power_balancer,
                              double min_power,
                              double max_power,
@@ -332,9 +328,13 @@ namespace geopm
                     bool are_steps_complete(void);
                     PlatformIO &m_platform_io;
                     const PlatformTopo &m_platform_topo;
+                    std::shared_ptr<SampleAggregator> m_sample_agg;
                     /// Number of power control domains
                     int m_num_domain;
-                    std::vector<std::vector<int> > m_pio_idx;
+                    std::vector<int> m_count_pio_idx;
+                    std::vector<int> m_time_agg_idx;
+                    std::vector<int> m_network_agg_idx;
+                    std::vector<int> m_ignore_agg_idx;
                     std::vector<std::shared_ptr<PowerBalancer> > m_power_balancer;
                     const double M_STABILITY_FACTOR;
                     struct m_package_s {

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -387,8 +387,6 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/PlatformTopoTest.ppc_num_domain \
               test/gtest_links/PlatformTopoTest.singleton_construction \
               test/gtest_links/PlatformTopoTest.call_c_wrappers \
-              test/gtest_links/PowerBalancerAgentTest.leaf_agent \
-              test/gtest_links/PowerBalancerAgentTest.power_balancer_agent \
               test/gtest_links/PowerBalancerAgentTest.tree_agent \
               test/gtest_links/PowerBalancerAgentTest.tree_root_agent \
               test/gtest_links/PowerBalancerAgentTest.enforce_policy \


### PR DESCRIPTION
Brings multi-socket support into the new-profile branch and fixes the balancer to use the ApplicationSampler in place of deprecated signals.