### PR TITLE
Make CI use clang-12 and ubuntu-20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,13 @@ on:
 jobs:
   build_and_test:
     name: "build_and_test: ${{ matrix.config.name }} ${{ matrix.debug-flag }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         config:
         - {
-          name: clang-9,
-          cc: "clang-9", cxx: "clang++-9"
+          name: clang-12,
+          cc: "clang-12", cxx: "clang++-12"
         }
         - {
           name: gcc-9,


### PR DESCRIPTION
- Previously used clang-9 and ubuntu-latest
- ubuntu-latest is currently ubuntu-20.04, which is an LTS release
- clang-9 is not available in ubuntu-20.04, and clang-12 is the newest
  one available in that image