### PR TITLE
Address GitHub Actions CI issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,23 +41,28 @@ on:
     branches: [ dev ]
 
 jobs:
-  build:
-    runs-on: ${{ matrix.config.os }}
+  build_and_test:
+    name: "build_and_test: ${{ matrix.config.name }} ${{ matrix.debug-flag }}"
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         config:
         - {
-          name: clang,
-          os: ubuntu-latest,
-          cc: "clang", cxx: "clang"
+          name: clang-9,
+          cc: "clang-9", cxx: "clang++-9"
         }
         - {
-          name: gcc,
-          os: ubuntu-latest,
-          cc: "gcc", cxx: "g++"
+          name: gcc-9,
+          cc: "gcc-9", cxx: "g++-9"
         }
         # Note: python2 is not supported as of April 2020; pip install breaks on tables in 3.8
         python-version: [3.7]
+        debug-flag: ["enable-debug", "disable-debug"]
+    env:
+      CC: ${{ matrix.config.cc }}
+      CXX: ${{ matrix.config.cxx }}
+      FC: gfortran-9
+      F77: gfortran-9
 
     steps:
     - uses: actions/checkout@v2
@@ -65,7 +70,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: install system dependencies
-      run: sudo apt-get update && sudo apt-get install libelf-dev mpich libmpich-dev
+      run: sudo apt-get update && sudo apt-get install libelf-dev mpich libmpich-dev libomp-9-dev
     - name: install python dependencies
       uses: py-actions/py-dependency-install@v2
       with:
@@ -81,16 +86,16 @@ jobs:
       shell: bash
       run: .github/include_guards.sh
     - name: configure
-      run: ./autogen.sh && ./configure --enable-beta
+      run: ./autogen.sh && ./configure --enable-beta --${{ matrix.debug-flag }}
     - name: make
       run: make -j2
     - name: make checkprogs
       run: make checkprogs -j2
     - name: make check
-      run: make check
       env:
         LD_LIBRARY_PATH: $PWD/.libs:$LD_LIBRARY_PATH
         PYTHONPATH: $PWD/scripts:/usr/lib/python${{ matrix.python-version }}/dist-packages:$PYTHONPATH
+      run: make check
     - name: test-dist
       run: ./copying_headers/test-dist
     - name: show failure logs

--- a/examples/Makefile.mk
+++ b/examples/Makefile.mk
@@ -81,22 +81,22 @@ if ENABLE_SCHED
                        #end
     examples_simple_prof_c_SOURCES = examples/simple_prof_c.c
     examples_simple_prof_c_LDADD = libgeopm.la $(MPI_CXXLIBS)
-    examples_simple_prof_c_CPPFLAGS = $(AM_CPPFLAGS) $(MPI_CPPFLAGS) $(OPENMP_CFLAGS)
-    examples_simple_prof_c_LDFLAGS = $(AM_LDFLAGS) $(MPI_CXXLDFLAGS) $(OPENMP_CFLAGS)
-    examples_simple_prof_c_CFLAGS = $(AM_CFLAGS) $(MPI_CFLAGS) $(OPENMP_CFLAGS)
-    examples_simple_prof_c_CXXFLAGS = $(AM_CXXFLAGS) $(MPI_CXXFLAGS) $(OPENMP_CFLAGS)
+    examples_simple_prof_c_CPPFLAGS = $(AM_CPPFLAGS)
+    examples_simple_prof_c_LDFLAGS = $(AM_LDFLAGS) $(MPI_CXXLDFLAGS)
+    examples_simple_prof_c_CFLAGS = $(AM_CFLAGS) $(MPI_CFLAGS)
+    examples_simple_prof_c_CXXFLAGS = $(AM_CXXFLAGS) $(MPI_CXXFLAGS)
     examples_print_affinity_SOURCES = examples/print_affinity.cpp
     examples_print_affinity_LDADD  = $(MPI_CXXLIBS)
     examples_print_affinity_LDFLAGS  = $(AM_LDFLAGS) $(MPI_CXXLDFLAGS)
-    examples_print_affinity_CFLAGS = $(AM_CFLAGS) $(MPI_CFLAGS) $(OPENMP_CFLAGS)
-    examples_print_affinity_CXXFLAGS = $(AM_CXXFLAGS) $(MPI_CXXFLAGS) $(OPENMP_CFLAGS)
+    examples_print_affinity_CFLAGS = $(AM_CFLAGS) $(MPI_CFLAGS)
+    examples_print_affinity_CXXFLAGS = $(AM_CXXFLAGS) $(MPI_CXXFLAGS)
 if ENABLE_FORTRAN
     noinst_PROGRAMS += examples/simple_prof_f
     examples_simple_prof_f_SOURCES = examples/simple_prof_f.f90
-    examples_simple_prof_f_CPPFLAGS = $(AM_CPPFLAGS) $(MPI_CPPFLAGS) $(OPENMP_CFLAGS)
+    examples_simple_prof_f_CPPFLAGS = $(AM_CPPFLAGS)
     examples_simple_prof_f_LDADD = libgeopm.la libgeopmfort.la $(MPI_FCLIBS) $(MPI_CXXLIBS)
-    examples_simple_prof_f_LDFLAGS = $(AM_LDFLAGS) $(MPI_LDFLAGS) $(OPENMP_CFLAGS)
-    examples_simple_prof_f_FCFLAGS = $(AM_FCFLAGS) $(MPI_FCFLAGS) $(OPENMP_CFLAGS)
+    examples_simple_prof_f_LDFLAGS = $(AM_LDFLAGS) $(MPI_LDFLAGS)
+    examples_simple_prof_f_FCFLAGS = $(AM_FCFLAGS) $(MPI_FCFLAGS)
 endif
 endif
 endif

--- a/examples/Makefile.mk
+++ b/examples/Makefile.mk
@@ -82,12 +82,12 @@ if ENABLE_SCHED
     examples_simple_prof_c_SOURCES = examples/simple_prof_c.c
     examples_simple_prof_c_LDADD = libgeopm.la $(MPI_CXXLIBS)
     examples_simple_prof_c_CPPFLAGS = $(AM_CPPFLAGS)
-    examples_simple_prof_c_LDFLAGS = $(AM_LDFLAGS) $(MPI_CXXLDFLAGS)
+    examples_simple_prof_c_LDFLAGS = $(AM_LDFLAGS) $(MPI_LDFLAGS)
     examples_simple_prof_c_CFLAGS = $(AM_CFLAGS) $(MPI_CFLAGS)
     examples_simple_prof_c_CXXFLAGS = $(AM_CXXFLAGS) $(MPI_CXXFLAGS)
     examples_print_affinity_SOURCES = examples/print_affinity.cpp
     examples_print_affinity_LDADD  = $(MPI_CXXLIBS)
-    examples_print_affinity_LDFLAGS  = $(AM_LDFLAGS) $(MPI_CXXLDFLAGS)
+    examples_print_affinity_LDFLAGS  = $(AM_LDFLAGS) $(MPI_LDFLAGS)
     examples_print_affinity_CFLAGS = $(AM_CFLAGS) $(MPI_CFLAGS)
     examples_print_affinity_CXXFLAGS = $(AM_CXXFLAGS) $(MPI_CXXFLAGS)
 if ENABLE_FORTRAN

--- a/src/ProfileSampler.cpp
+++ b/src/ProfileSampler.cpp
@@ -59,8 +59,6 @@
 
 namespace geopm
 {
-    const struct geopm_prof_message_s GEOPM_INVALID_PROF_MSG = {-1, 0, {{0,0}}, -1.0};
-
     ProfileSamplerImp::ProfileSamplerImp(size_t table_size)
         : ProfileSamplerImp(platform_topo(), table_size)
     {

--- a/src/ProfileSampler.hpp
+++ b/src/ProfileSampler.hpp
@@ -219,7 +219,7 @@ namespace geopm
             void controller_ready(void) override;
             void abort(void) override;
             std::vector<struct geopm_prof_message_s> sample_cache(void) override;
-            void check_sample_end(void);
+            void check_sample_end(void) override;
         private:
             /// Holds the shared memory region used for application coordination
             /// and control.

--- a/src/SSTSignal.cpp
+++ b/src/SSTSignal.cpp
@@ -49,7 +49,6 @@ namespace geopm
         , m_command(command)
         , m_subcommand(subcommand)
         , m_subcommand_arg(subcommand_arg)
-        , m_interface_parameter(interface_parameter)
         , m_batch_idx(-1)
     {
     }

--- a/src/SSTSignal.hpp
+++ b/src/SSTSignal.hpp
@@ -83,7 +83,6 @@ namespace geopm
             const uint16_t m_command;
             const uint16_t m_subcommand;
             const uint32_t m_subcommand_arg;
-            const uint32_t m_interface_parameter;
 
             int m_batch_idx;
     };


### PR DESCRIPTION
- Properly use clang and gcc.
- Use the latest available versions of the above compilers.
- Test debug and release builds.
- Install missing dependencies (libomp).
- Address compile time issues arising from clang build.

These changes bring us back to parity with what we had running on TravisCI.
