### PR TITLE
Convert frequency map agent test to use new pattern

### DIFF
--- a/integration/test/Makefile.mk
+++ b/integration/test/Makefile.mk
@@ -68,3 +68,4 @@ include integration/test/test_geopmagent.mk
 include integration/test/test_environment.mk
 include integration/test/test_power_governor.mk
 include integration/test/test_environment.mk
+include integration/test/test_frequency_map.mk

--- a/integration/test/__main__.py
+++ b/integration/test/__main__.py
@@ -58,7 +58,7 @@ from test_launch_pthread import *
 from test_geopmagent import *
 from test_environment import *
 from test_power_governor import *
-from test_environment import *
+from test_frequency_map import *
 
 
 if __name__ == '__main__':

--- a/integration/test/test_frequency_map.mk
+++ b/integration/test/test_frequency_map.mk
@@ -1,0 +1,32 @@
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+EXTRA_DIST += integration/test/test_frequency_map.py

--- a/integration/test/test_frequency_map.py
+++ b/integration/test/test_frequency_map.py
@@ -1,0 +1,100 @@
+@util.skip_unless_do_launch()
+class TestIntegration(unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        self._agent = 'power_governor'
+        self._options = {'power_budget': 150}
+        self._tmp_files = []
+        self._output = None
+        self._power_limit = geopm_test_launcher.geopmread("MSR::PKG_POWER_LIMIT:PL1_POWER_LIMIT board 0")
+        self._frequency = geopm_test_launcher.geopmread("MSR::PERF_CTL:FREQ board 0")
+        self._original_freq_map_env = os.environ.get('GEOPM_FREQUENCY_MAP')
+
+    def tearDown(self):
+        geopm_test_launcher.geopmwrite("MSR::PKG_POWER_LIMIT:PL1_POWER_LIMIT board 0 " + str(self._power_limit))
+        geopm_test_launcher.geopmwrite("MSR::PERF_CTL:FREQ board 0 " + str(self._frequency))
+        if self._original_freq_map_env is None:
+            if 'GEOPM_FREQUENCY_MAP' in os.environ:
+                os.environ.pop('GEOPM_FREQUENCY_MAP')
+        else:
+            os.environ['GEOPM_FREQUENCY_MAP'] = self._original_freq_map_env
+
+    def create_frequency_map_policy(max_freq, frequency_map):
+        """Create a frequency map to be consumed by the frequency map agent.
+
+        Arguments:
+        min_freq: Floor frequency for the agent
+        max_freq: Ceiling frequency for the agent
+        frequency_map: Dictionary mapping region names to frequencies
+        """
+        policy = {'FREQ_DEFAULT': max_freq, 'FREQ_UNCORE': float('nan')}
+        for i, (region_name, frequency) in enumerate(frequency_map.items()):
+            policy['HASH_{}'.format(i)] = geopmpy.hash.crc32_str(region_name)
+            policy['FREQ_{}'.format(i)] = frequency
+
+        return policy
+
+    def test_agent_frequency_map(self):
+        name = 'test_agent_frequency_map'
+        min_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_MIN board 0")
+        max_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_MAX board 0")
+        sticker_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_STICKER board 0")
+        freq_step = geopm_test_launcher.geopmread("CPUINFO::FREQ_STEP board 0")
+        self._agent = "frequency_map"
+        report_path = name + '.report'
+        trace_path = name + '.trace'
+        num_node = 1
+        num_rank = 4
+        loop_count = 5
+        dgemm_bigo = 15.0
+        stream_bigo = 1.0
+        dgemm_bigo_jlse = 35.647
+        dgemm_bigo_quartz = 29.12
+        stream_bigo_jlse = 1.6225
+        stream_bigo_quartz = 1.7941
+        hostname = socket.gethostname()
+        if hostname.endswith('.alcf.anl.gov'):
+            dgemm_bigo = dgemm_bigo_jlse
+            stream_bigo = stream_bigo_jlse
+        elif hostname.startswith('mcfly'):
+            dgemm_bigo = 28.0
+            stream_bigo = 1.5
+        elif hostname.startswith('quartz'):
+            dgemm_bigo = dgemm_bigo_quartz
+            stream_bigo = stream_bigo_quartz
+
+        app_conf = geopmpy.io.BenchConf(name + '_app.config')
+        self._tmp_files.append(app_conf.get_path())
+        app_conf.set_loop_count(loop_count)
+        app_conf.append_region('dgemm', dgemm_bigo)
+        app_conf.append_region('stream', stream_bigo)
+        app_conf.append_region('all2all', 1.0)
+        app_conf.write()
+        freq_map = {}
+        freq_map['dgemm'] = min_freq + 2 * freq_step
+        freq_map['stream'] = sticker_freq - 2 * freq_step
+        freq_map['all2all'] = min_freq
+        self._options = create_frequency_map_policy(max_freq, freq_map)
+        agent_conf = geopmpy.io.AgentConf(name + '_agent.config', self._agent, self._options)
+        self._tmp_files.append(agent_conf.get_path())
+        launcher = geopm_test_launcher.TestLauncher(app_conf, agent_conf, report_path,
+                                                    trace_path, region_barrier=True, time_limit=900)
+        launcher.set_num_node(num_node)
+        launcher.set_num_rank(num_rank)
+        launcher.run(name)
+
+        self._output = geopmpy.io.AppOutput(report_path, trace_path + '*')
+        node_names = self._output.get_node_names()
+        self.assertEqual(len(node_names), num_node)
+        regions = self._output.get_region_names()
+        for nn in node_names:
+            for region_name in regions:
+                region_data = self._output.get_report_data(node_name=nn, region=region_name)
+                if (region_name in ['dgemm', 'stream', 'all2all']):
+                    #todo verify trace frequencies
+                    #todo verify agent report augment frequecies
+                    msg = region_name + " frequency should be near assigned map frequency"
+                    util.assertNear(self, freq_map[region_name] / sticker_freq * 100, region_data['frequency'].item(), msg=msg)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/integration/test/test_frequency_map.py
+++ b/integration/test/test_frequency_map.py
@@ -1,49 +1,65 @@
-@util.skip_unless_do_launch()
-class TestIntegration(unittest.TestCase):
-    def setUp(self):
-        self.longMessage = True
-        self._agent = 'power_governor'
-        self._options = {'power_budget': 150}
-        self._tmp_files = []
-        self._output = None
-        self._power_limit = geopm_test_launcher.geopmread("MSR::PKG_POWER_LIMIT:PL1_POWER_LIMIT board 0")
-        self._frequency = geopm_test_launcher.geopmread("MSR::PERF_CTL:FREQ board 0")
-        self._original_freq_map_env = os.environ.get('GEOPM_FREQUENCY_MAP')
+#!/usr/bin/env python
+#
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
 
-    def tearDown(self):
-        geopm_test_launcher.geopmwrite("MSR::PKG_POWER_LIMIT:PL1_POWER_LIMIT board 0 " + str(self._power_limit))
-        geopm_test_launcher.geopmwrite("MSR::PERF_CTL:FREQ board 0 " + str(self._frequency))
-        if self._original_freq_map_env is None:
-            if 'GEOPM_FREQUENCY_MAP' in os.environ:
-                os.environ.pop('GEOPM_FREQUENCY_MAP')
-        else:
-            os.environ['GEOPM_FREQUENCY_MAP'] = self._original_freq_map_env
+import sys
+import unittest
+import os
+import pandas
+import socket
 
-    def create_frequency_map_policy(max_freq, frequency_map):
-        """Create a frequency map to be consumed by the frequency map agent.
+import geopm_context
+import geopmpy.io
+import geopmpy.hash
 
-        Arguments:
-        min_freq: Floor frequency for the agent
-        max_freq: Ceiling frequency for the agent
-        frequency_map: Dictionary mapping region names to frequencies
+import util
+import geopm_test_launcher
+
+
+class TestIntegration_frequency_map(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Create launcher, execute benchmark and set up class variables.
+
         """
-        policy = {'FREQ_DEFAULT': max_freq, 'FREQ_UNCORE': float('nan')}
-        for i, (region_name, frequency) in enumerate(frequency_map.items()):
-            policy['HASH_{}'.format(i)] = geopmpy.hash.crc32_str(region_name)
-            policy['FREQ_{}'.format(i)] = frequency
-
-        return policy
-
-    def test_agent_frequency_map(self):
-        name = 'test_agent_frequency_map'
-        min_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_MIN board 0")
-        max_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_MAX board 0")
-        sticker_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_STICKER board 0")
-        freq_step = geopm_test_launcher.geopmread("CPUINFO::FREQ_STEP board 0")
-        self._agent = "frequency_map"
-        report_path = name + '.report'
-        trace_path = name + '.trace'
-        num_node = 1
+        sys.stdout.write('(' + os.path.basename(__file__).split('.')[0] +
+                         '.' + cls.__name__ + ') ...')
+        cls._test_name = 'test_frequency_map'
+        cls._report_path = '{}.report'.format(cls._test_name)
+        cls._agent_conf_path = cls._test_name + '-agent-config.json'
+        # Clear out exception record for python 2 support
+        geopmpy.error.exc_clear()
+        # Set the job size parameters
+        cls._num_node = 1
         num_rank = 4
         loop_count = 5
         dgemm_bigo = 15.0
@@ -63,38 +79,68 @@ class TestIntegration(unittest.TestCase):
             dgemm_bigo = dgemm_bigo_quartz
             stream_bigo = stream_bigo_quartz
 
-        app_conf = geopmpy.io.BenchConf(name + '_app.config')
-        self._tmp_files.append(app_conf.get_path())
+        app_conf = geopmpy.io.BenchConf(cls._test_name + '_app.config')
         app_conf.set_loop_count(loop_count)
         app_conf.append_region('dgemm', dgemm_bigo)
         app_conf.append_region('stream', stream_bigo)
         app_conf.append_region('all2all', 1.0)
         app_conf.write()
-        freq_map = {}
-        freq_map['dgemm'] = min_freq + 2 * freq_step
-        freq_map['stream'] = sticker_freq - 2 * freq_step
-        freq_map['all2all'] = min_freq
-        self._options = create_frequency_map_policy(max_freq, freq_map)
-        agent_conf = geopmpy.io.AgentConf(name + '_agent.config', self._agent, self._options)
-        self._tmp_files.append(agent_conf.get_path())
-        launcher = geopm_test_launcher.TestLauncher(app_conf, agent_conf, report_path,
-                                                    trace_path, region_barrier=True, time_limit=900)
-        launcher.set_num_node(num_node)
-        launcher.set_num_rank(num_rank)
-        launcher.run(name)
 
-        self._output = geopmpy.io.AppOutput(report_path, trace_path + '*')
-        node_names = self._output.get_node_names()
-        self.assertEqual(len(node_names), num_node)
-        regions = self._output.get_region_names()
-        for nn in node_names:
-            for region_name in regions:
-                region_data = self._output.get_report_data(node_name=nn, region=region_name)
+        min_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_MIN board 0")
+        max_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_MAX board 0")
+        sticker_freq = geopm_test_launcher.geopmread("CPUINFO::FREQ_STICKER board 0")
+        freq_step = geopm_test_launcher.geopmread("CPUINFO::FREQ_STEP board 0")
+        cls._freq_map = {}
+        cls._freq_map['dgemm'] = min_freq + 2 * freq_step
+        cls._freq_map['stream'] = sticker_freq - 2 * freq_step
+        cls._freq_map['all2all'] = min_freq
+        cls._options = cls.create_frequency_map_policy(max_freq, cls._freq_map)
+        cls._agent = 'frequency_map'
+        agent_conf = geopmpy.io.AgentConf(cls._test_name + '_agent.config',
+                                          cls._agent, cls._options)
+
+        # Create the test launcher with the above configuration
+        launcher = geopm_test_launcher.TestLauncher(app_conf,
+                                                    agent_conf,
+                                                    cls._report_path)
+        launcher.set_num_node(cls._num_node)
+        launcher.set_num_rank(num_rank)
+        # Run the test application
+        launcher.run(cls._test_name)
+
+        # Output to be reused by all tests
+        cls._report = geopmpy.io.RawReport(cls._report_path)
+
+    @classmethod
+    def create_frequency_map_policy(cls, max_freq, frequency_map):
+        """Create a frequency map to be consumed by the frequency map agent.
+
+        Arguments:
+        min_freq: Floor frequency for the agent
+        max_freq: Ceiling frequency for the agent
+        frequency_map: Dictionary mapping region names to frequencies
+        """
+        policy = {'FREQ_DEFAULT': max_freq, 'FREQ_UNCORE': float('nan')}
+        for i, (region_name, frequency) in enumerate(frequency_map.items()):
+            policy['HASH_{}'.format(i)] = geopmpy.hash.crc32_str(region_name)
+            policy['FREQ_{}'.format(i)] = frequency
+
+        return policy
+
+    def test_agent_frequency_map(self):
+        host_names = self._report.host_names()
+        self.assertEqual(len(host_names), self._num_node)
+        for host in host_names:
+            for region_name in self._report.region_names(host):
+                raw_region = self._report.raw_region(host_name=host,
+                                                     region_name=region_name)
                 if (region_name in ['dgemm', 'stream', 'all2all']):
                     #todo verify trace frequencies
                     #todo verify agent report augment frequecies
-                    msg = region_name + " frequency should be near assigned map frequency"
-                    util.assertNear(self, freq_map[region_name] / sticker_freq * 100, region_data['frequency'].item(), msg=msg)
+                    msg = region_name + ": frequency should be near assigned map frequency"
+                    actual = raw_region['frequency (Hz)']
+                    expect = self._freq_map[region_name]
+                    util.assertNear(self, expect, actual, msg=msg)
 
 if __name__ == '__main__':
     unittest.main()

--- a/integration/test/test_frequency_map.py
+++ b/integration/test/test_frequency_map.py
@@ -91,6 +91,7 @@ class TestIntegration_frequency_map(unittest.TestCase):
         cls._machine = machine.Machine()
         try:
             cls._machine.load()
+            sys.stderr.write('Warning: {}: using existing file "machine.json", delete if invalid\n'.format(cls._test_name))
         except RuntimeError:
             cls._machine.save()
 

--- a/ronn/geopm_agent_frequency_map.7.ronn
+++ b/ronn/geopm_agent_frequency_map.7.ronn
@@ -69,11 +69,14 @@ name (see **geopm(7)**).  This name can also be passed to the
   `FREQ_DEFAULT`: The operating frequency in units of Hz set by the
                   agent on CPUs executing the application while the
                   application is not within a policy-mapped region.
-                  This policy parameter is required and must be
-                  specified with a CPU frequency that is allowed by
-                  the system.  Failure to provide this parameter,
-                  setting it to an out of range value or specifying
-                  NAN will result in a runtime error.
+                  The cores not associated with the application
+                  (including the one running the geopm controller)
+                  will run at the default frequency.  This policy
+                  parameter is required and must be specified with a
+                  CPU frequency that is allowed by the system.
+                  Failure to provide this parameter, setting it to an
+                  out of range value or specifying NAN will result in
+                  a runtime error.
 
   `FREQ_UNCORE`: The operating frequency for the uncore clock in units
                  of Hz.  If specified the uncore clock will operate


### PR DESCRIPTION
Test is currently failing:

```
======================================================================
FAIL: test_agent_frequency_map (__main__.TestIntegration_frequency_map)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cmcantal/Git/geopm/integration/test/test_frequency_map.py", line 143, in test_agent_frequency_map
    util.assertNear(self, expect, actual, msg=msg)
  File "/home/cmcantal/Git/geopm/integration/test/util.py", line 285, in assertNear
    self.fail('The fractional difference between {a} and {b} is greater than {epsilon}.  {msg}'.format(a=a, b=b, epsilon=epsilon, msg=msg))
AssertionError: The fractional difference between 1000000000.0 and 1112660000.0 is greater than 0.05.  all2all: frequency should be near assigned map frequency

----------------------------------------------------------------------
```

There also seem to be some strange hint runtime numbers in the report.