### PR TITLE
Fix irregularities in hash/hint reporting

### DIFF
--- a/src/ApplicationSamplerImp.hpp
+++ b/src/ApplicationSamplerImp.hpp
@@ -92,6 +92,7 @@ namespace geopm
             std::vector<bool> m_is_cpu_active;
             geopm_time_s m_update_time;
             bool m_is_first_update;
+            std::vector<uint64_t> m_hint_last;
     };
 }
 

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -112,20 +112,6 @@ namespace geopm
         return result;
     }
 
-    void ApplicationStatusImp::set_hash(int cpu_idx, uint64_t hash)
-    {
-        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
-            throw Exception("ApplicationStatusImp::set_hash(): invalid CPU index: " + std::to_string(cpu_idx),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-        if (((~0ULL << 32) & hash) != 0) {
-            throw Exception("ApplicationStatusImp::set_hash(): invalid region hash: " + std::to_string(hash),
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
-        m_buffer[cpu_idx].hash = (uint32_t)hash;
-    }
-
     void ApplicationStatusImp::set_hash(int cpu_idx, uint64_t hash, uint64_t hint)
     {
         if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
@@ -218,12 +204,10 @@ namespace geopm
             }
             m_buffer[cpu].process = process;
             if (process == -1) {
-                set_hash(cpu, GEOPM_REGION_HASH_INVALID);
-                set_hint(cpu, GEOPM_REGION_HINT_INACTIVE);
+                set_hash(cpu, GEOPM_REGION_HASH_INVALID, GEOPM_REGION_HINT_INACTIVE);
             }
             else {
-                set_hash(cpu, GEOPM_REGION_HASH_UNMARKED);
-                set_hint(cpu, GEOPM_REGION_HINT_UNSET);
+                set_hash(cpu, GEOPM_REGION_HASH_UNMARKED, GEOPM_REGION_HINT_UNSET);
             }
         }
     }

--- a/src/ApplicationStatus.cpp
+++ b/src/ApplicationStatus.cpp
@@ -126,6 +126,21 @@ namespace geopm
         m_buffer[cpu_idx].hash = (uint32_t)hash;
     }
 
+    void ApplicationStatusImp::set_hash(int cpu_idx, uint64_t hash, uint64_t hint)
+    {
+        if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {
+            throw Exception("ApplicationStatusImp::set_hash(): invalid CPU index: " + std::to_string(cpu_idx),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (((~0ULL << 32) & hash) != 0) {
+            throw Exception("ApplicationStatusImp::set_hash(): invalid region hash: " + std::to_string(hash),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        GEOPM_DEBUG_ASSERT(m_buffer != nullptr, "m_buffer not set");
+        m_buffer[cpu_idx].hash = (uint32_t)hash;
+        m_buffer[cpu_idx].hint = (uint32_t)(hint >> 32);
+    }
+
     uint64_t ApplicationStatusImp::get_hash(int cpu_idx) const
     {
         if (cpu_idx < 0 || cpu_idx >= m_num_cpu) {

--- a/src/ApplicationStatus.hpp
+++ b/src/ApplicationStatus.hpp
@@ -68,6 +68,7 @@ namespace geopm
             /// @brief Set the hash of the region currently running on
             ///        a CPU.
             virtual void set_hash(int cpu_idx, uint64_t hash) = 0;
+            virtual void set_hash(int cpu_idx, uint64_t hash, uint64_t hint) = 0;
             /// @brief Get the hash of the region currently running on
             ///        a CPU.
             virtual uint64_t get_hash(int cpu_idx) const = 0;
@@ -140,6 +141,7 @@ namespace geopm
             void set_hint(int cpu_idx, uint64_t hint) override;
             uint64_t get_hint(int cpu_idx) const override;
             void set_hash(int cpu_idx, uint64_t hash) override;
+            void set_hash(int cpu_idx, uint64_t hash, uint64_t hint) override;
             uint64_t get_hash(int cpu_idx) const override;
             void reset_work_units(int cpu_idx) override;
             void set_total_work_units(int cpu_idx, int work_units) override;

--- a/src/ApplicationStatus.hpp
+++ b/src/ApplicationStatus.hpp
@@ -65,9 +65,8 @@ namespace geopm
             /// @param [in] cpu_idx Index of the Linux logical CPU.
             /// @return The current hint for the given CPU.
             virtual uint64_t get_hint(int cpu_idx) const = 0;
-            /// @brief Set the hash of the region currently running on
-            ///        a CPU.
-            virtual void set_hash(int cpu_idx, uint64_t hash) = 0;
+            /// @brief Set the hash and hint of the region currently
+            ///        running on a CPU.
             virtual void set_hash(int cpu_idx, uint64_t hash, uint64_t hint) = 0;
             /// @brief Get the hash of the region currently running on
             ///        a CPU.
@@ -140,7 +139,6 @@ namespace geopm
             virtual ~ApplicationStatusImp() = default;
             void set_hint(int cpu_idx, uint64_t hint) override;
             uint64_t get_hint(int cpu_idx) const override;
-            void set_hash(int cpu_idx, uint64_t hash) override;
             void set_hash(int cpu_idx, uint64_t hash, uint64_t hint) override;
             uint64_t get_hash(int cpu_idx) const override;
             void reset_work_units(int cpu_idx) override;

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -448,12 +448,14 @@ namespace geopm
             geopm_time(&now);
             m_app_record_log->enter(hash, now);
             for (const int &cpu_idx : m_cpu_set) {
-                m_app_status->set_hash(cpu_idx, hash);
+                m_app_status->set_hash(cpu_idx, hash, hint);
             }
         }
-        // top level and nested entries inside a region both update hints
+        else {
+            // top level and nested entries inside a region both update hints
+            set_hint(hint);
+        }
         m_hint_stack.push(hint);
-        set_hint(hint);
 
 #ifdef GEOPM_OVERHEAD
         m_overhead_time += geopm_time_since(&overhead_entry);
@@ -484,7 +486,6 @@ namespace geopm
         m_hint_stack.pop();
         if (m_hint_stack.empty()) {
             // leaving outermost region, clear hints and exit region
-            set_hint(GEOPM_REGION_HINT_UNSET);
             m_app_record_log->exit(hash, now);
             m_current_hash = GEOPM_REGION_HASH_UNMARKED;
             // reset both progress ints; calling post() outside of
@@ -495,7 +496,7 @@ namespace geopm
                 // progress from decreasing at the end of a region.
                 // The thread progress value is not valid outside of a
                 // region.
-                m_app_status->set_hash(cpu, m_current_hash);
+                m_app_status->set_hash(cpu, m_current_hash, GEOPM_REGION_HINT_UNSET);
                 m_app_status->reset_work_units(cpu);
             }
         }

--- a/test/ApplicationSamplerTest.cpp
+++ b/test/ApplicationSamplerTest.cpp
@@ -411,6 +411,9 @@ TEST_F(ApplicationSamplerTest, hint_time)
             .WillOnce(DoAll(SetArgReferee<0>(empty_message_buffer),
                             SetArgReferee<1>(empty_short_region_buffer)));
         EXPECT_CALL(*m_mock_status, update_cache());
+        EXPECT_CALL(*m_mock_status, get_hint(_))
+            .WillOnce(Return(GEOPM_REGION_HINT_NETWORK))
+            .WillOnce(Return(GEOPM_REGION_HINT_COMPUTE));
         m_app_sampler->update({{1, 0}});
     }
     compute_time = m_app_sampler->cpu_hint_time(0, GEOPM_REGION_HINT_COMPUTE);
@@ -435,7 +438,7 @@ TEST_F(ApplicationSamplerTest, hint_time)
         EXPECT_CALL(*m_mock_status, update_cache());
         EXPECT_CALL(*m_mock_status, get_hint(_))
             .WillOnce(Return(GEOPM_REGION_HINT_NETWORK))
-            .WillOnce(Return(GEOPM_REGION_HINT_COMPUTE));
+            .WillOnce(Return(GEOPM_REGION_HINT_MEMORY));
         m_app_sampler->update({{2, 0}});
     }
     compute_time = m_app_sampler->cpu_hint_time(0, GEOPM_REGION_HINT_COMPUTE);
@@ -459,8 +462,8 @@ TEST_F(ApplicationSamplerTest, hint_time)
                             SetArgReferee<1>(empty_short_region_buffer)));
         EXPECT_CALL(*m_mock_status, update_cache());
         EXPECT_CALL(*m_mock_status, get_hint(_))
-            .WillOnce(Return(GEOPM_REGION_HINT_NETWORK))
-            .WillOnce(Return(GEOPM_REGION_HINT_MEMORY));
+            .WillOnce(Return(GEOPM_REGION_HINT_COMPUTE))
+            .WillOnce(Return(GEOPM_REGION_HINT_NETWORK));
         m_app_sampler->update({{4, 0}});
     }
     compute_time = m_app_sampler->cpu_hint_time(0, GEOPM_REGION_HINT_COMPUTE);
@@ -484,8 +487,8 @@ TEST_F(ApplicationSamplerTest, hint_time)
                             SetArgReferee<1>(empty_short_region_buffer)));
         EXPECT_CALL(*m_mock_status, update_cache());
         EXPECT_CALL(*m_mock_status, get_hint(_))
-            .WillOnce(Return(GEOPM_REGION_HINT_COMPUTE))
-            .WillOnce(Return(GEOPM_REGION_HINT_NETWORK));
+            .WillOnce(Return(GEOPM_REGION_HINT_UNSET))
+            .WillOnce(Return(GEOPM_REGION_HINT_UNSET));
         m_app_sampler->update({{7, 0}});
     }
     compute_time = m_app_sampler->cpu_hint_time(0, GEOPM_REGION_HINT_COMPUTE);

--- a/test/ApplicationStatusTest.cpp
+++ b/test/ApplicationStatusTest.cpp
@@ -141,21 +141,25 @@ TEST_F(ApplicationStatusTest, hash)
     EXPECT_EQ(GEOPM_REGION_HASH_INVALID, m_status->get_hash(2));
     EXPECT_EQ(GEOPM_REGION_HASH_INVALID, m_status->get_hash(3));
 
-    m_status->set_hash(0, 0xAA);
-    m_status->set_hash(1, 0xAA);
-    m_status->set_hash(2, 0xBB);
-    m_status->set_hash(3, 0xCC);
+    m_status->set_hash(0, 0xAA, GEOPM_REGION_HINT_MEMORY);
+    m_status->set_hash(1, 0xAA, GEOPM_REGION_HINT_NETWORK);
+    m_status->set_hash(2, 0xBB, GEOPM_REGION_HINT_COMPUTE);
+    m_status->set_hash(3, 0xCC, GEOPM_REGION_HINT_IGNORE);
     m_status->update_cache();
     EXPECT_EQ(0xAAULL, m_status->get_hash(0));
     EXPECT_EQ(0xAAULL, m_status->get_hash(1));
     EXPECT_EQ(0xBBULL, m_status->get_hash(2));
     EXPECT_EQ(0xCCULL, m_status->get_hash(3));
+    EXPECT_EQ(GEOPM_REGION_HINT_MEMORY, m_status->get_hint(0));
+    EXPECT_EQ(GEOPM_REGION_HINT_NETWORK, m_status->get_hint(1));
+    EXPECT_EQ(GEOPM_REGION_HINT_COMPUTE, m_status->get_hint(2));
+    EXPECT_EQ(GEOPM_REGION_HINT_IGNORE, m_status->get_hint(3));
 
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(-1, 0xDD),
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(-1, 0xDD, GEOPM_REGION_HINT_UNSET),
                                GEOPM_ERROR_INVALID, "invalid CPU index");
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(99, 0xDD),
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(99, 0xDD, GEOPM_REGION_HINT_UNSET),
                                GEOPM_ERROR_INVALID, "invalid CPU index");
-    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(0, (0xFFULL << 32)),
+    GEOPM_EXPECT_THROW_MESSAGE(m_status->set_hash(0, (0xFFULL << 32), GEOPM_REGION_HINT_UNSET),
                                GEOPM_ERROR_INVALID, "invalid region hash");
     GEOPM_EXPECT_THROW_MESSAGE(m_status->get_hash(-1),
                                GEOPM_ERROR_INVALID, "invalid CPU index");
@@ -288,8 +292,7 @@ TEST_F(ApplicationStatusTest, update_cache)
     EXPECT_EQ(GEOPM_REGION_HASH_INVALID, m_status->get_hash(2));
     EXPECT_EQ(GEOPM_REGION_HASH_INVALID, m_status->get_hash(3));
 
-    m_status->set_hint(0, hint);
-    m_status->set_hash(0, hash);
+    m_status->set_hash(0, hash, hint);
     m_status->set_total_work_units(0, 4);
     m_status->increment_work_unit(0);
     // default values before cache update
@@ -304,8 +307,7 @@ TEST_F(ApplicationStatusTest, update_cache)
     EXPECT_EQ(0.25, m_status->get_progress_cpu(0));
     EXPECT_EQ(process, m_status->get_process(0));
 
-    m_status->set_hint(0, GEOPM_REGION_HINT_UNSET);
-    m_status->set_hash(0, GEOPM_REGION_HASH_INVALID);
+    m_status->set_hash(0, GEOPM_REGION_HASH_INVALID, GEOPM_REGION_HINT_UNSET);
     m_status->set_total_work_units(0, 8);
     m_status->increment_work_unit(0);
     m_status->set_process({0, 1}, process);

--- a/test/MockApplicationStatus.hpp
+++ b/test/MockApplicationStatus.hpp
@@ -44,8 +44,6 @@ class MockApplicationStatus : public geopm::ApplicationStatus
                      void(int cpu_idx, uint64_t hints));
         MOCK_CONST_METHOD1(get_hint,
                            uint64_t(int cpu_idx));
-        MOCK_METHOD2(set_hash,
-                     void(int cpu_idx, uint64_t hash));
         MOCK_METHOD3(set_hash,
                      void(int cpu_idx, uint64_t hash, uint64_t hint));
         MOCK_CONST_METHOD1(get_hash,

--- a/test/MockApplicationStatus.hpp
+++ b/test/MockApplicationStatus.hpp
@@ -46,6 +46,8 @@ class MockApplicationStatus : public geopm::ApplicationStatus
                            uint64_t(int cpu_idx));
         MOCK_METHOD2(set_hash,
                      void(int cpu_idx, uint64_t hash));
+        MOCK_METHOD3(set_hash,
+                     void(int cpu_idx, uint64_t hash, uint64_t hint));
         MOCK_CONST_METHOD1(get_hash,
                            uint64_t(int cpu_idx));
         MOCK_METHOD1(reset_work_units,


### PR DESCRIPTION
This PR contains two changes.  One writes the hash and hint on the same pass through the CPU list when entering or exiting an outer most region. The other fix is for an off-by-one inconsistency between how the region aggregation is done and how the hint time aggregation is done.  