### PR TITLE
Allow MSRIOGroup to be used on systems with restricted allow lists

### DIFF
--- a/src/MSRIOGroup.cpp
+++ b/src/MSRIOGroup.cpp
@@ -522,10 +522,19 @@ namespace geopm
 
     void MSRIOGroup::save_control(void)
     {
+        std::vector<std::string> unallowed_controls;
         for (auto &ctl : m_control_available) {
-            for (auto &dom_ctl : ctl.second.controls) {
-                dom_ctl->save();
+            try {
+                for (auto &dom_ctl : ctl.second.controls) {
+                    dom_ctl->save();
+                }
             }
+            catch (const Exception &) {
+                unallowed_controls.push_back(ctl.first);
+            }
+        }
+        for (auto &ctl : unallowed_controls) {
+            m_control_available.erase(ctl);
         }
     }
 

--- a/src/PlatformIO.cpp
+++ b/src/PlatformIO.cpp
@@ -299,6 +299,10 @@ namespace geopm
             throw Exception("PlatformIOImp::push_control(): pushing controls after read_batch() or adjust().",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
+        if (!m_do_restore) {
+            throw Exception("PlatformIOImp::push_control(): pushing controls before calling save_control().",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
         if (domain_type < 0 || domain_type >= GEOPM_NUM_DOMAIN) {
             throw Exception("PlatformIOImp::push_control(): domain_type is out of range",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);

--- a/test/PlatformIOTest.cpp
+++ b/test/PlatformIOTest.cpp
@@ -288,6 +288,8 @@ TEST_F(PlatformIOTest, push_control)
 
     EXPECT_CALL(*m_control_iogroup, control_domain_type("FREQ"));
     EXPECT_CALL(*m_control_iogroup, push_control("FREQ", GEOPM_DOMAIN_CPU, 0));
+    EXPECT_CALL(*m_control_iogroup, save_control());
+    m_platio->save_control();
     int idx = m_platio->push_control("FREQ", GEOPM_DOMAIN_CPU, 0);
     EXPECT_EQ(0, idx);
     EXPECT_EQ(idx, m_platio->push_control("FREQ", GEOPM_DOMAIN_CPU, 0));
@@ -304,6 +306,8 @@ TEST_F(PlatformIOTest, push_control_agg)
     EXPECT_CALL(*m_topo, domain_nested(GEOPM_DOMAIN_CPU, GEOPM_DOMAIN_PACKAGE, 0));
     EXPECT_EQ(0, m_platio->num_control_pushed());
     EXPECT_CALL(*m_control_iogroup, control_domain_type("FREQ")).Times(AtLeast(1));
+    EXPECT_CALL(*m_control_iogroup, save_control());
+    m_platio->save_control();
     for (auto cpu : m_cpu_set0) {
         EXPECT_CALL(*m_control_iogroup, push_control("FREQ", GEOPM_DOMAIN_CPU, cpu));
     }
@@ -376,6 +380,8 @@ TEST_F(PlatformIOTest, adjust)
 {
     EXPECT_CALL(*m_control_iogroup, control_domain_type("FREQ"));
     EXPECT_CALL(*m_control_iogroup, push_control("FREQ", _, _));
+    EXPECT_CALL(*m_control_iogroup, save_control());
+    m_platio->save_control();
     int freq_idx = m_platio->push_control("FREQ", GEOPM_DOMAIN_CPU, 0);
     EXPECT_EQ(0, freq_idx);
 
@@ -397,6 +403,8 @@ TEST_F(PlatformIOTest, adjust_agg)
     EXPECT_CALL(*m_topo, domain_nested(GEOPM_DOMAIN_CPU, GEOPM_DOMAIN_PACKAGE, 0));
     double value = 1.23e9;
     EXPECT_CALL(*m_control_iogroup, control_domain_type("FREQ")).Times(AtLeast(1));
+    EXPECT_CALL(*m_control_iogroup, save_control());
+    m_platio->save_control();
     for (auto cpu : m_cpu_set0) {
         EXPECT_CALL(*m_control_iogroup, push_control("FREQ", GEOPM_DOMAIN_CPU, cpu))
             .WillOnce(Return(cpu));


### PR DESCRIPTION
- If a control is not in the allow list, throw only when
  the user tries to write the control, not when the save
  happens.
- Fixes #1395


