### PR TITLE
Update to allow for testing NVML accelerator code without nvml libraries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -446,6 +446,8 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             contrib/json11/json11.hpp \
                             src/AcceleratorTopo.cpp \
                             src/AcceleratorTopo.hpp \
+                            src/AcceleratorTopoNull.cpp \
+                            src/AcceleratorTopoNull.hpp \
                             src/Accumulator.cpp \
                             src/Accumulator.hpp \
                             src/Admin.cpp \
@@ -637,17 +639,23 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/msr_data_snb.cpp \
                             src/record.cpp \
                             src/record.hpp \
+                            src/NVMLAcceleratorTopo.cpp \
+                            src/NVMLAcceleratorTopo.hpp \
+                            src/NVMLDevicePool.hpp \
+                            src/NVMLIOGroup.cpp \
+                            src/NVMLIOGroup.hpp \
                             # end
 
+nvml_source_files = src/NVMLDevicePool.cpp \
+                    src/NVMLDevicePoolImp.hpp \
+                    #end
+
 if ENABLE_NVML
-    libgeopmpolicy_la_SOURCES += src/NVMLAcceleratorTopo.cpp \
-                                 src/NVMLAcceleratorTopo.hpp \
-                                 src/NVMLDevicePool.cpp \
-                                 src/NVMLDevicePool.hpp \
-                                 src/NVMLDevicePoolImp.hpp \
-                                 src/NVMLIOGroup.cpp \
-                                 src/NVMLIOGroup.hpp \
-                                 #end
+    libgeopmpolicy_la_SOURCES += $(nvml_source_files)
+else
+    libgeopmpolicy_la_SOURCES += src/NVMLDevicePoolThrow.cpp
+    EXTRA_DIST += $(nvml_source_files) \
+                  #end
 endif
 
 beta_source_files = src/Daemon.cpp \

--- a/src/AcceleratorTopo.cpp
+++ b/src/AcceleratorTopo.cpp
@@ -30,14 +30,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "config.h"
+
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
 
-#include "config.h"
 #include "Exception.hpp"
+#include "AcceleratorTopoNull.hpp"
+
+#ifdef GEOPM_ENABLE_NVML
 #include "NVMLAcceleratorTopo.hpp"
+#endif
 
 namespace geopm
 {
@@ -46,18 +51,8 @@ namespace geopm
 #ifdef GEOPM_ENABLE_NVML
         static NVMLAcceleratorTopo instance;
 #else
-        static AcceleratorTopo instance;
+        static AcceleratorTopoNull instance;
 #endif
         return instance;
-    }
-
-    int AcceleratorTopo::num_accelerator(void) const
-    {
-        return 0;
-    }
-
-    std::set<int> AcceleratorTopo::cpu_affinity_ideal(int domain_idx) const
-    {
-        return {};
     }
 }

--- a/src/AcceleratorTopoNull.cpp
+++ b/src/AcceleratorTopoNull.cpp
@@ -30,28 +30,23 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ACCELERATORTOPO_HPP_INCLUDE
-#define ACCELERATORTOPO_HPP_INCLUDE
+#include "config.h"
 
-#include <cstdint>
-#include <vector>
-#include <set>
+#include <fstream>
+#include <string>
+
+#include "Exception.hpp"
+#include "AcceleratorTopoNull.hpp"
 
 namespace geopm
 {
-    class AcceleratorTopo
+    int AcceleratorTopoNull::num_accelerator(void) const
     {
-        public:
-            AcceleratorTopo() = default;
-            virtual ~AcceleratorTopo() = default;
-            /// @brief Number of accelerators on the platform.
-            virtual int num_accelerator(void) const = 0;
-            /// @brief CPU Affinitization set for a particular accelerator
-            /// @param [in] domain_idx The index indicating a particular
-            ///        accelerator
-            virtual std::set<int> cpu_affinity_ideal(int domain_idx) const = 0;
-    };
+        return 0;
+    }
 
-    const AcceleratorTopo &accelerator_topo(void);
+    std::set<int> AcceleratorTopoNull::cpu_affinity_ideal(int domain_idx) const
+    {
+        return {};
+    }
 }
-#endif

--- a/src/AcceleratorTopoNull.hpp
+++ b/src/AcceleratorTopoNull.hpp
@@ -30,28 +30,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ACCELERATORTOPO_HPP_INCLUDE
-#define ACCELERATORTOPO_HPP_INCLUDE
+#ifndef ACCELERATORTOPONULL_HPP_INCLUDE
+#define ACCELERATORTOPONULL_HPP_INCLUDE
 
 #include <cstdint>
 #include <vector>
 #include <set>
 
+#include "AcceleratorTopo.hpp"
+
 namespace geopm
 {
-    class AcceleratorTopo
+    class AcceleratorTopoNull : public AcceleratorTopo
     {
         public:
-            AcceleratorTopo() = default;
-            virtual ~AcceleratorTopo() = default;
-            /// @brief Number of accelerators on the platform.
-            virtual int num_accelerator(void) const = 0;
-            /// @brief CPU Affinitization set for a particular accelerator
-            /// @param [in] domain_idx The index indicating a particular
-            ///        accelerator
-            virtual std::set<int> cpu_affinity_ideal(int domain_idx) const = 0;
+            AcceleratorTopoNull() = default ;
+            virtual ~AcceleratorTopoNull() = default;
+            int num_accelerator(void) const override;
+            std::set<int> cpu_affinity_ideal(int accel_idx) const override;
     };
-
-    const AcceleratorTopo &accelerator_topo(void);
 }
 #endif

--- a/src/NVMLAcceleratorTopo.cpp
+++ b/src/NVMLAcceleratorTopo.cpp
@@ -65,13 +65,13 @@ namespace geopm
             m_cpu_affinity_ideal.resize(m_num_accelerator);
 
             // Cache ideal affinitization due to the overhead associated with the NVML calls
-            for (int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
+            for (unsigned int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
                 ideal_affinitization_mask_vec.push_back(m_nvml_device_pool.cpu_affinity_ideal_mask(accel_idx));
             }
 
             /// @todo: As an optimization this may be replacable with CPU_OR of all masks in ideal_affinitzation_mask_vec
             //       and CPU_COUNT of the output
-            for (int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
+            for (unsigned int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
                 for (int cpu_idx = 0; cpu_idx < num_cpu; cpu_idx++) {
                     if (CPU_ISSET(cpu_idx, ideal_affinitization_mask_vec.at(accel_idx))) {
                         if (CPU_ISSET(cpu_idx, affinitized_cpuset) == 0) {
@@ -96,7 +96,7 @@ namespace geopm
                 // This is a greedy approach for mapping CPUs to accelerators, and as such may result in some CPUs
                 // not being affinitized at all.  A potential improvement is to always determine affinity
                 // for the accelerator with the fewest possible CPUs in the accelerator mask
-                for (int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
+                for (unsigned int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
                     unsigned int accelerator_cpu_count = 0;
                     for (int cpu_idx = 0;
                          cpu_idx != num_cpu &&
@@ -108,7 +108,7 @@ namespace geopm
                             ++accelerator_cpu_count;
 
                             // Remove this CPU from the affinity mask of all Accelerators
-                            for (int accel_idx_inner = 0; accel_idx_inner <  m_num_accelerator; ++accel_idx_inner) {
+                            for (unsigned int accel_idx_inner = 0; accel_idx_inner <  m_num_accelerator; ++accel_idx_inner) {
                                 CPU_CLR(cpu_idx, ideal_affinitization_mask_vec.at(accel_idx_inner));
                             }
                         }
@@ -132,7 +132,7 @@ namespace geopm
 
     std::set<int> NVMLAcceleratorTopo::cpu_affinity_ideal(int accel_idx) const
     {
-        if (accel_idx < 0 || accel_idx >= m_num_accelerator) {
+        if (accel_idx < 0 || (unsigned int) accel_idx >= m_num_accelerator) {
             throw Exception("NVMLAcceleratorTopo::" + std::string(__func__) + ": accel_idx " +
                             std::to_string(accel_idx) + " is out of range",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);

--- a/src/NVMLDevicePool.cpp
+++ b/src/NVMLDevicePool.cpp
@@ -38,6 +38,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <nvml.h>
 
 #include "Exception.hpp"
 #include "Agg.hpp"
@@ -301,7 +302,7 @@ namespace geopm
 
         nvmlReturn_t nvml_result = nvmlDeviceGetComputeRunningProcesses(m_nvml_device[accel_idx], &temp, &process_info_list[0]);
         if (nvml_result == NVML_SUCCESS) {
-            for (int i = 0; i<temp; i++) {
+            for (unsigned int i = 0; i<temp; i++) {
                 result.push_back(process_info_list[i].pid);
             }
         }
@@ -323,7 +324,7 @@ namespace geopm
                               ": NVML failed to acquire running processes for accelerator " +
                               std::to_string(accel_idx) + ".", __LINE__);
 
-            for (int i = 0; i<temp; i++) {
+            for (unsigned int i = 0; i<temp; i++) {
                 result.push_back(process_info_list[i].pid);
             }
         }

--- a/src/NVMLDevicePool.hpp
+++ b/src/NVMLDevicePool.hpp
@@ -37,8 +37,6 @@
 #include <string>
 #include <cstdint>
 
-#include <nvml.h>
-
 #include "geopm_sched.h"
 
 namespace geopm

--- a/src/NVMLDevicePoolThrow.cpp
+++ b/src/NVMLDevicePoolThrow.cpp
@@ -30,28 +30,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <unistd.h>
-#include <limits.h>
+#include "config.h"
+
+#include <cmath>
 
 #include <fstream>
+#include <iostream>
+#include <sstream>
 #include <string>
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-
-#include "config.h"
-#include "Helper.hpp"
 #include "Exception.hpp"
-#include "AcceleratorTopo.hpp"
+#include "Agg.hpp"
+#include "Helper.hpp"
+#include "geopm_sched.h"
 
-using geopm::AcceleratorTopo;
-using geopm::Exception;
-using testing::Return;
+#include "NVMLDevicePool.hpp"
 
-TEST(AcceleratorTopoTest, default_config)
+namespace geopm
 {
-    std::unique_ptr<AcceleratorTopo> topo;
-    topo = geopm::make_unique<AcceleratorTopo>();
-    EXPECT_EQ(0, topo->num_accelerator());
-    EXPECT_EQ(topo->cpu_affinity_ideal(0), std::set<int>{});
+
+    const NVMLDevicePool &nvml_device_pool(const int num_cpu)
+    {
+        throw Exception("NVMLDevicePoolThrow::" + std::string(__func__) +
+                        ": GEOPM configured without nvml library support.  Please configure with --enable-nvml",
+                        GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+    }
+
 }

--- a/src/NVMLIOGroup.cpp
+++ b/src/NVMLIOGroup.cpp
@@ -402,14 +402,14 @@ namespace geopm
             if (sv.first == "NVML::CPU_ACCELERATOR_ACTIVE_AFFINITIZATION") {
                 std::map<pid_t, double> process_map = accelerator_process_map();
 
-                for (int domain_idx = 0; domain_idx < sv.second.signals.size(); ++domain_idx) {
+                for (unsigned int domain_idx = 0; domain_idx < sv.second.signals.size(); ++domain_idx) {
                     if (sv.second.signals.at(domain_idx)->m_do_read) {
                         sv.second.signals.at(domain_idx)->m_value = cpu_accelerator_affinity(domain_idx, process_map);
                     }
                 }
             }
             else {
-                for (int domain_idx = 0; domain_idx < sv.second.signals.size(); ++domain_idx) {
+                for (unsigned int domain_idx = 0; domain_idx < sv.second.signals.size(); ++domain_idx) {
                     if (sv.second.signals.at(domain_idx)->m_do_read) {
                         sv.second.signals.at(domain_idx)->m_value = read_signal(sv.first, sv.second.domain, domain_idx);
                     }
@@ -422,7 +422,7 @@ namespace geopm
     void NVMLIOGroup::write_batch(void)
     {
         for (auto &sv : m_control_available) {
-            for (int domain_idx = 0; domain_idx < sv.second.controls.size(); ++domain_idx) {
+            for (unsigned int domain_idx = 0; domain_idx < sv.second.controls.size(); ++domain_idx) {
                 if (sv.second.controls.at(domain_idx)->m_is_adjusted) {
                     write_control(sv.first, sv.second.domain, domain_idx, sv.second.controls.at(domain_idx)->m_setting);
                 }

--- a/src/NVMLIOGroup.hpp
+++ b/src/NVMLIOGroup.hpp
@@ -40,8 +40,6 @@
 
 #include "IOGroup.hpp"
 
-#include <nvml.h>
-
 namespace geopm
 {
     class PlatformTopo;
@@ -72,8 +70,8 @@ namespace geopm
             void restore_control(void) override;
             std::function<double(const std::vector<double> &)> agg_function(const std::string &signal_name) const override;
             std::function<std::string(double)> format_function(const std::string &signal_name) const override;
-            std::string signal_description(const std::string &signal_name) const;
-            std::string control_description(const std::string &control_name) const;
+            std::string signal_description(const std::string &signal_name) const override;
+            std::string control_description(const std::string &control_name) const override;
             int signal_behavior(const std::string &signal_name) const override;
             static std::string plugin_name(void);
             static std::unique_ptr<geopm::IOGroup> make_plugin(void);

--- a/test/AcceleratorTopoNullTest.cpp
+++ b/test/AcceleratorTopoNullTest.cpp
@@ -30,28 +30,29 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ACCELERATORTOPO_HPP_INCLUDE
-#define ACCELERATORTOPO_HPP_INCLUDE
+#include <unistd.h>
+#include <limits.h>
 
-#include <cstdint>
-#include <vector>
-#include <set>
+#include <fstream>
+#include <string>
 
-namespace geopm
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "config.h"
+#include "Helper.hpp"
+#include "Exception.hpp"
+#include "AcceleratorTopoNull.hpp"
+
+using geopm::AcceleratorTopo;
+using geopm::AcceleratorTopoNull;
+using geopm::Exception;
+using testing::Return;
+
+TEST(AcceleratorTopoNullTest, default_config)
 {
-    class AcceleratorTopo
-    {
-        public:
-            AcceleratorTopo() = default;
-            virtual ~AcceleratorTopo() = default;
-            /// @brief Number of accelerators on the platform.
-            virtual int num_accelerator(void) const = 0;
-            /// @brief CPU Affinitization set for a particular accelerator
-            /// @param [in] domain_idx The index indicating a particular
-            ///        accelerator
-            virtual std::set<int> cpu_affinity_ideal(int domain_idx) const = 0;
-    };
-
-    const AcceleratorTopo &accelerator_topo(void);
+    std::unique_ptr<AcceleratorTopoNull> topo;
+    topo = geopm::make_unique<AcceleratorTopoNull>();
+    EXPECT_EQ(0, topo->num_accelerator());
+    EXPECT_EQ(topo->cpu_affinity_ideal(0), std::set<int>{});
 }
-#endif

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -35,7 +35,7 @@ if ENABLE_MPI
     check_PROGRAMS += test/geopm_mpi_test_api
 endif
 
-GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
+GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/AccumulatorTest.sum_ones \
               test/gtest_links/AccumulatorTest.sum_idx \
@@ -337,6 +337,22 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoTest.default_config \
               test/gtest_links/ModelApplicationTest.parse_config_errors \
               test/gtest_links/MonitorAgentTest.policy_names \
               test/gtest_links/MonitorAgentTest.sample_names \
+              test/gtest_links/NVMLAcceleratorTopoTest.hpe_sx40_default_config \
+              test/gtest_links/NVMLAcceleratorTopoTest.no_gpu_config \
+              test/gtest_links/NVMLAcceleratorTopoTest.mutex_affinitization_config \
+              test/gtest_links/NVMLAcceleratorTopoTest.equidistant_affinitization_config \
+              test/gtest_links/NVMLAcceleratorTopoTest.n1_superset_n_affinitization_config \
+              test/gtest_links/NVMLAcceleratorTopoTest.greedbuster_affinitization_config \
+              test/gtest_links/NVMLAcceleratorTopoTest.hpe_6500_affinitization_config \
+              test/gtest_links/NVMLAcceleratorTopoTest.uneven_affinitization_config \
+              test/gtest_links/NVMLAcceleratorTopoTest.high_cpu_count_config \
+              test/gtest_links/NVMLAcceleratorTopoTest.high_cpu_count_gaps_config \
+              test/gtest_links/NVMLIOGroupTest.read_signal \
+              test/gtest_links/NVMLIOGroupTest.read_signal_and_batch \
+              test/gtest_links/NVMLIOGroupTest.write_control \
+              test/gtest_links/NVMLIOGroupTest.push_control_adjust_write_batch \
+              test/gtest_links/NVMLIOGroupTest.error_path \
+              test/gtest_links/NVMLIOGroupTest.valid_signals \
               test/gtest_links/OptionParserTest.get_invalid \
               test/gtest_links/OptionParserTest.parse_errors \
               test/gtest_links/OptionParserTest.add_option_errors \
@@ -536,26 +552,6 @@ if ENABLE_OMPT
                    # end
 endif
 
-if ENABLE_NVML
-    GTEST_TESTS += test/gtest_links/NVMLAcceleratorTopoTest.hpe_sx40_default_config \
-                   test/gtest_links/NVMLAcceleratorTopoTest.no_gpu_config \
-                   test/gtest_links/NVMLAcceleratorTopoTest.mutex_affinitization_config \
-                   test/gtest_links/NVMLAcceleratorTopoTest.equidistant_affinitization_config \
-                   test/gtest_links/NVMLAcceleratorTopoTest.n1_superset_n_affinitization_config \
-                   test/gtest_links/NVMLAcceleratorTopoTest.greedbuster_affinitization_config \
-                   test/gtest_links/NVMLAcceleratorTopoTest.hpe_6500_affinitization_config \
-                   test/gtest_links/NVMLAcceleratorTopoTest.uneven_affinitization_config \
-                   test/gtest_links/NVMLAcceleratorTopoTest.high_cpu_count_config \
-                   test/gtest_links/NVMLAcceleratorTopoTest.high_cpu_count_gaps_config \
-                   test/gtest_links/NVMLIOGroupTest.read_signal \
-                   test/gtest_links/NVMLIOGroupTest.read_signal_and_batch \
-                   test/gtest_links/NVMLIOGroupTest.write_control \
-                   test/gtest_links/NVMLIOGroupTest.push_control_adjust_write_batch \
-                   test/gtest_links/NVMLIOGroupTest.error_path \
-                   test/gtest_links/NVMLIOGroupTest.valid_signals \
-                   # end
-endif
-
 TESTS_ENVIRONMENT = PYTHON='$(PYTHON)'
 
 TESTS += $(GTEST_TESTS) \
@@ -582,7 +578,7 @@ EXTRA_DIST += test/InternalProfile.cpp \
               test/EditDistPeriodicityDetectorTest.cpp \
               # end
 
-test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
+test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/AccumulatorTest.cpp \
                           test/AdminTest.cpp \
                           test/AgentFactoryTest.cpp \
@@ -640,6 +636,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
                           test/MockFrequencyGovernor.hpp \
                           test/MockIOGroup.hpp \
                           test/MockMSRIO.hpp \
+                          test/MockNVMLDevicePool.hpp \
                           test/MockPlatformIO.hpp \
                           test/MockPlatformTopo.cpp \
                           test/MockPlatformTopo.hpp \
@@ -660,6 +657,8 @@ test_geopm_test_SOURCES = test/AcceleratorTopoTest.cpp \
                           test/MockTreeCommLevel.hpp \
                           test/ModelApplicationTest.cpp \
                           test/MonitorAgentTest.cpp \
+                          test/NVMLAcceleratorTopoTest.cpp \
+                          test/NVMLIOGroupTest.cpp \
                           test/OptionParserTest.cpp \
                           test/PlatformIOTest.cpp \
                           test/PlatformTopoTest.cpp \
@@ -698,21 +697,10 @@ beta_test_sources = test/DaemonTest.cpp \
                     test/PolicyStoreImpTest.cpp \
                     # end
 
-nvml_test_sources = test/NVMLAcceleratorTopoTest.cpp \
-                    test/MockNVMLDevicePool.hpp \
-                    test/NVMLIOGroupTest.cpp \
-                    # end
-
 if ENABLE_BETA
     test_geopm_test_SOURCES += $(beta_test_sources)
 else
     EXTRA_DIST += $(beta_test_sources)
-endif
-
-if ENABLE_NVML
-    test_geopm_test_SOURCES += $(nvml_test_sources)
-else
-    EXTRA_DIST += $(nvml_test_sources)
 endif
 
 if ENABLE_OMPT

--- a/test/NVMLIOGroupTest.cpp
+++ b/test/NVMLIOGroupTest.cpp
@@ -117,7 +117,6 @@ void NVMLIOGroupTest::TearDown()
 
 TEST_F(NVMLIOGroupTest, valid_signals)
 {
-    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
     NVMLIOGroup nvml_io(*m_platform_topo, *m_device_pool);
     for (const auto &sig : nvml_io.signal_names()) {
         EXPECT_TRUE(nvml_io.is_valid_signal(sig));


### PR DESCRIPTION
GEOPM Accelerator code updates to allow for testing of NVML libraries without nvml.h.  
Tested on systems with and without NVML accelerators.

Signed-off-by: lowren.h.lawson@intel.com <lowren.h.lawson@intel.com>

Summary of change.
- Updates to AcceleratorTopo that break out default functionality to AcceleratorTopoNull
- Addition of NVMLDevicePoolThrow to provide nvml_device_pool in absence of a full implementation
- Changed AcceleratorTopoTest to AcceleratorTopoNullTest   
- Fixes #1295 from github issues.
- Fixes #1490 from github issues.
