### PR TITLE
Added explicit include of limits to PowerBalancerAgent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -593,9 +593,11 @@ AC_DEFINE_UNQUOTED([GEOPM_SOURCE_DIR], ["$GEOPM_SOURCE_DIR"], [Root of the GEOPM
 AC_CONFIG_FILES([Makefile geopm.spec geopm-ohpc.spec geopm-theta.spec scripts/geopmpy/version.py])
 AC_OUTPUT
 
+CC_VERSION=$(${CC} --version | head -n1)
 # ============================================================================
 # Print out the results of configuration.
 AC_MSG_RESULT([===============================================================================])
+AC_MSG_RESULT([CC version         : ${CC_VERSION}])
 AC_MSG_RESULT([version            : ${VERSION}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([CPPFLAGS           : ${CPPFLAGS}])

--- a/src/Endpoint.cpp
+++ b/src/Endpoint.cpp
@@ -74,13 +74,13 @@ namespace geopm
     }
 
     EndpointImp::EndpointImp(const std::string &path,
-                             std::unique_ptr<SharedMemory> policy_shmem,
-                             std::unique_ptr<SharedMemory> sample_shmem,
+                             std::shared_ptr<SharedMemory> policy_shmem,
+                             std::shared_ptr<SharedMemory> sample_shmem,
                              size_t num_policy,
                              size_t num_sample)
         : m_path(path)
-        , m_policy_shmem(std::move(policy_shmem))
-        , m_sample_shmem(std::move(sample_shmem))
+        , m_policy_shmem(policy_shmem)
+        , m_sample_shmem(sample_shmem)
         , m_num_policy(num_policy)
         , m_num_sample(num_sample)
         , m_is_open(false)

--- a/src/EndpointImp.hpp
+++ b/src/EndpointImp.hpp
@@ -96,8 +96,8 @@ namespace geopm
 
             EndpointImp(const std::string &data_path);
             EndpointImp(const std::string &data_path,
-                        std::unique_ptr<SharedMemory> policy_shmem,
-                        std::unique_ptr<SharedMemory> sample_shmem,
+                        std::shared_ptr<SharedMemory> policy_shmem,
+                        std::shared_ptr<SharedMemory> sample_shmem,
                         size_t num_policy,
                         size_t num_sample);
             virtual ~EndpointImp();
@@ -117,8 +117,8 @@ namespace geopm
             static std::string shm_sample_postfix(void);
         private:
             std::string m_path;
-            std::unique_ptr<SharedMemory> m_policy_shmem;
-            std::unique_ptr<SharedMemory> m_sample_shmem;
+            std::shared_ptr<SharedMemory> m_policy_shmem;
+            std::shared_ptr<SharedMemory> m_sample_shmem;
             size_t m_num_policy;
             size_t m_num_sample;
             bool m_is_open;

--- a/src/PowerBalancerAgent.cpp
+++ b/src/PowerBalancerAgent.cpp
@@ -35,6 +35,7 @@
 #include <cfloat>
 #include <cmath>
 #include <algorithm>
+#include <limits>
 
 #include "PowerBalancer.hpp"
 #include "PlatformIO.hpp"


### PR DESCRIPTION
Signed-off-by: Lowren Lawson <lowren.h.lawson@intel.com>

Added explicit include of <limits> to avoid issues with newer (10+) gnu compiler versions. 
Without explicit inclusion the following may be encountered:
    src/PowerBalancerAgent.cpp:496:36: error: ‘numeric_limits’ is not a member of ‘std’
      496 |         double min_headroom = std::numeric_limits<double>::max();
