### PR TITLE
Address recent user feedback

### DIFF
--- a/README
+++ b/README
@@ -222,14 +222,6 @@ The source code can be rebuilt from the source RPMs available from
 OpenHPC.  To build from the git repository follow the instructions
 below.
 
-To build all targets and install it in a "build/geopm" subdirectory of your
-home directory run the following commands:
-
-    ./autogen.sh
-    ./configure --prefix=$HOME/build/geopm
-    make
-    make install
-
 If building with the Intel toolchain the following environment variables
 must be set prior to running configure:
 
@@ -241,6 +233,14 @@ must be set prior to running configure:
     export MPICXX=mpiicpc
     export MPIFC=mpiifort
     export MPIF77=mpiifort
+
+To build all targets and install it in a "build/geopm" subdirectory of your
+home directory run the following commands:
+
+    ./autogen.sh
+    ./configure --prefix=$HOME/build/geopm
+    make
+    make install
 
 An RPM can be created on a RHEL or SUSE system with the
 

--- a/README
+++ b/README
@@ -198,7 +198,6 @@ Requirements that can be avoided by removing features with configure
 option:
 
    - MPI compiler: --disable-mpi
-   - Ruby, Ruby Gems and Ronn:  --disable-ronn
    - A Fortran compiler:  --disable-fortran
    - The elfutils library: --disable-ompt
 

--- a/examples/simple_pio_example.c
+++ b/examples/simple_pio_example.c
@@ -53,7 +53,6 @@ if [ ! -e $HOME/build/geopm/lib/libgeopmpolicy.so ]; then
     cd geopm/
     ./autogen.sh
     ./configure --disable-mpi \
-                --disable-ronn \
                 --disable-openmp \
                 --disable-fortran \
                 --prefix=$HOME/build/geopm

--- a/geopm-ohpc.spec.in
+++ b/geopm-ohpc.spec.in
@@ -53,8 +53,6 @@ BuildRequires: openssh
 %ohpc_setup_compiler
 test -f configure || ./autogen.sh
 ./configure --prefix=%{install_path} \
-            --disable-ronn \
-            --with-python=python2 \
             || ( cat config.log && false )
 %{__make}
 

--- a/geopm.spec.in
+++ b/geopm.spec.in
@@ -117,7 +117,7 @@ test -f configure || ./autogen.sh
             --includedir=%{_includedir} --sbindir=%{_sbindir} \
             --mandir=%{_mandir} --docdir=%{docdir} \
             --disable-mpi --disable-openmp \
-            --disable-fortran --disable-ronn \
+            --disable-fortran \
             --with-python=%{python_bin} \
             || ( cat config.log && false )
 %else
@@ -125,7 +125,7 @@ test -f configure || ./autogen.sh
             --includedir=%{_includedir} --sbindir=%{_sbindir} \
             --mandir=%{_mandir} --docdir=%{docdir} \
             --disable-mpi --disable-openmp \
-            --disable-fortran --disable-ronn \
+            --disable-fortran \
             --with-python=%{python_bin} \
             || ( cat config.log && false )
 %endif

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -705,14 +705,11 @@ class Launcher(object):
                 core_index -= app_core_per_rank
 
         if core_index <= 0:
-            sys.stderr.write("Warning: <geopm> geopmpy.launcher: User requested all cores for application. ")
             if self.config.allow_ht_pinning and core_per_node * app_thread_per_core < self.num_linux_cpu:
-                sys.stderr.write("GEOPM controller will share a core with the application.\n")
                 # Run controller on the lowest hyperthread that is not
                 # occupied by the application
                 geopm_ctl_cpu = core_per_node * app_thread_per_core
             else:
-                sys.stderr.write("GEOPM controller will share a core with the OS.\n")
                 # Oversubscribe Linux CPU 0, no better solution
                 geopm_ctl_cpu = 0
         else:

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -424,6 +424,13 @@ namespace geopm
 #ifdef GEOPM_DEBUG
         std::cout << "Info: <geopm> ApplicationSampler::sampler_cpu(): The Controller will run on logical CPU " << result << std::endl;
 #endif
+
+        if (result == m_num_cpu - 1) {
+            std::cerr << "Warning: <geopm> ApplicationSampler::sampler_cpu(): User requested "
+                      << "all cores for application.  GEOPM will share a core with the "
+                      << "Application, running on logical CPU " << result << std::endl;
+        }
+
         return result;
     }
 

--- a/src/MSRIOGroup.cpp
+++ b/src/MSRIOGroup.cpp
@@ -848,7 +848,7 @@ namespace geopm
                 scaling_governor = geopm::read_file("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor");
                 size_t cr_pos = scaling_governor.find('\n');
                 scaling_governor = scaling_governor.substr(0, cr_pos);
-                if (scaling_governor != "performance") {
+                if (scaling_governor != "performance" && scaling_governor != "userspace") {
                     do_print_warning = true;
                 }
             }
@@ -859,8 +859,8 @@ namespace geopm
                 std::cerr << "Warning: <geopm> MSRIOGroup::" << std::string(__func__)
                           << "(): Incompatible CPU frequency driver/governor detected ("
                           << scaling_driver << "/" << scaling_governor << "). "
-                          << "The \"acpi-cpufreq\" driver and \"performance\" governor are required when setting "
-                          << "CPU frequency or power limit with GEOPM.  Other Linux power settings, including the intel_pstate driver,"
+                          << "The \"acpi-cpufreq\" driver and \"performance\" or \"userspace\" governor are required when setting "
+                          << "CPU frequency or power limits with GEOPM.  Other Linux power settings, including the intel_pstate driver,"
                           << "may overwrite GEOPM controls for frequency and power limits." << std::endl;
                     }
             do_check_governor = false;

--- a/test/ApplicationSamplerTest.cpp
+++ b/test/ApplicationSamplerTest.cpp
@@ -46,6 +46,7 @@
 #include "geopm.h"
 #include "geopm_internal.h"
 #include "geopm_test.hpp"
+#include "config.h"
 
 using testing::_;
 using testing::Return;
@@ -563,6 +564,12 @@ TEST_F(ApplicationSamplerTest, sampler_cpu)
         .WillOnce(Return(0));
     EXPECT_CALL(*m_mock_topo, domain_idx(GEOPM_DOMAIN_CORE, 1))
         .WillOnce(Return(0));
+#ifdef GEOPM_DEBUG
+    // In the case of debug builds, an additional call is performed
+    // to see if we're sharing a core with the OS
+    EXPECT_CALL(*m_mock_topo, domain_idx(GEOPM_DOMAIN_CORE, 3))
+        .WillOnce(Return(0));
+#endif
     // Since core 1 has no active CPU's the topo is queried for the
     // CPUs associated with core 1 (which are CPU 2 and 3)
     std::set<int> core_cpu = {2, 3};


### PR DESCRIPTION
- Move README section about Intel compiler overrides.
- Allow acpi-cpufreq/userspace to be a valid combination for the frequency driver and governor.
- Move warning about the Controller oversubscribing CPUs.
