### PR TITLE
Update environment integration test to be in its own python file

### DIFF
--- a/integration/test/Makefile.mk
+++ b/integration/test/Makefile.mk
@@ -65,3 +65,4 @@ include integration/test/test_geopmio.mk
 include integration/test/test_launch_application.mk
 include integration/test/test_launch_pthread.mk
 include integration/test/test_geopmagent.mk
+include integration/test/test_environment.mk

--- a/integration/test/test_environment.mk
+++ b/integration/test/test_environment.mk
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -31,32 +29,4 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
-
-import sys
-import os
-import unittest
-
-from geopm_test_integration import *
-from test_omp_outer_loop import *
-from test_ee_timed_scaling_mix import *
-from test_enforce_policy import *
-from test_profile_policy import *
-from test_plugin_static_policy import *
-from test_power_balancer import *
-from test_tutorial_base import *
-from test_frequency_hint_usage import *
-from test_scaling_region import *
-from test_timed_scaling_region import *
-from test_profile_overflow import *
-from test_trace import *
-from test_monitor import *
-from test_geopmio import *
-from test_ompt import *
-from test_launch_application import *
-from test_launch_pthread import *
-from test_geopmagent import *
-from test_environment import *
-
-if __name__ == '__main__':
-    unittest.main()
+EXTRA_DIST += integration/test/test_environment.py

--- a/integration/test/test_environment.py
+++ b/integration/test/test_environment.py
@@ -34,11 +34,13 @@
 import sys
 import unittest
 import os
+import json
 
-import geopm_context
+from integration.test import geopm_context
 import geopmpy.io
 
 import util
+import geopm_test_launcher
 
 environment_default_path = os.path.join(util.get_config_value('GEOPM_CONFIG_PATH'), 'environment-default.json')
 environment_override_path = os.path.join(util.get_config_value('GEOPM_CONFIG_PATH'), 'environment-override.json')
@@ -57,15 +59,12 @@ class TestIntegrationEnvironment(unittest.TestCase):
         num_node = 1
         num_rank = 1
         app_conf = geopmpy.io.BenchConf(context + '.app.config')
-        self._tmp_files.append(app_conf.get_path())
         app_conf.append_region('sleep', 0.01)
         user_agent_conf = geopmpy.io.AgentConf(context + '.user.agent.config', self._agent, {} if user_policy is None else user_policy)
-        self._tmp_files.append(user_agent_conf.get_path())
         launcher = geopm_test_launcher.TestLauncher(app_conf, user_agent_conf, report_path)
         launcher.set_num_node(num_node)
         launcher.set_num_rank(num_rank)
         launcher.run(context, include_geopm_policy=user_policy is not None)
-        self._tmp_files.append(report_path)
 
         actual_policy = geopmpy.io.RawReport(report_path).meta_data()['Policy']
         for expected_key, expected_value in expected_policy.items():
@@ -90,24 +89,24 @@ class TestIntegrationEnvironment(unittest.TestCase):
                 util.run_script_on_compute_nodes(
                     'mv -f {policy_file} {policy_file}.backup ; '
                     'echo \'{policy}\' > {policy_file} && '
-                    'echo \'{{"GEOPM_POLICY": "{policy_file}", "GEOPM_AGENT": "energy_efficient"}}\' > {etc_file}'.format(
+                    'echo \'{{"GEOPM_POLICY": "{policy_file}", "GEOPM_AGENT": "frequency_map"}}\' > {etc_file}'.format(
                         policy=policy_string, policy_file=policy_file_path, etc_file=etc_config_path),
                     dev_null, dev_null)
 
         test_name = 'test_geopm_environment'
-        self._agent = 'energy_efficient'
-        user_policy = { 'PERF_MARGIN': 0.13 }
+        self._agent = 'frequency_map'
+        user_policy = { 'FREQ_DEFAULT': 1.5e9 }
 
         with util.temporarily_remove_compute_node_file(environment_default_path), \
                 util.temporarily_remove_compute_node_file(environment_override_path):
             # Only the default is set. Can be overridden by the user.
-            default_policy = { 'PERF_MARGIN': 0.11 }
+            default_policy = { 'FREQ_DEFAULT': 1.6e9 }
             create_policy_file_on_compute_node(default_policy, test_name + '.default.agent.config', environment_default_path)
             self.assert_geopm_uses_policy(default_policy, test_name + '_default_no_user')
             self.assert_geopm_uses_policy(user_policy, test_name + '_default_with_user', user_policy=user_policy)
 
             # Both default and override are set. Override is always used.
-            override_policy = { 'PERF_MARGIN': 0.12 }
+            override_policy = { 'FREQ_DEFAULT': 1.7e9 }
             create_policy_file_on_compute_node(override_policy, test_name + '.override.agent.config', environment_override_path)
             self.assert_geopm_uses_policy(override_policy, test_name + '_override_and_default_no_user')
             self.assert_geopm_uses_policy(override_policy, test_name + '_override_and_default_with_user', user_policy=user_policy)

--- a/integration/test/test_environment.py
+++ b/integration/test/test_environment.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+import unittest
+import os
+
+import geopm_context
+import geopmpy.io
+
+import util
+
+environment_default_path = os.path.join(util.get_config_value('GEOPM_CONFIG_PATH'), 'environment-default.json')
+environment_override_path = os.path.join(util.get_config_value('GEOPM_CONFIG_PATH'), 'environment-override.json')
+
+class TestIntegrationEnvironment(unittest.TestCase):
+
+    def assert_geopm_uses_policy(self, expected_policy, context, user_policy=None):
+        """Assert that geopm uses the given policy.
+
+        Arguments:
+        expected_policy (dict str->float): Policy to expect in generated reports.
+        context (str): Additional context for test file names and failure messages.
+        user_policy (dict str->float): Policy to request in the geopmlaunch command.
+        """
+        report_path = '{}.report'.format(context)
+        num_node = 1
+        num_rank = 1
+        app_conf = geopmpy.io.BenchConf(context + '.app.config')
+        self._tmp_files.append(app_conf.get_path())
+        app_conf.append_region('sleep', 0.01)
+        user_agent_conf = geopmpy.io.AgentConf(context + '.user.agent.config', self._agent, {} if user_policy is None else user_policy)
+        self._tmp_files.append(user_agent_conf.get_path())
+        launcher = geopm_test_launcher.TestLauncher(app_conf, user_agent_conf, report_path)
+        launcher.set_num_node(num_node)
+        launcher.set_num_rank(num_rank)
+        launcher.run(context, include_geopm_policy=user_policy is not None)
+        self._tmp_files.append(report_path)
+
+        actual_policy = geopmpy.io.RawReport(report_path).meta_data()['Policy']
+        for expected_key, expected_value in expected_policy.items():
+            self.assertEqual(expected_value, actual_policy[expected_key],
+                             msg='Wrong policy value for {} (context: {})'.format(expected_key, context))
+        for actual_key, actual_value in actual_policy.items():
+            if actual_key not in expected_policy:
+                self.assertEqual('NAN', actual_value,
+                                 msg='Unexpected value for {} (context: {})'.format(actual_key, context))
+
+    @util.skip_unless_batch()
+    @util.skip_or_ensure_writable_file(environment_default_path)
+    @util.skip_or_ensure_writable_file(environment_override_path)
+    @util.skip_unless_library_in_ldconfig('libgeopmpolicy.so')
+    def test_geopm_environment(self):
+        """Test behavior of geopm environment files.
+        """
+        def create_policy_file_on_compute_node(policy, policy_file_name, etc_config_path):
+            policy_string = json.dumps(policy)
+            policy_file_path = os.path.join('/tmp', policy_file_name)
+            with open('/dev/null', 'w') as dev_null:
+                util.run_script_on_compute_nodes(
+                    'mv -f {policy_file} {policy_file}.backup ; '
+                    'echo \'{policy}\' > {policy_file} && '
+                    'echo \'{{"GEOPM_POLICY": "{policy_file}", "GEOPM_AGENT": "energy_efficient"}}\' > {etc_file}'.format(
+                        policy=policy_string, policy_file=policy_file_path, etc_file=etc_config_path),
+                    dev_null, dev_null)
+
+        test_name = 'test_geopm_environment'
+        self._agent = 'energy_efficient'
+        user_policy = { 'PERF_MARGIN': 0.13 }
+
+        with util.temporarily_remove_compute_node_file(environment_default_path), \
+                util.temporarily_remove_compute_node_file(environment_override_path):
+            # Only the default is set. Can be overridden by the user.
+            default_policy = { 'PERF_MARGIN': 0.11 }
+            create_policy_file_on_compute_node(default_policy, test_name + '.default.agent.config', environment_default_path)
+            self.assert_geopm_uses_policy(default_policy, test_name + '_default_no_user')
+            self.assert_geopm_uses_policy(user_policy, test_name + '_default_with_user', user_policy=user_policy)
+
+            # Both default and override are set. Override is always used.
+            override_policy = { 'PERF_MARGIN': 0.12 }
+            create_policy_file_on_compute_node(override_policy, test_name + '.override.agent.config', environment_override_path)
+            self.assert_geopm_uses_policy(override_policy, test_name + '_override_and_default_no_user')
+            self.assert_geopm_uses_policy(override_policy, test_name + '_override_and_default_with_user', user_policy=user_policy)
+
+            # Only override is set. Override is always used.
+            util.remove_file_on_compute_nodes(environment_default_path)
+            self.assert_geopm_uses_policy(override_policy, test_name + '_override_no_user')
+            self.assert_geopm_uses_policy(override_policy, test_name + '_override_with_user', user_policy=user_policy)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/integration/test/util.py
+++ b/integration/test/util.py
@@ -116,11 +116,7 @@ def skip_unless_platform_bdx():
         return unittest.skip("Performance test is tuned for BDX server, The family {}, model {} is not supported.".format(fam, mod))
     return lambda func: func
 
-
-def get_config_value(key):
-    """Get the value of an option from the build configuration, returning None
-    if no such key is present.
-    """
+def get_config_log():
     path = os.path.join(
            os.path.dirname(
             os.path.dirname(
@@ -131,6 +127,13 @@ def get_config_value(key):
         path = os.path.join(
                os.path.dirname(path),
                 'integration/build/config.log')
+    return path
+
+def get_config_value(key):
+    """Get the value of an option from the build configuration, returning None
+    if no such key is present.
+    """
+    path = get_config_log()
     with open(path) as config_file:
         for line in config_file:
             line_start = "{}='".format(key)
@@ -148,12 +151,7 @@ def skip_unless_config_enable(feature):
 
 
 def skip_unless_optimized():
-    path = os.path.join(
-           os.path.dirname(
-            os.path.dirname(
-             os.path.dirname(
-              os.path.realpath(__file__)))),
-           'config.log')
+    path = get_config_log()
     with open(path) as fid:
         for line in fid.readlines():
             if line.startswith("enable_debug='1'"):

--- a/src/Agent.cpp
+++ b/src/Agent.cpp
@@ -73,10 +73,6 @@ namespace geopm
                         PowerGovernorAgent::make_plugin,
                         Agent::make_dictionary(PowerGovernorAgent::policy_names(),
                                                PowerGovernorAgent::sample_names()));
-        register_plugin(EnergyEfficientAgent::plugin_name(),
-                        EnergyEfficientAgent::make_plugin,
-                        Agent::make_dictionary(EnergyEfficientAgent::policy_names(),
-                                               EnergyEfficientAgent::sample_names()));
         register_plugin(FrequencyMapAgent::plugin_name(),
                         FrequencyMapAgent::make_plugin,
                         Agent::make_dictionary(FrequencyMapAgent::policy_names(),


### PR DESCRIPTION
Mostly just moving the code into a separate file, but also modified the test to use the frequency map agent instead of the ee agent.  This PR also disables the EE agent from the Agent factory.