### PR TITLE
Avoid division by zero explicitly

### DIFF
--- a/src/PowerBalancerAgent.cpp
+++ b/src/PowerBalancerAgent.cpp
@@ -516,7 +516,10 @@ namespace geopm
         for (auto &balancer : role.m_power_balancer) {
             double headroom = role.M_MAX_PKG_POWER_SETTING -
                               (balancer->power_limit() + even_slack);
-            double factor = headroom / total_headroom;
+            double factor = 1.0;
+            if (total_headroom != 0.0) {
+                factor = headroom / total_headroom;
+            }
             double cap = balancer->power_limit() + even_slack + factor * slack_power;
             balancer->power_cap(cap);
         }


### PR DESCRIPTION
- I do not think that total_headroom can be zero, but lets be explicit.
- Fixes #1572 where other issues were false positives.