### PR TITLE
Add callbacks for ompt progress and add test that shows it works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@
 /integration/test/test_power_balancer
 /integration/test/test_profile_overflow
 /integration/test/test_profile_policy
+/integration/test/test_progress
 /integration/test/test_scaling_region
 /integration/test/test_timed_scaling_region
 /integration/test/test_tutorial_base

--- a/integration/experiment/machine.py
+++ b/integration/experiment/machine.py
@@ -32,6 +32,7 @@
 
 import json
 import os
+import sys
 import glob
 
 from . import util
@@ -156,4 +157,18 @@ def init_output_dir(output_dir):
 def get_machine(output_dir):
     mm = Machine(output_dir)
     mm.load()
+    return mm
+
+def try_machine(output_dir, msg_tag=None):
+    mm = Machine()
+    try:
+        mm.load()
+        err_msg = ['Warning']
+        if msg_tag:
+           err_msg.append(msg_tag)
+        err_msg.append('using existing file "machine.json", delete if invalid\n')
+        err_msg = ': '.join(err_msg)
+        sys.stderr.write(err_msg)
+    except RuntimeError:
+        mm.save()
     return mm

--- a/integration/test/Makefile.mk
+++ b/integration/test/Makefile.mk
@@ -70,3 +70,4 @@ include integration/test/test_power_governor.mk
 include integration/test/test_environment.mk
 include integration/test/test_frequency_map.mk
 include integration/test/test_hint_time.mk
+include integration/test/test_progress.mk

--- a/integration/test/test_hint_time.py
+++ b/integration/test/test_hint_time.py
@@ -104,7 +104,6 @@ class TestIntegration_hint_time(unittest.TestCase):
                          '.' + cls.__name__ + ') ...')
         cls._test_name = 'hint_time'
         cls._report_path = 'test_{}.report'.format(cls._test_name)
-        cls._trace_path = 'test_{}.trace'.format(cls._test_name)
         cls._image_path = 'test_{}.png'.format(cls._test_name)
         cls._skip_launch = not util.do_launch()
         cls._agent_conf_path = 'test_' + cls._test_name + '-agent-config.json'

--- a/integration/test/test_progress.cpp
+++ b/integration/test/test_progress.cpp
@@ -94,7 +94,7 @@ void loop_dgemm_with_post(double big_o, int count)
     std::shared_ptr<geopm::ModelRegion> dgemm_model(
         geopm::ModelRegion::model_region("dgemm-unmarked", big_o, false));
 #pragma omp for
-    for (size_t idx = 0; idx < count; ++idx) {
+    for (int idx = 0; idx < count; ++idx) {
         geopm_tprof_post();
         dgemm_model->run();
     }
@@ -109,7 +109,7 @@ void loop_dgemm_no_post(double big_o, int count)
     std::shared_ptr<geopm::ModelRegion> dgemm_model(
         geopm::ModelRegion::model_region("dgemm-unmarked", big_o, false));
 #pragma omp for
-    for (size_t idx = 0; idx < count; ++idx) {
+    for (int idx = 0; idx < count; ++idx) {
         dgemm_model->run();
     }
 }
@@ -123,7 +123,7 @@ void loop_dgemm_warmup(double big_o, int count)
     std::shared_ptr<geopm::ModelRegion> dgemm_model(
         geopm::ModelRegion::model_region("dgemm-unmarked", big_o, false));
 #pragma omp for
-    for (size_t idx = 0; idx < count; ++idx) {
+    for (int idx = 0; idx < count; ++idx) {
         dgemm_model->run();
     }
 }

--- a/integration/test/test_progress.cpp
+++ b/integration/test/test_progress.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <mpi.h>
+#include <vector>
+#include "geopm.h"
+#include "ModelRegion.hpp"
+
+
+__attribute__((noinline))
+void setup(std::vector<double> &aa_vec,
+           std::vector<double> &bb_vec,
+           std::vector<double> &cc_vec)
+{
+#pragma omp parallel for
+    for (size_t idx = 0; idx < aa_vec.size(); ++idx) {
+        aa_vec[idx] = 0.0;
+        aa_vec[idx] = 1.0;
+        aa_vec[idx] = 2.0;
+    }
+}
+
+__attribute__((noinline))
+void triad_with_post(std::vector<double> &aa_vec,
+                     const std::vector<double> &bb_vec,
+                     const std::vector<double> &cc_vec)
+{
+    double scalar = 3.0;
+#pragma omp parallel for
+    for (size_t idx = 0; idx < aa_vec.size(); ++idx) {
+        geopm_tprof_post();
+        aa_vec[idx] = bb_vec[idx] + scalar * cc_vec[idx];
+    }
+}
+
+__attribute__((noinline))
+void triad_no_post(std::vector<double> &aa_vec,
+                   const std::vector<double> &bb_vec,
+                   const std::vector<double> &cc_vec)
+{
+    double scalar = 3.0;
+#pragma omp parallel for
+    for (size_t idx = 0; idx < aa_vec.size(); ++idx) {
+        aa_vec[idx] = bb_vec[idx] + scalar * cc_vec[idx];
+    }
+}
+
+__attribute__((noinline))
+void warmup(std::vector<double> &aa_vec,
+            const std::vector<double> &bb_vec,
+            const std::vector<double> &cc_vec)
+{
+    double scalar = 3.0;
+#pragma omp parallel for
+    for (size_t idx = 0; idx < aa_vec.size(); ++idx) {
+        aa_vec[idx] = bb_vec[idx] + scalar * cc_vec[idx];
+    }
+}
+
+__attribute__((noinline))
+void loop_dgemm_with_post(double big_o, int count)
+{
+#pragma omp parallel
+{
+    std::shared_ptr<geopm::ModelRegion> dgemm_model(
+        geopm::ModelRegion::model_region("dgemm-unmarked", big_o, false));
+#pragma omp for
+    for (size_t idx = 0; idx < count; ++idx) {
+        geopm_tprof_post();
+        dgemm_model->run();
+    }
+}
+}
+
+__attribute__((noinline))
+void loop_dgemm_no_post(double big_o, int count)
+{
+#pragma omp parallel
+{
+    std::shared_ptr<geopm::ModelRegion> dgemm_model(
+        geopm::ModelRegion::model_region("dgemm-unmarked", big_o, false));
+#pragma omp for
+    for (size_t idx = 0; idx < count; ++idx) {
+        dgemm_model->run();
+    }
+}
+}
+
+__attribute__((noinline))
+void loop_dgemm_warmup(double big_o, int count)
+{
+#pragma omp parallel
+{
+    std::shared_ptr<geopm::ModelRegion> dgemm_model(
+        geopm::ModelRegion::model_region("dgemm-unmarked", big_o, false));
+#pragma omp for
+    for (size_t idx = 0; idx < count; ++idx) {
+        dgemm_model->run();
+    }
+}
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    int vec_size = 134217728; // 1 GiB
+
+    std::vector<double> aa_vec(vec_size);
+    std::vector<double> bb_vec(vec_size);
+    std::vector<double> cc_vec(vec_size);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    setup(aa_vec, bb_vec, cc_vec);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    warmup(aa_vec, bb_vec, cc_vec);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    triad_with_post(aa_vec, bb_vec, cc_vec);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    triad_no_post(aa_vec, bb_vec, cc_vec);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    loop_dgemm_warmup(0.01, 100);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    loop_dgemm_with_post(0.01, 10000);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    loop_dgemm_no_post(0.01, 10000);
+
+    MPI_Finalize();
+    return 0;
+}

--- a/integration/test/test_progress.mk
+++ b/integration/test/test_progress.mk
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 #  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -31,37 +29,15 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
+EXTRA_DIST += integration/test/test_progress.py
 
-import sys
-import os
-import unittest
-
-from geopm_test_integration import *
-from test_omp_outer_loop import *
-from test_ee_timed_scaling_mix import *
-from test_enforce_policy import *
-from test_profile_policy import *
-from test_plugin_static_policy import *
-from test_power_balancer import *
-from test_tutorial_base import *
-from test_frequency_hint_usage import *
-from test_scaling_region import *
-from test_timed_scaling_region import *
-from test_profile_overflow import *
-from test_trace import *
-from test_monitor import *
-from test_geopmio import *
-from test_ompt import *
-from test_launch_application import *
-from test_launch_pthread import *
-from test_geopmagent import *
-from test_environment import *
-from test_power_governor import *
-from test_frequency_map import *
-from test_hint_time import *
-from test_progress import *
-
-
-if __name__ == '__main__':
-    unittest.main()
+if ENABLE_MPI
+noinst_PROGRAMS += integration/test/test_progress
+integration_test_test_progress_SOURCES = integration/test/test_progress.cpp
+integration_test_test_progress_SOURCES += $(model_source_files)
+integration_test_test_progress_LDADD = libgeopm.la $(MATH_LIB) $(MPI_CLIBS)
+integration_test_test_progress_LDFLAGS = $(AM_LDFLAGS) $(MPI_CLDFLAGS) $(MATH_CLDFLAGS)
+integration_test_test_progress_CXXFLAGS = $(AM_CXXFLAGS) $(MPI_CFLAGS) -D_GNU_SOURCE -std=c++11 $(MATH_CFLAGS)
+else
+EXTRA_DIST += integration/test/test_progress.cpp
+endif

--- a/integration/test/test_progress.py
+++ b/integration/test/test_progress.py
@@ -163,7 +163,9 @@ class TestIntegration_progress(unittest.TestCase):
             msg: Error message to include with any failures
 
         """
-        good_idx = numpy.isfinite(progress)
+        # Get rid of nan values and values
+        good_idx = numpy.isfinite(progress) & ~numpy.isin(progress, expected_max)
+        self.assertLess(len(progress) * 0.6, sum(good_idx))
         progress = progress[good_idx]
         time = time[good_idx]
         poly_out = numpy.polyfit(time,

--- a/integration/test/test_progress.py
+++ b/integration/test/test_progress.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+import unittest
+import os
+import pandas
+import numpy
+import socket
+import matplotlib.pyplot as plt
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from integration.test import geopm_context
+from integration.test import util
+import geopmpy.io
+import geopmpy.hash
+from integration.experiment import machine
+import geopm_test_launcher
+
+
+class AppConf(object):
+    """Class that is used by the test launcher in place of a
+    geopmpy.io.BenchConf when running the progress benchmark.
+
+    """
+    def write(self):
+        """Called by the test launcher prior to executing the test application
+        to write any files required by the application.
+
+        """
+        pass
+
+    def get_exec_path(self):
+        """Path to benchmark filled in by template automatically.
+
+        """
+        return util.get_exec_path('test_progress')
+
+    def get_exec_args(self):
+        """Returns a list of strings representing the command line arguments
+        to pass to the test-application for the next run.  This is
+        especially useful for tests that execute the test-application
+        multiple times.
+
+        """
+        return []
+
+
+class TestIntegration_progress(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Create launcher, execute benchmark and set up class variables.
+
+        """
+        sys.stdout.write('(' + os.path.basename(__file__).split('.')[0] +
+                         '.' + cls.__name__ + ') ...')
+        cls._test_name = 'test_progress'
+        cls._report_path = '{}.report'.format(cls._test_name)
+        cls._trace_path = '{}.trace'.format(cls._test_name)
+        cls._agent_conf_path = cls._test_name + '-agent-config.json'
+        # Clear out exception record for python 2 support
+        geopmpy.error.exc_clear()
+
+        # Create machine
+        cls._machine = machine.Machine()
+        try:
+            cls._machine.load()
+            sys.stderr.write('Warning: {}: using existing file "machine.json", delete if invalid\n'.format(cls._test_name))
+        except RuntimeError:
+            cls._machine.save()
+
+        # Set the job size parameters
+        cls._num_node = 1
+        cls._num_rank = 10
+        cls._num_active_cpu = cls._machine.num_core() - 2 * cls._machine.num_package()
+        cls._thread_per_rank = int(cls._num_active_cpu / cls._num_rank)
+
+        app_conf = AppConf()
+
+        trace_signals = 'REGION_PROGRESS@cpu'
+        agent_conf = geopmpy.io.AgentConf(cls._test_name + '_agent.config')
+
+        # Create the test launcher with the above configuration
+        launcher = geopm_test_launcher.TestLauncher(app_conf=app_conf,
+                                                    agent_conf=agent_conf,
+                                                    report_path=cls._report_path,
+                                                    trace_path=cls._trace_path,
+                                                    trace_signals=trace_signals)
+        launcher.set_num_node(cls._num_node)
+        launcher.set_num_rank(cls._num_rank)
+        # Run the test application
+        launcher.run(cls._test_name)
+
+        # Output to be reused by all tests
+        cls._report = geopmpy.io.RawReport(cls._report_path)
+        cls._trace = geopmpy.io.AppOutput(cls._trace_path + '*')
+
+    def get_hash(self, function_name):
+        host = self._report.host_names()[0]
+        region_names = self._report.region_names(host)
+        full_name = [rn for rn in region_names if function_name in rn]
+        if len(full_name) != 1:
+            raise RuntimeError("Single match not found for {}".format(function_name))
+        return hex(self._report.raw_region(host, full_name[0])['hash'])
+
+    def check_progress(self, time, progress, expected_max, msg):
+        poly_out = numpy.polyfit(time,
+                                 progress,
+                                 1, full=True)
+        min_prog = min(progress)
+        max_prog = max(progress)
+        epsilon = 0.05
+        abs_epsilon = epsilon * expected_max
+        self.assertLessEqual(0.0, min_prog)
+        util.assertNear(self, 0.0, min_prog, epsilon=abs_epsilon,
+                        msg='{}: minimum value'.format(msg))
+        util.assertNear(self, expected_max, max_prog, epsilon=epsilon,
+                        msg='{}: maximum value'.format(msg))
+        # Assert that the expected deviation from the fit is is no
+        # larger than 1%.
+        rr = max_prog - min_prog
+        error = (poly_out[1][0] / len(progress)) ** 0.5 / rr
+        self.assertLess(error, 0.01, msg)
+
+    def sum_progress(self, cpu_wp, df):
+        result = numpy.zeros(len(df))
+        for cpu in cpu_wp:
+            name = 'REGION_PROGRESS-cpu-{}'.format(cpu)
+            result += df[name]
+        return result
+
+    def test_num_host(self):
+        host_names = self._report.host_names()
+        self.assertEqual(len(host_names), self._num_node)
+
+    def get_cpu_with_progress(self):
+        df = self._trace.get_trace_df()
+        result = set()
+        for cpu in range(self._machine.num_cpu()):
+            name = 'REGION_PROGRESS-cpu-{}'.format(cpu)
+            if len(df[name].unique()) > 1:
+                result.add(cpu)
+        return result
+
+    def test_num_active_cpu(self):
+        cpu_with_progress = self.get_cpu_with_progress()
+        err_msg ='CPUs with progress:\n    {}\n'.format(cpu_with_progress)
+        self.assertEqual(self._num_active_cpu, len(cpu_with_progress),
+                         msg=err_msg)
+
+    def test_linear_progress_triad(self):
+        df = self._trace.get_trace_df()
+        grouped_df = df.groupby('REGION_HASH')
+        cpu_with_progress = self.get_cpu_with_progress()
+        max_progress = 1.0 / self._thread_per_rank
+
+        triad_post_hash = self.get_hash('triad_with_post')
+        triad_post_df = grouped_df.get_group(triad_post_hash)
+        total_progress = self.sum_progress(cpu_with_progress, triad_post_df)
+        err_msg = 'Bad fit for triad total proggress'
+        self.check_progress(triad_post_df['TIME'],
+                            total_progress,
+                            self._num_rank,
+                            err_msg)
+        for cpu in cpu_with_progress:
+            name = 'REGION_PROGRESS-cpu-{}'.format(cpu)
+            err_msg = 'Bad fit for triad cpu {} proggress'.format(cpu)
+            self.check_progress(triad_post_df['TIME'],
+                                triad_post_df[name],
+                                max_progress,
+                                err_msg)
+
+    def test_linear_progress_dgemm(self):
+        df = self._trace.get_trace_df()
+        grouped_df = df.groupby('REGION_HASH')
+        cpu_with_progress = self.get_cpu_with_progress()
+        max_progress = 1.0 / self._thread_per_rank
+
+        dgemm_post_hash = self.get_hash('dgemm_with_post')
+        dgemm_post_df = grouped_df.get_group(dgemm_post_hash)
+        total_progress = self.sum_progress(cpu_with_progress, dgemm_post_df)
+        err_msg = 'Bad fit for dgemm total proggress'
+        self.check_progress(dgemm_post_df['TIME'],
+                            total_progress,
+                            self._num_rank,
+                            err_msg)
+        for cpu in cpu_with_progress:
+            name = 'REGION_PROGRESS-cpu-{}'.format(cpu)
+            err_msg = 'Bad fit for dgemm cpu {} proggress'.format(cpu)
+            self.check_progress(dgemm_post_df['TIME'],
+                                dgemm_post_df[name],
+                                max_progress,
+                                err_msg)
+
+    def test_zero_progress(self):
+        df = self._trace.get_trace_df()
+        grouped_df = df.groupby('REGION_HASH')
+        cpu_with_progress = self.get_cpu_with_progress()
+
+        triad_post_hash = self.get_hash('triad_with_post')
+        dgemm_post_hash = self.get_hash('dgemm_with_post')
+        unmarked_hash = hex(geopmpy.hash.crc32_str('GEOPM_REGION_HASH_UNMARKED'))
+        other_groups = [gg for gg in list(grouped_df.groups)
+                        if gg not in (triad_post_hash,
+                                      dgemm_post_hash,
+                                      unmarked_hash,
+                                      'NAN')]
+        for gg in other_groups:
+           for cpu in cpu_with_progress:
+               name = 'REGION_PROGRESS-cpu-{}'.format(cpu)
+               uu = grouped_df.get_group(gg)[name].dropna().unique()
+               if len(uu) != 0:
+                   err_msg = 'Expected all zero, group {} had {}'.format(gg, uu)
+                   self.assertEqual(1, len(uu), msg=err_msg)
+                   self.assertEqual(0.0, uu[0], msg=err_msg)
+
+        self.assertLessEqual(0, min(df['REGION_PROGRESS'].dropna()))
+        self.assertGreaterEqual(1.0, max(df['REGION_PROGRESS'].dropna()))
+
+    def check_overhead(self, key, epsilon):
+        for host in self._report.host_names():
+            region_names = self._report.region_names(host)
+            ref_energy = None
+            ref_time = None
+            actual_energy = None
+            actual_time = None
+            for rn in region_names:
+                if '{}_no_post'.format(key) in rn:
+                    raw_region = self._report.raw_region(host, rn)
+                    ref_energy = raw_region['package-energy (J)']
+                    ref_time = raw_region['runtime (s)']
+                elif '{}_with_post'.format(key) in rn:
+                    raw_region = self._report.raw_region(host, rn)
+                    actual_energy = raw_region['package-energy (J)']
+                    actual_time = raw_region['runtime (s)']
+            self.assertTrue(ref_energy is not None,
+                            'Reference energy not found for {}'.format(key))
+            self.assertTrue(ref_time is not None,
+                            'Reference time not found for {}'.format(key))
+            self.assertTrue(actual_energy is not None,
+                            'Actual energy not found for {}'.format(key))
+            self.assertTrue(actual_time is not None,
+                            'Actual time not found for {}'.format(key))
+            util.assertNear(self, ref_energy, actual_energy, epsilon=epsilon,
+                            msg='Energy overhead of post for {} is too high'.format(key))
+            util.assertNear(self, ref_time, actual_time, epsilon=epsilon,
+                            msg='Time overhead of post for {} is too high'.format(key))
+
+    def test_overhead_dgemm(self):
+        self.check_overhead('dgemm', 0.05)
+
+    def test_overhead_triad(self):
+        self.check_overhead('triad', 1.5)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/integration/test/test_progress.py
+++ b/integration/test/test_progress.py
@@ -90,12 +90,7 @@ class TestIntegration_progress(unittest.TestCase):
         geopmpy.error.exc_clear()
 
         # Create machine
-        cls._machine = machine.Machine()
-        try:
-            cls._machine.load()
-            sys.stderr.write('Warning: {}: using existing file "machine.json", delete if invalid\n'.format(cls._test_name))
-        except RuntimeError:
-            cls._machine.save()
+        cls._machine = machine.try_machine('.', cls._test_name)
 
         # Set the job size parameters
         cls._num_node = 1
@@ -228,8 +223,9 @@ class TestIntegration_progress(unittest.TestCase):
         self.assertLessEqual(0, min(progress.diff()[1:]), err_msg)
 
     def test_linear_progress_triad(self):
-        """Test that the triad region with with the post reports progress that
-        is well behaved for all CPUs and also collectively.
+        """Test that the triad region with the geopm_tprof_post() call reports
+        progress that is well behaved for all CPUs and also
+        collectively.
 
         """
         triad_post_hash = self.get_hash('triad_with_post')
@@ -248,8 +244,9 @@ class TestIntegration_progress(unittest.TestCase):
                                 err_msg)
 
     def test_linear_progress_dgemm(self):
-        """Test that the dgemm region with with the post reports progress that
-        is well behaved for all CPUs and also collectively.
+        """Test that the dgemm region with the calls to geopm_tprof_post()
+        reports progress that is well behaved for all CPUs and also
+        collectively.
 
         """
         dgemm_post_hash = self.get_hash('dgemm_with_post')
@@ -342,8 +339,8 @@ class TestIntegration_progress(unittest.TestCase):
         self.check_overhead('dgemm', 0.05)
 
     def test_overhead_triad(self):
-        """Test that the overhead not huge for triad which does only 3
-        operations per work chunk (FMA,add,store).
+        """Test that the overhead is not huge for triad which does only 3
+        operations per work chunk (FMA, add, and store).
 
         """
         self.check_overhead('triad', 2.0)

--- a/integration/test/util.py
+++ b/integration/test/util.py
@@ -142,6 +142,24 @@ def get_config_value(key):
                 return line[len(line_start):-len(line_end)]
     return None
 
+def get_exec_path(bin_name):
+    """Find test binary
+
+    """
+    path_list = []
+    int_test_dir = os.path.dirname(os.path.realpath(__file__))
+    path_list.append(os.path.join(int_test_dir, '.libs'))
+    int_dir = os.path.dirname(int_test_dir)
+    # Look for out of place build from using apps/build_func.sh
+    path_list.append(os.path.join(int_dir, 'build/integration/test/.libs'))
+    bin_list = [os.path.join(pp, bin_name) for pp in path_list]
+    for bb in bin_list:
+        if os.path.exists(bb):
+            return bb
+
+    sep = '\n    '
+    msg = 'Could not find application binary, tried {}{}'.format(sep, sep.join(bin_list))
+    raise RuntimeError(msg)
 
 def skip_unless_config_enable(feature):
     if get_config_value('enable_{}'.format(feature)) == '1':

--- a/integration/test/util.py
+++ b/integration/test/util.py
@@ -123,7 +123,7 @@ def get_config_log():
              os.path.dirname(
               os.path.realpath(__file__)))),
            'config.log')
-    if not os.path.exists(path):
+    if not os.path.isfile(path):
         path = os.path.join(
                os.path.dirname(path),
                 'integration/build/config.log')
@@ -154,7 +154,7 @@ def get_exec_path(bin_name):
     path_list.append(os.path.join(int_dir, 'build/integration/test/.libs'))
     bin_list = [os.path.join(pp, bin_name) for pp in path_list]
     for bb in bin_list:
-        if os.path.exists(bb):
+        if os.path.isfile(bb):
             return bb
 
     sep = '\n    '

--- a/scripts/test/TestAgent.py
+++ b/scripts/test/TestAgent.py
@@ -51,7 +51,7 @@ class TestAgent(unittest.TestCase):
 
     def test_agent_names(self):
         names = geopmpy.agent.names()
-        expected = set(['energy_efficient', 'power_balancer', 'power_governor',
+        expected = set(['power_balancer', 'power_governor',
                         'frequency_map', 'monitor'])
         self.assertEqual(expected, set(names))
 

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -41,6 +41,7 @@
 #include "Exception.hpp"
 #include "geopm_debug.hpp"
 
+
 namespace geopm
 {
 
@@ -159,8 +160,7 @@ namespace geopm
 
         }
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
-        // completed_work must be written first to prevent invalid
-        // progress in case of a race
+        // total_work non-zero gates per thread use of completed_work
         m_buffer[cpu_idx].total_work = work_units;
     }
 

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -76,7 +76,6 @@ namespace geopm
         // initialize shmem if all zero is not appropriate
         for (int cpu = 0; cpu < m_num_cpu; ++cpu) {
             set_process({cpu}, -1);
-            reset_work_units(cpu);
         }
         update_cache();
     }

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -143,10 +143,8 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
-        // completed_work must be written first to prevent invalid
-        // progress in case of a race
-        m_buffer[cpu_idx].completed_work = 0;
         m_buffer[cpu_idx].total_work = 0;
+        m_buffer[cpu_idx].completed_work = 0;
     }
 
     void ApplicationStatusImp::set_total_work_units(int cpu_idx, int work_units)
@@ -174,7 +172,9 @@ namespace geopm
         }
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
 
-        m_buffer[cpu_idx].completed_work += 1;
+        if (m_buffer[cpu_idx].total_work != 0) {
+            ++(m_buffer[cpu_idx].completed_work);
+        }
     }
 
     double ApplicationStatusImp::get_progress_cpu(int cpu_idx) const
@@ -187,7 +187,7 @@ namespace geopm
                            "Memory for m_cache not sized correctly");
         double result = NAN;
         int total_work = m_cache[cpu_idx].total_work;
-        if (total_work > 0) {
+        if (total_work != 0) {
             result = (double)m_cache[cpu_idx].completed_work / total_work;
         }
         return result;

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -174,12 +174,6 @@ namespace geopm
         }
         GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
 
-        // only this thread is writing, so don't need to lock
-        if (m_buffer[cpu_idx].completed_work >= m_buffer[cpu_idx].total_work) {
-            throw Exception("ApplicationStatusImp::increment_work_unit(): more increments than total work",
-                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
-
-        }
         m_buffer[cpu_idx].completed_work += 1;
     }
 

--- a/src/ApplicationStatus.hpp
+++ b/src/ApplicationStatus.hpp
@@ -71,6 +71,7 @@ namespace geopm
             /// @brief Get the hash of the region currently running on
             ///        a CPU.
             virtual uint64_t get_hash(int cpu_idx) const = 0;
+            virtual void reset_work_units(int cpu_idx) = 0;
             /// @brief Reset the total work units for all threads to
             ///        be completed as part of a parallel region.
             ///        Calling this method also resets the work
@@ -140,6 +141,7 @@ namespace geopm
             uint64_t get_hint(int cpu_idx) const override;
             void set_hash(int cpu_idx, uint64_t hash) override;
             uint64_t get_hash(int cpu_idx) const override;
+            void reset_work_units(int cpu_idx) override;
             void set_total_work_units(int cpu_idx, int work_units) override;
             void increment_work_unit(int cpu_idx) override;
             double get_progress_cpu(int cpu_idx) const override;

--- a/src/DGEMMModelRegion.cpp
+++ b/src/DGEMMModelRegion.cpp
@@ -98,9 +98,9 @@ namespace geopm
 
     void DGEMMModelRegion::big_o(double big_o_in)
     {
-        geopm::Profile &prof = geopm::Profile::default_profile();
-        uint64_t start_rid = prof.region("geopm_dgemm_model_region_startup", GEOPM_REGION_HINT_IGNORE);
-        prof.enter(start_rid);
+        uint64_t start_rid = 0;
+        geopm_prof_region("geopm_dgemm_model_region_startup", GEOPM_REGION_HINT_IGNORE, &start_rid);
+        geopm_prof_enter(start_rid);
 
         if (m_big_o && m_big_o != big_o_in) {
             free(m_matrix_c);
@@ -131,7 +131,7 @@ namespace geopm
             }
         }
         m_big_o = big_o_in;
-        prof.exit(start_rid);
+        geopm_prof_exit(start_rid);
     }
 
     void DGEMMModelRegion::run(void)

--- a/src/DefaultProfile.cpp
+++ b/src/DefaultProfile.cpp
@@ -185,8 +185,7 @@ extern "C"
         int err = 0;
         if (g_pmpi_tprof_enabled) {
             try {
-                int cpu = geopm::Profile::get_cpu();
-                geopm::Profile::default_profile().thread_init(cpu, num_work_unit);
+                geopm::Profile::default_profile().thread_init(num_work_unit);
             }
             catch (...) {
                 err = geopm::exception_handler(std::current_exception());

--- a/src/DefaultProfile.cpp
+++ b/src/DefaultProfile.cpp
@@ -183,14 +183,14 @@ extern "C"
     int geopm_tprof_init(uint32_t num_work_unit)
     {
         int err = 0;
-        try {
-            auto &prof = geopm::Profile::default_profile();
-            if (g_pmpi_prof_enabled) {
-                prof.thread_init(num_work_unit);
+        // Only the lead thread calls through to thread_init()
+        if (g_pmpi_prof_enabled) {
+            try {
+                geopm::Profile::default_profile().thread_init(num_work_unit);
             }
-        }
-        catch (...) {
-            err = geopm::exception_handler(std::current_exception());
+            catch (...) {
+                err = geopm::exception_handler(std::current_exception());
+            }
         }
         return err;
     }
@@ -198,6 +198,7 @@ extern "C"
     int geopm_tprof_post(void)
     {
         int err = 0;
+        // All threads call through to thread_post()
         if (g_pmpi_tprof_enabled) {
             try {
                 int cpu = geopm::Profile::get_cpu();

--- a/src/DefaultProfile.cpp
+++ b/src/DefaultProfile.cpp
@@ -183,13 +183,17 @@ extern "C"
     int geopm_tprof_init(uint32_t num_work_unit)
     {
         int err = 0;
-        if (g_pmpi_tprof_enabled) {
-            try {
-                geopm::Profile::default_profile().thread_init(num_work_unit);
+        try {
+            auto &prof = geopm::Profile::default_profile();
+            if (g_pmpi_tprof_enabled) {
+                prof.thread_init(geopm::Profile::get_cpu());
             }
-            catch (...) {
-                err = geopm::exception_handler(std::current_exception());
+            if (g_pmpi_prof_enabled) {
+                prof.thread_work(num_work_unit);
             }
+        }
+        catch (...) {
+            err = geopm::exception_handler(std::current_exception());
         }
         return err;
     }

--- a/src/DefaultProfile.cpp
+++ b/src/DefaultProfile.cpp
@@ -185,11 +185,8 @@ extern "C"
         int err = 0;
         try {
             auto &prof = geopm::Profile::default_profile();
-            if (g_pmpi_tprof_enabled) {
-                prof.thread_init(geopm::Profile::get_cpu());
-            }
             if (g_pmpi_prof_enabled) {
-                prof.thread_work(num_work_unit);
+                prof.thread_init(num_work_unit);
             }
         }
         catch (...) {

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -534,16 +534,7 @@ namespace geopm
 
     }
 
-    void ProfileImp::thread_init(int cpu)
-    {
-        if (!m_is_enabled) {
-            return;
-        }
-
-        m_app_status->reset_work_units(cpu);
-    }
-
-    void ProfileImp::thread_work(uint32_t num_work_unit)
+    void ProfileImp::thread_init(uint32_t num_work_unit)
     {
         if (!m_is_enabled) {
             return;

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -536,7 +536,7 @@ namespace geopm
 
     void ProfileImp::thread_init(uint32_t num_work_unit)
     {
-        if (!m_is_enabled) {
+        if (!m_is_enabled || num_work_unit <= 1) {
             return;
         }
 

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -536,6 +536,8 @@ namespace geopm
 
     void ProfileImp::thread_init(uint32_t num_work_unit)
     {
+        // Ignore calls with num_work_unit set to 1: work cannot be
+        // shared between threads.
         if (!m_is_enabled || num_work_unit <= 1) {
             return;
         }

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -500,6 +500,7 @@ namespace geopm
                 // region.
                 m_app_status->set_total_work_units(cpu, 0);
             }
+
         }
         else {
             // still nested, restore previous hint
@@ -536,13 +537,15 @@ namespace geopm
 
     }
 
-    void ProfileImp::thread_init(int cpu, uint32_t num_work_unit)
+    void ProfileImp::thread_init(uint32_t num_work_unit)
     {
         if (!m_is_enabled) {
             return;
         }
 
-        m_app_status->set_total_work_units(cpu, num_work_unit);
+        for (const auto &cpu : m_cpu_set) {
+            m_app_status->set_total_work_units(cpu, num_work_unit);
+        }
     }
 
     void ProfileImp::thread_post(int cpu)

--- a/src/Profile.hpp
+++ b/src/Profile.hpp
@@ -148,20 +148,27 @@ namespace geopm
             /// application.
             virtual void epoch(void) = 0;
             virtual void shutdown(void) = 0;
-            /// @brief Update the total work for one CPU and reset the
-            ///        work completed.  This method should be called
-            ///        by all threads in the same parallel region with
-            ///        the total expected to be completed by the
-            ///        entire group.
-            /// @param [in] cpu The Linux logical CPU obtained with
-            ///             get_cpu().
+            /// @brief Update the total work for all CPUs. This method
+            ///        should be called by one thread in the same
+            ///        parallel region with the total work units
+            ///        expected to be completed by the entire group.
+            ///
             /// @param [in] num_work_unit The total work units for all
-            ///             threads in the same parallel region.
-            virtual void thread_init(uint32_t num_work_unit) = 0;
+            ///        threads in the same parallel region.
+            virtual void thread_work(uint32_t num_work_unit) = 0;
+            /// @brief Reset the total amount of work completed by a
+            ///        CPU.  This should be called by each thread in
+            ///        the parallel region prior to the first call to
+            ///        thread_post().
+            ///
+            /// @param [in] cpu The Linux logical CPU obtained with
+            ///        get_cpu().
+            virtual void thread_init(int cpu) = 0;
             /// @brief Mark one unit of work completed by the thread
             ///        on this CPU.
+            //
             /// @param [in] cpu The Linux logical CPU obtained with
-            ///             get_cpu().
+            ///        get_cpu().
             virtual void thread_post(int cpu) = 0;
 
             virtual void enable_pmpi(void) = 0;
@@ -240,7 +247,8 @@ namespace geopm
             void exit(uint64_t region_id) override;
             void epoch(void) override;
             void shutdown(void) override;
-            void thread_init(uint32_t num_work_unit) override;
+            void thread_init(int cpu) override;
+            void thread_work(uint32_t num_work_unit) override;
             void thread_post(int cpu) override;
             virtual void enable_pmpi(void) override;
         protected:

--- a/src/Profile.hpp
+++ b/src/Profile.hpp
@@ -157,7 +157,7 @@ namespace geopm
             ///             get_cpu().
             /// @param [in] num_work_unit The total work units for all
             ///             threads in the same parallel region.
-            virtual void thread_init(int cpu, uint32_t num_work_unit) = 0;
+            virtual void thread_init(uint32_t num_work_unit) = 0;
             /// @brief Mark one unit of work completed by the thread
             ///        on this CPU.
             /// @param [in] cpu The Linux logical CPU obtained with
@@ -240,7 +240,7 @@ namespace geopm
             void exit(uint64_t region_id) override;
             void epoch(void) override;
             void shutdown(void) override;
-            void thread_init(int cpu, uint32_t num_work_unit) override;
+            void thread_init(uint32_t num_work_unit) override;
             void thread_post(int cpu) override;
             virtual void enable_pmpi(void) override;
         protected:

--- a/src/Profile.hpp
+++ b/src/Profile.hpp
@@ -155,15 +155,7 @@ namespace geopm
             ///
             /// @param [in] num_work_unit The total work units for all
             ///        threads in the same parallel region.
-            virtual void thread_work(uint32_t num_work_unit) = 0;
-            /// @brief Reset the total amount of work completed by a
-            ///        CPU.  This should be called by each thread in
-            ///        the parallel region prior to the first call to
-            ///        thread_post().
-            ///
-            /// @param [in] cpu The Linux logical CPU obtained with
-            ///        get_cpu().
-            virtual void thread_init(int cpu) = 0;
+            virtual void thread_init(uint32_t num_work_unit) = 0;
             /// @brief Mark one unit of work completed by the thread
             ///        on this CPU.
             //
@@ -247,8 +239,7 @@ namespace geopm
             void exit(uint64_t region_id) override;
             void epoch(void) override;
             void shutdown(void) override;
-            void thread_init(int cpu) override;
-            void thread_work(uint32_t num_work_unit) override;
+            void thread_init(uint32_t num_work_unit) override;
             void thread_post(int cpu) override;
             virtual void enable_pmpi(void) override;
         protected:

--- a/src/ScalingModelRegion.cpp
+++ b/src/ScalingModelRegion.cpp
@@ -151,9 +151,9 @@ namespace geopm
             run_atom();
         }
 
-        geopm::Profile &prof = geopm::Profile::default_profile();
-        uint64_t start_rid = prof.region("geopm_scaling_model_region_startup", GEOPM_REGION_HINT_IGNORE);
-        prof.enter(start_rid);
+        uint64_t start_rid = 0;
+        geopm_prof_region("geopm_scaling_model_region_startup", GEOPM_REGION_HINT_IGNORE, &start_rid);
+        geopm_prof_enter(start_rid);
         m_big_o = big_o_in;
         size_t num_trial = 11;
         size_t median_idx = num_trial / 2;
@@ -172,7 +172,7 @@ namespace geopm
         m_num_atom = big_o_in / median_atom_time;
         m_num_atom = m_num_atom ? m_num_atom : 1;
         m_norm = 1.0 / m_num_atom;
-        prof.exit(start_rid);
+        geopm_prof_exit(start_rid);
     }
 
     void ScalingModelRegion::run(void)

--- a/src/StreamModelRegion.cpp
+++ b/src/StreamModelRegion.cpp
@@ -73,9 +73,9 @@ namespace geopm
 
     void StreamModelRegion::big_o(double big_o_in)
     {
-        geopm::Profile &prof = geopm::Profile::default_profile();
-        uint64_t start_rid = prof.region("geopm_stream_model_region_startup", GEOPM_REGION_HINT_IGNORE);
-        prof.enter(start_rid);
+        uint64_t start_rid = 0;
+        geopm_prof_region("geopm_stream_model_region_startup", GEOPM_REGION_HINT_IGNORE, &start_rid);
+        geopm_prof_enter(start_rid);
 
         if (m_big_o && m_big_o != big_o_in) {
             free(m_array_c);
@@ -107,7 +107,7 @@ namespace geopm
         }
         m_big_o = big_o_in;
 
-        prof.exit(start_rid);
+        geopm_prof_exit(start_rid);
     }
 
     void StreamModelRegion::run(void)

--- a/src/ompt_callback.cpp
+++ b/src/ompt_callback.cpp
@@ -65,7 +65,7 @@ extern "C"
                                    uint64_t count,
                                    const void *parallel_function)
     {
-        // Undertanding based on inpection of the values passed by the
+        // Understanding based on inpection of the values passed by the
         // intel compiler implementation when running a test:
         //
         // - The omp team leader calls this function with the "count"

--- a/src/ompt_callback.cpp
+++ b/src/ompt_callback.cpp
@@ -74,9 +74,7 @@ extern "C"
         //
         // - The omp non-lead threads call this function with "count"
         //   set to zero.
-        if (count != 0ULL) {
-            geopm_tprof_init(count);
-        }
+        geopm_tprof_init(count);
     }
 
     int ompt_initialize(ompt_function_lookup_t lookup,

--- a/src/ompt_callback.cpp
+++ b/src/ompt_callback.cpp
@@ -74,6 +74,10 @@ extern "C"
         //
         // - The omp non-lead threads call this function with "count"
         //   set to zero.
+        //
+        // - When independent work (e.g. not in a "#pragma omp for"
+        //   section) is executed in a parallel section this function
+        //   is called with count == 1.
         geopm_tprof_init(count);
     }
 

--- a/test/AgentFactoryTest.cpp
+++ b/test/AgentFactoryTest.cpp
@@ -105,7 +105,7 @@ TEST(AgentFactoryTest, static_info_governor)
     EXPECT_EQ(exp_policy, Agent::policy_names(agent_name));
 }
 
-TEST(AgentFactoryTest, static_info_energy_efficient)
+TEST(AgentFactoryTest, DISABLED_static_info_energy_efficient)
 {
     auto &factory = geopm::agent_factory();
     std::string agent_name = geopm::EnergyEfficientAgent::plugin_name();

--- a/test/ApplicationStatusTest.cpp
+++ b/test/ApplicationStatusTest.cpp
@@ -166,7 +166,9 @@ TEST_F(ApplicationStatusTest, hash)
 TEST_F(ApplicationStatusTest, work_progress)
 {
     // CPUs 2 and 3 are inactive, 0 work units
+    m_status->reset_work_units(0);
     m_status->set_total_work_units(0, 4);
+    m_status->reset_work_units(1);
     m_status->set_total_work_units(1, 8);
     m_status->update_cache();
     EXPECT_DOUBLE_EQ(0.000, m_status->get_progress_cpu(0));
@@ -201,15 +203,16 @@ TEST_F(ApplicationStatusTest, work_progress)
                                GEOPM_ERROR_RUNTIME, "more increments than total work");
 
     // reset progress
-    m_status->set_total_work_units(0, 8);
+    m_status->reset_work_units(0);
+    m_status->set_total_work_units(0, 1);
     m_status->update_cache();
     EXPECT_DOUBLE_EQ(0.00, m_status->get_progress_cpu(0));
 
     // leave region
-    m_status->set_total_work_units(0, 0);
-    m_status->set_total_work_units(1, 0);
-    m_status->set_total_work_units(2, 0);
-    m_status->set_total_work_units(3, 0);
+    m_status->reset_work_units(0);
+    m_status->reset_work_units(1);
+    m_status->reset_work_units(2);
+    m_status->reset_work_units(3);
     m_status->update_cache();
     EXPECT_TRUE(std::isnan(m_status->get_progress_cpu(0)));
     EXPECT_TRUE(std::isnan(m_status->get_progress_cpu(1)));
@@ -219,6 +222,8 @@ TEST_F(ApplicationStatusTest, work_progress)
     GEOPM_EXPECT_THROW_MESSAGE(m_status->get_progress_cpu(-1),
                                GEOPM_ERROR_INVALID, "invalid CPU index");
     GEOPM_EXPECT_THROW_MESSAGE(m_status->get_progress_cpu(99),
+                               GEOPM_ERROR_INVALID, "invalid CPU index");
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->reset_work_units(-1),
                                GEOPM_ERROR_INVALID, "invalid CPU index");
     GEOPM_EXPECT_THROW_MESSAGE(m_status->set_total_work_units(-1, 100),
                                GEOPM_ERROR_INVALID, "invalid CPU index");

--- a/test/ApplicationStatusTest.cpp
+++ b/test/ApplicationStatusTest.cpp
@@ -199,9 +199,6 @@ TEST_F(ApplicationStatusTest, work_progress)
     EXPECT_DOUBLE_EQ(1.000, m_status->get_progress_cpu(0));
     EXPECT_DOUBLE_EQ(0.500, m_status->get_progress_cpu(1));
 
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->increment_work_unit(0),
-                               GEOPM_ERROR_RUNTIME, "more increments than total work");
-
     // reset progress
     m_status->reset_work_units(0);
     m_status->set_total_work_units(0, 1);

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -56,7 +56,6 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/AgentFactoryTest.static_info_monitor \
               test/gtest_links/AgentFactoryTest.static_info_balancer \
               test/gtest_links/AgentFactoryTest.static_info_governor \
-              test/gtest_links/AgentFactoryTest.static_info_energy_efficient \
               test/gtest_links/AgentFactoryTest.static_info_frequency_map \
               test/gtest_links/AggTest.agg_function \
               test/gtest_links/AggTest.function_strings \

--- a/test/MockApplicationStatus.hpp
+++ b/test/MockApplicationStatus.hpp
@@ -48,6 +48,8 @@ class MockApplicationStatus : public geopm::ApplicationStatus
                      void(int cpu_idx, uint64_t hash));
         MOCK_CONST_METHOD1(get_hash,
                            uint64_t(int cpu_idx));
+        MOCK_METHOD1(reset_work_units,
+                     void(int cpu_idx));
         MOCK_METHOD2(set_total_work_units,
                      void(int cpu_idx, int work_units));
         MOCK_METHOD1(increment_work_unit,

--- a/test/ProfileTest.cpp
+++ b/test/ProfileTest.cpp
@@ -215,10 +215,9 @@ TEST_F(ProfileTest, progress_multithread)
         m_profile->enter(0xABCD);
     }
     {
-        EXPECT_CALL(*m_status, set_total_work_units(2, 5));
+        EXPECT_CALL(*m_status, set_total_work_units(2, 6));
         EXPECT_CALL(*m_status, set_total_work_units(3, 6));
-        m_profile->thread_init(2, 5);
-        m_profile->thread_init(3, 6);
+        m_profile->thread_init(6);
     }
     {
         EXPECT_CALL(*m_status, increment_work_unit(3));

--- a/test/ProfileTest.cpp
+++ b/test/ProfileTest.cpp
@@ -215,15 +215,9 @@ TEST_F(ProfileTest, progress_multithread)
         m_profile->enter(0xABCD);
     }
     {
-        EXPECT_CALL(*m_status, reset_work_units(2));
-        EXPECT_CALL(*m_status, reset_work_units(3));
-        m_profile->thread_init(2);
-        m_profile->thread_init(3);
-    }
-    {
         EXPECT_CALL(*m_status, set_total_work_units(2, 6));
         EXPECT_CALL(*m_status, set_total_work_units(3, 6));
-        m_profile->thread_work(6);
+        m_profile->thread_init(6);
     }
     {
         EXPECT_CALL(*m_status, increment_work_unit(3));

--- a/test/ProfileTest.cpp
+++ b/test/ProfileTest.cpp
@@ -144,8 +144,8 @@ TEST_F(ProfileTest, enter_exit)
     EXPECT_CALL(*m_status, set_hint(2, GEOPM_REGION_HINT_UNSET));
     EXPECT_CALL(*m_status, set_hint(3, GEOPM_REGION_HINT_UNSET));
     // progress is cleared when exiting top-level region
-    EXPECT_CALL(*m_status, set_total_work_units(2, 0));
-    EXPECT_CALL(*m_status, set_total_work_units(3, 0));
+    EXPECT_CALL(*m_status, reset_work_units(2));
+    EXPECT_CALL(*m_status, reset_work_units(3));
 
     m_profile->exit(region_id);
 }
@@ -193,8 +193,8 @@ TEST_F(ProfileTest, enter_exit_nested)
         EXPECT_CALL(*m_status, set_hash(3, GEOPM_REGION_HASH_UNMARKED));
         EXPECT_CALL(*m_status, set_hint(2, GEOPM_REGION_HINT_UNSET));
         EXPECT_CALL(*m_status, set_hint(3, GEOPM_REGION_HINT_UNSET));
-        EXPECT_CALL(*m_status, set_total_work_units(2, 0));
-        EXPECT_CALL(*m_status, set_total_work_units(3, 0));
+        EXPECT_CALL(*m_status, reset_work_units(2));
+        EXPECT_CALL(*m_status, reset_work_units(3));
         m_profile->exit(usr_region_id);
     }
 }
@@ -215,9 +215,15 @@ TEST_F(ProfileTest, progress_multithread)
         m_profile->enter(0xABCD);
     }
     {
+        EXPECT_CALL(*m_status, reset_work_units(2));
+        EXPECT_CALL(*m_status, reset_work_units(3));
+        m_profile->thread_init(2);
+        m_profile->thread_init(3);
+    }
+    {
         EXPECT_CALL(*m_status, set_total_work_units(2, 6));
         EXPECT_CALL(*m_status, set_total_work_units(3, 6));
-        m_profile->thread_init(6);
+        m_profile->thread_work(6);
     }
     {
         EXPECT_CALL(*m_status, increment_work_unit(3));
@@ -235,8 +241,8 @@ TEST_F(ProfileTest, progress_multithread)
         EXPECT_CALL(*m_status, set_hash(_, _)).Times(2);
         EXPECT_CALL(*m_status, set_hint(_, _)).Times(2);
         // clear progress when exiting
-        EXPECT_CALL(*m_status, set_total_work_units(2, 0));
-        EXPECT_CALL(*m_status, set_total_work_units(3, 0));
+        EXPECT_CALL(*m_status, reset_work_units(2));
+        EXPECT_CALL(*m_status, reset_work_units(3));
         m_profile->exit(0xABCD);
     }
     // TODO: make it an error to set values for other CPUs not

--- a/test/ProfileTestIntegration.cpp
+++ b/test/ProfileTestIntegration.cpp
@@ -309,7 +309,9 @@ TEST_F(ProfileTestIntegration, epoch)
 TEST_F(ProfileTestIntegration, progress_multithread)
 {
     m_profile->enter(0xABCD);
-    m_profile->thread_init(8);
+    m_profile->thread_init(2);
+    m_profile->thread_init(3);
+    m_profile->thread_work(8);
     m_ctl_status->update_cache();
     EXPECT_EQ(0.0, m_ctl_status->get_progress_cpu(2));
     EXPECT_EQ(0.0, m_ctl_status->get_progress_cpu(3));

--- a/test/ProfileTestIntegration.cpp
+++ b/test/ProfileTestIntegration.cpp
@@ -309,9 +309,7 @@ TEST_F(ProfileTestIntegration, epoch)
 TEST_F(ProfileTestIntegration, progress_multithread)
 {
     m_profile->enter(0xABCD);
-    m_profile->thread_init(2);
-    m_profile->thread_init(3);
-    m_profile->thread_work(8);
+    m_profile->thread_init(8);
     m_ctl_status->update_cache();
     EXPECT_EQ(0.0, m_ctl_status->get_progress_cpu(2));
     EXPECT_EQ(0.0, m_ctl_status->get_progress_cpu(3));

--- a/test/ProfileTestIntegration.cpp
+++ b/test/ProfileTestIntegration.cpp
@@ -309,31 +309,33 @@ TEST_F(ProfileTestIntegration, epoch)
 TEST_F(ProfileTestIntegration, progress_multithread)
 {
     m_profile->enter(0xABCD);
-    m_profile->thread_init(2, 4);
-    m_profile->thread_init(3, 8);
+    m_profile->thread_init(8);
+    m_ctl_status->update_cache();
+    EXPECT_EQ(0.0, m_ctl_status->get_progress_cpu(2));
+    EXPECT_EQ(0.0, m_ctl_status->get_progress_cpu(3));
 
     m_profile->thread_post(3);
     m_profile->thread_post(2);
     m_ctl_status->update_cache();
-    EXPECT_EQ(0.25, m_ctl_status->get_progress_cpu(2));
+    EXPECT_EQ(0.125, m_ctl_status->get_progress_cpu(2));
     EXPECT_EQ(0.125, m_ctl_status->get_progress_cpu(3));
 
     m_profile->thread_post(3);
     m_ctl_status->update_cache();
-    EXPECT_EQ(0.25, m_ctl_status->get_progress_cpu(2));
+    EXPECT_EQ(0.125, m_ctl_status->get_progress_cpu(2));
     EXPECT_EQ(0.25, m_ctl_status->get_progress_cpu(3));
 
     m_profile->thread_post(2);
     m_profile->thread_post(2);
     m_profile->thread_post(3);
     m_ctl_status->update_cache();
-    EXPECT_EQ(0.75, m_ctl_status->get_progress_cpu(2));
+    EXPECT_EQ(0.375, m_ctl_status->get_progress_cpu(2));
     EXPECT_EQ(0.375, m_ctl_status->get_progress_cpu(3));
 
     m_profile->thread_post(3);
     m_profile->thread_post(2);
     m_ctl_status->update_cache();
-    EXPECT_EQ(1.0, m_ctl_status->get_progress_cpu(2));
+    EXPECT_EQ(0.5, m_ctl_status->get_progress_cpu(2));
     EXPECT_EQ(0.5, m_ctl_status->get_progress_cpu(3));
     m_profile->exit(0xABCD);
 }


### PR DESCRIPTION
- The ompt callback "dispatch" does not seem to be active.
- The ompt work callback does seem to be active
- [x] TODO: remove dispatch callback until it can be tested
- [x] TODO: validate that the work callback is doing exactly what is expected
- [x] TODO: Add loose assertions about total runtime of the test_progress run
- [x] TODO: Add assertions that the progress signal goes up twice
- [x] TODO: Add assertions that the progress signal is monotone within each OMPT detected region
- [x] TODO: Clean up history