### PR TITLE
Allow MSRIOGroup to be used on systems with restricted allow lists

### DIFF
--- a/src/MSRIOGroup.cpp
+++ b/src/MSRIOGroup.cpp
@@ -522,10 +522,19 @@ namespace geopm
 
     void MSRIOGroup::save_control(void)
     {
+        std::vector<std::string> unallowed_controls;
         for (auto &ctl : m_control_available) {
-            for (auto &dom_ctl : ctl.second.controls) {
-                dom_ctl->save();
+            try {
+                for (auto &dom_ctl : ctl.second.controls) {
+                    dom_ctl->save();
+                }
             }
+            catch (const Exception &) {
+                unallowed_controls.push_back(ctl.first);
+            }
+        }
+        for (auto &bc : unallowed_controls) {
+            m_control_available.erase(bc);
         }
     }
 

--- a/src/PlatformIO.cpp
+++ b/src/PlatformIO.cpp
@@ -299,6 +299,10 @@ namespace geopm
             throw Exception("PlatformIOImp::push_control(): pushing controls after read_batch() or adjust().",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
+        if (!m_do_restore) {
+            throw Exception("PlatformIOImp::push_control(): pushing controls before calling save_control().",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
         if (domain_type < 0 || domain_type >= GEOPM_NUM_DOMAIN) {
             throw Exception("PlatformIOImp::push_control(): domain_type is out of range",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);


### PR DESCRIPTION
- If a control is not in the allow list, throw only when
  the user tries to write the control, not when the save
  happens.

- fixes #1395