### PR TITLE
Fix MSR save/restore feature for some systems

### DIFF
--- a/src/MSRIOGroup.cpp
+++ b/src/MSRIOGroup.cpp
@@ -529,6 +529,7 @@ namespace geopm
             try {
                 for (auto &dom_ctl : ctl.second.controls) {
                     dom_ctl->save();
+                    dom_ctl->restore();
                 }
             }
             catch (const Exception &) {


### PR DESCRIPTION
- Systems that have allowed lists that have MSR controls that
  are readable but not writable cause an error at shutdown time
  without this change.


