### PR TITLE
Pin the Controller away from the OS in all cases

### DIFF
--- a/README
+++ b/README
@@ -384,7 +384,8 @@ While the GEOPM control thread connects to the application it will
 automatically affinitize itself to the highest indexed core not used
 by the application if the application is not affinitized to a CPU on
 every core.  In the case were the application is utilizing all cores
-of the system, the GEOPM control thread will be pinned to CPU zero.
+of the system, the GEOPM control thread will be pinned to the highest
+logical CPU.
 
 There are many ways to launch an MPI application, and there is no
 single uniform way of enforcing MPI rank CPU affinities across

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -407,10 +407,13 @@ namespace geopm
                                                                   core_idx);
                 GEOPM_DEBUG_ASSERT(inactive_cpu.size() != 0,
                                    "Valid core index returned no nested CPUs");
-                result = *(inactive_cpu.begin());
+                result = *(inactive_cpu.rbegin());
                 break;
             }
         }
+#ifdef GEOPM_DEBUG
+        std::cout << "Info: <geopm> ApplicationSampler::sampler_cpu(): The Controller will run on logical CPU " << result << std::endl;
+#endif
         return result;
     }
 

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -392,8 +392,9 @@ namespace geopm
 
     int ApplicationSamplerImp::sampler_cpu(void)
     {
-        int result = 0;
+        int result = m_num_cpu - 1;
         int num_core = m_topo.num_domain(GEOPM_DOMAIN_CORE);
+        bool found_inactive_core = false;
         std::vector<bool> is_core_active(num_core, false);
         for (int cpu_idx = 0; cpu_idx != m_num_cpu; ++cpu_idx) {
             if (m_is_cpu_active[cpu_idx]) {
@@ -408,7 +409,16 @@ namespace geopm
                 GEOPM_DEBUG_ASSERT(inactive_cpu.size() != 0,
                                    "Valid core index returned no nested CPUs");
                 result = *(inactive_cpu.rbegin());
+                found_inactive_core = true;
                 break;
+            }
+        }
+        if (!found_inactive_core) {
+            for (int cpu_idx = m_num_cpu - 1; cpu_idx != -1; --cpu_idx) {
+                if(!m_is_cpu_active[cpu_idx]) {
+                    result = cpu_idx;
+                    break;
+                }
             }
         }
 #ifdef GEOPM_DEBUG

--- a/test/ApplicationSamplerTest.cpp
+++ b/test/ApplicationSamplerTest.cpp
@@ -569,9 +569,9 @@ TEST_F(ApplicationSamplerTest, sampler_cpu)
     EXPECT_CALL(*m_mock_topo, domain_nested(GEOPM_DOMAIN_CPU,
                                             GEOPM_DOMAIN_CORE, 1))
         .WillOnce(Return(core_cpu));
-    // The sampler should pick the first CPU on the last unused core
-    // which is CPU 2
-    EXPECT_EQ(2, m_app_sampler->sampler_cpu());
+    // The sampler should pick the last CPU on the last unused core
+    // which is CPU 3
+    EXPECT_EQ(3, m_app_sampler->sampler_cpu());
 
     // Check that make_cpu_set() as it would be called in connect() in
     // this example creates a cpu_set_t that has all but the third bit


### PR DESCRIPTION
- If there is an inactive core, run on the highest logical CPU associated with that core.
- If there are no inactive cores, run on the highest logical CPU to keep from having the OS interfere with sampling.
- Resolves #1594, #1598.
