### PR TITLE
Add an interface between generic GEOPM signals and the interfaces from SSTIO

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -590,6 +590,8 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/SSTIO.cpp \
                             src/SSTIOImp.hpp \
                             src/SSTIO.hpp \
+                            src/SSTControl.cpp \
+                            src/SSTControl.hpp \
                             src/SSTSignal.cpp \
                             src/SSTSignal.hpp \
                             src/TimeIOGroup.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -590,6 +590,8 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/SSTIO.cpp \
                             src/SSTIOImp.hpp \
                             src/SSTIO.hpp \
+                            src/SSTSignal.cpp \
+                            src/SSTSignal.hpp \
                             src/TimeIOGroup.cpp \
                             src/TimeIOGroup.hpp \
                             src/TimeSignal.cpp \

--- a/src/SSTControl.cpp
+++ b/src/SSTControl.cpp
@@ -63,7 +63,7 @@ namespace geopm
 
     void SSTControl::setup_batch(void)
     {
-        if (m_control_type == MMIO) {
+        if (m_control_type == M_MMIO) {
             m_adjust_idx = m_sstio->add_mmio_write(
                 m_cpu_idx, m_interface_parameter, m_write_value, m_rmw_read_mask);
         }
@@ -83,7 +83,7 @@ namespace geopm
 
     void SSTControl::write(double value)
     {
-        if (m_control_type == MMIO) {
+        if (m_control_type == M_MMIO) {
             m_sstio->write_mmio_once(
                 m_cpu_idx, m_interface_parameter, m_write_value, m_rmw_read_mask,
                 static_cast<uint64_t>(value * m_multiplier) << m_shift, m_mask);
@@ -98,7 +98,7 @@ namespace geopm
 
     void SSTControl::save(void)
     {
-        if (m_control_type == MMIO) {
+        if (m_control_type == M_MMIO) {
             m_saved_value = m_sstio->read_mmio_once(m_cpu_idx, m_interface_parameter);
         }
         else {
@@ -116,7 +116,7 @@ namespace geopm
 
     void SSTControl::restore(void)
     {
-        if (m_control_type == MMIO) {
+        if (m_control_type == M_MMIO) {
             m_sstio->write_mmio_once(
                 m_cpu_idx, m_interface_parameter, m_write_value, m_rmw_read_mask,
                 m_saved_value, m_mask);

--- a/src/SSTControl.cpp
+++ b/src/SSTControl.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SSTControl.hpp"
+
+#include "SSTIO.hpp"
+
+namespace geopm
+{
+    SSTControl::SSTControl(std::shared_ptr<SSTIO> sstio, ControlType control_type,
+                           int cpu_idx, uint32_t command, uint32_t subcommand,
+                           uint32_t interface_parameter, uint32_t write_value,
+                           uint32_t begin_bit, uint32_t end_bit, double scale,
+                           uint32_t rmw_subcommand,
+                           uint32_t rmw_interface_parameter, uint32_t rmw_read_mask)
+        : m_sstio(sstio)
+        , m_control_type(control_type)
+        , m_cpu_idx(cpu_idx)
+        , m_command(command)
+        , m_subcommand(subcommand)
+        , m_interface_parameter(interface_parameter)
+        , m_write_value(write_value)
+        , m_shift(begin_bit)
+        , m_num_bit(end_bit - begin_bit + 1)
+        , m_mask(((1ULL << m_num_bit) - 1) << begin_bit)
+        , m_rmw_subcommand(rmw_subcommand)
+        , m_rmw_interface_parameter(rmw_interface_parameter)
+        , m_rmw_read_mask(rmw_read_mask)
+        , m_multiplier(scale)
+    {
+
+    }
+
+    void SSTControl::setup_batch(void)
+    {
+        if (m_control_type == MMIO) {
+            m_adjust_idx = m_sstio->add_mmio_write(
+                m_cpu_idx, m_interface_parameter, m_write_value, m_rmw_read_mask);
+        }
+        else {
+            m_adjust_idx = m_sstio->add_mbox_write(
+                m_cpu_idx, m_command, m_subcommand, m_interface_parameter,
+                m_rmw_subcommand, m_rmw_interface_parameter, m_rmw_read_mask);
+        }
+    }
+
+    void SSTControl::adjust(double value)
+    {
+        m_sstio->adjust(m_adjust_idx,
+                        static_cast<uint64_t>(value * m_multiplier) << m_shift,
+                        m_mask);
+    }
+
+    void SSTControl::write(double value)
+    {
+        if (m_control_type == MMIO) {
+            m_sstio->write_mmio_once(
+                m_cpu_idx, m_interface_parameter, m_write_value, m_rmw_read_mask,
+                static_cast<uint64_t>(value * m_multiplier) << m_shift, m_mask);
+        }
+        else {
+            m_sstio->write_mbox_once(
+                m_cpu_idx, m_command, m_subcommand, m_interface_parameter,
+                m_rmw_subcommand, m_rmw_interface_parameter, m_rmw_read_mask,
+                static_cast<uint64_t>(value * m_multiplier) << m_shift, m_mask);
+        }
+    }
+
+    void SSTControl::save(void)
+    {
+
+    }
+
+    void SSTControl::restore(void)
+    {
+
+    }
+}

--- a/src/SSTControl.hpp
+++ b/src/SSTControl.hpp
@@ -101,6 +101,7 @@ namespace geopm
                 const uint32_t m_rmw_interface_parameter;
                 const uint32_t m_rmw_read_mask;
                 const double m_multiplier;
+                uint32_t m_saved_value;
     };
 }
 

--- a/src/SSTControl.hpp
+++ b/src/SSTControl.hpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SSTCONTROL_HPP_INCLUDE
+#define SSTCONTROL_HPP_INCLUDE
+
+#include <memory>
+
+#include "Control.hpp"
+
+namespace geopm
+{
+    class SSTIO;
+
+    /// This is the abstraction layer that exposes GEOPM controls from the
+    /// SSTIO object.
+    class SSTControl : public geopm::Control
+    {
+        public:
+            enum ControlType
+            {
+                MBOX, // SST Mailbox interface
+                MMIO  // SST MMIO interface
+            };
+
+            /// @brief Create an SSTIO Control.
+            /// @param [in] sstio Interface through which SST interactions are handled.
+            /// @param [in] control_type Which SST interface to use.
+            /// @param [in] cpu_index Index of the cpu to which the interface
+            ///             write is being issued.
+            /// @param [in] command Which SST interface command to issue.
+            /// @param [in] subcommand Which SST interface subcommand to issue.
+            /// @param [in] interface_parameter Which SST mailbox paramter to use.
+            /// @param [in] write_value The value to write to the interface.
+            /// @param [in] begin_bit The first (least-significant) bit to
+            ///             include in the write mask.
+            /// @param [in] end_bit The last bit to include in the write mask.
+            /// @param [in] scale The scaling factor to apply to written values.
+            /// @param [in] rmw_subcommand Which subcommand to use for read
+            ///             as part of read-modify-write. This is not always
+            ///             the same as the write subcommand.
+            /// @param [in] rmw_interface_parameter Which interface parameter to
+            ///             use for read as part of read-modify-write. This is
+            ///             not always the same as the write interface parameter.
+            /// @param [in] rmw_read_mask Which mask to use for read as part of
+            ///             read-modify-write. This is not always the same as
+            ///             the write mask.
+            SSTControl(std::shared_ptr<SSTIO> sstio, ControlType control_type,
+                       int cpu_idx, uint32_t command, uint32_t subcommand,
+                       uint32_t interface_parameter, uint32_t write_value, uint32_t begin_bit,
+                       uint32_t end_bit, double scale, uint32_t rmw_subcommand,
+                       uint32_t rmw_interface_parameter, uint32_t rmw_read_mask);
+            virtual ~SSTControl() = default;
+            void setup_batch(void) override;
+            void adjust(double value) override;
+            void write(double value) override;
+            void save(void) override;
+            void restore(void) override;
+            private:
+                std::shared_ptr<SSTIO> m_sstio;
+                const ControlType m_control_type;
+                const int m_cpu_idx;
+                const uint32_t m_command;
+                const uint32_t m_subcommand;
+                const uint32_t m_interface_parameter;
+                const uint32_t m_write_value;
+                int m_adjust_idx;
+                const int m_shift;
+                const int m_num_bit;
+                const uint64_t m_mask;
+                const uint32_t m_rmw_subcommand;
+                const uint32_t m_rmw_interface_parameter;
+                const uint32_t m_rmw_read_mask;
+                const double m_multiplier;
+    };
+}
+
+#endif

--- a/src/SSTControl.hpp
+++ b/src/SSTControl.hpp
@@ -48,8 +48,8 @@ namespace geopm
         public:
             enum ControlType
             {
-                MBOX, // SST Mailbox interface
-                MMIO  // SST MMIO interface
+                M_MBOX, // SST Mailbox interface
+                M_MMIO  // SST MMIO interface
             };
 
             /// @brief Create an SSTIO Control.

--- a/src/SSTIO.cpp
+++ b/src/SSTIO.cpp
@@ -111,13 +111,12 @@ namespace geopm
     }
 
     int SSTIOImp::add_mbox_read(uint32_t cpu_index, uint16_t command,
-                                uint16_t subcommand, uint32_t subcommand_arg,
-                                uint32_t interface_parameter)
+                                uint16_t subcommand, uint32_t subcommand_arg)
     {
         // save the stuff in the list
         struct sst_mbox_interface_s mbox {
             .cpu_index = cpu_index,
-            .mbox_interface_param = interface_parameter,
+            .mbox_interface_param = 0,
             .write_value = subcommand_arg,
             .read_value = 0,
             .command = command,
@@ -230,14 +229,13 @@ namespace geopm
         return idx;
     }
 
-    int SSTIOImp::add_mmio_read(uint32_t cpu_index, uint16_t register_offset,
-                                uint32_t register_value)
+    int SSTIOImp::add_mmio_read(uint32_t cpu_index, uint16_t register_offset)
     {
         struct sst_mmio_interface_s mmio {
             .is_write = 0,
             .cpu_index = cpu_index,
             .register_offset = register_offset,
-            .value = register_value,
+            .value = 0,
         };
         int mmio_idx = m_mmio_read_interfaces.size();
         m_mmio_read_interfaces.push_back(mmio);
@@ -405,13 +403,12 @@ namespace geopm
     }
 
     uint32_t SSTIOImp::read_mbox_once(uint32_t cpu_index, uint16_t command,
-                                      uint16_t subcommand, uint32_t subcommand_arg,
-                                      uint32_t interface_parameter)
+                                      uint16_t subcommand, uint32_t subcommand_arg)
     {
         sst_mbox_interface_batch_s read_batch{
             .num_entries = 1,
             .interfaces = { { .cpu_index = cpu_index,
-                              .mbox_interface_param = interface_parameter,
+                              .mbox_interface_param = 0,
                               .write_value = subcommand_arg,
                               .read_value = 0,
                               .command = command,
@@ -461,8 +458,7 @@ namespace geopm
         }
     }
 
-    uint32_t SSTIOImp::read_mmio_once(uint32_t cpu_index, uint16_t register_offset,
-                                      uint32_t register_value)
+    uint32_t SSTIOImp::read_mmio_once(uint32_t cpu_index, uint16_t register_offset)
     {
         sst_mmio_interface_batch_s read_batch{
             .num_entries = 1,

--- a/src/SSTIO.hpp
+++ b/src/SSTIO.hpp
@@ -50,10 +50,8 @@ namespace geopm
             /// @param [in] subcommand Which SST mailbox subcommand to issue
             /// @param [in] subcommand_arg Which argument to use for the SST
             ///             mailbox subcommand
-            /// @param [in] interface_parameter Which SST mailbox paramter to use
             virtual int add_mbox_read(uint32_t cpu_index, uint16_t command,
-                                      uint16_t subcommand, uint32_t subcommand_arg,
-                                      uint32_t interface_parameter) = 0;
+                                      uint16_t subcommand, uint32_t subcommand_arg) = 0;
 
             /// @brief Interact with the mailbox on commands that are not expected to return data
             /// @param [in] cpu_index Index of the cpu to which the mailbox
@@ -77,10 +75,7 @@ namespace geopm
             /// @param [in] cpu_index Index of the cpu to which the MMIO
             ///             read is being issued
             /// @param [in] register_offset Which SST MMIO register offset to use
-            /// @param [in] register_value Which SST MMIO register value to set
-            ///             prior to the read.
-            virtual int add_mmio_read(uint32_t cpu_index, uint16_t register_offset,
-                                      uint32_t register_value) = 0;
+            virtual int add_mmio_read(uint32_t cpu_index, uint16_t register_offset) = 0;
 
             /// @brief Interact with the mmio interface on commands that are not expected to return data
             /// @param [in] cpu_index Index of the cpu to which the MMIO
@@ -112,10 +107,8 @@ namespace geopm
             /// @param [in] subcommand Which SST mailbox subcommand to issue
             /// @param [in] subcommand_arg Which argument to use for the SST
             ///             mailbox subcommand
-            /// @param [in] interface_parameter Which SST mailbox paramter to use
             virtual uint32_t read_mbox_once(uint32_t cpu_index, uint16_t command,
-                                            uint16_t subcommand, uint32_t subcommand_arg,
-                                            uint32_t interface_parameter) = 0;
+                                            uint16_t subcommand, uint32_t subcommand_arg) = 0;
 
             /// @brief Immediately query the SST mailbox for a write operation.
             /// @param [in] cpu_index Index of the cpu to which the mailbox
@@ -143,10 +136,7 @@ namespace geopm
             /// @param [in] cpu_index Index of the cpu to which the MMIO
             ///             read is being issued
             /// @param [in] register_offset Which SST MMIO register offset to use
-            /// @param [in] register_value Which SST MMIO register value to set
-            ///             prior to the read.
-            virtual uint32_t read_mmio_once(uint32_t cpu_index, uint16_t register_offset,
-                                            uint32_t register_value) = 0;
+            virtual uint32_t read_mmio_once(uint32_t cpu_index, uint16_t register_offset) = 0;
 
             /// @brief Immediately write a value to the SST MMIO interface.
             /// @param [in] cpu_index Index of the cpu to which the MMIO

--- a/src/SSTIOImp.hpp
+++ b/src/SSTIOImp.hpp
@@ -52,15 +52,13 @@ namespace geopm
 
             /// Interact with the mailbox on commands that are expected to return data
             int add_mbox_read(uint32_t cpu_index, uint16_t command,
-                              uint16_t subcommand, uint32_t subcommand_arg,
-                              uint32_t interface_parameter) override;
+                              uint16_t subcommand, uint32_t subcommand_arg) override;
             int add_mbox_write(uint32_t cpu_index, uint16_t command,
                                uint16_t subcommand, uint32_t interface_parameter,
                                uint16_t read_subcommand,
                                uint32_t read_interface_parameter,
                                uint32_t read_mask) override;
-            int add_mmio_read(uint32_t cpu_index, uint16_t register_offset,
-                              uint32_t register_value) override;
+            int add_mmio_read(uint32_t cpu_index, uint16_t register_offset) override;
             int add_mmio_write(uint32_t cpu_index, uint16_t register_offset,
                                uint32_t register_value, uint32_t read_mask) override;
             // call ioctl() for both mbox list and mmio list,
@@ -70,16 +68,14 @@ namespace geopm
             uint64_t sample(int batch_idx) const override;
             void write_batch(void) override;
             uint32_t read_mbox_once(uint32_t cpu_index, uint16_t command,
-                                    uint16_t subcommand, uint32_t subcommand_arg,
-                                    uint32_t interface_parameter) override;
+                                    uint16_t subcommand, uint32_t subcommand_arg) override;
             void write_mbox_once(uint32_t cpu_index, uint16_t command,
                                  uint16_t subcommand, uint32_t interface_parameter,
                                  uint16_t read_subcommand,
                                  uint32_t read_interface_parameter,
                                  uint32_t read_mask, uint64_t write_value,
                                  uint64_t write_mask) override;
-            uint32_t read_mmio_once(uint32_t cpu_index, uint16_t register_offset,
-                                    uint32_t register_value) override;
+            uint32_t read_mmio_once(uint32_t cpu_index, uint16_t register_offset) override;
             void write_mmio_once(uint32_t cpu_index, uint16_t register_offset,
                                  uint32_t register_value, uint32_t read_mask,
                                  uint64_t write_value, uint64_t write_mask) override;

--- a/src/SSTSignal.cpp
+++ b/src/SSTSignal.cpp
@@ -58,13 +58,11 @@ namespace geopm
     {
         if (m_batch_idx == -1) {
             if (m_signal_type == MMIO) {
-                m_batch_idx = m_sstio->add_mmio_read(m_cpu_idx, m_subcommand_arg,
-                                                     m_interface_parameter);
+                m_batch_idx = m_sstio->add_mmio_read(m_cpu_idx, m_subcommand_arg);
             }
             else {
-                m_batch_idx = m_sstio->add_mbox_read(m_cpu_idx, m_command,
-                                                     m_subcommand, m_subcommand_arg,
-                                                     m_interface_parameter);
+                m_batch_idx = m_sstio->add_mbox_read(
+                    m_cpu_idx, m_command, m_subcommand, m_subcommand_arg);
             }
         }
     }
@@ -78,12 +76,11 @@ namespace geopm
     {
         uint32_t ret;
         if (m_signal_type == MMIO) {
-            ret = m_sstio->read_mmio_once(m_cpu_idx, m_subcommand_arg,
-                                          m_interface_parameter);
+            ret = m_sstio->read_mmio_once(m_cpu_idx, m_subcommand_arg);
         }
         else {
             ret = m_sstio->read_mbox_once(m_cpu_idx, m_command, m_subcommand,
-                                          m_subcommand_arg, m_interface_parameter);
+                                          m_subcommand_arg);
         }
         return geopm_field_to_signal(ret);
     }

--- a/src/SSTSignal.cpp
+++ b/src/SSTSignal.cpp
@@ -57,7 +57,7 @@ namespace geopm
     void SSTSignal::setup_batch(void)
     {
         if (m_batch_idx == -1) {
-            if (m_signal_type == MMIO) {
+            if (m_signal_type == M_MMIO) {
                 m_batch_idx = m_sstio->add_mmio_read(m_cpu_idx, m_subcommand_arg);
             }
             else {
@@ -75,7 +75,7 @@ namespace geopm
     double SSTSignal::read(void) const
     {
         uint32_t ret;
-        if (m_signal_type == MMIO) {
+        if (m_signal_type == M_MMIO) {
             ret = m_sstio->read_mmio_once(m_cpu_idx, m_subcommand_arg);
         }
         else {

--- a/src/SSTSignal.cpp
+++ b/src/SSTSignal.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SSTSignal.hpp"
+
+#include "geopm_hash.h"
+#include "SSTIO.hpp"
+
+namespace geopm
+{
+
+    SSTSignal::SSTSignal(std::shared_ptr<geopm::SSTIO> sstio, SignalType signal_type,
+                         int cpu_idx, uint16_t command, uint16_t subcommand,
+                         uint32_t subcommand_arg,      // write_value
+                         uint32_t interface_parameter) // mbox_interface_param
+        : m_sstio(sstio)
+        , m_signal_type(signal_type)
+        , m_cpu_idx(cpu_idx)
+        , m_command(command)
+        , m_subcommand(subcommand)
+        , m_subcommand_arg(subcommand_arg)
+        , m_interface_parameter(interface_parameter)
+        , m_batch_idx(-1)
+    {
+    }
+
+    void SSTSignal::setup_batch(void)
+    {
+        if (m_batch_idx == -1) {
+            if (m_signal_type == MMIO) {
+                m_batch_idx = m_sstio->add_mmio_read(m_cpu_idx, m_subcommand_arg,
+                                                     m_interface_parameter);
+            }
+            else {
+                m_batch_idx = m_sstio->add_mbox_read(m_cpu_idx, m_command,
+                                                     m_subcommand, m_subcommand_arg,
+                                                     m_interface_parameter);
+            }
+        }
+    }
+
+    double SSTSignal::sample(void)
+    {
+        return geopm_field_to_signal(m_sstio->sample(m_batch_idx));
+    }
+
+    double SSTSignal::read(void) const
+    {
+        uint32_t ret;
+        if (m_signal_type == MMIO) {
+            ret = m_sstio->read_mmio_once(m_cpu_idx, m_subcommand_arg,
+                                          m_interface_parameter);
+        }
+        else {
+            ret = m_sstio->read_mbox_once(m_cpu_idx, m_command, m_subcommand,
+                                          m_subcommand_arg, m_interface_parameter);
+        }
+        return geopm_field_to_signal(ret);
+    }
+}

--- a/src/SSTSignal.hpp
+++ b/src/SSTSignal.hpp
@@ -48,8 +48,8 @@ namespace geopm
         public:
             enum SignalType
             {
-                MBOX, // SST Mailbox interface
-                MMIO  // SST MMIO interface
+                M_MBOX, // SST Mailbox interface
+                M_MMIO  // SST MMIO interface
             };
 
             /// @brief Create an SSTIO Signal.

--- a/src/SSTSignal.hpp
+++ b/src/SSTSignal.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SSTSIGNAL_HPP_INCLUDE
+#define SSTSIGNAL_HPP_INCLUDE
+
+#include <memory>
+
+#include "Signal.hpp"
+
+namespace geopm
+{
+    class SSTIO;
+
+    /// This is the abstraction layer that exposes GEOPM signals from the
+    /// SSTIO object.
+    class SSTSignal : public geopm::Signal
+    {
+        public:
+            enum SignalType
+            {
+                MBOX, // SST Mailbox interface
+                MMIO  // SST MMIO interface
+            };
+
+            /// @brief Create an SSTIO Signal.
+            /// @param [in] sstio Interface through which SST interactions are handled.
+            /// @param [in] signal_type Which SST interface to use.
+            /// @param [in] cpu_index Index of the cpu to which the mailbox
+            ///             read is being issued.
+            /// @param [in] command Which SST interface command to issue.
+            /// @param [in] subcommand Which SST interface subcommand to issue
+            /// @param [in] subcommand_arg Which SST interface subcommand
+            ///             argument to use.
+            /// @param [in] interface_parameter Which SST interface parameter
+            ///             to use.
+            SSTSignal(std::shared_ptr<geopm::SSTIO> sstio,
+                      SignalType signal_type,
+                      int cpu_idx,
+                      uint16_t command,
+                      uint16_t subcommand,
+                      uint32_t subcommand_arg,
+                      uint32_t interface_parameter);
+
+            virtual ~SSTSignal() = default;
+
+            void setup_batch(void) override;
+            double sample(void) override;
+            double read(void) const override;
+        private:
+            std::shared_ptr<geopm::SSTIO> m_sstio;
+            SignalType m_signal_type;
+            const int m_cpu_idx;
+            const uint16_t m_command;
+            const uint16_t m_subcommand;
+            const uint32_t m_subcommand_arg;
+            const uint32_t m_interface_parameter;
+
+            int m_batch_idx;
+    };
+
+}
+
+#endif

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -465,6 +465,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/SharedMemoryTest.share_data_ipc \
               test/gtest_links/SSTControlTest.mailbox_adjust_batch \
               test/gtest_links/SSTControlTest.mmio_adjust_batch \
+              test/gtest_links/SSTControlTest.save_restore_mmio \
+              test/gtest_links/SSTControlTest.save_restore_mbox \
               test/gtest_links/SSTSignalTest.mailbox_read_batch \
               test/gtest_links/SSTSignalTest.mmio_read_batch \
               test/gtest_links/TimeIOGroupTest.adjust \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -637,6 +637,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
                           test/MockSampleAggregator.hpp \
                           test/MockSharedMemory.hpp \
                           test/MockSignal.hpp \
+                          test/MockSSTIO.hpp \
                           test/MockTracer.hpp \
                           test/MockTreeComm.hpp \
                           test/MockTreeCommLevel.hpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -463,6 +463,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/SharedMemoryTest.lock_shmem_u \
               test/gtest_links/SharedMemoryTest.share_data \
               test/gtest_links/SharedMemoryTest.share_data_ipc \
+              test/gtest_links/SSTSignalTest.mailbox_read_batch \
+              test/gtest_links/SSTSignalTest.mmio_read_batch \
               test/gtest_links/TimeIOGroupTest.adjust \
               test/gtest_links/TimeIOGroupTest.is_valid \
               test/gtest_links/TimeIOGroupTest.push \
@@ -663,6 +665,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
                           test/SampleAggregatorTest.cpp \
                           test/SchedTest.cpp \
                           test/SharedMemoryTest.cpp \
+                          test/SSTSignalTest.cpp \
                           test/TimeIOGroupTest.cpp \
                           test/TracerTest.cpp \
                           test/TreeCommLevelTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -463,6 +463,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/SharedMemoryTest.lock_shmem_u \
               test/gtest_links/SharedMemoryTest.share_data \
               test/gtest_links/SharedMemoryTest.share_data_ipc \
+              test/gtest_links/SSTControlTest.mailbox_adjust_batch \
+              test/gtest_links/SSTControlTest.mmio_adjust_batch \
               test/gtest_links/SSTSignalTest.mailbox_read_batch \
               test/gtest_links/SSTSignalTest.mmio_read_batch \
               test/gtest_links/TimeIOGroupTest.adjust \
@@ -665,6 +667,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
                           test/SampleAggregatorTest.cpp \
                           test/SchedTest.cpp \
                           test/SharedMemoryTest.cpp \
+                          test/SSTControlTest.cpp \
                           test/SSTSignalTest.cpp \
                           test/TimeIOGroupTest.cpp \
                           test/TracerTest.cpp \

--- a/test/MockSSTIO.hpp
+++ b/test/MockSSTIO.hpp
@@ -42,32 +42,28 @@ class MockSSTIO : public geopm::SSTIO
 {
     public:
         virtual ~MockSSTIO() = default;
-        MOCK_METHOD5(add_mbox_read,
+        MOCK_METHOD4(add_mbox_read,
                      int(uint32_t cpu_index, uint16_t command,
-                         uint16_t subcommand, uint32_t subcommand_arg,
-                         uint32_t interface_parameter));
+                         uint16_t subcommand, uint32_t subcommand_arg));
         MOCK_METHOD7(add_mbox_write,
                      int(uint32_t cpu_index, uint16_t command, uint16_t subcommand,
                          uint32_t interface_parameter, uint16_t read_subcommand,
                          uint32_t read_interface_parameter, uint32_t read_mask));
-        MOCK_METHOD3(add_mmio_read, int(uint32_t cpu_index, uint16_t register_offset,
-                                        uint32_t register_value));
+        MOCK_METHOD2(add_mmio_read, int(uint32_t cpu_index, uint16_t register_offset));
         MOCK_METHOD4(add_mmio_write,
                      int(uint32_t cpu_index, uint16_t register_offset,
                          uint32_t register_value, uint32_t read_mask));
         MOCK_METHOD0(read_batch, void(void));
         MOCK_CONST_METHOD1(sample, uint64_t(int batch_idx));
         MOCK_METHOD0(write_batch, void(void));
-        MOCK_METHOD5(read_mbox_once, uint32_t(uint32_t cpu_index, uint16_t command,
-                                              uint16_t subcommand, uint32_t subcommand_arg,
-                                              uint32_t interface_parameter));
+        MOCK_METHOD4(read_mbox_once, uint32_t(uint32_t cpu_index, uint16_t command,
+                                              uint16_t subcommand, uint32_t subcommand_arg));
         MOCK_METHOD9(write_mbox_once,
                      void(uint32_t cpu_index, uint16_t command, uint16_t subcommand,
                           uint32_t interface_parameter, uint16_t read_subcommand,
                           uint32_t read_interface_parameter, uint32_t read_mask,
                           uint64_t write_value, uint64_t write_mask));
-        MOCK_METHOD3(read_mmio_once, uint32_t(uint32_t cpu_index, uint16_t register_offset,
-                                              uint32_t register_value));
+        MOCK_METHOD2(read_mmio_once, uint32_t(uint32_t cpu_index, uint16_t register_offset));
         MOCK_METHOD6(write_mmio_once,
                      void(uint32_t cpu_index, uint16_t register_offset,
                           uint32_t register_value, uint32_t read_mask,

--- a/test/MockSSTIO.hpp
+++ b/test/MockSSTIO.hpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MOCKSSTIO_HPP_INCLUDE
+#define MOCKSSTIO_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "SSTIO.hpp"
+
+
+class MockSSTIO : public geopm::SSTIO
+{
+    public:
+        virtual ~MockSSTIO() = default;
+        MOCK_METHOD5(add_mbox_read,
+                     int(uint32_t cpu_index, uint16_t command,
+                         uint16_t subcommand, uint32_t subcommand_arg,
+                         uint32_t interface_parameter));
+        MOCK_METHOD7(add_mbox_write,
+                     int(uint32_t cpu_index, uint16_t command, uint16_t subcommand,
+                         uint32_t interface_parameter, uint16_t read_subcommand,
+                         uint32_t read_interface_parameter, uint32_t read_mask));
+        MOCK_METHOD3(add_mmio_read, int(uint32_t cpu_index, uint16_t register_offset,
+                                        uint32_t register_value));
+        MOCK_METHOD4(add_mmio_write,
+                     int(uint32_t cpu_index, uint16_t register_offset,
+                         uint32_t register_value, uint32_t read_mask));
+        MOCK_METHOD0(read_batch, void(void));
+        MOCK_CONST_METHOD1(sample, uint64_t(int batch_idx));
+        MOCK_METHOD0(write_batch, void(void));
+        MOCK_METHOD5(read_mbox_once, uint32_t(uint32_t cpu_index, uint16_t command,
+                                              uint16_t subcommand, uint32_t subcommand_arg,
+                                              uint32_t interface_parameter));
+        MOCK_METHOD9(write_mbox_once,
+                     void(uint32_t cpu_index, uint16_t command, uint16_t subcommand,
+                          uint32_t interface_parameter, uint16_t read_subcommand,
+                          uint32_t read_interface_parameter, uint32_t read_mask,
+                          uint64_t write_value, uint64_t write_mask));
+        MOCK_METHOD3(read_mmio_once, uint32_t(uint32_t cpu_index, uint16_t register_offset,
+                                              uint32_t register_value));
+        MOCK_METHOD6(write_mmio_once,
+                     void(uint32_t cpu_index, uint16_t register_offset,
+                          uint32_t register_value, uint32_t read_mask,
+                          uint64_t write_value, uint64_t write_mask));
+        MOCK_METHOD3(adjust, void(int batch_idx, uint64_t write_value, uint64_t write_mask));
+        MOCK_METHOD1(get_punit_from_cpu, uint32_t(uint32_t cpu_index));
+};
+
+#endif

--- a/test/SSTControlTest.cpp
+++ b/test/SSTControlTest.cpp
@@ -76,7 +76,7 @@ TEST_F(SSTControlTest, mailbox_adjust_batch)
     uint32_t read_interface_param = 0x94;
     uint32_t read_mask = 0xf0;
 
-    SSTControl control{ m_sstio, SSTControl::MBOX, cpu, command, subcommand,
+    SSTControl control{ m_sstio, SSTControl::M_MBOX, cpu, command, subcommand,
                         interface_param, write_value, begin_bit, end_bit, scale,
                         read_subcommand, read_interface_param, read_mask };
 
@@ -110,7 +110,7 @@ TEST_F(SSTControlTest, mmio_adjust_batch)
     uint32_t read_interface_param = 0x94;
     uint32_t read_mask = 0xf0;
 
-    SSTControl control{ m_sstio, SSTControl::MMIO, cpu, command, subcommand,
+    SSTControl control{ m_sstio, SSTControl::M_MMIO, cpu, command, subcommand,
                         interface_param, write_value, begin_bit, end_bit, scale,
                         read_subcommand, read_interface_param, read_mask };
 
@@ -147,7 +147,7 @@ TEST_F(SSTControlTest, save_restore_mmio)
     uint32_t read_mask = 0xf0;
     uint32_t write_mask = 0x30; /* bits 4-5 */
 
-    SSTControl control{ m_sstio, SSTControl::MMIO, cpu, command, subcommand,
+    SSTControl control{ m_sstio, SSTControl::M_MMIO, cpu, command, subcommand,
                         interface_param, write_value, begin_bit, end_bit, scale,
                         read_subcommand, read_interface_param, read_mask };
 
@@ -181,7 +181,7 @@ TEST_F(SSTControlTest, save_restore_mbox)
     uint32_t read_mask = 0xf0;
     uint32_t write_mask = 0x30; /* bits 4-5 */
 
-    SSTControl control{ m_sstio, SSTControl::MBOX, cpu, command, subcommand,
+    SSTControl control{ m_sstio, SSTControl::M_MBOX, cpu, command, subcommand,
                         interface_param, write_value, begin_bit, end_bit, scale,
                         read_subcommand, read_interface_param, read_mask };
 

--- a/test/SSTControlTest.cpp
+++ b/test/SSTControlTest.cpp
@@ -126,3 +126,73 @@ TEST_F(SSTControlTest, mmio_adjust_batch)
     EXPECT_CALL(*m_sstio, adjust(batch_idx, internal_write_value, write_mask));
     control.adjust(user_write_value);
 }
+
+TEST_F(SSTControlTest, save_restore_mmio)
+{
+    int cpu = 3;
+    uint16_t command = 0x7f;
+    uint16_t subcommand = 0x33;
+    uint32_t interface_param = 0x93;
+    uint32_t write_value = 0x56;
+    uint32_t begin_bit = 4;
+    uint32_t end_bit = 5;
+    double scale = 2.0;
+
+    uint32_t read_subcommand = 0x34;
+    uint32_t read_interface_param = 0x94;
+    /* read mask is typically going to be a superset of the bits in the write
+     * mask for MMIO-type signals (will read back the whole control to do RMW
+     * on a field in that control)
+     */
+    uint32_t read_mask = 0xf0;
+    uint32_t write_mask = 0x30; /* bits 4-5 */
+
+    SSTControl control{ m_sstio, SSTControl::MMIO, cpu, command, subcommand,
+                        interface_param, write_value, begin_bit, end_bit, scale,
+                        read_subcommand, read_interface_param, read_mask };
+
+    uint64_t read_value = 0x1234;
+    uint64_t restored_bits = read_value & write_mask;
+    EXPECT_CALL(*m_sstio, read_mmio_once(cpu, interface_param))
+        .WillOnce(Return(read_value));  // extra bits should be masked off for write
+    control.save();
+    EXPECT_CALL(*m_sstio, write_mmio_once(cpu, interface_param, write_value,
+                                          read_mask, restored_bits, write_mask));
+    control.restore();
+}
+
+TEST_F(SSTControlTest, save_restore_mbox)
+{
+    int cpu = 3;
+    uint16_t command = 0x7f;
+    uint16_t subcommand = 0x33;
+    uint32_t interface_param = 0x93;
+    uint32_t write_value = 0x56;
+    uint32_t begin_bit = 4;
+    uint32_t end_bit = 5;
+    double scale = 2.0;
+
+    uint32_t read_subcommand = 0x34;
+    uint32_t read_interface_param = 0x94;
+    /* read mask is typically going to be a superset of the bits in the write
+     * mask for MBOX-type signals (will read back the whole control to do RMW
+     * on a field in that control)
+     */
+    uint32_t read_mask = 0xf0;
+    uint32_t write_mask = 0x30; /* bits 4-5 */
+
+    SSTControl control{ m_sstio, SSTControl::MBOX, cpu, command, subcommand,
+                        interface_param, write_value, begin_bit, end_bit, scale,
+                        read_subcommand, read_interface_param, read_mask };
+
+    uint64_t read_value = 0x1234;
+    uint64_t restored_bits = read_value & write_mask;
+    EXPECT_CALL(*m_sstio, read_mbox_once(cpu, command, read_subcommand, read_interface_param))
+        .WillOnce(Return(read_value));  // extra bits should be masked off for write
+    control.save();
+    EXPECT_CALL(*m_sstio, write_mbox_once(cpu, command, subcommand,
+                                          interface_param, read_subcommand,
+                                          read_interface_param, read_mask,
+                                          restored_bits, write_mask));
+    control.restore();
+}

--- a/test/SSTControlTest.cpp
+++ b/test/SSTControlTest.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "SSTControl.hpp"
+#include "MockSSTIO.hpp"
+#include "geopm_hash.h"
+
+using geopm::SSTControl;
+using testing::Return;
+
+class SSTControlTest : public :: testing :: Test
+{
+    protected:
+        void SetUp(void);
+        void TearDown(void);
+        std::shared_ptr<MockSSTIO> m_sstio;
+        int m_num_cpu = 4;
+};
+
+void SSTControlTest::SetUp(void)
+{
+    m_sstio = std::make_shared<MockSSTIO>();
+}
+
+void SSTControlTest::TearDown(void)
+{
+
+}
+
+TEST_F(SSTControlTest, mailbox_adjust_batch)
+{
+    int cpu = 3;
+    uint16_t command = 0x7f;
+    uint16_t subcommand = 0x33;
+    uint32_t interface_param = 0x93;
+    uint32_t write_value = 0x56;
+    uint32_t begin_bit = 4;
+    uint32_t end_bit = 5;
+    double scale = 2.0;
+
+    uint32_t read_subcommand = 0x34;
+    uint32_t read_interface_param = 0x94;
+    uint32_t read_mask = 0xf0;
+
+    SSTControl control{ m_sstio, SSTControl::MBOX, cpu, command, subcommand,
+                        interface_param, write_value, begin_bit, end_bit, scale,
+                        read_subcommand, read_interface_param, read_mask };
+
+    int batch_idx = 42;
+    EXPECT_CALL(*m_sstio,
+                add_mbox_write(cpu, command, subcommand, interface_param,
+                               read_subcommand, read_interface_param, read_mask))
+        .WillOnce(Return(batch_idx));
+
+    control.setup_batch();
+
+    double user_write_value = 1.0;
+    uint32_t internal_write_value = 2 /* scaled */ << begin_bit;
+    uint32_t write_mask = 0x30;
+    EXPECT_CALL(*m_sstio, adjust(batch_idx, internal_write_value, write_mask));
+    control.adjust(user_write_value);
+}
+
+TEST_F(SSTControlTest, mmio_adjust_batch)
+{
+    int cpu = 3;
+    uint16_t command = 0x7f;
+    uint16_t subcommand = 0x33;
+    uint32_t interface_param = 0x93;
+    uint32_t write_value = 0x56;
+    uint32_t begin_bit = 4;
+    uint32_t end_bit = 5;
+    double scale = 2.0;
+
+    uint32_t read_subcommand = 0x34;
+    uint32_t read_interface_param = 0x94;
+    uint32_t read_mask = 0xf0;
+
+    SSTControl control{ m_sstio, SSTControl::MMIO, cpu, command, subcommand,
+                        interface_param, write_value, begin_bit, end_bit, scale,
+                        read_subcommand, read_interface_param, read_mask };
+
+    int batch_idx = 42;
+    EXPECT_CALL(*m_sstio, add_mmio_write(cpu, interface_param, write_value, read_mask))
+        .WillOnce(Return(batch_idx));
+
+    control.setup_batch();
+
+    double user_write_value = 1.0;
+    uint32_t internal_write_value = 2 /* scaled */ << begin_bit;
+    uint32_t write_mask = 0x30;
+    EXPECT_CALL(*m_sstio, adjust(batch_idx, internal_write_value, write_mask));
+    control.adjust(user_write_value);
+}

--- a/test/SSTSignalTest.cpp
+++ b/test/SSTSignalTest.cpp
@@ -74,7 +74,7 @@ TEST_F(SSTSignalTest, mailbox_read_batch)
                    interface_param};
 
     int batch_idx = 42;
-    EXPECT_CALL(*m_sstio, add_mbox_read(cpu, command, subcommand, sub_arg, interface_param))
+    EXPECT_CALL(*m_sstio, add_mbox_read(cpu, command, subcommand, sub_arg))
         .WillOnce(Return(batch_idx));
 
     sig.setup_batch();
@@ -98,7 +98,7 @@ TEST_F(SSTSignalTest, mmio_read_batch)
                    interface_param};
 
     int batch_idx = 42;
-    EXPECT_CALL(*m_sstio, add_mmio_read(cpu, sub_arg, interface_param))
+    EXPECT_CALL(*m_sstio, add_mmio_read(cpu, sub_arg))
         .WillOnce(Return(batch_idx));
 
     sig.setup_batch();

--- a/test/SSTSignalTest.cpp
+++ b/test/SSTSignalTest.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "SSTSignal.hpp"
+#include "MockSSTIO.hpp"
+#include "geopm_hash.h"
+
+using geopm::SSTSignal;
+using testing::Return;
+using testing::_;
+
+class SSTSignalTest : public :: testing :: Test
+{
+    protected:
+        void SetUp(void);
+        void TearDown(void);
+        std::shared_ptr<MockSSTIO> m_sstio;
+        int m_num_cpu = 4;
+};
+
+void SSTSignalTest::SetUp(void)
+{
+    m_sstio = std::make_shared<MockSSTIO>();
+}
+
+void SSTSignalTest::TearDown(void)
+{
+
+}
+
+TEST_F(SSTSignalTest, mailbox_read_batch)
+{
+    int cpu = 3;
+    uint16_t command = 0x7f;
+    uint16_t subcommand = 0x33;
+    uint32_t sub_arg = 0x56;
+    uint32_t interface_param = 0x93;
+
+    SSTSignal sig {m_sstio, SSTSignal::MBOX, cpu, command, subcommand, sub_arg,
+                   interface_param};
+
+    int batch_idx = 42;
+    EXPECT_CALL(*m_sstio, add_mbox_read(cpu, command, subcommand, sub_arg, interface_param))
+        .WillOnce(Return(batch_idx));
+
+    sig.setup_batch();
+
+    double expected = 6.0;
+    EXPECT_CALL(*m_sstio, sample(batch_idx)).WillOnce(Return(geopm_signal_to_field(expected)));
+
+    double result = sig.sample();
+    EXPECT_EQ(expected, result);
+}
+
+TEST_F(SSTSignalTest, mmio_read_batch)
+{
+    int cpu = 3;
+    uint16_t command = 0x7f;
+    uint16_t subcommand = 0x33;
+    uint32_t sub_arg = 0x56;
+    uint32_t interface_param = 0x93;
+
+    SSTSignal sig {m_sstio, SSTSignal::MMIO, cpu, command, subcommand, sub_arg,
+                   interface_param};
+
+    int batch_idx = 42;
+    EXPECT_CALL(*m_sstio, add_mmio_read(cpu, sub_arg, interface_param))
+        .WillOnce(Return(batch_idx));
+
+    sig.setup_batch();
+
+    double expected = 6.0;
+    EXPECT_CALL(*m_sstio, sample(batch_idx)).WillOnce(Return(geopm_signal_to_field(expected)));
+
+    double result = sig.sample();
+    EXPECT_EQ(expected, result);
+}

--- a/test/SSTSignalTest.cpp
+++ b/test/SSTSignalTest.cpp
@@ -70,7 +70,7 @@ TEST_F(SSTSignalTest, mailbox_read_batch)
     uint32_t sub_arg = 0x56;
     uint32_t interface_param = 0x93;
 
-    SSTSignal sig {m_sstio, SSTSignal::MBOX, cpu, command, subcommand, sub_arg,
+    SSTSignal sig {m_sstio, SSTSignal::M_MBOX, cpu, command, subcommand, sub_arg,
                    interface_param};
 
     int batch_idx = 42;
@@ -94,7 +94,7 @@ TEST_F(SSTSignalTest, mmio_read_batch)
     uint32_t sub_arg = 0x56;
     uint32_t interface_param = 0x93;
 
-    SSTSignal sig {m_sstio, SSTSignal::MMIO, cpu, command, subcommand, sub_arg,
+    SSTSignal sig {m_sstio, SSTSignal::M_MMIO, cpu, command, subcommand, sub_arg,
                    interface_param};
 
     int batch_idx = 42;


### PR DESCRIPTION
- Create a new SSTSignal class for signals from SSTIO
- Create a new SSTControl class for controls from SSTIO
- Create a new SSTIO mock for testing the new signal and control interfaces