### PR TITLE
Switch to pdf version of architecture diagram

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -57,7 +57,7 @@ implementation for the GEOPM service D-Bus interfaces.
 Architecture Diagram
 --------------------
 
-![](https://geopm.github.io/images/geopm-service-diagram.svg)
+[![](https://geopm.github.io/images/geopm-service-diagram.svg)](https://geopm.github.io/pdf/geopm-service-diagram.pdf)
 
 
 Signals and Controls


### PR DESCRIPTION
Avoids the "redirect" page (two clicks to get to link instead of three).