### PR TITLE
Enable user control of process pinning in launcher

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -581,6 +581,8 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/SampleAggregator.cpp \
                             src/SampleAggregator.hpp \
                             src/SampleAggregatorImp.hpp \
+                            src/Scheduler.cpp \
+                            src/Scheduler.hpp \
                             src/SharedMemory.cpp \
                             src/SharedMemory.hpp \
                             src/SharedMemoryImp.hpp \

--- a/README
+++ b/README
@@ -381,7 +381,7 @@ the --geopm-affinity-disable command line option is provided (see
 geopmlaunch(1)).
 
 While the GEOPM control thread connects to the application it will
-automatically affinitize iteself to the highest indexed core not used
+automatically affinitize itself to the highest indexed core not used
 by the application if the application is not affinitized to a CPU on
 every core.  In the case were the application is utilizing all cores
 of the system, the GEOPM control thread will be pinned to CPU zero.

--- a/README
+++ b/README
@@ -375,15 +375,16 @@ script.
 The GEOPM runtime requires that each MPI process of the application
 under control is affinitized to distinct CPUs.  This is a strict
 requirement for the runtime and must be enforced by the MPI launch
-command.
+command.  When using the geopmlaunch wrapper described in the previous
+section, these affinity requirements are handled by geopmlaunch unless
+the --geopm-affinity-disable command line option is provided (see
+geopmlaunch(1)).
 
-Affinitizing the GEOPM control thread to a CPU that is distinct from
-the application CPUs may improve performance of the application, but
-this is not a requirement.  On systems where an application achieves
-highest performance when leaving a CPU unused by the application so
-that this CPU can be dedicated to the operating system, it is usually
-best to affinitize the GEOPM control thread to this CPU designated for
-system threads.
+While the GEOPM control thread connects to the application it will
+automatically affinitize iteself to the highest indexed core not used
+by the application if the application is not affinitized to a CPU on
+every core.  In the case were the application is utilizing all cores
+of the system, the GEOPM control thread will be pinned to CPU zero.
 
 There are many ways to launch an MPI application, and there is no
 single uniform way of enforcing MPI rank CPU affinities across

--- a/ronn/geopmlaunch.1.ronn
+++ b/ronn/geopmlaunch.1.ronn
@@ -245,18 +245,14 @@ listed below.
   that each MPI process be assigned the same number of CPUs which may
   waste resources by assigning more than one CPU to the GEOPM
   controller process.  The _pthread_ option requires support for
-  MPI_THREAD_MULTIPLE, which is not enabled at many sites; in
-  addition, on some systems affinitizing one extra CPU to the MPI
-  process containing the controller thread may be not be possible,
-  resulting in running the GEOPM controller on the same CPU as the
-  main compute application.  The _application_ method of launch is not
-  compatible with `aprun`; with `srun`, the call must be made inside
-  of an existing allocation made with salloc or sbatch and the command
-  must request all of the compute nodes assigned to the allocation.
-  This option is used by the launcher to set the GEOPM_CTL environment
-  variable.  The command line option will override any value currently
-  set in the environment.  See the ENVIRONMENT section of
-  **geopm(7)**.
+  MPI_THREAD_MULTIPLE, which is not enabled at many sites.  The
+  _application_ method of launch is not compatible with `aprun`; with
+  `srun`, the call must be made inside of an existing allocation made
+  with salloc or sbatch and the command must request all of the
+  compute nodes assigned to the allocation.  This option is used by
+  the launcher to set the GEOPM_CTL environment variable.  The command
+  line option will override any value currently set in the
+  environment.  See the ENVIRONMENT section of **geopm(7)**.
 
 * `--geopm-agent` agent:
   Specify the Agent type.  The Agent defines the control algorithm

--- a/ronn/geopmlaunch.1.ronn
+++ b/ronn/geopmlaunch.1.ronn
@@ -286,6 +286,20 @@ listed below.
   override any value currently set in the environment.  See the
   ENVIRONMENT section of **geopm(7)**.
 
+* `--geopm-affinity-disable`:
+  Enable direct user control of all application CPU affinity settings.
+  When specified, the launcher will not emit command line arguments or
+  environment variables related to affinity settings for the
+  underlying launcher.  The user is free to provide whatever affinity
+  settings are best for their application.  It is recommended that at
+  least one core is left free for the GEOPM controller thread, and if
+  there is a free core, the controller will automatically affinitize
+  itself to a CPU on that core when it connects with the application.
+  When this option is specified the user is responsible for providing
+  settings that affinitize MPI ranks to distinct CPUs.  Note: this
+  requirement is satisfied by the default behavior for some launchers
+  like Intel MPI.
+
 * `--geopm-endpoint` endpoint:
   Prefix for shared memory keys used by the endpoint.  The endpoint
   will be used to receive policies dynamically from the resource
@@ -342,7 +356,6 @@ listed below.
   ENVIRONMENT section of **geopm(7)**.
 
 * `--geopm-record-filter` filter:
-
   Applies the user specified filter to the application record data
   feed.  The filters currently supported are "proxy_epoch" and
   "edit_distance".  These filters can be used to infer the application

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -1651,12 +1651,12 @@ GEOPM_OPTIONS:
       --geopm-debug-attach=rk  attach serial debugger to rank "rk"
       --geopm-record-filter=filter
                                apply the "filter" to the application record stream
-      --geopm-preload          use LD_PRELOAD to link libgeopm.so at runtime
       --geopm-hyperthreads-disable
                                do not allow pinning to HTs
       --geopm-ctl-disable      do not launch geopm; pass through commands to
                                underlying launcher
       --geopm-ompt-disable     disable automatic OpenMP region detection
+      --geopm-affinity-disable do not emit CPU affinity settings
 
 {}
 

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -720,8 +720,6 @@ class Launcher(object):
 
         if self.config.get_ctl() == 'process' or is_geopmctl:
             result.insert(0, {geopm_ctl_cpu})
-        elif self.config.get_ctl() == 'pthread':
-            result[0].add(geopm_ctl_cpu)
 
         return result
 

--- a/scripts/test/TestAffinity.py
+++ b/scripts/test/TestAffinity.py
@@ -106,7 +106,7 @@ class TestAffinity(unittest.TestCase):
         self.pthread_argv += args.pop('add_args', [])
         launcher = TestAffinityLauncher(self.pthread_argv, **args)
         actual = launcher.affinity_list(False)
-        expect = [geopm_cpus | app_cpus[0]] + app_cpus[1:]
+        expect = app_cpus
         self.assertEqual(expect, actual)
 
     def check_application_mode(self, geopm_cpus, app_cpus, launch_args):

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -384,7 +384,7 @@ namespace geopm
         if (err) {
 #ifdef GEOPM_DEBUG
             std::cerr << "Warning: <geopm> Unable to affinitize sampling thread to CPU "
-                      << *sampler_cpu_set.begin()
+                      << *(sampler_cpu_set.begin())
                       << ", sched_setaffinity() failed: " << strerror(errno) << "\n";
 #endif
         }

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -34,6 +34,9 @@
 
 #include <map>
 #include <functional>
+#include <iostream>
+#include <cstring>
+#include <cerrno>
 
 #include "ApplicationSamplerImp.hpp"
 #include "ApplicationRecordLog.hpp"
@@ -376,7 +379,15 @@ namespace geopm
         // Try to pin the sampling thread to a free core
         std::set<int> sampler_cpu_set = {sampler_cpu()};
         auto sampler_cpu_mask = make_cpu_set(m_num_cpu, sampler_cpu_set);
-        (void)sched_setaffinity(0, CPU_ALLOC_SIZE(m_num_cpu), sampler_cpu_mask.get());
+
+        int err = sched_setaffinity(0, CPU_ALLOC_SIZE(m_num_cpu), sampler_cpu_mask.get());
+        if (err) {
+#ifdef GEOPM_DEBUG
+            std::cerr << "Warning: <geopm> Unable to affinitize sampling thread to CPU "
+                      << *sampler_cpu_set.begin()
+                      << ", sched_setaffinity() failed: " << strerror(errno) << "\n";
+#endif
+        }
     }
 
     int ApplicationSamplerImp::sampler_cpu(void)

--- a/src/ApplicationSamplerImp.hpp
+++ b/src/ApplicationSamplerImp.hpp
@@ -42,6 +42,7 @@ namespace geopm
     class RecordFilter;
     class ApplicationStatus;
     class SharedMemory;
+    class PlatformTopo;
 
     class ApplicationSamplerImp : public ApplicationSampler
     {
@@ -56,7 +57,7 @@ namespace geopm
             };
             ApplicationSamplerImp();
             ApplicationSamplerImp(std::shared_ptr<ApplicationStatus> status,
-                                  int num_cpu,
+                                  const PlatformTopo &platform_topo,
                                   const std::map<int, m_process_s> &process_map,
                                   bool is_filtered,
                                   const std::string &filter_name,
@@ -86,6 +87,7 @@ namespace geopm
             std::vector<short_region_s> m_short_region_buffer;
             std::shared_ptr<SharedMemory> m_status_shmem;
             std::shared_ptr<ApplicationStatus> m_status;
+            const PlatformTopo &m_topo;
             int m_num_cpu;
             std::map<int, m_process_s> m_process_map;
             const bool m_is_filtered;

--- a/src/ApplicationSamplerImp.hpp
+++ b/src/ApplicationSamplerImp.hpp
@@ -77,6 +77,9 @@ namespace geopm
             void set_sampler(std::shared_ptr<ProfileSampler> sampler) override;
             std::shared_ptr<ProfileSampler> get_sampler(void) override;
         private:
+            int sampler_cpu(void);
+            static std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> > make_cpu_set(std::vector<bool> cpu_enabled);
+            static size_t cpu_set_size(int num_cpu);
             std::shared_ptr<ProfileSampler> m_sampler;
             struct geopm_time_s m_time_zero;
             std::vector<record_s> m_record_buffer;

--- a/src/ApplicationSamplerImp.hpp
+++ b/src/ApplicationSamplerImp.hpp
@@ -74,13 +74,11 @@ namespace geopm
             double cpu_progress(int cpu_idx) const override;
             std::vector<int> per_cpu_process(void) const override;
             void connect(const std::string &shm_key) override;
+            int sampler_cpu(void);
 
             void set_sampler(std::shared_ptr<ProfileSampler> sampler) override;
             std::shared_ptr<ProfileSampler> get_sampler(void) override;
         private:
-            int sampler_cpu(void);
-            static std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> > make_cpu_set(std::vector<bool> cpu_enabled);
-            static size_t cpu_set_size(int num_cpu);
             std::shared_ptr<ProfileSampler> m_sampler;
             struct geopm_time_s m_time_zero;
             std::vector<record_s> m_record_buffer;

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Scheduler.hpp"
+
+namespace geopm
+{
+    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >
+        make_cpu_set(int num_cpu, const std::set<int> &cpu_enabled)
+    {
+        std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> > result(
+            CPU_ALLOC(num_cpu),
+            [](cpu_set_t *ptr)
+            {
+                CPU_FREE(ptr);
+            });
+
+        auto enabled_it = cpu_enabled.cbegin();
+        for (int cpu_idx = 0; cpu_idx != num_cpu; ++cpu_idx) {
+            if (enabled_it != cpu_enabled.cend() &&
+                *enabled_it == cpu_idx) {
+                CPU_SET(cpu_idx, result.get());
+                ++enabled_it;
+            }
+            else {
+                CPU_CLR(cpu_idx, result.get());
+            }
+        }
+        return result;
+    }
+}

--- a/src/Scheduler.hpp
+++ b/src/Scheduler.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SCHEDULER_HPP_INCLUDE
+#define SCHEDULER_HPP_INCLUDE
+
+#include <memory>
+#include <set>
+#include <functional>
+#include <sched.h>
+
+namespace geopm
+{
+    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >
+        make_cpu_set(int num_cpu, const std::set<int> &cpu_enabled);
+
+    // TODO: Add a "Scheduler" class that provides a mockable
+    // abstraction to the Linux sched_* interfaces in place of
+    // geopm_sched_*().
+}
+
+#endif

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -85,6 +85,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/ApplicationSamplerTest.hint_time \
               test/gtest_links/ApplicationSamplerTest.cpu_process \
               test/gtest_links/ApplicationSamplerTest.cpu_progress \
+              test/gtest_links/ApplicationSamplerTest.sampler_cpu \
               test/gtest_links/ApplicationStatusTest.bad_shmem \
               test/gtest_links/ApplicationStatusTest.hash \
               test/gtest_links/ApplicationStatusTest.hints \


### PR DESCRIPTION
This adds a new command line option to geopmlaunch --geopm-affinity-disable which will allow the user to control all cpu affinity options for the underlying launch command.  This is coupled with a change to the ApplicationSampler::connect() method that affinitizes the thread using the sampler to a core not used by the application.
