### PR TITLE
Add an IOGroup for the isst_interface driver

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -592,6 +592,8 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/SSTIO.hpp \
                             src/SSTControl.cpp \
                             src/SSTControl.hpp \
+                            src/SSTIOGroup.cpp \
+                            src/SSTIOGroup.hpp \
                             src/SSTSignal.cpp \
                             src/SSTSignal.hpp \
                             src/TimeIOGroup.cpp \

--- a/src/IOGroup.cpp
+++ b/src/IOGroup.cpp
@@ -41,6 +41,7 @@
 #include "TimeIOGroup.hpp"
 #include "ProfileIOGroup.hpp"
 #include "EpochIOGroup.hpp"
+#include "SSTIOGroup.hpp"
 #include "Helper.hpp"
 #include "config.h"
 #ifdef GEOPM_CNL_IOGROUP
@@ -103,6 +104,8 @@ namespace geopm
                         ProfileIOGroup::make_plugin);
         register_plugin(EpochIOGroup::plugin_name(),
                         EpochIOGroup::make_plugin);
+        register_plugin(SSTIOGroup::plugin_name(),
+                        SSTIOGroup::make_plugin);
 #ifdef GEOPM_CNL_IOGROUP
         register_plugin(CNLIOGroup::plugin_name(),
                         CNLIOGroup::make_plugin);

--- a/src/SSTIOGroup.cpp
+++ b/src/SSTIOGroup.cpp
@@ -1,0 +1,834 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "SSTIOGroup.hpp"
+
+#include <algorithm>
+#include <cinttypes>
+#include <iomanip>
+#include <iterator>
+#include <sstream>
+
+#include "Agg.hpp"
+#include "Exception.hpp"
+#include "Helper.hpp"
+#include "MSR.hpp"
+#include "MSRFieldSignal.hpp"
+#include "PlatformTopo.hpp"
+#include "SSTControl.hpp"
+#include "SSTIO.hpp"
+#include "SSTSignal.hpp"
+#include "geopm_debug.hpp"
+#include "geopm_topo.h"
+
+namespace geopm
+{
+    const std::map<std::string, SSTIOGroup::sst_signal_mailbox_raw_s> SSTIOGroup::sst_signal_mbox_info = {
+        { "SST::CONFIG_LEVEL",
+          { SSTIOGroup::SSTMailboxCommand::M_TURBO_FREQUENCY, 0x00,
+            {{ "LEVEL", { 0x00, 16, 23, 1.0, M_UNITS_NONE,
+                            "SST configuration level", M_SIGNAL_BEHAVIOR_CONSTANT } }}
+          } },
+        { "SST::TURBOFREQ_SUPPORT",
+          { SSTIOGroup::SSTMailboxCommand::M_TURBO_FREQUENCY, 0x01,
+            {{ "SUPPORTED", { 0x00, 0, 0, 1.0, M_UNITS_NONE,
+                              "SST-TF is supported",
+                              M_SIGNAL_BEHAVIOR_CONSTANT } }}
+          } },
+        { "SST::HIGHPRIORITY_NCORES",
+          { SSTIOGroup::SSTMailboxCommand::M_TURBO_FREQUENCY, 0x10,
+            {{ "0", { 0x0000, 0, 7, 1.0, M_UNITS_NONE,
+                      "Count of high-priority turbo frequency cores in bucket 0",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "1", { 0x0000, 8, 15, 1.0, M_UNITS_NONE,
+                      "Count of high-priority turbo frequency cores in bucket 1",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "2", { 0x0000, 16, 23, 1.0, M_UNITS_NONE,
+                      "Count of high-priority turbo frequency cores in bucket 2",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "3", { 0x0000, 24, 31, 1.0, M_UNITS_NONE,
+                      "Count of high-priority turbo frequency cores in bucket 3",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "4", { 0x0100, 0, 7, 1.0, M_UNITS_NONE,
+                      "Count of high-priority turbo frequency cores in bucket 4",
+                       M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "5", { 0x0100, 8, 15, 1.0, M_UNITS_NONE,
+                      "Count of high-priority turbo frequency cores in bucket 5",
+                       M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "6", { 0x0100, 16, 23, 1.0, M_UNITS_NONE,
+                      "Count of high-priority turbo frequency cores in bucket 6",
+                       M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "7", { 0x0100, 24, 31, 1.0, M_UNITS_NONE,
+                      "Count of high-priority turbo frequency cores in bucket 7",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } }}
+          } },
+        { "SST::HIGHPRIORITY_FREQUENCY_SSE",
+          { SSTIOGroup::SSTMailboxCommand::M_TURBO_FREQUENCY, 0x11,
+            {
+             { "0", { 0x000000, 0, 7, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 0 at the SSE license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "1", { 0x000000, 8, 15, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 1 at the SSE license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "2", { 0x000000, 16, 23, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 2 at the SSE license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "3", { 0x000000, 24, 31, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 3 at the SSE license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "4", { 0x000100, 0, 7, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 4 at the SSE license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "5", { 0x000100, 8, 15, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 5 at the SSE license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "6", { 0x000100, 16, 23, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 6 at the SSE license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "7", { 0x000100, 24, 31, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 7 at the SSE license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } }}
+          } },
+        { "SST::HIGHPRIORITY_FREQUENCY_AVX2",
+          { SSTIOGroup::SSTMailboxCommand::M_TURBO_FREQUENCY, 0x11,
+            {{ "0", { 0x010000, 0, 7, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 0 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "1", { 0x010000, 8, 15, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 1 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "2", { 0x010000, 16, 23, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 2 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "3", { 0x010000, 24, 31, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 3 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "4", { 0x010100, 0, 7, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 4 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "5", { 0x010100, 8, 15, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 5 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "6", { 0x010100, 16, 23, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 6 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "7", { 0x010100, 24, 31, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 7 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } }}
+          } },
+        { "SST::HIGHPRIORITY_FREQUENCY_AVX512",
+          { SSTIOGroup::SSTMailboxCommand::M_TURBO_FREQUENCY, 0x11,
+            {{ "0", { 0x020000, 0, 7, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 0 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "1", { 0x020000, 8, 15, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 1 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "2", { 0x020000, 16, 23, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 2 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "3", { 0x020000, 24, 31, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 3 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "4", { 0x020100, 0, 7, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 4 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "5", { 0x020100, 8, 15, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 5 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "6", { 0x020100, 16, 23, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 6 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "7", { 0x020100, 24, 31, 1e8, M_UNITS_HERTZ,
+                      "High-priority turbo frequency for bucket 7 at the AVX2 license level",
+                      M_SIGNAL_BEHAVIOR_CONSTANT } }}
+          } },
+        { "SST::LOWPRIORITY_FREQUENCY",
+          { SSTIOGroup::SSTMailboxCommand::M_TURBO_FREQUENCY, 0x12,
+            {{ "SSE", { 0x00, 0, 7, 1e8, M_UNITS_HERTZ,
+                        "Low-priority turbo frequency at the SSE license level",
+                        M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "AVX2", { 0x00, 8, 15, 1e8, M_UNITS_HERTZ,
+                         "Low-priority turbo frequency at the AVX2 license level",
+                         M_SIGNAL_BEHAVIOR_CONSTANT } },
+             { "AVX512", { 0x00, 16, 23, 1e8, M_UNITS_HERTZ,
+                           "Low-priority turbo frequency at the AVX512 license level",
+                           M_SIGNAL_BEHAVIOR_CONSTANT } }}
+          } },
+        { "SST::COREPRIORITY_SUPPORT",
+          { SSTIOGroup::SSTMailboxCommand::M_SUPPORT_CAPABILITIES, 0x03,
+            {{ "CAPABILITIES", { 0x00, 0, 0, 1.0, M_UNITS_NONE,
+                                 "SST-CP is supported",
+                                 M_SIGNAL_BEHAVIOR_CONSTANT } }}
+          } }
+    };
+
+    const std::map<std::string, SSTIOGroup::sst_control_mailbox_raw_s> SSTIOGroup::sst_control_mbox_info = {
+        { "SST::TURBO_ENABLE",
+            { SSTIOGroup::SSTMailboxCommand::M_TURBO_FREQUENCY,
+                // Control
+                0x02, 0x00 /* N/A */,
+                {{ "ENABLE", { 0x01, 16, 16, M_UNITS_NONE,
+                               "SST-TF is enabled" } }},
+                // Signal
+                0x01, 0x00
+            },
+        },
+        { "SST::COREPRIORITY_ENABLE",
+            // 0x03 when enabling; 0x01 when disabling
+            { SSTIOGroup::SSTMailboxCommand::M_CORE_PRIORITY,
+                // Control
+                0x02, 0x100,
+                {{ "ENABLE", { 0x01, 1, 1, M_UNITS_NONE, "SST-CP is enabled" } },
+                 { "DISABLE_RMID_REPORTING", { 0x01, 0, 0, M_UNITS_NONE, "SST RMID reporting is disabled"  } }},
+                // Signal
+                0x02, 0x00
+            },
+        },
+    };
+
+    const std::map<std::string, SSTIOGroup::sst_control_mmio_raw_s> SSTIOGroup::sst_control_mmio_info = {
+        { "SST::COREPRIORITY:0",
+          { GEOPM_DOMAIN_PACKAGE, 0x08,
+            { { "WEIGHT", { 4, 7, 1.0, M_UNITS_NONE, "Proportional priority for core priority level 0"  } },
+              { "FREQUENCY_MIN", { 8, 15, 1e-8, M_UNITS_HERTZ, "Minimum frequency of core priority level 0"  } },
+              { "FREQUENCY_MAX", { 16, 23, 1e-8, M_UNITS_HERTZ, "Maximum frequency of core priority level 0"  } } } } },
+        { "SST::COREPRIORITY:1",
+          { GEOPM_DOMAIN_PACKAGE, 0x0c,
+            { { "WEIGHT", { 4, 7, 1.0, M_UNITS_NONE, "Proportional priority for core priority level 1"  } },
+              { "FREQUENCY_MIN", { 8, 15, 1e-8, M_UNITS_HERTZ, "Minimum frequency of core priority level 1"  } },
+              { "FREQUENCY_MAX", { 16, 23, 1e-8, M_UNITS_HERTZ, "Maximum frequency of core priority level 1"  } } } } },
+        { "SST::COREPRIORITY:2",
+          { GEOPM_DOMAIN_PACKAGE, 0x10,
+            { { "WEIGHT", { 4, 7, 1.0, M_UNITS_NONE, "Proportional priority for core priority level 2"  } },
+              { "FREQUENCY_MIN", { 8, 15, 1e-8, M_UNITS_HERTZ, "Minimum frequency of core priority level 2"  } },
+              { "FREQUENCY_MAX", { 16, 23, 1e-8, M_UNITS_HERTZ, "Maximum frequency of core priority level 2"  } } } } },
+        { "SST::COREPRIORITY:3",
+          { GEOPM_DOMAIN_PACKAGE, 0x14,
+            { { "WEIGHT", { 4, 7, 1.0, M_UNITS_NONE, "Proportional priority for core priority level 3"  } },
+              { "FREQUENCY_MIN", { 8, 15, 1e-8, M_UNITS_HERTZ, "Minimum frequency of core priority level 3"  } },
+              { "FREQUENCY_MAX", { 16, 23, 1e-8, M_UNITS_HERTZ, "Maximum frequency of core priority level 3"  } } } } },
+        { "SST::COREPRIORITY",
+          { GEOPM_DOMAIN_CORE, 0x20, /* offset will be augmented by core index */
+            { { "ASSOCIATION", { 16, 17, 1.0, M_UNITS_NONE, "Assigned core priority level"  } } } } },
+    };
+
+    SSTIOGroup::SSTIOGroup(const PlatformTopo &topo, std::shared_ptr<SSTIO> sstio)
+        : m_topo(topo)
+        , m_sstio(sstio)
+        , m_is_read(false)
+        , m_signal_available()
+        , m_control_available()
+        , m_signal_pushed()
+        , m_control_pushed()
+    {
+        if (m_sstio == nullptr) {
+            m_sstio = SSTIO::make_shared(m_topo.num_domain(GEOPM_DOMAIN_CPU));
+        }
+
+        // Directly register MBOX-based signals
+        for (const auto &kv : sst_signal_mbox_info) {
+            auto raw_name = kv.first;
+            auto raw_desc = kv.second;
+
+            add_mbox_signals(raw_name, raw_desc.command, raw_desc.subcommand,
+                             raw_desc.fields);
+        }
+
+        // For MBOX-based controls, register both a control and a signal. The
+        // control needs to be aware of how the signal reads are performed so
+        // it can do software read/modify/write.
+        for (const auto &kv : sst_control_mbox_info) {
+            auto raw_name = kv.first;
+            auto raw_desc = kv.second;
+
+            // Create a read mask for pre-write reads in the control. The mask
+            // is a union of all known fields.
+            uint32_t control_read_mask = 0;
+
+            std::map<std::string, sst_signal_mailbox_field_s> fields;
+            for (const auto& field : raw_desc.fields)
+            {
+                fields.emplace(field.first,
+                               sst_signal_mailbox_field_s{
+                                   raw_desc.read_request_data, field.second.begin_bit,
+                                   field.second.end_bit, 1.0, field.second.units,
+                                   field.second.description, M_SIGNAL_BEHAVIOR_VARIABLE });
+                auto bit_count = field.second.end_bit - field.second.begin_bit + 1;
+                auto field_mask = ((1ull << bit_count) - 1) << field.second.begin_bit;
+                control_read_mask |= field_mask;
+            }
+
+            add_mbox_signals(raw_name, raw_desc.command,
+                             raw_desc.read_subcommand, fields);
+            add_mbox_controls(raw_name, raw_desc.command, raw_desc.subcommand,
+                              raw_desc.write_param, raw_desc.fields,
+                              raw_desc.read_subcommand,
+                              raw_desc.read_request_data, control_read_mask);
+        }
+
+        // This IOGroup currently has no MMIO-based signals, except for those
+        // that are registered with their related controls below.
+
+        // For MMIO-based controls, register both a control and a signal.
+        for (const auto &kv : sst_control_mmio_info) {
+            auto raw_name = kv.first;
+            auto raw_desc = kv.second;
+
+            uint32_t control_read_mask = 0;
+
+            std::map<std::string, sst_signal_mmio_field_s> fields;
+            for (const auto& field : raw_desc.fields)
+            {
+                fields.emplace(field.first,
+                               sst_signal_mmio_field_s{
+                                   0, field.second.begin_bit, field.second.end_bit,
+                                   1 / field.second.multiplier, field.second.units,
+                                   field.second.description, M_SIGNAL_BEHAVIOR_VARIABLE });
+                auto bit_count = field.second.end_bit - field.second.begin_bit + 1;
+                auto field_mask = ((1ull << bit_count) - 1) << field.second.begin_bit;
+                control_read_mask |= field_mask;
+            }
+
+            add_mmio_signals(raw_name, raw_desc.domain_type, raw_desc.register_offset, fields);
+            add_mmio_controls(raw_name, raw_desc.domain_type, raw_desc.register_offset,
+                              raw_desc.fields, control_read_mask);
+        }
+    }
+
+    std::set<std::string> SSTIOGroup::signal_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &kv : m_signal_available) {
+            result.insert(kv.first);
+        }
+        return result;
+    }
+
+    std::set<std::string> SSTIOGroup::control_names(void) const
+    {
+        std::set<std::string> names;
+        for (const auto &kv : m_control_available) {
+            names.insert(kv.first);
+        }
+        return names;
+    }
+
+    bool SSTIOGroup::is_valid_signal(const std::string &signal_name) const
+    {
+        return (m_signal_available.find(signal_name) != m_signal_available.end());
+    }
+
+    bool SSTIOGroup::is_valid_control(const std::string &control_name) const
+    {
+        return m_control_available.find(control_name) != m_control_available.end();
+    }
+
+    int SSTIOGroup::signal_domain_type(const std::string &signal_name) const
+    {
+        int result = GEOPM_DOMAIN_INVALID;
+        auto it = m_signal_available.find(signal_name);
+        if (it != m_signal_available.end()) {
+            result = it->second.domain;
+        }
+        return result;
+    }
+
+    int SSTIOGroup::control_domain_type(const std::string &control_name) const
+    {
+        int result = GEOPM_DOMAIN_INVALID;
+        auto it = m_control_available.find(control_name);
+        if (it != m_control_available.end()) {
+            result = it->second.domain;
+        }
+        return result;
+    }
+
+    int SSTIOGroup::push_signal(const std::string &signal_name, int domain_type, int domain_idx)
+    {
+        int result = -1;
+        auto it = m_signal_available.find(signal_name);
+        if (it != m_signal_available.end()) {
+            if (domain_type != it->second.domain) {
+                throw Exception("SSTIOGroup::push_signal(): wrong domain type",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            auto signal = it->second.signals[domain_idx];
+            auto already_pushed_signal = std::find(m_signal_pushed.begin(),
+                                                   m_signal_pushed.end(), signal);
+            if (already_pushed_signal == m_signal_pushed.end()) {
+                result = m_signal_pushed.size();
+                m_signal_pushed.push_back(signal);
+                signal->setup_batch();
+            }
+            else {
+                result = std::distance(m_signal_pushed.begin(), already_pushed_signal);
+            }
+        }
+        else {
+            throw Exception("SSTIOGroup::push_signal(): invalid signal",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return result;
+    }
+
+    int SSTIOGroup::push_control(const std::string &control_name, int domain_type, int domain_idx)
+    {
+        int result = -1;
+        auto it = m_control_available.find(control_name);
+        if (it != m_control_available.end()) {
+            if (domain_type != it->second.domain) {
+                throw Exception("SSTIOGroup::push_control(): wrong domain type",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            auto control = it->second.controls[domain_idx];
+            auto already_pushed_control = std::find(
+                m_control_pushed.begin(), m_control_pushed.end(), control);
+            if (already_pushed_control == m_control_pushed.end()) {
+                result = m_control_pushed.size();
+                m_control_pushed.push_back(control);
+                control->setup_batch();
+            }
+            else {
+                result = std::distance(m_control_pushed.begin(), already_pushed_control);
+            }
+        }
+        else {
+            throw Exception("SSTIOGroup::push_control(): invalid control",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return result;
+    }
+
+    void SSTIOGroup::read_batch(void)
+    {
+        m_sstio->read_batch();
+        m_is_read = true;
+    }
+
+    void SSTIOGroup::write_batch(void)
+    {
+        m_sstio->write_batch();
+    }
+
+    double SSTIOGroup::sample(int batch_idx)
+    {
+        if (batch_idx < 0 || batch_idx >= static_cast<int>(m_signal_pushed.size())) {
+            throw Exception("SSTIOGroup::sample(): batch_idx out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (!m_is_read) {
+            throw Exception("SSTIOGroup::sample() called before the signal was read.",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        return m_signal_pushed[batch_idx]->sample();
+    }
+
+    void SSTIOGroup::adjust(int batch_idx, double setting)
+    {
+        m_control_pushed[batch_idx]->adjust(setting);
+    }
+
+    double SSTIOGroup::read_signal(const std::string &signal_name,
+                                   int domain_type, int domain_idx)
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("SSTIOGroup::read_signal(): invalid signal",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (domain_type != it->second.domain) {
+            throw Exception("SSTIOGroup::read_signal(): wrong domain type",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return it->second.signals[domain_idx]->read();
+    }
+
+    void SSTIOGroup::write_control(const std::string &control_name,
+                                   int domain_type, int domain_idx, double setting)
+    {
+        auto it = m_control_available.find(control_name);
+        if (it == m_control_available.end()) {
+            throw Exception("SSTIOGroup::write_control(): invalid control",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (domain_type != it->second.domain) {
+            throw Exception("SSTIOGroup::write_control(): wrong domain type",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        it->second.controls[domain_idx]->write(setting);
+    }
+
+    void SSTIOGroup::save_control(void)
+    {
+        // Try both safe/restore at the time of save. We can detect potential
+        // restore failures before we actually need to restore later. If any
+        // failures are encountered now, remove the control from our list of
+        // available controls.
+        std::vector<std::string> unallowed_controls;
+        for (auto &control : m_control_available) {
+            try {
+                for (auto &domain_control : control.second.controls) {
+                    domain_control->save();
+                    domain_control->restore();
+                }
+            }
+            catch (...) {
+                unallowed_controls.push_back(control.first);
+            }
+        }
+        for (auto &control : unallowed_controls) {
+            m_control_available.erase(control);
+        }
+    }
+
+    void SSTIOGroup::restore_control(void)
+    {
+        for (auto &control : m_control_available) {
+            for (auto &domain_control : control.second.controls) {
+                domain_control->restore();
+            }
+        }
+    }
+
+    std::string SSTIOGroup::plugin_name(void)
+    {
+        return "SST";
+    }
+
+    std::unique_ptr<IOGroup> SSTIOGroup::make_plugin(void)
+    {
+        return geopm::make_unique<SSTIOGroup>(platform_topo(), nullptr);
+    }
+
+    std::function<double(const std::vector<double> &)> SSTIOGroup::agg_function(const std::string &signal_name) const
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("SSTIOGroup::agg_function(): " + signal_name +
+                            "not valid for SSTIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return Agg::select_first;
+    }
+
+    std::function<std::string(double)> SSTIOGroup::format_function(const std::string &signal_name) const
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("SSTIOGroup::format_function(): " + signal_name +
+                            "not valid for SSTIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return string_format_double;
+    }
+
+    std::string SSTIOGroup::signal_description(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("SSTIOGroup::signal_description(): " + signal_name +
+                                "not valid for SSTIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::ostringstream oss;
+        oss << "    description: " << it->second.description << "\n"
+            << "    units: " << IOGroup::units_to_string(it->second.units) << "\n"
+            << "    aggregation: " << Agg::function_to_name(Agg::select_first) << "\n"
+            << "    domain: " << platform_topo().domain_type_to_name(it->second.domain) << "\n"
+            << "    iogroup: SSTIOGroup";
+
+        return oss.str();
+    }
+
+    std::string SSTIOGroup::control_description(const std::string &control_name) const
+    {
+        auto it = m_control_available.find(control_name);
+        if (it == m_control_available.end()) {
+            throw Exception("SSTIOGroup::control_description(): " + control_name +
+                                "not valid for SSTIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::ostringstream oss;
+        oss << "    description: " << it->second.description << "\n"
+            << "    units: " << IOGroup::units_to_string(it->second.units) << "\n"
+            << "    aggregation: " << Agg::function_to_name(Agg::select_first) << "\n"
+            << "    domain: " << platform_topo().domain_type_to_name(it->second.domain) << "\n"
+            << "    iogroup: SSTIOGroup";
+
+        return oss.str();
+    }
+
+    int SSTIOGroup::signal_behavior(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("SSTIOGroup::signal_behavior(): " + signal_name +
+                                "not valid for SSTIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return it->second.behavior;
+    }
+
+    void SSTIOGroup::add_mbox_signals(
+        const std::string &raw_name, SSTIOGroup::SSTMailboxCommand command,
+        uint16_t subcommand, const std::map<std::string, sst_signal_mailbox_field_s> &fields)
+
+    {
+        int domain_type = GEOPM_DOMAIN_PACKAGE;
+        int num_domain = m_topo.num_domain(domain_type);
+
+        for (const auto &ff : fields) {
+            auto field_name = ff.first;
+            auto field_desc = ff.second;
+            auto request_data = field_desc.request_data;
+            auto begin_bit = field_desc.begin_bit;
+            auto end_bit = field_desc.end_bit;
+            auto description = field_desc.description;
+            auto behavior = field_desc.behavior;
+            auto units = field_desc.units;
+            double multiplier = field_desc.multiplier;
+
+            char hex[32];
+            snprintf(hex, 32, "0x%05" PRIx32, request_data);
+            std::string raw_signal_name = raw_name + "_" + hex + "#";
+
+            // add raw signal for every domain index
+            auto it = m_signal_available.find(raw_signal_name);
+            if (it == m_signal_available.end()) {
+                std::vector<std::shared_ptr<Signal> > signals;
+                for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+                    auto cpus = m_topo.domain_nested(GEOPM_DOMAIN_CPU, domain_type, domain_idx);
+                    int cpu_idx = *(cpus.begin());
+                    auto raw_sst = std::make_shared<SSTSignal>(
+                        m_sstio, SSTSignal::M_MBOX, cpu_idx, static_cast<uint16_t>(command),
+                        subcommand, request_data, 0 /* interface parameter */);
+                    signals.push_back(raw_sst);
+                }
+                m_signal_available[raw_signal_name] = {
+                    .signals = signals,
+                    .domain = domain_type,
+                    .units = units,
+                    .agg_function = Agg::select_first,
+                    .description = description,
+                    .behavior = behavior
+                };
+            }
+            std::string field_signal_name = raw_name + ":" + field_name;
+            auto raw_sst_list = m_signal_available.at(raw_signal_name).signals;
+            std::vector<std::shared_ptr<Signal> > signals;
+            for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+                auto field_signal = std::make_shared<MSRFieldSignal>(
+                    raw_sst_list[domain_idx], begin_bit, end_bit,
+                    MSR::M_FUNCTION_SCALE, multiplier);
+                signals.push_back(field_signal);
+            }
+            m_signal_available[field_signal_name] = {
+                .signals = signals,
+                .domain = domain_type,
+                .units = units,
+                .agg_function = Agg::select_first,
+                .description = description,
+                .behavior = behavior
+            };
+        }
+    }
+
+    void SSTIOGroup::add_mbox_controls(
+        const std::string &raw_name, SSTMailboxCommand command,
+        uint16_t subcommand, uint32_t write_param,
+        const std::map<std::string, sst_control_mailbox_field_s> &fields,
+        uint16_t read_subcommand, uint32_t read_request_data, uint32_t read_mask)
+    {
+        int domain_type = GEOPM_DOMAIN_PACKAGE;
+        int num_domain = m_topo.num_domain(domain_type);
+
+        for (const auto &ff : fields) {
+            auto field_name = ff.first;
+            auto field_description = ff.second;
+            auto write_data = field_description.write_data;
+            auto begin_bit = field_description.begin_bit;
+            auto end_bit = field_description.end_bit;
+            auto description = field_description.description;
+            auto units = field_description.units;
+
+            std::string field_control_name = raw_name + ":" + field_name;
+
+            // add raw control for every domain index
+            auto it = m_control_available.find(field_control_name);
+            if (it == m_control_available.end()) {
+                std::vector<std::shared_ptr<Control> > controls;
+                for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+                    auto cpus = m_topo.domain_nested(GEOPM_DOMAIN_CPU,
+                                                     domain_type, domain_idx);
+                    int cpu_idx = *(cpus.begin());
+
+                    auto raw_sst = std::make_shared<SSTControl>(
+                        m_sstio, SSTControl::M_MBOX, cpu_idx, static_cast<uint16_t>(command),
+                        subcommand, write_param, write_data, begin_bit, end_bit,
+                        1.0, read_subcommand, read_request_data, read_mask);
+
+                    controls.push_back(raw_sst);
+                }
+                m_control_available[field_control_name] = {
+                    .controls = controls,
+                    .domain = domain_type,
+                    .units = units,
+                    .agg_function = Agg::select_first,
+                    .description = description
+                };
+            }
+        }
+    }
+
+    void SSTIOGroup::add_mmio_signals(const std::string &raw_name,
+                                      int domain_type, uint32_t register_offset,
+                                      const std::map<std::string, sst_signal_mmio_field_s> &fields)
+    {
+        int num_domain = m_topo.num_domain(domain_type);
+
+        for (const auto &ff : fields) {
+            auto field_name = ff.first;
+            auto field_desc = ff.second;
+            auto write_value = field_desc.write_value;
+            auto begin_bit = field_desc.begin_bit;
+            auto end_bit = field_desc.end_bit;
+            auto description = field_desc.description;
+            auto behavior = field_desc.behavior;
+            auto units = field_desc.units;
+            double multiplier = field_desc.multiplier;
+
+            char hex[32];
+            snprintf(hex, 32, "0x%05" PRIx32, register_offset);
+            std::string raw_signal_name = raw_name + "_" + hex + "#";
+
+            // add raw signal for every domain index
+            auto it = m_signal_available.find(raw_signal_name);
+            if (it == m_signal_available.end()) {
+                std::vector<std::shared_ptr<Signal> > signals;
+                for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+                    auto cpus = m_topo.domain_nested(GEOPM_DOMAIN_CPU, domain_type, domain_idx);
+                    int cpu_idx = *(cpus.begin());
+                    uint32_t augmented_offset = domain_type == GEOPM_DOMAIN_CORE
+                        ? register_offset + m_sstio->get_punit_from_cpu(domain_idx) * 4
+                        : register_offset;
+                    auto raw_sst = std::make_shared<SSTSignal>(
+                        m_sstio, SSTSignal::M_MMIO, cpu_idx, 0x00, 0x00, augmented_offset, write_value);
+
+                    signals.push_back(raw_sst);
+                }
+                m_signal_available[raw_signal_name] = {
+                    .signals = signals,
+                    .domain = domain_type,
+                    .units = units,
+                    .agg_function = Agg::select_first,
+                    .description = description,
+                    .behavior = behavior
+                };
+            }
+
+            std::string field_signal_name = raw_name + ":" + field_name;
+            auto raw_sst_list = m_signal_available.at(raw_signal_name).signals;
+            std::vector<std::shared_ptr<Signal> > signals;
+            for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+                // This isn't necessarily an MSR, but these signals have the
+                // same need for read masks and scaling as MSR's need, so
+                // we are able to use the same helper class here.
+                auto field_signal = std::make_shared<MSRFieldSignal>(
+                    raw_sst_list[domain_idx], begin_bit, end_bit,
+                    MSR::M_FUNCTION_SCALE, multiplier);
+                signals.push_back(field_signal);
+            }
+            m_signal_available[field_signal_name] = {
+                .signals = signals,
+                .domain = domain_type,
+                .units = units,
+                .agg_function = Agg::select_first,
+                .description = description,
+                .behavior = behavior
+            };
+        }
+    }
+
+    void SSTIOGroup::add_mmio_controls(
+        const std::string &raw_name, int domain_type, uint32_t register_offset,
+        const std::map<std::string, sst_control_mmio_field_s> &fields, uint32_t read_mask)
+    {
+        int num_domain = m_topo.num_domain(domain_type);
+
+        for (const auto &ff : fields) {
+            auto field_name = ff.first;
+            auto field_desc = ff.second;
+            auto begin_bit = field_desc.begin_bit;
+            auto end_bit = field_desc.end_bit;
+            auto description = field_desc.description;
+            auto units = field_desc.units;
+            double multiplier = field_desc.multiplier;
+
+            // add raw control for every domain index
+            std::string raw_control_name = raw_name + ":" + field_name;
+            auto it = m_control_available.find(raw_control_name);
+            if (it == m_control_available.end()) {
+                std::vector<std::shared_ptr<Control> > controls;
+                for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+                    auto cpus = m_topo.domain_nested(GEOPM_DOMAIN_CPU, domain_type, domain_idx);
+                    int cpu_idx = *(cpus.begin());
+                    uint32_t augmented_offset = domain_type == GEOPM_DOMAIN_CORE
+                        ? register_offset + m_sstio->get_punit_from_cpu(domain_idx) * 4
+                        : register_offset;
+                    auto control = std::make_shared<SSTControl>(
+                        m_sstio, SSTControl::M_MMIO, cpu_idx, 0x00, 0x00, augmented_offset,
+                        0x00 /* Write value. adjust later */, begin_bit,
+                        end_bit, multiplier, 0x00, 0x00, read_mask);
+
+                    controls.push_back(control);
+                }
+                m_control_available[raw_control_name] = {
+                    .controls = controls,
+                    .domain = domain_type,
+                    .units = units,
+                    .agg_function = Agg::select_first,
+                    .description = description
+                };
+            }
+        }
+    }
+}

--- a/src/SSTIOGroup.hpp
+++ b/src/SSTIOGroup.hpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SSTIOGROUP_HPP_INCLUDE
+#define SSTIOGROUP_HPP_INCLUDE
+
+#include <set>
+#include <functional>
+
+#include "IOGroup.hpp"
+
+
+namespace geopm
+{
+    class PlatformTopo;
+    class SSTIO;
+    class Signal;
+    class Control;
+
+    /// @brief IOGroup that provides a signal for the time since GEOPM startup.
+    class SSTIOGroup : public IOGroup
+    {
+        public:
+            SSTIOGroup(const PlatformTopo &topo, std::shared_ptr<SSTIO> sstio);
+            virtual ~SSTIOGroup() = default;
+            std::set<std::string> signal_names(void) const override;
+            std::set<std::string> control_names(void) const override;
+            bool is_valid_signal(const std::string &signal_name) const override;
+            bool is_valid_control(const std::string &control_name) const override;
+            int signal_domain_type(const std::string &signal_name) const override;
+            int control_domain_type(const std::string &control_name) const override;
+            int push_signal(const std::string &signal_name, int domain_type, int domain_idx)  override;
+            int push_control(const std::string &control_name, int domain_type, int domain_idx) override;
+            void read_batch(void) override;
+            void write_batch(void) override;
+            double sample(int batch_idx) override;
+            void adjust(int batch_idx, double setting) override;
+            double read_signal(const std::string &signal_name, int domain_type, int domain_idx) override;
+            void write_control(const std::string &control_name, int domain_type, int domain_idx, double setting) override;
+            void save_control(void) override;
+            void restore_control(void) override;
+            std::function<double(const std::vector<double> &)> agg_function(const std::string &signal_name) const override;
+            std::function<std::string(double)> format_function(const std::string &signal_name) const override;
+            std::string signal_description(const std::string &signal_name) const override;
+            std::string control_description(const std::string &control_name) const override;
+            int signal_behavior(const std::string &signal_name) const override;
+            static std::string plugin_name(void);
+            static std::unique_ptr<IOGroup> make_plugin(void);
+
+            enum class SSTMailboxCommand : uint16_t {
+                M_TURBO_FREQUENCY = 0x7f,
+                M_CORE_PRIORITY = 0xd0,
+                M_SUPPORT_CAPABILITIES = 0x94,
+            };
+        private:
+            struct sst_signal_mailbox_field_s {
+                //! Fields for an SST mailbox signal command
+                //! @param request_data Data to write to the mailbox prior to
+                //!        requesting new data. Often used to indicate which data to
+                //!        request for a given subcommand.
+                //! @param begin_bit LSB position to read from the output value.
+                //! @param end_bit MSB position to read from the output value.
+                //! @param multiplier Scaling factor to apply to the read value.
+                sst_signal_mailbox_field_s(uint32_t request_data, uint32_t begin_bit,
+                                           uint32_t end_bit, double multiplier,
+                                           int units, const std::string &description,
+                                           m_signal_behavior_e behavior)
+                    : request_data(request_data)
+                    , begin_bit(begin_bit)
+                    , end_bit(end_bit)
+                    , multiplier(multiplier)
+                    , units(units)
+                    , description(description)
+                    , behavior(behavior)
+                {
+                }
+                uint32_t request_data;
+                uint32_t begin_bit;
+                uint32_t end_bit;
+                double multiplier;
+                int units;
+                std::string description;
+                m_signal_behavior_e behavior;
+            };
+            struct sst_signal_mailbox_raw_s {
+                //! @param command Which type of mailbox command
+                //! @param subcommand Subtype of the given command
+                //! @param fields Subfields of the mailbox
+                sst_signal_mailbox_raw_s(SSTIOGroup::SSTMailboxCommand command, uint16_t subcommand,
+                                         const std::map<std::string, sst_signal_mailbox_field_s>& fields)
+                    : command(command)
+                    , subcommand(subcommand)
+                    , fields(fields)
+                {
+                }
+                SSTMailboxCommand command;
+                uint16_t subcommand;
+                std::map<std::string, sst_signal_mailbox_field_s> fields;
+            };
+
+            struct sst_control_mailbox_field_s {
+                sst_control_mailbox_field_s(uint32_t write_data, uint32_t begin_bit,
+                                            uint32_t end_bit, int units,
+                                            const std::string &description)
+                    : write_data(write_data)
+                    , begin_bit(begin_bit)
+                    , end_bit(end_bit)
+                    , units(units)
+                    , description(description)
+                {
+                }
+                uint32_t write_data;
+                uint32_t begin_bit;
+                uint32_t end_bit;
+                int units;
+                std::string description;
+            };
+            struct sst_control_mailbox_raw_s {
+                //! @param command Which type of mailbox command
+                //! @param subcommand Subtype of the given command
+                //! @param fields Subfields of the mailbox
+                sst_control_mailbox_raw_s(
+                    SSTMailboxCommand command, uint16_t subcommand, uint32_t write_param,
+                    const std::map<std::string, sst_control_mailbox_field_s>& fields,
+                    uint16_t read_subcommand, uint32_t read_request_data)
+                    : command(command)
+                    , subcommand(subcommand)
+                    , write_param(write_param)
+                    , fields(fields)
+                    , read_subcommand(read_subcommand)
+                    , read_request_data(read_request_data)
+                {
+                }
+                SSTMailboxCommand command;
+                uint16_t subcommand;
+                uint32_t write_param;
+                std::map<std::string, sst_control_mailbox_field_s> fields;
+                uint16_t read_subcommand;
+                uint32_t read_request_data;
+            };
+
+            struct sst_control_mmio_field_s {
+                sst_control_mmio_field_s(uint32_t begin_bit, uint32_t end_bit,
+                                         double multiplier, int units,
+                                         const std::string &description)
+                    : begin_bit(begin_bit)
+                    , end_bit(end_bit)
+                    , multiplier(multiplier)
+                    , units(units)
+                    , description(description)
+                {
+                }
+                uint32_t begin_bit;
+                uint32_t end_bit;
+                double multiplier;
+                int units;
+                std::string description;
+            };
+            struct sst_control_mmio_raw_s {
+                //! @param command Which type of mailbox command
+                //! @param subcommand Subtype of the given command
+                //! @param fields Subfields of the mailbox
+                sst_control_mmio_raw_s(int domain_type, uint32_t register_offset,
+                                       const std::map<std::string, sst_control_mmio_field_s>& fields)
+                    : domain_type(domain_type)
+                    , register_offset(register_offset)
+                    , fields(fields)
+                {
+                }
+                int domain_type;
+                uint32_t register_offset;
+                std::map<std::string, sst_control_mmio_field_s> fields;
+            };
+
+            struct sst_signal_mmio_field_s {
+                sst_signal_mmio_field_s(uint32_t write_value, uint32_t begin_bit,
+                                        uint32_t end_bit, double multiplier,
+                                        int units, const std::string &description,
+                                        m_signal_behavior_e behavior)
+                    : write_value(write_value)
+                    , begin_bit(begin_bit)
+                    , end_bit(end_bit)
+                    , multiplier(multiplier)
+                    , units(units)
+                    , description(description)
+                    , behavior(behavior)
+                {
+                }
+                uint32_t write_value;
+                uint32_t begin_bit;
+                uint32_t end_bit;
+                double multiplier;
+                int units;
+                std::string description;
+                m_signal_behavior_e behavior;
+            };
+
+            void add_mbox_signals(const std::string &raw_name,
+                                  SSTMailboxCommand command, uint16_t subcommand,
+                                  const std::map<std::string, sst_signal_mailbox_field_s> &fields);
+            void add_mbox_controls(
+                const std::string &raw_name, SSTMailboxCommand command,
+                uint16_t subcommand, uint32_t write_param,
+                const std::map<std::string, sst_control_mailbox_field_s> &fields,
+                uint16_t read_subcommand, uint32_t read_request_data,
+                uint32_t read_mask);
+
+            void add_mmio_signals(const std::string &raw_name, int domain_type,
+                                  uint32_t register_offset,
+                                  const std::map<std::string, sst_signal_mmio_field_s> &fields);
+            void add_mmio_controls(const std::string &raw_name, int domain_type,
+                                   uint32_t register_offset,
+                                   const std::map<std::string, sst_control_mmio_field_s> &fields,
+                                   uint32_t read_mask);
+
+            static const std::map<std::string, sst_signal_mailbox_raw_s> sst_signal_mbox_info;
+            static const std::map<std::string, sst_control_mailbox_raw_s> sst_control_mbox_info;
+            static const std::map<std::string, sst_control_mmio_raw_s> sst_control_mmio_info;
+            const PlatformTopo &m_topo;
+            std::shared_ptr<SSTIO> m_sstio;
+            bool m_is_read;
+
+            // All available signals: map from name to signal_info.
+            // The signals vector is over the indices for the domain.
+            // The signals pointers should be copied when signal is
+            // pushed and used directly for read_signal.
+            struct signal_info
+            {
+                std::vector<std::shared_ptr<Signal> > signals;
+                int domain;
+                int units;
+                std::function<double(const std::vector<double> &)> agg_function;
+                std::string description;
+                m_signal_behavior_e behavior;
+            };
+            std::map<std::string, signal_info> m_signal_available;
+
+            struct control_info
+            {
+                std::vector<std::shared_ptr<Control> > controls;
+                int domain;
+                int units;
+                std::function<double(const std::vector<double> &)> agg_function;
+                std::string description;
+            };
+            std::map<std::string, control_info> m_control_available;
+
+            // Mapping of signal index to pushed signals.
+            std::vector<std::shared_ptr<Signal> > m_signal_pushed;
+
+            // Mapping of control index to pushed controls
+            std::vector<std::shared_ptr<Control> > m_control_pushed;
+    };
+}
+
+#endif

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -467,6 +467,16 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/SSTControlTest.mmio_adjust_batch \
               test/gtest_links/SSTControlTest.save_restore_mmio \
               test/gtest_links/SSTControlTest.save_restore_mbox \
+              test/gtest_links/SSTIOGroupTest.adjust_mbox_control \
+              test/gtest_links/SSTIOGroupTest.adjust_mmio_control \
+              test/gtest_links/SSTIOGroupTest.error_in_save_removes_control \
+              test/gtest_links/SSTIOGroupTest.sample_mbox_control \
+              test/gtest_links/SSTIOGroupTest.sample_mbox_signal \
+              test/gtest_links/SSTIOGroupTest.sample_mmio_percore_control \
+              test/gtest_links/SSTIOGroupTest.valid_control_domains \
+              test/gtest_links/SSTIOGroupTest.valid_control_names \
+              test/gtest_links/SSTIOGroupTest.valid_signal_domains \
+              test/gtest_links/SSTIOGroupTest.valid_signal_names \
               test/gtest_links/SSTSignalTest.mailbox_read_batch \
               test/gtest_links/SSTSignalTest.mmio_read_batch \
               test/gtest_links/TimeIOGroupTest.adjust \
@@ -670,6 +680,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
                           test/SchedTest.cpp \
                           test/SharedMemoryTest.cpp \
                           test/SSTControlTest.cpp \
+                          test/SSTIOGroupTest.cpp \
                           test/SSTSignalTest.cpp \
                           test/TimeIOGroupTest.cpp \
                           test/TracerTest.cpp \

--- a/test/SSTIOGroupTest.cpp
+++ b/test/SSTIOGroupTest.cpp
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "Helper.hpp"
+#include "SSTIOGroup.hpp"
+#include "MockPlatformTopo.hpp"
+#include "MockSSTIO.hpp"
+
+using geopm::SSTIOGroup;
+using testing::Return;
+using testing::_;
+using testing::AtLeast;
+using testing::Throw;
+
+class SSTIOGroupTest : public :: testing :: Test
+{
+    protected:
+        void SetUp();
+        std::shared_ptr<MockSSTIO> m_sstio;
+        std::unique_ptr<SSTIOGroup> m_group;
+        std::shared_ptr<MockPlatformTopo> m_topo;
+        int m_num_package = 2;
+        int m_num_core = 4;
+        int m_num_cpu = 16;
+};
+
+void SSTIOGroupTest::SetUp()
+{
+    m_topo = make_topo(m_num_package, m_num_core, m_num_cpu);
+    EXPECT_CALL(*m_topo, domain_nested(_, _, _)).Times(AtLeast(0));
+    EXPECT_CALL(*m_topo, num_domain(_)).Times(AtLeast(0));
+
+    m_sstio = std::make_shared<MockSSTIO>();
+
+    for (int i = 0; i < m_num_cpu; ++i) {
+        /* Punit index doesn't necessarily equal cpu index. Make them different
+         * to make sure we calculate offsets based on punit instead of cpu.
+         */
+        ON_CALL(*m_sstio, get_punit_from_cpu(i)).WillByDefault(Return(i*2));
+    }
+
+    m_group = geopm::make_unique<SSTIOGroup>(*m_topo, m_sstio);
+}
+
+TEST_F(SSTIOGroupTest, valid_signal_names)
+{
+    auto names = m_group->signal_names();
+    for (auto nn : names) {
+        EXPECT_TRUE(m_group->is_valid_signal(nn)) << "nn = " << nn;
+    }
+    EXPECT_FALSE(m_group->is_valid_signal("SST::TOTALLY_MADE_UP:SIGNAL"));
+}
+
+TEST_F(SSTIOGroupTest, valid_control_names)
+{
+    auto names = m_group->control_names();
+    for (auto name : names) {
+        EXPECT_TRUE(m_group->is_valid_control(name)) << "name = " << name;
+    }
+    EXPECT_FALSE(m_group->is_valid_control("SST::TOTALLY_MADE_UP:CONTROL"));
+}
+
+TEST_F(SSTIOGroupTest, valid_signal_domains)
+{
+    auto names = m_group->signal_names();
+    for (auto name : names) {
+        if (name == "SST::COREPRIORITY:ASSOCIATION" || name == "SST::COREPRIORITY_0x00020#")
+        {
+            // These are the only signals that have per-core handling. If this
+            // test fails, then a new per-core signal was added. Make sure you
+            // handle any new special cases that appear.
+            EXPECT_EQ(GEOPM_DOMAIN_CORE, m_group->signal_domain_type(name))
+                << "name = " << name;
+        }
+        else {
+            EXPECT_EQ(GEOPM_DOMAIN_PACKAGE, m_group->signal_domain_type(name))
+                << "name = " << name;
+        }
+    }
+}
+
+TEST_F(SSTIOGroupTest, valid_control_domains)
+{
+    auto names = m_group->control_names();
+    for (auto name : names) {
+        if (name == "SST::COREPRIORITY:ASSOCIATION" || name == "SST::COREPRIORITY_0x00020#")
+        {
+            // These are the only controls that have per-core handling. If this
+            // test fails, then a new per-core control was added. Make sure you
+            // handle any new special cases that appear.
+            EXPECT_EQ(GEOPM_DOMAIN_CORE, m_group->control_domain_type(name))
+                << "name = " << name;
+        }
+        else {
+            EXPECT_EQ(GEOPM_DOMAIN_PACKAGE, m_group->control_domain_type(name))
+                << "name = " << name;
+        }
+    }
+}
+
+TEST_F(SSTIOGroupTest, sample_mbox_signal)
+{
+    enum sst_idx_e {
+        CONFIG_LEVEL_0,
+        CONFIG_LEVEL_1
+    };
+
+    int pkg_0_cpu = 0;
+    int pkg_1_cpu = 2;
+
+    EXPECT_CALL(*m_sstio, add_mbox_read(pkg_0_cpu, 0x7F, 0x00, 0x00))
+        .WillOnce(Return(CONFIG_LEVEL_0));
+    EXPECT_CALL(*m_sstio, add_mbox_read(pkg_1_cpu, 0x7F, 0x00, 0x00))
+        .WillOnce(Return(CONFIG_LEVEL_1));
+
+    int idx0 = m_group->push_signal("SST::CONFIG_LEVEL:LEVEL", GEOPM_DOMAIN_PACKAGE, 0);
+    int idx1 = m_group->push_signal("SST::CONFIG_LEVEL:LEVEL", GEOPM_DOMAIN_PACKAGE, 1);
+    EXPECT_NE(idx0, idx1);
+
+    EXPECT_CALL(*m_sstio, read_batch());
+    m_group->read_batch();
+    uint32_t raw0 = 0x1428000;
+    uint32_t raw1 = 0x1678000;
+    uint32_t expected0 = 0x42;
+    uint32_t expected1 = 0x67;
+    EXPECT_CALL(*m_sstio, sample(CONFIG_LEVEL_0)).WillOnce(Return(raw0));
+    EXPECT_CALL(*m_sstio, sample(CONFIG_LEVEL_1)).WillOnce(Return(raw1));
+    uint32_t result = m_group->sample(idx0);
+    EXPECT_EQ(expected0, result);
+    result = m_group->sample(idx1);
+    EXPECT_EQ(expected1, result);
+}
+
+// This tests a different path from sample_mbox_signal. While both cover signals
+// that go through the mailbox interface, this test covers signals that are
+// generated from a definition for a mailbox control.
+TEST_F(SSTIOGroupTest, sample_mbox_control)
+{
+    enum sst_idx_e {
+        CONFIG_LEVEL_0,
+        CONFIG_LEVEL_1
+    };
+
+    int pkg_0_cpu = 0;
+    int pkg_1_cpu = 2;
+
+    EXPECT_CALL(*m_sstio, add_mbox_read(pkg_0_cpu, 0x7f, 0x01, 0x00))
+        .WillOnce(Return(CONFIG_LEVEL_0));
+    EXPECT_CALL(*m_sstio, add_mbox_read(pkg_1_cpu, 0x7f, 0x01, 0x00))
+        .WillOnce(Return(CONFIG_LEVEL_1));
+
+    int idx0 = m_group->push_signal("SST::TURBO_ENABLE:ENABLE", GEOPM_DOMAIN_PACKAGE, 0);
+    int idx1 = m_group->push_signal("SST::TURBO_ENABLE:ENABLE", GEOPM_DOMAIN_PACKAGE, 1);
+    EXPECT_NE(idx0, idx1);
+
+    EXPECT_CALL(*m_sstio, read_batch());
+    m_group->read_batch();
+    // Should only read bit 16
+    uint32_t raw0 = 0xffffff;
+    uint32_t raw1 = 0xfeffff;
+    uint32_t expected0 = 0x1;
+    uint32_t expected1 = 0x0;
+    EXPECT_CALL(*m_sstio, sample(CONFIG_LEVEL_0)).WillOnce(Return(raw0));
+    EXPECT_CALL(*m_sstio, sample(CONFIG_LEVEL_1)).WillOnce(Return(raw1));
+    uint32_t result = m_group->sample(idx0);
+    EXPECT_EQ(expected0, result);
+    result = m_group->sample(idx1);
+    EXPECT_EQ(expected1, result);
+}
+
+// There aren't currently any MMIO signals, except those that are generated
+// from MMIO controls. This tests an MMIO signal generated from a control.
+// Specifically, this tests one that operates in the core domain.
+TEST_F(SSTIOGroupTest, sample_mmio_percore_control)
+{
+    enum sst_idx_e {
+        COREPRIORITY_0 = 10,
+        COREPRIORITY_1 = 20
+    };
+
+    int core_0_cpu = 0;
+    int core_1_cpu = 1;
+
+    EXPECT_CALL(*m_sstio, add_mmio_read(core_0_cpu, 0x20))
+        .WillOnce(Return(COREPRIORITY_0));
+    EXPECT_CALL(*m_sstio, add_mmio_read(core_1_cpu, 0x28 /* punit 2 */))
+        .WillOnce(Return(COREPRIORITY_1));
+
+    int idx0 = m_group->push_signal("SST::COREPRIORITY:ASSOCIATION", GEOPM_DOMAIN_CORE, 0);
+    int idx1 = m_group->push_signal("SST::COREPRIORITY:ASSOCIATION", GEOPM_DOMAIN_CORE, 1);
+    EXPECT_NE(idx0, idx1);
+
+    EXPECT_CALL(*m_sstio, read_batch());
+    m_group->read_batch();
+
+    // It should read bits 16..17 (lower 2 bits of e and 1) 
+    uint32_t raw0 = 0xfeffff;
+    uint32_t raw1 = 0xf1ffff;
+    uint32_t expected0 = 0x2;
+    uint32_t expected1 = 0x1;
+
+    EXPECT_CALL(*m_sstio, sample(COREPRIORITY_0)).WillOnce(Return(raw0));
+    EXPECT_CALL(*m_sstio, sample(COREPRIORITY_1)).WillOnce(Return(raw1));
+    uint32_t result = m_group->sample(idx0);
+    EXPECT_EQ(expected0, result);
+    result = m_group->sample(idx1);
+    EXPECT_EQ(expected1, result);
+}
+
+TEST_F(SSTIOGroupTest, adjust_mbox_control)
+{
+    enum sst_idx_e {
+        /* Arbitrary values. Just make them different from other offsets in this
+         * test to reduce chances of false passes.
+         */
+        TURBO_ENABLE_0 = 10,
+        TURBO_ENABLE_1 = 20
+    };
+
+    int pkg_0_cpu = 0;
+    int pkg_1_cpu = 2;
+
+    EXPECT_CALL(*m_sstio, add_mbox_write(pkg_0_cpu, 0x7F, 0x02, 0x00, 0x01, 0x00, 0x10000))
+        .WillOnce(Return(TURBO_ENABLE_0));
+    EXPECT_CALL(*m_sstio, add_mbox_write(pkg_1_cpu, 0x7F, 0x02, 0x00, 0x01, 0x00, 0x10000))
+        .WillOnce(Return(TURBO_ENABLE_1));
+
+    int idx0 = m_group->push_control("SST::TURBO_ENABLE:ENABLE", GEOPM_DOMAIN_PACKAGE, 0);
+    int idx1 = m_group->push_control("SST::TURBO_ENABLE:ENABLE", GEOPM_DOMAIN_PACKAGE, 1);
+    EXPECT_NE(idx0, idx1);
+
+    int shift = 16;  // bit 16
+    EXPECT_CALL(*m_sstio, adjust(TURBO_ENABLE_0, 0x1 << shift, 0x10000));
+    EXPECT_CALL(*m_sstio, adjust(TURBO_ENABLE_1, 0x0 << shift, 0x10000));
+    m_group->adjust(idx0, 0x1);
+    m_group->adjust(idx1, 0x0);
+}
+
+
+TEST_F(SSTIOGroupTest, adjust_mmio_control)
+{
+    enum sst_idx_e {
+        /* Arbitrary values. Just make them different from other offsets in this
+         * test to reduce chances of false passes.
+         */
+        FREQ_0 = 10,
+        FREQ_1 = 20
+    };
+
+    int pkg_0_cpu = 0;
+    int pkg_1_cpu = 2;
+
+    // Expectations for SST::COREPRIORITY:1:FREQUENCY_MIN
+    EXPECT_CALL(*m_sstio, add_mmio_write(pkg_0_cpu, 0x0c, 0, 0x00fffff0 /* bits 4..23. All known fields */))
+        .WillOnce(Return(FREQ_0));
+    EXPECT_CALL(*m_sstio, add_mmio_write(pkg_1_cpu, 0x0c, 0, 0x00fffff0 /* bits 4..23. All known fields */))
+        .WillOnce(Return(FREQ_1));
+
+    int idx0 = m_group->push_control("SST::COREPRIORITY:1:FREQUENCY_MIN", GEOPM_DOMAIN_PACKAGE, 0);
+    int idx1 = m_group->push_control("SST::COREPRIORITY:1:FREQUENCY_MIN", GEOPM_DOMAIN_PACKAGE, 1);
+    EXPECT_NE(idx0, idx1);
+
+    int shift = 8;  // bits 8-15
+    EXPECT_CALL(*m_sstio, adjust(FREQ_0, 10 /* 100s of MHz */ << shift, 0xff00 /* just this field */));
+    m_group->adjust(idx0, 1e9);
+    EXPECT_CALL(*m_sstio, adjust(FREQ_1, 21 /* 100s of MHz */ << shift, 0xff00 /* just this field */));
+    m_group->adjust(idx1, 2.1e9);
+}
+
+
+TEST_F(SSTIOGroupTest, error_in_save_removes_control)
+{
+    auto names = m_group->control_names();
+    int pkg_0_cpu = 0;
+    const std::array<std::string, 3> broken_controls{ {
+        "SST::COREPRIORITY:1:WEIGHT",
+        "SST::COREPRIORITY:1:FREQUENCY_MIN",
+        "SST::COREPRIORITY:1:FREQUENCY_MAX",
+    } };
+    const std::string unimpacted_control{"SST::COREPRIORITY:2:FREQUENCY_MIN"};
+
+    for (const auto control_name : broken_controls) {
+        EXPECT_TRUE(m_group->is_valid_control(control_name))
+            << control_name << " before failed save";
+    }
+    EXPECT_TRUE(m_group->is_valid_control(unimpacted_control))
+        << unimpacted_control << " before failed save";
+
+    // save_control will hit a lot of other controls. Let them all succeed
+    // except for the ones we are testing. Google Test docs recommend using 
+    // ON_CALL for don't-care cases like this, but the EXPECT_CALL we do later
+    // on a subest of these calls will not work with that pattern.
+    EXPECT_CALL(*m_sstio, write_mmio_once(_, _, _, _, _, _)).WillRepeatedly(Return());
+    EXPECT_CALL(*m_sstio, write_mbox_once(_, _, _, _, _, _, _, _, _)).WillRepeatedly(Return());
+
+    // Fail writes in the SST::COREPRIORITY:1:* fields
+    EXPECT_CALL(*m_sstio, write_mmio_once(pkg_0_cpu, 0x0c, 0, 0x00fffff0, _, _))
+        .Times(3)
+        .WillRepeatedly(Throw(std::runtime_error("Test-injected failure")));
+
+    m_group->save_control();
+
+    for (const auto control_name : broken_controls) {
+        EXPECT_FALSE(m_group->is_valid_control(control_name))
+            << control_name << " after failed save";
+    }
+    EXPECT_TRUE(m_group->is_valid_control(unimpacted_control))
+        << unimpacted_control << " after failed save";
+}


### PR DESCRIPTION
This change creates the SSTIOGroup class, and registers it as an IOGroup in GEOPM. 

The new IOGroup maps GEOPM signal and control names to specific inputs for the SST ioctl interface. The name-to-ioctl mappings are encoded into the SSTIOGroup class via the following variables:
* `sst_signal_mbox_info`: Signals that depend on SST mailbox operations
* `sst_control_mbox_info`: Controls (and their equivalent signals) that depend on SST mailbox operations
* `sst_control_mmio_info`: Controls (and their equivalent signals) that depend on SST mmio operations

There is no `sst_signal_mmio_info` because the only MMIO-type signals that exist in this iogroup are those that are derived from their controls.

The SST driver has more interfaces than just those two (e.g., an msr interface). The above ones are the only ones we use at this time.

Interactions with the ioctl interface are managed through SSTControl and SSTSignal objects. Those objects are created from the above name-to-ioctl mappings when the IOGroup is constructed.