### PR TITLE
Use new-style MOCK_METHOD calls in gmock

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -530,20 +530,6 @@ AC_COMPILE_IFELSE([
     AM_CONDITIONAL([GEOPM_ENABLE_MPI3], [false])
 ])
 
-[CFLAGS="$CFLAGS_SAVE"]
-[CFLAGS="$CFLAGS -Wall -Werror -Wno-inconsistent-missing-override"]
-AC_MSG_CHECKING([for support for -Wno-inconsistent-missing-override])
-AC_COMPILE_IFELSE([
-    AC_LANG_PROGRAM([[#include <stdio.h>]],
-          [[printf("Hello World.\n");]])
-],[
-    AC_MSG_RESULT(yes)
-    AM_CONDITIONAL([GEOPM_DISABLE_INCONSISTENT_OVERRIDE], [true])
-],[
-    AC_MSG_RESULT(no)
-    AM_CONDITIONAL([GEOPM_DISABLE_INCONSISTENT_OVERRIDE], [false])
-])
-
 [LDFLAGS="$LDFLAGS_SAVE"]
 [CFLAGS="$CFLAGS_SAVE"]
 [CXXFLAGS="$CXXFLAGS_SAVE"]

--- a/test/MSRIOTest.cpp
+++ b/test/MSRIOTest.cpp
@@ -74,8 +74,8 @@ class MSRIOMockFiles
 class MockMSRPath : public MSRPath
 {
     public:
-        MOCK_METHOD2(msr_path, std::string(int cpu_idx, int fallback_idx));
-        MOCK_METHOD0(msr_batch_path, std::string(void));
+        MOCK_METHOD(std::string, msr_path, (int cpu_idx, int fallback_idx), (override));
+        MOCK_METHOD(std::string, msr_batch_path, (), (override));
 };
 
 MSRIOMockFiles::MSRIOMockFiles(int num_cpu)

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -731,11 +731,6 @@ test_geopm_test_CPPFLAGS = $(AM_CPPFLAGS) -Iplugin
 test_geopm_test_CFLAGS = $(AM_CFLAGS)
 test_geopm_test_CXXFLAGS = $(AM_CXXFLAGS)
 
-if GEOPM_DISABLE_INCONSISTENT_OVERRIDE
-    test_geopm_test_CFLAGS += -Wno-inconsistent-missing-override
-    test_geopm_test_CXXFLAGS += -Wno-inconsistent-missing-override
-endif
-
 if ENABLE_MPI
     test_geopm_mpi_test_api_SOURCES = test/MPIInterfaceTest.cpp \
                                       test/geopm_test.cpp \

--- a/test/MockAcceleratorTopo.hpp
+++ b/test/MockAcceleratorTopo.hpp
@@ -40,8 +40,8 @@
 class MockAcceleratorTopo : public geopm::AcceleratorTopo
 {
     public:
-        MOCK_CONST_METHOD0(num_accelerator, int(void));
-        MOCK_CONST_METHOD1(cpu_affinity_ideal, std::set<int>(int));
+        MOCK_METHOD(int, num_accelerator, (), (const, override));
+        MOCK_METHOD(std::set<int>, cpu_affinity_ideal, (int), (const, override));
 };
 
 #endif

--- a/test/MockAcceleratorTopo.hpp
+++ b/test/MockAcceleratorTopo.hpp
@@ -40,10 +40,8 @@
 class MockAcceleratorTopo : public geopm::AcceleratorTopo
 {
     public:
-        MOCK_CONST_METHOD0(num_accelerator,
-                           int(void));
-        MOCK_CONST_METHOD1(cpu_affinity_ideal,
-                           std::set<int>(int));
+        MOCK_CONST_METHOD0(num_accelerator, int(void));
+        MOCK_CONST_METHOD1(cpu_affinity_ideal, std::set<int>(int));
 };
 
 #endif

--- a/test/MockAgent.hpp
+++ b/test/MockAgent.hpp
@@ -41,31 +41,37 @@
 class MockAgent : public geopm::Agent
 {
     public:
-        MOCK_METHOD3(init, void(int level, const std::vector<int> &fan_in,
-                                bool is_level_root));
-        MOCK_CONST_METHOD1(validate_policy, void(std::vector<double> &policy));
-        MOCK_METHOD2(split_policy, void(const std::vector<double> &in_policy,
-                                        std::vector<std::vector<double> > &out_policy));
-        MOCK_CONST_METHOD0(do_send_policy, bool(void));
-        MOCK_METHOD2(aggregate_sample,
-                     void(const std::vector<std::vector<double> > &in_signal,
-                          std::vector<double> &out_signal));
-        MOCK_CONST_METHOD0(do_send_sample, bool(void));
-        MOCK_METHOD1(adjust_platform, void(const std::vector<double> &in_policy));
-        MOCK_CONST_METHOD0(do_write_batch, bool(void));
-        MOCK_METHOD1(sample_platform, void(std::vector<double> &out_sample));
-        MOCK_METHOD0(wait, void(void));
-        MOCK_CONST_METHOD0(report_header,
-                           std::vector<std::pair<std::string, std::string> >(void));
-        MOCK_CONST_METHOD0(report_host,
-                           std::vector<std::pair<std::string, std::string> >(void));
-        MOCK_CONST_METHOD0(
-            report_region,
-            std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >(void));
-        MOCK_CONST_METHOD0(trace_names, std::vector<std::string>(void));
-        MOCK_CONST_METHOD0(trace_formats,
-                           std::vector<std::function<std::string(double)> >(void));
-        MOCK_METHOD1(trace_values, void(std::vector<double> &values));
+        MOCK_METHOD(void, init,
+                    (int level, const std::vector<int> &fan_in, bool is_level_root),
+                    (override));
+        MOCK_METHOD(void, validate_policy, (std::vector<double> & policy),
+                    (const, override));
+        MOCK_METHOD(void, split_policy,
+                    (const std::vector<double> &in_policy,
+                     std::vector<std::vector<double> > &out_policy),
+                    (override));
+        MOCK_METHOD(bool, do_send_policy, (), (const, override));
+        MOCK_METHOD(void, aggregate_sample,
+                    (const std::vector<std::vector<double> > &in_signal,
+                     std::vector<double> &out_signal),
+                    (override));
+        MOCK_METHOD(bool, do_send_sample, (), (const, override));
+        MOCK_METHOD(void, adjust_platform,
+                    (const std::vector<double> &in_policy), (override));
+        MOCK_METHOD(bool, do_write_batch, (), (const, override));
+        MOCK_METHOD(void, sample_platform, (std::vector<double> & out_sample),
+                    (override));
+        MOCK_METHOD(void, wait, (), (override));
+        MOCK_METHOD(std::vector<std::pair<std::string, std::string> >,
+                    report_header, (), (const, override));
+        MOCK_METHOD(std::vector<std::pair<std::string, std::string> >,
+                    report_host, (), (const, override));
+        MOCK_METHOD(std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >,
+                    report_region, (), (const, override));
+        MOCK_METHOD(std::vector<std::string>, trace_names, (), (const, override));
+        MOCK_METHOD(std::vector<std::function<std::string, trace_formats, (double)> >(),
+                    (const, override));
+        MOCK_METHOD(void, trace_values, (std::vector<double> & values), (override));
 };
 
 #endif

--- a/test/MockAgent.hpp
+++ b/test/MockAgent.hpp
@@ -41,40 +41,31 @@
 class MockAgent : public geopm::Agent
 {
     public:
-        MOCK_METHOD3(init,
-                     void(int level, const std::vector<int> &fan_in, bool is_level_root));
-        MOCK_CONST_METHOD1(validate_policy,
-                           void(std::vector<double> &policy));
-        MOCK_METHOD2(split_policy,
-                     void(const std::vector<double> &in_policy,
-                          std::vector<std::vector<double> >&out_policy));
-        MOCK_CONST_METHOD0(do_send_policy,
-                           bool(void));
+        MOCK_METHOD3(init, void(int level, const std::vector<int> &fan_in,
+                                bool is_level_root));
+        MOCK_CONST_METHOD1(validate_policy, void(std::vector<double> &policy));
+        MOCK_METHOD2(split_policy, void(const std::vector<double> &in_policy,
+                                        std::vector<std::vector<double> > &out_policy));
+        MOCK_CONST_METHOD0(do_send_policy, bool(void));
         MOCK_METHOD2(aggregate_sample,
                      void(const std::vector<std::vector<double> > &in_signal,
                           std::vector<double> &out_signal));
-        MOCK_CONST_METHOD0(do_send_sample,
-                           bool(void));
-        MOCK_METHOD1(adjust_platform,
-                     void(const std::vector<double> &in_policy));
-        MOCK_CONST_METHOD0(do_write_batch,
-                           bool(void));
-        MOCK_METHOD1(sample_platform,
-                     void(std::vector<double> &out_sample));
-        MOCK_METHOD0(wait,
-                     void(void));
+        MOCK_CONST_METHOD0(do_send_sample, bool(void));
+        MOCK_METHOD1(adjust_platform, void(const std::vector<double> &in_policy));
+        MOCK_CONST_METHOD0(do_write_batch, bool(void));
+        MOCK_METHOD1(sample_platform, void(std::vector<double> &out_sample));
+        MOCK_METHOD0(wait, void(void));
         MOCK_CONST_METHOD0(report_header,
                            std::vector<std::pair<std::string, std::string> >(void));
         MOCK_CONST_METHOD0(report_host,
                            std::vector<std::pair<std::string, std::string> >(void));
-        MOCK_CONST_METHOD0(report_region,
-                           std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >(void));
-        MOCK_CONST_METHOD0(trace_names,
-                           std::vector<std::string>(void));
+        MOCK_CONST_METHOD0(
+            report_region,
+            std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >(void));
+        MOCK_CONST_METHOD0(trace_names, std::vector<std::string>(void));
         MOCK_CONST_METHOD0(trace_formats,
                            std::vector<std::function<std::string(double)> >(void));
-        MOCK_METHOD1(trace_values,
-                     void(std::vector<double> &values));
+        MOCK_METHOD1(trace_values, void(std::vector<double> &values));
 };
 
 #endif

--- a/test/MockAgent.hpp
+++ b/test/MockAgent.hpp
@@ -62,14 +62,14 @@ class MockAgent : public geopm::Agent
         MOCK_METHOD(void, sample_platform, (std::vector<double> & out_sample),
                     (override));
         MOCK_METHOD(void, wait, (), (override));
-        MOCK_METHOD(std::vector<std::pair<std::string, std::string> >,
+        MOCK_METHOD((std::vector<std::pair<std::string, std::string> >),
                     report_header, (), (const, override));
-        MOCK_METHOD(std::vector<std::pair<std::string, std::string> >,
+        MOCK_METHOD((std::vector<std::pair<std::string, std::string> >),
                     report_host, (), (const, override));
-        MOCK_METHOD(std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >,
+        MOCK_METHOD((std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >),
                     report_region, (), (const, override));
         MOCK_METHOD(std::vector<std::string>, trace_names, (), (const, override));
-        MOCK_METHOD(std::vector<std::function<std::string, trace_formats, (double)> >(),
+        MOCK_METHOD((std::vector<std::function<std::string(double)> >), trace_formats, (),
                     (const, override));
         MOCK_METHOD(void, trace_values, (std::vector<double> & values), (override));
 };

--- a/test/MockApplicationIO.hpp
+++ b/test/MockApplicationIO.hpp
@@ -40,48 +40,27 @@
 class MockApplicationIO : public geopm::ApplicationIO
 {
     public:
-        MOCK_METHOD0(connect,
-                     void(void));
-        MOCK_CONST_METHOD0(do_shutdown,
-                           bool(void));
-        MOCK_CONST_METHOD0(report_name,
-                           std::string(void));
-        MOCK_CONST_METHOD0(profile_name,
-                           std::string(void));
-        MOCK_CONST_METHOD0(region_name_set,
-                           std::set<std::string>(void));
-        MOCK_CONST_METHOD1(total_region_runtime,
-                           double(uint64_t region_id));
-        MOCK_CONST_METHOD1(total_region_runtime_mpi,
-                           double(uint64_t region_id));
-        MOCK_CONST_METHOD0(total_epoch_runtime_ignore,
-                           double(void));
-        MOCK_CONST_METHOD0(total_app_runtime_mpi,
-                           double(void));
-        MOCK_CONST_METHOD0(total_app_runtime_ignore,
-                           double(void));
-        MOCK_CONST_METHOD0(total_epoch_runtime,
-                           double(void));
-        MOCK_CONST_METHOD0(total_epoch_runtime_network,
-                           double(void));
-        MOCK_CONST_METHOD0(total_epoch_energy_pkg,
-                           double(void));
-        MOCK_CONST_METHOD0(total_epoch_energy_dram,
-                           double(void));
-        MOCK_CONST_METHOD0(total_epoch_count,
-                           int(void));
-        MOCK_CONST_METHOD1(total_count,
-                           int(uint64_t region_id));
-        MOCK_METHOD1(update,
-                     void(std::shared_ptr<geopm::Comm> comm));
-        MOCK_CONST_METHOD0(region_info,
-                           std::list<geopm_region_info_s>(void));
-        MOCK_METHOD0(clear_region_info,
-                     void(void));
-        MOCK_METHOD0(controller_ready,
-                     void(void));
-        MOCK_METHOD0(abort,
-                     void(void));
+        MOCK_METHOD0(connect, void(void));
+        MOCK_CONST_METHOD0(do_shutdown, bool(void));
+        MOCK_CONST_METHOD0(report_name, std::string(void));
+        MOCK_CONST_METHOD0(profile_name, std::string(void));
+        MOCK_CONST_METHOD0(region_name_set, std::set<std::string>(void));
+        MOCK_CONST_METHOD1(total_region_runtime, double(uint64_t region_id));
+        MOCK_CONST_METHOD1(total_region_runtime_mpi, double(uint64_t region_id));
+        MOCK_CONST_METHOD0(total_epoch_runtime_ignore, double(void));
+        MOCK_CONST_METHOD0(total_app_runtime_mpi, double(void));
+        MOCK_CONST_METHOD0(total_app_runtime_ignore, double(void));
+        MOCK_CONST_METHOD0(total_epoch_runtime, double(void));
+        MOCK_CONST_METHOD0(total_epoch_runtime_network, double(void));
+        MOCK_CONST_METHOD0(total_epoch_energy_pkg, double(void));
+        MOCK_CONST_METHOD0(total_epoch_energy_dram, double(void));
+        MOCK_CONST_METHOD0(total_epoch_count, int(void));
+        MOCK_CONST_METHOD1(total_count, int(uint64_t region_id));
+        MOCK_METHOD1(update, void(std::shared_ptr<geopm::Comm> comm));
+        MOCK_CONST_METHOD0(region_info, std::list<geopm_region_info_s>(void));
+        MOCK_METHOD0(clear_region_info, void(void));
+        MOCK_METHOD0(controller_ready, void(void));
+        MOCK_METHOD0(abort, void(void));
 };
 
 #endif

--- a/test/MockApplicationIO.hpp
+++ b/test/MockApplicationIO.hpp
@@ -40,27 +40,29 @@
 class MockApplicationIO : public geopm::ApplicationIO
 {
     public:
-        MOCK_METHOD0(connect, void(void));
-        MOCK_CONST_METHOD0(do_shutdown, bool(void));
-        MOCK_CONST_METHOD0(report_name, std::string(void));
-        MOCK_CONST_METHOD0(profile_name, std::string(void));
-        MOCK_CONST_METHOD0(region_name_set, std::set<std::string>(void));
-        MOCK_CONST_METHOD1(total_region_runtime, double(uint64_t region_id));
-        MOCK_CONST_METHOD1(total_region_runtime_mpi, double(uint64_t region_id));
-        MOCK_CONST_METHOD0(total_epoch_runtime_ignore, double(void));
-        MOCK_CONST_METHOD0(total_app_runtime_mpi, double(void));
-        MOCK_CONST_METHOD0(total_app_runtime_ignore, double(void));
-        MOCK_CONST_METHOD0(total_epoch_runtime, double(void));
-        MOCK_CONST_METHOD0(total_epoch_runtime_network, double(void));
-        MOCK_CONST_METHOD0(total_epoch_energy_pkg, double(void));
-        MOCK_CONST_METHOD0(total_epoch_energy_dram, double(void));
-        MOCK_CONST_METHOD0(total_epoch_count, int(void));
-        MOCK_CONST_METHOD1(total_count, int(uint64_t region_id));
-        MOCK_METHOD1(update, void(std::shared_ptr<geopm::Comm> comm));
-        MOCK_CONST_METHOD0(region_info, std::list<geopm_region_info_s>(void));
-        MOCK_METHOD0(clear_region_info, void(void));
-        MOCK_METHOD0(controller_ready, void(void));
-        MOCK_METHOD0(abort, void(void));
+        MOCK_METHOD(void, connect, (), (override));
+        MOCK_METHOD(bool, do_shutdown, (), (const, override));
+        MOCK_METHOD(std::string, report_name, (), (const, override));
+        MOCK_METHOD(std::string, profile_name, (), (const, override));
+        MOCK_METHOD(std::set<std::string>, region_name_set, (), (const, override));
+        MOCK_METHOD(double, total_region_runtime, (uint64_t region_id),
+                    (const, override));
+        MOCK_METHOD(double, total_region_runtime_mpi, (uint64_t region_id),
+                    (const, override));
+        MOCK_METHOD(double, total_epoch_runtime_ignore, (), (const, override));
+        MOCK_METHOD(double, total_app_runtime_mpi, (), (const, override));
+        MOCK_METHOD(double, total_app_runtime_ignore, (), (const, override));
+        MOCK_METHOD(double, total_epoch_runtime, (), (const, override));
+        MOCK_METHOD(double, total_epoch_runtime_network, (), (const, override));
+        MOCK_METHOD(double, total_epoch_energy_pkg, (), (const, override));
+        MOCK_METHOD(double, total_epoch_energy_dram, (), (const, override));
+        MOCK_METHOD(int, total_epoch_count, (), (const, override));
+        MOCK_METHOD(int, total_count, (uint64_t region_id), (const, override));
+        MOCK_METHOD(void, update, (std::shared_ptr<geopm::Comm> comm), (override));
+        MOCK_METHOD(std::list<geopm_region_info_s>, region_info, (), (const, override));
+        MOCK_METHOD(void, clear_region_info, (), (override));
+        MOCK_METHOD(void, controller_ready, (), (override));
+        MOCK_METHOD(void, abort, (), (override));
 };
 
 #endif

--- a/test/MockApplicationIO.hpp
+++ b/test/MockApplicationIO.hpp
@@ -45,22 +45,6 @@ class MockApplicationIO : public geopm::ApplicationIO
         MOCK_METHOD(std::string, report_name, (), (const, override));
         MOCK_METHOD(std::string, profile_name, (), (const, override));
         MOCK_METHOD(std::set<std::string>, region_name_set, (), (const, override));
-        MOCK_METHOD(double, total_region_runtime, (uint64_t region_id),
-                    (const, override));
-        MOCK_METHOD(double, total_region_runtime_mpi, (uint64_t region_id),
-                    (const, override));
-        MOCK_METHOD(double, total_epoch_runtime_ignore, (), (const, override));
-        MOCK_METHOD(double, total_app_runtime_mpi, (), (const, override));
-        MOCK_METHOD(double, total_app_runtime_ignore, (), (const, override));
-        MOCK_METHOD(double, total_epoch_runtime, (), (const, override));
-        MOCK_METHOD(double, total_epoch_runtime_network, (), (const, override));
-        MOCK_METHOD(double, total_epoch_energy_pkg, (), (const, override));
-        MOCK_METHOD(double, total_epoch_energy_dram, (), (const, override));
-        MOCK_METHOD(int, total_epoch_count, (), (const, override));
-        MOCK_METHOD(int, total_count, (uint64_t region_id), (const, override));
-        MOCK_METHOD(void, update, (std::shared_ptr<geopm::Comm> comm), (override));
-        MOCK_METHOD(std::list<geopm_region_info_s>, region_info, (), (const, override));
-        MOCK_METHOD(void, clear_region_info, (), (override));
         MOCK_METHOD(void, controller_ready, (), (override));
         MOCK_METHOD(void, abort, (), (override));
 };

--- a/test/MockApplicationRecordLog.hpp
+++ b/test/MockApplicationRecordLog.hpp
@@ -40,13 +40,15 @@
 class MockApplicationRecordLog : public geopm::ApplicationRecordLog
 {
     public:
-        MOCK_METHOD1(set_process, void(int process));
-        MOCK_METHOD1(set_time_zero, void(const geopm_time_s &time));
-        MOCK_METHOD2(enter, void(uint64_t hash, const geopm_time_s &time));
-        MOCK_METHOD2(exit, void(uint64_t hash, const geopm_time_s &time));
-        MOCK_METHOD1(epoch, void(const geopm_time_s &time));
-        MOCK_METHOD2(dump, void(std::vector<geopm::record_s> &records,
-                                std::vector<geopm::short_region_s> &short_regions));
+        MOCK_METHOD(void, set_process, (int process), (override));
+        MOCK_METHOD(void, set_time_zero, (const geopm_time_s &time), (override));
+        MOCK_METHOD(void, enter, (uint64_t hash, const geopm_time_s &time), (override));
+        MOCK_METHOD(void, exit, (uint64_t hash, const geopm_time_s &time), (override));
+        MOCK_METHOD(void, epoch, (const geopm_time_s &time), (override));
+        MOCK_METHOD(void, dump,
+                    (std::vector<geopm::record_s> & records,
+                     std::vector<geopm::short_region_s> &short_regions),
+                    (override));
 };
 
 #endif

--- a/test/MockApplicationRecordLog.hpp
+++ b/test/MockApplicationRecordLog.hpp
@@ -40,19 +40,13 @@
 class MockApplicationRecordLog : public geopm::ApplicationRecordLog
 {
     public:
-        MOCK_METHOD1(set_process,
-                     void(int process));
-        MOCK_METHOD1(set_time_zero,
-                     void(const geopm_time_s &time));
-        MOCK_METHOD2(enter,
-                     void(uint64_t hash, const geopm_time_s &time));
-        MOCK_METHOD2(exit,
-                     void(uint64_t hash, const geopm_time_s &time));
-        MOCK_METHOD1(epoch,
-                     void(const geopm_time_s &time));
-        MOCK_METHOD2(dump,
-                     void(std::vector<geopm::record_s> &records,
-                          std::vector<geopm::short_region_s> &short_regions));
+        MOCK_METHOD1(set_process, void(int process));
+        MOCK_METHOD1(set_time_zero, void(const geopm_time_s &time));
+        MOCK_METHOD2(enter, void(uint64_t hash, const geopm_time_s &time));
+        MOCK_METHOD2(exit, void(uint64_t hash, const geopm_time_s &time));
+        MOCK_METHOD1(epoch, void(const geopm_time_s &time));
+        MOCK_METHOD2(dump, void(std::vector<geopm::record_s> &records,
+                                std::vector<geopm::short_region_s> &short_regions));
 };
 
 #endif

--- a/test/MockApplicationSampler.hpp
+++ b/test/MockApplicationSampler.hpp
@@ -41,20 +41,23 @@
 class MockApplicationSampler : public geopm::ApplicationSampler
 {
     public:
-        MOCK_METHOD1(time_zero, void(const geopm_time_s &start_time));
-        MOCK_METHOD1(update, void(const geopm_time_s &curr_time));
-        MOCK_CONST_METHOD1(cpu_region_hash, uint64_t(int cpu_idx));
-        MOCK_CONST_METHOD1(cpu_hint, uint64_t(int cpu_idx));
-        MOCK_CONST_METHOD2(cpu_hint_time, double(int cpu_idx, uint64_t hint));
-        MOCK_CONST_METHOD1(cpu_progress, double(int cpu_idx));
-        MOCK_CONST_METHOD0(per_cpu_process, std::vector<int>(void));
-        MOCK_METHOD1(connect, void(const std::string &shm_key));
-        MOCK_METHOD1(set_sampler, void(std::shared_ptr<geopm::ProfileSampler> sampler));
-        MOCK_METHOD0(get_sampler, std::shared_ptr<geopm::ProfileSampler>(void));
-        MOCK_CONST_METHOD1(get_name_map,
-                           std::map<uint64_t, std::string>(uint64_t name_key));
-        MOCK_CONST_METHOD1(get_short_region,
-                           geopm::short_region_s(uint64_t event_signal));
+        MOCK_METHOD(void, time_zero, (const geopm_time_s &start_time), (override));
+        MOCK_METHOD(void, update, (const geopm_time_s &curr_time), (override));
+        MOCK_METHOD(uint64_t, cpu_region_hash, (int cpu_idx), (const, override));
+        MOCK_METHOD(uint64_t, cpu_hint, (int cpu_idx), (const, override));
+        MOCK_METHOD(double, cpu_hint_time, (int cpu_idx, uint64_t hint),
+                    (const, override));
+        MOCK_METHOD(double, cpu_progress, (int cpu_idx), (const, override));
+        MOCK_METHOD(std::vector<int>, per_cpu_process, (), (const, override));
+        MOCK_METHOD(void, connect, (const std::string &shm_key), (override));
+        MOCK_METHOD(void, set_sampler,
+                    (std::shared_ptr<geopm::ProfileSampler> sampler), (override));
+        MOCK_METHOD(std::shared_ptr<geopm::ProfileSampler>, get_sampler, (),
+                    (override));
+        MOCK_METHOD(std::map<uint64_t, std::string>, get_name_map,
+                    (uint64_t name_key), (const, override));
+        MOCK_METHOD(geopm::short_region_s, get_short_region,
+                    (uint64_t event_signal), (const, override));
         std::vector<geopm::record_s> get_records(void) const override;
         /// Inject records to be used by next call to get_records()
         /// @todo: figure out input type for this

--- a/test/MockApplicationSampler.hpp
+++ b/test/MockApplicationSampler.hpp
@@ -54,7 +54,7 @@ class MockApplicationSampler : public geopm::ApplicationSampler
                     (std::shared_ptr<geopm::ProfileSampler> sampler), (override));
         MOCK_METHOD(std::shared_ptr<geopm::ProfileSampler>, get_sampler, (),
                     (override));
-        MOCK_METHOD(std::map<uint64_t, std::string>, get_name_map,
+        MOCK_METHOD((std::map<uint64_t, std::string>), get_name_map,
                     (uint64_t name_key), (const, override));
         MOCK_METHOD(geopm::short_region_s, get_short_region,
                     (uint64_t event_signal), (const, override));

--- a/test/MockApplicationSampler.hpp
+++ b/test/MockApplicationSampler.hpp
@@ -38,30 +38,19 @@
 #include "ApplicationSampler.hpp"
 #include "record.hpp"
 
-
 class MockApplicationSampler : public geopm::ApplicationSampler
 {
     public:
-        MOCK_METHOD1(time_zero,
-                     void(const geopm_time_s &start_time));
-        MOCK_METHOD1(update,
-                     void(const geopm_time_s &curr_time));
-        MOCK_CONST_METHOD1(cpu_region_hash,
-                           uint64_t(int cpu_idx));
-        MOCK_CONST_METHOD1(cpu_hint,
-                           uint64_t(int cpu_idx));
-        MOCK_CONST_METHOD2(cpu_hint_time,
-                           double(int cpu_idx, uint64_t hint));
-        MOCK_CONST_METHOD1(cpu_progress,
-                           double(int cpu_idx));
-        MOCK_CONST_METHOD0(per_cpu_process,
-                           std::vector<int>(void));
-        MOCK_METHOD1(connect,
-                     void(const std::string &shm_key));
-        MOCK_METHOD1(set_sampler,
-                     void(std::shared_ptr<geopm::ProfileSampler> sampler));
-        MOCK_METHOD0(get_sampler,
-                     std::shared_ptr<geopm::ProfileSampler>(void));
+        MOCK_METHOD1(time_zero, void(const geopm_time_s &start_time));
+        MOCK_METHOD1(update, void(const geopm_time_s &curr_time));
+        MOCK_CONST_METHOD1(cpu_region_hash, uint64_t(int cpu_idx));
+        MOCK_CONST_METHOD1(cpu_hint, uint64_t(int cpu_idx));
+        MOCK_CONST_METHOD2(cpu_hint_time, double(int cpu_idx, uint64_t hint));
+        MOCK_CONST_METHOD1(cpu_progress, double(int cpu_idx));
+        MOCK_CONST_METHOD0(per_cpu_process, std::vector<int>(void));
+        MOCK_METHOD1(connect, void(const std::string &shm_key));
+        MOCK_METHOD1(set_sampler, void(std::shared_ptr<geopm::ProfileSampler> sampler));
+        MOCK_METHOD0(get_sampler, std::shared_ptr<geopm::ProfileSampler>(void));
         MOCK_CONST_METHOD1(get_name_map,
                            std::map<uint64_t, std::string>(uint64_t name_key));
         MOCK_CONST_METHOD1(get_short_region,
@@ -72,6 +61,7 @@ class MockApplicationSampler : public geopm::ApplicationSampler
         void inject_records(const std::vector<geopm::record_s> &records);
         void inject_records(const std::string &record_trace);
         void update_time(double time);
+
     private:
         std::vector<geopm::record_s> m_records;
         double m_time_0;

--- a/test/MockApplicationStatus.hpp
+++ b/test/MockApplicationStatus.hpp
@@ -40,17 +40,20 @@
 class MockApplicationStatus : public geopm::ApplicationStatus
 {
     public:
-        MOCK_METHOD2(set_hint, void(int cpu_idx, uint64_t hints));
-        MOCK_CONST_METHOD1(get_hint, uint64_t(int cpu_idx));
-        MOCK_METHOD3(set_hash, void(int cpu_idx, uint64_t hash, uint64_t hint));
-        MOCK_CONST_METHOD1(get_hash, uint64_t(int cpu_idx));
-        MOCK_METHOD1(reset_work_units, void(int cpu_idx));
-        MOCK_METHOD2(set_total_work_units, void(int cpu_idx, int work_units));
-        MOCK_METHOD1(increment_work_unit, void(int cpu_idx));
-        MOCK_CONST_METHOD1(get_progress_cpu, double(int cpu_idx));
-        MOCK_METHOD2(set_process, void(const std::set<int> &cpu_idx, int process));
-        MOCK_CONST_METHOD1(get_process, int(int cpu_idx));
-        MOCK_METHOD0(update_cache, void(void));
+        MOCK_METHOD(void, set_hint, (int cpu_idx, uint64_t hints), (override));
+        MOCK_METHOD(uint64_t, get_hint, (int cpu_idx), (const, override));
+        MOCK_METHOD(void, set_hash, (int cpu_idx, uint64_t hash, uint64_t hint),
+                    (override));
+        MOCK_METHOD(uint64_t, get_hash, (int cpu_idx), (const, override));
+        MOCK_METHOD(void, reset_work_units, (int cpu_idx), (override));
+        MOCK_METHOD(void, set_total_work_units, (int cpu_idx, int work_units),
+                    (override));
+        MOCK_METHOD(void, increment_work_unit, (int cpu_idx), (override));
+        MOCK_METHOD(double, get_progress_cpu, (int cpu_idx), (const, override));
+        MOCK_METHOD(void, set_process,
+                    (const std::set<int> &cpu_idx, int process), (override));
+        MOCK_METHOD(int, get_process, (int cpu_idx), (const, override));
+        MOCK_METHOD(void, update_cache, (), (override));
 };
 
 #endif

--- a/test/MockApplicationStatus.hpp
+++ b/test/MockApplicationStatus.hpp
@@ -40,28 +40,17 @@
 class MockApplicationStatus : public geopm::ApplicationStatus
 {
     public:
-        MOCK_METHOD2(set_hint,
-                     void(int cpu_idx, uint64_t hints));
-        MOCK_CONST_METHOD1(get_hint,
-                           uint64_t(int cpu_idx));
-        MOCK_METHOD3(set_hash,
-                     void(int cpu_idx, uint64_t hash, uint64_t hint));
-        MOCK_CONST_METHOD1(get_hash,
-                           uint64_t(int cpu_idx));
-        MOCK_METHOD1(reset_work_units,
-                     void(int cpu_idx));
-        MOCK_METHOD2(set_total_work_units,
-                     void(int cpu_idx, int work_units));
-        MOCK_METHOD1(increment_work_unit,
-                     void(int cpu_idx));
-        MOCK_CONST_METHOD1(get_progress_cpu,
-                           double(int cpu_idx));
-        MOCK_METHOD2(set_process,
-                     void(const std::set<int> &cpu_idx, int process));
-        MOCK_CONST_METHOD1(get_process,
-                           int(int cpu_idx));
-        MOCK_METHOD0(update_cache,
-                     void(void));
+        MOCK_METHOD2(set_hint, void(int cpu_idx, uint64_t hints));
+        MOCK_CONST_METHOD1(get_hint, uint64_t(int cpu_idx));
+        MOCK_METHOD3(set_hash, void(int cpu_idx, uint64_t hash, uint64_t hint));
+        MOCK_CONST_METHOD1(get_hash, uint64_t(int cpu_idx));
+        MOCK_METHOD1(reset_work_units, void(int cpu_idx));
+        MOCK_METHOD2(set_total_work_units, void(int cpu_idx, int work_units));
+        MOCK_METHOD1(increment_work_unit, void(int cpu_idx));
+        MOCK_CONST_METHOD1(get_progress_cpu, double(int cpu_idx));
+        MOCK_METHOD2(set_process, void(const std::set<int> &cpu_idx, int process));
+        MOCK_CONST_METHOD1(get_process, int(int cpu_idx));
+        MOCK_METHOD0(update_cache, void(void));
 };
 
 #endif

--- a/test/MockComm.hpp
+++ b/test/MockComm.hpp
@@ -40,44 +40,57 @@
 class MockComm : public geopm::Comm
 {
     public:
-        MOCK_CONST_METHOD0(split, std::shared_ptr<Comm>(void));
-        MOCK_CONST_METHOD2(split, std::shared_ptr<Comm>(int color, int key));
-        MOCK_CONST_METHOD2(split, std::shared_ptr<Comm>(const std::string &tag,
-                                                        int split_type));
-        MOCK_CONST_METHOD3(split, std::shared_ptr<Comm>(std::vector<int> dimensions,
-                                                        std::vector<int> periods,
-                                                        bool is_reorder));
-        MOCK_CONST_METHOD1(split_cart,
-                           std::shared_ptr<Comm>(std::vector<int> dimensions));
-        MOCK_CONST_METHOD1(comm_supported, bool(const std::string &description));
-        MOCK_CONST_METHOD1(cart_rank, int(const std::vector<int> &coords));
-        MOCK_CONST_METHOD0(rank, int(void));
-        MOCK_CONST_METHOD0(num_rank, int(void));
-        MOCK_CONST_METHOD2(dimension_create,
-                           void(int num_nodes, std::vector<int> &dimension));
-        MOCK_METHOD1(free_mem, void(void *base));
-        MOCK_METHOD2(alloc_mem, void(size_t size, void **base));
-        MOCK_METHOD2(window_create, size_t(size_t size, void *base));
-        MOCK_METHOD1(window_destroy, void(size_t window_id));
-        MOCK_CONST_METHOD4(window_lock, void(size_t window_id, bool isExclusive,
-                                             int rank, int assert));
-        MOCK_CONST_METHOD2(window_unlock, void(size_t window_id, int rank));
-        MOCK_CONST_METHOD2(coordinate, void(int rank, std::vector<int> &coord));
-        MOCK_CONST_METHOD1(coordinate, std::vector<int>(int rank));
-        MOCK_CONST_METHOD0(barrier, void(void));
-        MOCK_CONST_METHOD3(broadcast, void(void *buffer, size_t size, int root));
-        MOCK_CONST_METHOD1(test, bool(bool is_true));
-        MOCK_CONST_METHOD4(reduce_max, void(double *send_buf, double *recv_buf,
-                                            size_t count, int root));
-        MOCK_CONST_METHOD5(gather, void(const void *send_buf, size_t send_size,
-                                        void *recv_buf, size_t recv_size, int root));
-        MOCK_CONST_METHOD6(gatherv,
-                           void(const void *send_buf, size_t send_size,
-                                void *recv_buf, const std::vector<size_t> &recv_sizes,
-                                const std::vector<off_t> &rank_offset, int root));
-        MOCK_CONST_METHOD5(window_put, void(const void *send_buf, size_t send_size,
-                                            int rank, off_t disp, size_t window_id));
-        MOCK_METHOD0(tear_down, void(void));
+        MOCK_METHOD(std::shared_ptr<Comm>, split, (), (const, override));
+        MOCK_METHOD(std::shared_ptr<Comm>, split, (int color, int key),
+                    (const, override));
+        MOCK_METHOD(std::shared_ptr<Comm>, split,
+                    (const std::string &tag, int split_type), (const, override));
+        MOCK_METHOD(std::shared_ptr<Comm>, split,
+                    (std::vector<int> dimensions, std::vector<int> periods, bool is_reorder),
+                    (const, override));
+        MOCK_METHOD(std::shared_ptr<Comm>, split_cart,
+                    (std::vector<int> dimensions), (const, override));
+        MOCK_METHOD(bool, comm_supported, (const std::string &description),
+                    (const, override));
+        MOCK_METHOD(int, cart_rank, (const std::vector<int> &coords),
+                    (const, override));
+        MOCK_METHOD(int, rank, (), (const, override));
+        MOCK_METHOD(int, num_rank, (), (const, override));
+        MOCK_METHOD(void, dimension_create,
+                    (int num_nodes, std::vector<int> &dimension), (const, override));
+        MOCK_METHOD(void, free_mem, (void *base), (override));
+        MOCK_METHOD(void, alloc_mem, (size_t size, void **base), (override));
+        MOCK_METHOD(size_t, window_create, (size_t size, void *base), (override));
+        MOCK_METHOD(void, window_destroy, (size_t window_id), (override));
+        MOCK_METHOD(void, window_lock,
+                    (size_t window_id, bool isExclusive, int rank, int assert),
+                    (const, override));
+        MOCK_METHOD(void, window_unlock, (size_t window_id, int rank),
+                    (const, override));
+        MOCK_METHOD(void, coordinate, (int rank, std::vector<int> &coord),
+                    (const, override));
+        MOCK_METHOD(std::vector<int>, coordinate, (int rank), (const, override));
+        MOCK_METHOD(void, barrier, (), (const, override));
+        MOCK_METHOD(void, broadcast, (void *buffer, size_t size, int root),
+                    (const, override));
+        MOCK_METHOD(bool, test, (bool is_true), (const, override));
+        MOCK_METHOD(void, reduce_max,
+                    (double *send_buf, double *recv_buf, size_t count, int root),
+                    (const, override));
+        MOCK_METHOD(void, gather,
+                    (const void *send_buf, size_t send_size, void *recv_buf,
+                     size_t recv_size, int root),
+                    (const, override));
+        MOCK_METHOD(void, gatherv,
+                    (const void *send_buf, size_t send_size, void *recv_buf,
+                     const std::vector<size_t> &recv_sizes,
+                     const std::vector<off_t> &rank_offset, int root),
+                    (const, override));
+        MOCK_METHOD(void, window_put,
+                    (const void *send_buf, size_t send_size, int rank,
+                     off_t disp, size_t window_id),
+                    (const, override));
+        MOCK_METHOD(void, tear_down, (), (override));
 };
 
 #endif

--- a/test/MockComm.hpp
+++ b/test/MockComm.hpp
@@ -40,60 +40,44 @@
 class MockComm : public geopm::Comm
 {
     public:
-        MOCK_CONST_METHOD0(split,
-            std::shared_ptr<Comm> (void));
-        MOCK_CONST_METHOD2(split,
-            std::shared_ptr<Comm> (int color, int key));
-        MOCK_CONST_METHOD2(split,
-            std::shared_ptr<Comm> (const std::string &tag, int split_type));
-        MOCK_CONST_METHOD3(split,
-            std::shared_ptr<Comm> (std::vector<int> dimensions, std::vector<int> periods, bool is_reorder));
+        MOCK_CONST_METHOD0(split, std::shared_ptr<Comm>(void));
+        MOCK_CONST_METHOD2(split, std::shared_ptr<Comm>(int color, int key));
+        MOCK_CONST_METHOD2(split, std::shared_ptr<Comm>(const std::string &tag,
+                                                        int split_type));
+        MOCK_CONST_METHOD3(split, std::shared_ptr<Comm>(std::vector<int> dimensions,
+                                                        std::vector<int> periods,
+                                                        bool is_reorder));
         MOCK_CONST_METHOD1(split_cart,
-            std::shared_ptr<Comm>(std::vector<int> dimensions));
-        MOCK_CONST_METHOD1(comm_supported,
-            bool (const std::string &description));
-        MOCK_CONST_METHOD1(cart_rank,
-            int (const std::vector<int> &coords));
-        MOCK_CONST_METHOD0(rank,
-            int (void));
-        MOCK_CONST_METHOD0(num_rank,
-            int (void));
+                           std::shared_ptr<Comm>(std::vector<int> dimensions));
+        MOCK_CONST_METHOD1(comm_supported, bool(const std::string &description));
+        MOCK_CONST_METHOD1(cart_rank, int(const std::vector<int> &coords));
+        MOCK_CONST_METHOD0(rank, int(void));
+        MOCK_CONST_METHOD0(num_rank, int(void));
         MOCK_CONST_METHOD2(dimension_create,
-            void (int num_nodes, std::vector<int> &dimension));
-        MOCK_METHOD1(free_mem,
-            void (void *base));
-        MOCK_METHOD2(alloc_mem,
-            void (size_t size, void **base));
-        MOCK_METHOD2(window_create,
-            size_t (size_t size, void *base));
-        MOCK_METHOD1(window_destroy,
-            void (size_t window_id));
-        MOCK_CONST_METHOD4(window_lock,
-            void (size_t window_id, bool isExclusive, int rank, int assert));
-        MOCK_CONST_METHOD2(window_unlock,
-            void (size_t window_id, int rank));
-        MOCK_CONST_METHOD2(coordinate,
-            void (int rank, std::vector<int> &coord));
-        MOCK_CONST_METHOD1(coordinate,
-            std::vector<int>(int rank));
-        MOCK_CONST_METHOD0(barrier,
-            void (void));
-        MOCK_CONST_METHOD3(broadcast,
-            void (void *buffer, size_t size, int root));
-        MOCK_CONST_METHOD1(test,
-            bool (bool is_true));
-        MOCK_CONST_METHOD4(reduce_max,
-            void (double *send_buf, double *recv_buf, size_t count, int root));
-        MOCK_CONST_METHOD5(gather,
-            void (const void *send_buf, size_t send_size, void *recv_buf,
-                size_t recv_size, int root));
+                           void(int num_nodes, std::vector<int> &dimension));
+        MOCK_METHOD1(free_mem, void(void *base));
+        MOCK_METHOD2(alloc_mem, void(size_t size, void **base));
+        MOCK_METHOD2(window_create, size_t(size_t size, void *base));
+        MOCK_METHOD1(window_destroy, void(size_t window_id));
+        MOCK_CONST_METHOD4(window_lock, void(size_t window_id, bool isExclusive,
+                                             int rank, int assert));
+        MOCK_CONST_METHOD2(window_unlock, void(size_t window_id, int rank));
+        MOCK_CONST_METHOD2(coordinate, void(int rank, std::vector<int> &coord));
+        MOCK_CONST_METHOD1(coordinate, std::vector<int>(int rank));
+        MOCK_CONST_METHOD0(barrier, void(void));
+        MOCK_CONST_METHOD3(broadcast, void(void *buffer, size_t size, int root));
+        MOCK_CONST_METHOD1(test, bool(bool is_true));
+        MOCK_CONST_METHOD4(reduce_max, void(double *send_buf, double *recv_buf,
+                                            size_t count, int root));
+        MOCK_CONST_METHOD5(gather, void(const void *send_buf, size_t send_size,
+                                        void *recv_buf, size_t recv_size, int root));
         MOCK_CONST_METHOD6(gatherv,
-            void (const void *send_buf, size_t send_size, void *recv_buf,
-                const std::vector<size_t> &recv_sizes, const std::vector<off_t> &rank_offset, int root));
-        MOCK_CONST_METHOD5(window_put,
-            void (const void *send_buf, size_t send_size, int rank, off_t disp, size_t window_id));
-        MOCK_METHOD0(tear_down,
-            void (void));
+                           void(const void *send_buf, size_t send_size,
+                                void *recv_buf, const std::vector<size_t> &recv_sizes,
+                                const std::vector<off_t> &rank_offset, int root));
+        MOCK_CONST_METHOD5(window_put, void(const void *send_buf, size_t send_size,
+                                            int rank, off_t disp, size_t window_id));
+        MOCK_METHOD0(tear_down, void(void));
 };
 
 #endif

--- a/test/MockControl.hpp
+++ b/test/MockControl.hpp
@@ -40,16 +40,11 @@
 class MockControl : public geopm::Control
 {
     public:
-        MOCK_METHOD0(setup_batch,
-                     void(void));
-        MOCK_METHOD1(adjust,
-                     void(double value));
-        MOCK_METHOD1(write,
-                     void(double value));
-        MOCK_METHOD0(save,
-                     void(void));
-        MOCK_METHOD0(restore,
-                     void(void));
+        MOCK_METHOD0(setup_batch, void(void));
+        MOCK_METHOD1(adjust, void(double value));
+        MOCK_METHOD1(write, void(double value));
+        MOCK_METHOD0(save, void(void));
+        MOCK_METHOD0(restore, void(void));
 };
 
 #endif

--- a/test/MockControl.hpp
+++ b/test/MockControl.hpp
@@ -40,11 +40,11 @@
 class MockControl : public geopm::Control
 {
     public:
-        MOCK_METHOD0(setup_batch, void(void));
-        MOCK_METHOD1(adjust, void(double value));
-        MOCK_METHOD1(write, void(double value));
-        MOCK_METHOD0(save, void(void));
-        MOCK_METHOD0(restore, void(void));
+        MOCK_METHOD(void, setup_batch, (), (override));
+        MOCK_METHOD(void, adjust, (double value), (override));
+        MOCK_METHOD(void, write, (double value), (override));
+        MOCK_METHOD(void, save, (), (override));
+        MOCK_METHOD(void, restore, (), (override));
 };
 
 #endif

--- a/test/MockControlMessage.hpp
+++ b/test/MockControlMessage.hpp
@@ -40,26 +40,16 @@
 class MockControlMessage : public geopm::ControlMessage
 {
     public:
-        MOCK_METHOD0(step,
-                     void (void));
-        MOCK_METHOD0(wait,
-                     void (void));
-        MOCK_METHOD0(abort,
-                     void (void));
-        MOCK_METHOD2(cpu_rank,
-                     void (int cpu_idx, int rank));
-        MOCK_CONST_METHOD1(cpu_rank,
-                           int (int cpu_idx));
-        MOCK_CONST_METHOD0(is_sample_begin,
-                           bool (void));
-        MOCK_CONST_METHOD0(is_sample_end,
-                           bool (void));
-        MOCK_CONST_METHOD0(is_name_begin,
-                           bool (void));
-        MOCK_CONST_METHOD0(is_shutdown,
-                           bool (void));
-        MOCK_METHOD0(loop_begin,
-                     void (void));
+        MOCK_METHOD0(step, void(void));
+        MOCK_METHOD0(wait, void(void));
+        MOCK_METHOD0(abort, void(void));
+        MOCK_METHOD2(cpu_rank, void(int cpu_idx, int rank));
+        MOCK_CONST_METHOD1(cpu_rank, int(int cpu_idx));
+        MOCK_CONST_METHOD0(is_sample_begin, bool(void));
+        MOCK_CONST_METHOD0(is_sample_end, bool(void));
+        MOCK_CONST_METHOD0(is_name_begin, bool(void));
+        MOCK_CONST_METHOD0(is_shutdown, bool(void));
+        MOCK_METHOD0(loop_begin, void(void));
 };
 
 #endif

--- a/test/MockControlMessage.hpp
+++ b/test/MockControlMessage.hpp
@@ -40,16 +40,16 @@
 class MockControlMessage : public geopm::ControlMessage
 {
     public:
-        MOCK_METHOD0(step, void(void));
-        MOCK_METHOD0(wait, void(void));
-        MOCK_METHOD0(abort, void(void));
-        MOCK_METHOD2(cpu_rank, void(int cpu_idx, int rank));
-        MOCK_CONST_METHOD1(cpu_rank, int(int cpu_idx));
-        MOCK_CONST_METHOD0(is_sample_begin, bool(void));
-        MOCK_CONST_METHOD0(is_sample_end, bool(void));
-        MOCK_CONST_METHOD0(is_name_begin, bool(void));
-        MOCK_CONST_METHOD0(is_shutdown, bool(void));
-        MOCK_METHOD0(loop_begin, void(void));
+        MOCK_METHOD(void, step, (), (override));
+        MOCK_METHOD(void, wait, (), (override));
+        MOCK_METHOD(void, abort, (), (override));
+        MOCK_METHOD(void, cpu_rank, (int cpu_idx, int rank), (override));
+        MOCK_METHOD(int, cpu_rank, (int cpu_idx), (const, override));
+        MOCK_METHOD(bool, is_sample_begin, (), (const, override));
+        MOCK_METHOD(bool, is_sample_end, (), (const, override));
+        MOCK_METHOD(bool, is_name_begin, (), (const, override));
+        MOCK_METHOD(bool, is_shutdown, (), (const, override));
+        MOCK_METHOD(void, loop_begin, (), (override));
 };
 
 #endif

--- a/test/MockEndpoint.hpp
+++ b/test/MockEndpoint.hpp
@@ -40,17 +40,18 @@
 class MockEndpoint : public geopm::Endpoint
 {
     public:
-        MOCK_METHOD0(open, void(void));
-        MOCK_METHOD0(close, void(void));
-        MOCK_METHOD1(write_policy, void(const std::vector<double> &policy));
-        MOCK_METHOD1(read_sample, double(std::vector<double> &sample));
-        MOCK_METHOD0(get_agent, std::string(void));
-        MOCK_METHOD1(wait_for_agent_attach, void(double timeout));
-        MOCK_METHOD1(wait_for_agent_detach, void(double timeout));
-        MOCK_METHOD0(stop_wait_loop, void(void));
-        MOCK_METHOD0(reset_wait_loop, void(void));
-        MOCK_METHOD0(get_profile_name, std::string(void));
-        MOCK_METHOD0(get_hostnames, std::set<std::string>(void));
+        MOCK_METHOD(void, open, (), (override));
+        MOCK_METHOD(void, close, (), (override));
+        MOCK_METHOD(void, write_policy, (const std::vector<double> &policy),
+                    (override));
+        MOCK_METHOD(double, read_sample, (std::vector<double> & sample), (override));
+        MOCK_METHOD(std::string, get_agent, (), (override));
+        MOCK_METHOD(void, wait_for_agent_attach, (double timeout), (override));
+        MOCK_METHOD(void, wait_for_agent_detach, (double timeout), (override));
+        MOCK_METHOD(void, stop_wait_loop, (), (override));
+        MOCK_METHOD(void, reset_wait_loop, (), (override));
+        MOCK_METHOD(std::string, get_profile_name, (), (override));
+        MOCK_METHOD(std::set<std::string>, get_hostnames, (), (override));
 };
 
 #endif

--- a/test/MockEndpoint.hpp
+++ b/test/MockEndpoint.hpp
@@ -40,28 +40,17 @@
 class MockEndpoint : public geopm::Endpoint
 {
     public:
-        MOCK_METHOD0(open,
-                     void(void));
-        MOCK_METHOD0(close,
-                     void(void));
-        MOCK_METHOD1(write_policy,
-                     void(const std::vector<double> &policy));
-        MOCK_METHOD1(read_sample,
-                     double(std::vector<double> &sample));
-        MOCK_METHOD0(get_agent,
-                     std::string(void));
-        MOCK_METHOD1(wait_for_agent_attach,
-                    void(double timeout));
-        MOCK_METHOD1(wait_for_agent_detach,
-                    void(double timeout));
-        MOCK_METHOD0(stop_wait_loop,
-                     void(void));
-        MOCK_METHOD0(reset_wait_loop,
-                     void(void));
-        MOCK_METHOD0(get_profile_name,
-                     std::string(void));
-        MOCK_METHOD0(get_hostnames,
-                     std::set<std::string>(void));
+        MOCK_METHOD0(open, void(void));
+        MOCK_METHOD0(close, void(void));
+        MOCK_METHOD1(write_policy, void(const std::vector<double> &policy));
+        MOCK_METHOD1(read_sample, double(std::vector<double> &sample));
+        MOCK_METHOD0(get_agent, std::string(void));
+        MOCK_METHOD1(wait_for_agent_attach, void(double timeout));
+        MOCK_METHOD1(wait_for_agent_detach, void(double timeout));
+        MOCK_METHOD0(stop_wait_loop, void(void));
+        MOCK_METHOD0(reset_wait_loop, void(void));
+        MOCK_METHOD0(get_profile_name, std::string(void));
+        MOCK_METHOD0(get_hostnames, std::set<std::string>(void));
 };
 
 #endif

--- a/test/MockEndpointPolicyTracer.hpp
+++ b/test/MockEndpointPolicyTracer.hpp
@@ -40,7 +40,7 @@
 class MockEndpointPolicyTracer : public geopm::EndpointPolicyTracer
 {
     public:
-        MOCK_METHOD1(update, void(const std::vector<double> &policy));
+        MOCK_METHOD(void, update, (const std::vector<double> &policy), (override));
 };
 
 #endif

--- a/test/MockEndpointPolicyTracer.hpp
+++ b/test/MockEndpointPolicyTracer.hpp
@@ -40,8 +40,7 @@
 class MockEndpointPolicyTracer : public geopm::EndpointPolicyTracer
 {
     public:
-        MOCK_METHOD1(update,
-                     void(const std::vector<double> &policy));
+        MOCK_METHOD1(update, void(const std::vector<double> &policy));
 };
 
 #endif

--- a/test/MockEndpointUser.hpp
+++ b/test/MockEndpointUser.hpp
@@ -40,8 +40,9 @@
 class MockEndpointUser : public geopm::EndpointUser
 {
     public:
-        MOCK_METHOD1(read_policy, double(std::vector<double> &policy));
-        MOCK_METHOD1(write_sample, void(const std::vector<double> &sample));
+        MOCK_METHOD(double, read_policy, (std::vector<double> & policy), (override));
+        MOCK_METHOD(void, write_sample, (const std::vector<double> &sample),
+                    (override));
 };
 
 #endif

--- a/test/MockEndpointUser.hpp
+++ b/test/MockEndpointUser.hpp
@@ -40,10 +40,8 @@
 class MockEndpointUser : public geopm::EndpointUser
 {
     public:
-        MOCK_METHOD1(read_policy,
-                     double(std::vector<double> &policy));
-        MOCK_METHOD1(write_sample,
-                     void(const std::vector<double> &sample));
+        MOCK_METHOD1(read_policy, double(std::vector<double> &policy));
+        MOCK_METHOD1(write_sample, void(const std::vector<double> &sample));
 };
 
 #endif

--- a/test/MockEnergyEfficientRegion.hpp
+++ b/test/MockEnergyEfficientRegion.hpp
@@ -40,11 +40,11 @@
 class MockEnergyEfficientRegion : public geopm::EnergyEfficientRegion
 {
     public:
-        MOCK_CONST_METHOD0(freq, double(void));
-        MOCK_METHOD3(update_freq_range,
-                     void(double freq_min, double freq_max, double freq_step));
-        MOCK_METHOD1(update_exit, void(double curr_perf_metric));
-        MOCK_CONST_METHOD0(is_learning, bool(void));
+        MOCK_METHOD(double, freq, (), (const, override));
+        MOCK_METHOD(void, update_freq_range,
+                    (double freq_min, double freq_max, double freq_step), (override));
+        MOCK_METHOD(void, update_exit, (double curr_perf_metric), (override));
+        MOCK_METHOD(bool, is_learning, (), (const, override));
 };
 
 #endif

--- a/test/MockEnergyEfficientRegion.hpp
+++ b/test/MockEnergyEfficientRegion.hpp
@@ -43,10 +43,8 @@ class MockEnergyEfficientRegion : public geopm::EnergyEfficientRegion
         MOCK_CONST_METHOD0(freq, double(void));
         MOCK_METHOD3(update_freq_range,
                      void(double freq_min, double freq_max, double freq_step));
-        MOCK_METHOD1(update_exit,
-                     void(double curr_perf_metric));
-        MOCK_CONST_METHOD0(is_learning,
-                     bool(void));
+        MOCK_METHOD1(update_exit, void(double curr_perf_metric));
+        MOCK_CONST_METHOD0(is_learning, bool(void));
 };
 
 #endif

--- a/test/MockFrequencyGovernor.hpp
+++ b/test/MockFrequencyGovernor.hpp
@@ -40,16 +40,18 @@
 class MockFrequencyGovernor : public geopm::FrequencyGovernor
 {
     public:
-        MOCK_METHOD0(init_platform_io, void(void));
-        MOCK_CONST_METHOD0(frequency_domain_type, int(void));
-        MOCK_METHOD1(adjust_platform,
-                     void(const std::vector<double> &frequency_request));
-        MOCK_CONST_METHOD0(do_write_batch, bool());
-        MOCK_METHOD2(set_frequency_bounds, bool(double freq_min, double freq_max));
-        MOCK_CONST_METHOD0(get_frequency_min, double());
-        MOCK_CONST_METHOD0(get_frequency_max, double());
-        MOCK_CONST_METHOD0(get_frequency_step, double());
-        MOCK_CONST_METHOD2(validate_policy, void(double &freq_min, double &freq_max));
+        MOCK_METHOD(void, init_platform_io, (), (override));
+        MOCK_METHOD(int, frequency_domain_type, (), (const, override));
+        MOCK_METHOD(void, adjust_platform,
+                    (const std::vector<double> &frequency_request), (override));
+        MOCK_METHOD(bool, do_write_batch, (), (const, override));
+        MOCK_METHOD(bool, set_frequency_bounds,
+                    (double freq_min, double freq_max), (override));
+        MOCK_METHOD(double, get_frequency_min, (), (const, override));
+        MOCK_METHOD(double, get_frequency_max, (), (const, override));
+        MOCK_METHOD(double, get_frequency_step, (), (const, override));
+        MOCK_METHOD(void, validate_policy, (double &freq_min, double &freq_max),
+                    (const, override));
 };
 
 #endif

--- a/test/MockFrequencyGovernor.hpp
+++ b/test/MockFrequencyGovernor.hpp
@@ -40,24 +40,16 @@
 class MockFrequencyGovernor : public geopm::FrequencyGovernor
 {
     public:
-        MOCK_METHOD0(init_platform_io,
-                     void(void));
-        MOCK_CONST_METHOD0(frequency_domain_type,
-                           int(void));
+        MOCK_METHOD0(init_platform_io, void(void));
+        MOCK_CONST_METHOD0(frequency_domain_type, int(void));
         MOCK_METHOD1(adjust_platform,
                      void(const std::vector<double> &frequency_request));
-        MOCK_CONST_METHOD0(do_write_batch,
-                           bool());
-        MOCK_METHOD2(set_frequency_bounds,
-                     bool(double freq_min, double freq_max));
-        MOCK_CONST_METHOD0(get_frequency_min,
-                           double());
-        MOCK_CONST_METHOD0(get_frequency_max,
-                           double());
-        MOCK_CONST_METHOD0(get_frequency_step,
-                           double());
-        MOCK_CONST_METHOD2(validate_policy,
-                           void(double &freq_min, double &freq_max));
+        MOCK_CONST_METHOD0(do_write_batch, bool());
+        MOCK_METHOD2(set_frequency_bounds, bool(double freq_min, double freq_max));
+        MOCK_CONST_METHOD0(get_frequency_min, double());
+        MOCK_CONST_METHOD0(get_frequency_max, double());
+        MOCK_CONST_METHOD0(get_frequency_step, double());
+        MOCK_CONST_METHOD2(validate_policy, void(double &freq_min, double &freq_max));
 };
 
 #endif

--- a/test/MockIOGroup.hpp
+++ b/test/MockIOGroup.hpp
@@ -40,36 +40,47 @@
 class MockIOGroup : public geopm::IOGroup
 {
     public:
-        MOCK_CONST_METHOD0(signal_names, std::set<std::string>(void));
-        MOCK_CONST_METHOD0(control_names, std::set<std::string>(void));
-        MOCK_CONST_METHOD1(is_valid_signal, bool(const std::string &signal_name));
-        MOCK_CONST_METHOD1(is_valid_control, bool(const std::string &control_name));
-        MOCK_CONST_METHOD1(signal_domain_type, int(const std::string &signal_name));
-        MOCK_CONST_METHOD1(control_domain_type, int(const std::string &control_name));
-        MOCK_METHOD3(push_signal, int(const std::string &signal_name,
-                                      int domain_type, int domain_idx));
-        MOCK_METHOD3(push_control, int(const std::string &control_name,
-                                       int domain_type, int domain_idx));
-        MOCK_METHOD0(read_batch, void(void));
-        MOCK_METHOD0(write_batch, void(void));
-        MOCK_METHOD1(sample, double(int sample_idx));
-        MOCK_METHOD2(adjust, void(int control_idx, double setting));
-        MOCK_METHOD3(read_signal, double(const std::string &signal_name,
-                                         int domain_type, int domain_idx));
-        MOCK_METHOD4(write_control, void(const std::string &control_name, int domain_type,
-                                         int domain_idx, double setting));
-        MOCK_METHOD0(save_control, void(void));
-        MOCK_METHOD0(restore_control, void(void));
-        MOCK_CONST_METHOD1(agg_function,
-                           std::function<double(const std::vector<double> &)>(
-                               const std::string &signal_name));
-        MOCK_CONST_METHOD1(format_function,
-                           std::function<std::string(double)>(const std::string &signal_name));
-        MOCK_CONST_METHOD1(signal_description,
-                           std::string(const std::string &signal_name));
-        MOCK_CONST_METHOD1(control_description,
-                           std::string(const std::string &control_name));
-        MOCK_CONST_METHOD1(signal_behavior, int(const std::string &signal_name));
+        MOCK_METHOD(std::set<std::string>, signal_names, (), (const, override));
+        MOCK_METHOD(std::set<std::string>, control_names, (), (const, override));
+        MOCK_METHOD(bool, is_valid_signal, (const std::string &signal_name),
+                    (const, override));
+        MOCK_METHOD(bool, is_valid_control, (const std::string &control_name),
+                    (const, override));
+        MOCK_METHOD(int, signal_domain_type, (const std::string &signal_name),
+                    (const, override));
+        MOCK_METHOD(int, control_domain_type, (const std::string &control_name),
+                    (const, override));
+        MOCK_METHOD(int, push_signal,
+                    (const std::string &signal_name, int domain_type, int domain_idx),
+                    (override));
+        MOCK_METHOD(int, push_control,
+                    (const std::string &control_name, int domain_type, int domain_idx),
+                    (override));
+        MOCK_METHOD(void, read_batch, (), (override));
+        MOCK_METHOD(void, write_batch, (), (override));
+        MOCK_METHOD(double, sample, (int sample_idx), (override));
+        MOCK_METHOD(void, adjust, (int control_idx, double setting), (override));
+        MOCK_METHOD(double, read_signal,
+                    (const std::string &signal_name, int domain_type, int domain_idx),
+                    (override));
+        MOCK_METHOD(void, write_control,
+                    (const std::string &control_name, int domain_type,
+                     int domain_idx, double setting),
+                    (override));
+        MOCK_METHOD(void, save_control, (), (override));
+        MOCK_METHOD(void, restore_control, (), (override));
+        MOCK_METHOD(std::function<double, agg_function, (const std::vector<double> &)>(
+                        const std::string &signal_name),
+                    (const, override));
+        MOCK_METHOD(std::function<std::string, format_function, (double)>(
+                        const std::string &signal_name),
+                    (const, override));
+        MOCK_METHOD(std::string, signal_description,
+                    (const std::string &signal_name), (const, override));
+        MOCK_METHOD(std::string, control_description,
+                    (const std::string &control_name), (const, override));
+        MOCK_METHOD(int, signal_behavior, (const std::string &signal_name),
+                    (const, override));
 };
 
 #endif

--- a/test/MockIOGroup.hpp
+++ b/test/MockIOGroup.hpp
@@ -69,12 +69,10 @@ class MockIOGroup : public geopm::IOGroup
                     (override));
         MOCK_METHOD(void, save_control, (), (override));
         MOCK_METHOD(void, restore_control, (), (override));
-        MOCK_METHOD(std::function<double, agg_function, (const std::vector<double> &)>(
-                        const std::string &signal_name),
-                    (const, override));
-        MOCK_METHOD(std::function<std::string, format_function, (double)>(
-                        const std::string &signal_name),
-                    (const, override));
+        MOCK_METHOD(std::function<double(const std::vector<double> &)>, agg_function,
+                    (const std::string &signal_name), (const, override));
+        MOCK_METHOD(std::function<std::string(double)>, format_function,
+                    (const std::string &signal_name), (const, override));
         MOCK_METHOD(std::string, signal_description,
                     (const std::string &signal_name), (const, override));
         MOCK_METHOD(std::string, control_description,

--- a/test/MockIOGroup.hpp
+++ b/test/MockIOGroup.hpp
@@ -40,48 +40,36 @@
 class MockIOGroup : public geopm::IOGroup
 {
     public:
-        MOCK_CONST_METHOD0(signal_names,
-                           std::set<std::string>(void));
-        MOCK_CONST_METHOD0(control_names,
-                           std::set<std::string>(void));
-        MOCK_CONST_METHOD1(is_valid_signal,
-                           bool (const std::string &signal_name));
-        MOCK_CONST_METHOD1(is_valid_control,
-                           bool (const std::string &control_name));
-        MOCK_CONST_METHOD1(signal_domain_type,
-                           int (const std::string &signal_name));
-        MOCK_CONST_METHOD1(control_domain_type,
-                           int (const std::string &control_name));
-        MOCK_METHOD3(push_signal,
-                     int (const std::string &signal_name, int domain_type, int domain_idx));
-        MOCK_METHOD3(push_control,
-                     int (const std::string &control_name, int domain_type, int domain_idx));
-        MOCK_METHOD0(read_batch,
-                     void (void));
-        MOCK_METHOD0(write_batch,
-                     void (void));
-        MOCK_METHOD1(sample,
-                     double (int sample_idx));
-        MOCK_METHOD2(adjust,
-                     void (int control_idx, double setting));
-        MOCK_METHOD3(read_signal,
-                     double (const std::string &signal_name, int domain_type, int domain_idx));
-        MOCK_METHOD4(write_control,
-                     void (const std::string &control_name, int domain_type, int domain_idx, double setting));
-        MOCK_METHOD0(save_control,
-                     void(void));
-        MOCK_METHOD0(restore_control,
-                     void(void));
+        MOCK_CONST_METHOD0(signal_names, std::set<std::string>(void));
+        MOCK_CONST_METHOD0(control_names, std::set<std::string>(void));
+        MOCK_CONST_METHOD1(is_valid_signal, bool(const std::string &signal_name));
+        MOCK_CONST_METHOD1(is_valid_control, bool(const std::string &control_name));
+        MOCK_CONST_METHOD1(signal_domain_type, int(const std::string &signal_name));
+        MOCK_CONST_METHOD1(control_domain_type, int(const std::string &control_name));
+        MOCK_METHOD3(push_signal, int(const std::string &signal_name,
+                                      int domain_type, int domain_idx));
+        MOCK_METHOD3(push_control, int(const std::string &control_name,
+                                       int domain_type, int domain_idx));
+        MOCK_METHOD0(read_batch, void(void));
+        MOCK_METHOD0(write_batch, void(void));
+        MOCK_METHOD1(sample, double(int sample_idx));
+        MOCK_METHOD2(adjust, void(int control_idx, double setting));
+        MOCK_METHOD3(read_signal, double(const std::string &signal_name,
+                                         int domain_type, int domain_idx));
+        MOCK_METHOD4(write_control, void(const std::string &control_name, int domain_type,
+                                         int domain_idx, double setting));
+        MOCK_METHOD0(save_control, void(void));
+        MOCK_METHOD0(restore_control, void(void));
         MOCK_CONST_METHOD1(agg_function,
-                           std::function<double(const std::vector<double> &)> (const std::string &signal_name));
+                           std::function<double(const std::vector<double> &)>(
+                               const std::string &signal_name));
         MOCK_CONST_METHOD1(format_function,
-                           std::function<std::string(double)> (const std::string &signal_name));
+                           std::function<std::string(double)>(const std::string &signal_name));
         MOCK_CONST_METHOD1(signal_description,
                            std::string(const std::string &signal_name));
         MOCK_CONST_METHOD1(control_description,
                            std::string(const std::string &control_name));
-        MOCK_CONST_METHOD1(signal_behavior,
-                           int(const std::string &signal_name));
+        MOCK_CONST_METHOD1(signal_behavior, int(const std::string &signal_name));
 };
 
 #endif

--- a/test/MockMSRIO.hpp
+++ b/test/MockMSRIO.hpp
@@ -40,22 +40,15 @@
 class MockMSRIO : public geopm::MSRIO
 {
     public:
-        MOCK_METHOD2(read_msr,
-                     uint64_t(int cpu_idx, uint64_t offset));
-        MOCK_METHOD4(write_msr,
-                     void(int cpu_idx, uint64_t offset, uint64_t raw_value, uint64_t write_mask));
-        MOCK_METHOD2(add_read,
-                     int(int cpu_idx, uint64_t offset));
-        MOCK_METHOD0(read_batch,
-                     void(void));
-        MOCK_CONST_METHOD1(sample,
-                           uint64_t(int batch_idx));
-        MOCK_METHOD2(add_write,
-                     int(int cpu_idx, uint64_t offset));
-        MOCK_METHOD3(adjust,
-                     void(int batch_idx, uint64_t value, uint64_t write_mask));
-        MOCK_METHOD0(write_batch,
-                     void(void));
+        MOCK_METHOD2(read_msr, uint64_t(int cpu_idx, uint64_t offset));
+        MOCK_METHOD4(write_msr, void(int cpu_idx, uint64_t offset,
+                                     uint64_t raw_value, uint64_t write_mask));
+        MOCK_METHOD2(add_read, int(int cpu_idx, uint64_t offset));
+        MOCK_METHOD0(read_batch, void(void));
+        MOCK_CONST_METHOD1(sample, uint64_t(int batch_idx));
+        MOCK_METHOD2(add_write, int(int cpu_idx, uint64_t offset));
+        MOCK_METHOD3(adjust, void(int batch_idx, uint64_t value, uint64_t write_mask));
+        MOCK_METHOD0(write_batch, void(void));
 };
 
 #endif

--- a/test/MockMSRIO.hpp
+++ b/test/MockMSRIO.hpp
@@ -40,15 +40,17 @@
 class MockMSRIO : public geopm::MSRIO
 {
     public:
-        MOCK_METHOD2(read_msr, uint64_t(int cpu_idx, uint64_t offset));
-        MOCK_METHOD4(write_msr, void(int cpu_idx, uint64_t offset,
-                                     uint64_t raw_value, uint64_t write_mask));
-        MOCK_METHOD2(add_read, int(int cpu_idx, uint64_t offset));
-        MOCK_METHOD0(read_batch, void(void));
-        MOCK_CONST_METHOD1(sample, uint64_t(int batch_idx));
-        MOCK_METHOD2(add_write, int(int cpu_idx, uint64_t offset));
-        MOCK_METHOD3(adjust, void(int batch_idx, uint64_t value, uint64_t write_mask));
-        MOCK_METHOD0(write_batch, void(void));
+        MOCK_METHOD(uint64_t, read_msr, (int cpu_idx, uint64_t offset), (override));
+        MOCK_METHOD(void, write_msr,
+                    (int cpu_idx, uint64_t offset, uint64_t raw_value, uint64_t write_mask),
+                    (override));
+        MOCK_METHOD(int, add_read, (int cpu_idx, uint64_t offset), (override));
+        MOCK_METHOD(void, read_batch, (), (override));
+        MOCK_METHOD(uint64_t, sample, (int batch_idx), (const, override));
+        MOCK_METHOD(int, add_write, (int cpu_idx, uint64_t offset), (override));
+        MOCK_METHOD(void, adjust,
+                    (int batch_idx, uint64_t value, uint64_t write_mask), (override));
+        MOCK_METHOD(void, write_batch, (), (override));
 };
 
 #endif

--- a/test/MockNVMLDevicePool.hpp
+++ b/test/MockNVMLDevicePool.hpp
@@ -40,44 +40,25 @@
 class MockNVMLDevicePool : public geopm::NVMLDevicePool
 {
     public:
-        MOCK_CONST_METHOD0(num_accelerator,
-                           int(void));
-        MOCK_CONST_METHOD1(cpu_affinity_ideal_mask,
-                           cpu_set_t *(int));
-        MOCK_CONST_METHOD1(frequency_status,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(frequency_status_sm,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(utilization,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(power,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(power_limit,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(frequency_status_mem,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(throttle_reasons,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(temperature,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(energy,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(performance_state,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(throughput_rx_pcie,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(throughput_tx_pcie,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(utilization_mem,
-                           uint64_t(int));
-        MOCK_CONST_METHOD1(active_process_list,
-                           std::vector<int>(int));
-        MOCK_CONST_METHOD3(frequency_control_sm,
-                           void(int, int, int));
-        MOCK_CONST_METHOD1(frequency_reset_control,
-                           void(int));
-        MOCK_CONST_METHOD2(power_control,
-                           void(int, int));
+        MOCK_CONST_METHOD0(num_accelerator, int(void));
+        MOCK_CONST_METHOD1(cpu_affinity_ideal_mask, cpu_set_t *(int));
+        MOCK_CONST_METHOD1(frequency_status, uint64_t(int));
+        MOCK_CONST_METHOD1(frequency_status_sm, uint64_t(int));
+        MOCK_CONST_METHOD1(utilization, uint64_t(int));
+        MOCK_CONST_METHOD1(power, uint64_t(int));
+        MOCK_CONST_METHOD1(power_limit, uint64_t(int));
+        MOCK_CONST_METHOD1(frequency_status_mem, uint64_t(int));
+        MOCK_CONST_METHOD1(throttle_reasons, uint64_t(int));
+        MOCK_CONST_METHOD1(temperature, uint64_t(int));
+        MOCK_CONST_METHOD1(energy, uint64_t(int));
+        MOCK_CONST_METHOD1(performance_state, uint64_t(int));
+        MOCK_CONST_METHOD1(throughput_rx_pcie, uint64_t(int));
+        MOCK_CONST_METHOD1(throughput_tx_pcie, uint64_t(int));
+        MOCK_CONST_METHOD1(utilization_mem, uint64_t(int));
+        MOCK_CONST_METHOD1(active_process_list, std::vector<int>(int));
+        MOCK_CONST_METHOD3(frequency_control_sm, void(int, int, int));
+        MOCK_CONST_METHOD1(frequency_reset_control, void(int));
+        MOCK_CONST_METHOD2(power_control, void(int, int));
 };
 
 #endif

--- a/test/MockNVMLDevicePool.hpp
+++ b/test/MockNVMLDevicePool.hpp
@@ -42,7 +42,6 @@ class MockNVMLDevicePool : public geopm::NVMLDevicePool
     public:
         MOCK_METHOD(int, num_accelerator, (), (const, override));
         MOCK_METHOD(cpu_set_t *, cpu_affinity_ideal_mask, (int), (const, override));
-        MOCK_METHOD(uint64_t, frequency_status, (int), (const, override));
         MOCK_METHOD(uint64_t, frequency_status_sm, (int), (const, override));
         MOCK_METHOD(uint64_t, utilization, (int), (const, override));
         MOCK_METHOD(uint64_t, power, (int), (const, override));

--- a/test/MockNVMLDevicePool.hpp
+++ b/test/MockNVMLDevicePool.hpp
@@ -40,25 +40,25 @@
 class MockNVMLDevicePool : public geopm::NVMLDevicePool
 {
     public:
-        MOCK_CONST_METHOD0(num_accelerator, int(void));
-        MOCK_CONST_METHOD1(cpu_affinity_ideal_mask, cpu_set_t *(int));
-        MOCK_CONST_METHOD1(frequency_status, uint64_t(int));
-        MOCK_CONST_METHOD1(frequency_status_sm, uint64_t(int));
-        MOCK_CONST_METHOD1(utilization, uint64_t(int));
-        MOCK_CONST_METHOD1(power, uint64_t(int));
-        MOCK_CONST_METHOD1(power_limit, uint64_t(int));
-        MOCK_CONST_METHOD1(frequency_status_mem, uint64_t(int));
-        MOCK_CONST_METHOD1(throttle_reasons, uint64_t(int));
-        MOCK_CONST_METHOD1(temperature, uint64_t(int));
-        MOCK_CONST_METHOD1(energy, uint64_t(int));
-        MOCK_CONST_METHOD1(performance_state, uint64_t(int));
-        MOCK_CONST_METHOD1(throughput_rx_pcie, uint64_t(int));
-        MOCK_CONST_METHOD1(throughput_tx_pcie, uint64_t(int));
-        MOCK_CONST_METHOD1(utilization_mem, uint64_t(int));
-        MOCK_CONST_METHOD1(active_process_list, std::vector<int>(int));
-        MOCK_CONST_METHOD3(frequency_control_sm, void(int, int, int));
-        MOCK_CONST_METHOD1(frequency_reset_control, void(int));
-        MOCK_CONST_METHOD2(power_control, void(int, int));
+        MOCK_METHOD(int, num_accelerator, (), (const, override));
+        MOCK_METHOD(cpu_set_t *, cpu_affinity_ideal_mask, (int), (const, override));
+        MOCK_METHOD(uint64_t, frequency_status, (int), (const, override));
+        MOCK_METHOD(uint64_t, frequency_status_sm, (int), (const, override));
+        MOCK_METHOD(uint64_t, utilization, (int), (const, override));
+        MOCK_METHOD(uint64_t, power, (int), (const, override));
+        MOCK_METHOD(uint64_t, power_limit, (int), (const, override));
+        MOCK_METHOD(uint64_t, frequency_status_mem, (int), (const, override));
+        MOCK_METHOD(uint64_t, throttle_reasons, (int), (const, override));
+        MOCK_METHOD(uint64_t, temperature, (int), (const, override));
+        MOCK_METHOD(uint64_t, energy, (int), (const, override));
+        MOCK_METHOD(uint64_t, performance_state, (int), (const, override));
+        MOCK_METHOD(uint64_t, throughput_rx_pcie, (int), (const, override));
+        MOCK_METHOD(uint64_t, throughput_tx_pcie, (int), (const, override));
+        MOCK_METHOD(uint64_t, utilization_mem, (int), (const, override));
+        MOCK_METHOD(std::vector<int>, active_process_list, (int), (const, override));
+        MOCK_METHOD(void, frequency_control_sm, (int, int, int), (const, override));
+        MOCK_METHOD(void, frequency_reset_control, (int), (const, override));
+        MOCK_METHOD(void, power_control, (int, int), (const, override));
 };
 
 #endif

--- a/test/MockPlatformIO.hpp
+++ b/test/MockPlatformIO.hpp
@@ -41,43 +41,54 @@
 class MockPlatformIO : public geopm::PlatformIO
 {
     public:
-        MOCK_METHOD1(register_iogroup, void(std::shared_ptr<geopm::IOGroup> iogroup));
-        MOCK_METHOD1(register_profileio,
-                     void(std::shared_ptr<geopm::ProfileIOGroup> iogroup));
-        MOCK_METHOD0(get_profileio, std::shared_ptr<geopm::ProfileIOGroup>(void));
-        MOCK_CONST_METHOD0(signal_names, std::set<std::string>(void));
-        MOCK_CONST_METHOD0(control_names, std::set<std::string>(void));
-        MOCK_CONST_METHOD1(signal_domain_type, int(const std::string &signal_name));
-        MOCK_CONST_METHOD1(control_domain_type, int(const std::string &control_name));
-        MOCK_METHOD3(push_signal, int(const std::string &signal_name,
-                                      int domain_type, int domain_idx));
-        MOCK_METHOD4(push_combined_signal,
-                     int(const std::string &signal_name, int domain_type,
-                         int domain_idx, const std::vector<int> &sub_signal_idx));
-        MOCK_METHOD3(push_control, int(const std::string &control_name,
-                                       int domain_type, int domain_idx));
-        MOCK_CONST_METHOD0(num_signal_pushed, int(void));
-        MOCK_CONST_METHOD0(num_control_pushed, int(void));
-        MOCK_METHOD1(sample, double(int signal_idx));
-        MOCK_METHOD2(adjust, void(int control_idx, double setting));
-        MOCK_METHOD0(read_batch, void(void));
-        MOCK_METHOD0(write_batch, void(void));
-        MOCK_METHOD3(read_signal, double(const std::string &signal_name,
-                                         int domain_type, int domain_idx));
-        MOCK_METHOD4(write_control, void(const std::string &control_name, int domain_type,
-                                         int domain_idx, double setting));
-        MOCK_METHOD0(save_control, void(void));
-        MOCK_METHOD0(restore_control, void(void));
-        MOCK_CONST_METHOD1(agg_function,
-                           std::function<double(const std::vector<double> &)>(
-                               const std::string &));
-        MOCK_CONST_METHOD1(format_function,
-                           std::function<std::string(double)>(const std::string &));
-        MOCK_CONST_METHOD1(signal_description,
-                           std::string(const std::string &signal_name));
-        MOCK_CONST_METHOD1(control_description,
-                           std::string(const std::string &control_name));
-        MOCK_CONST_METHOD1(signal_behavior, int(const std::string &signal_name));
+        MOCK_METHOD(void, register_iogroup,
+                    (std::shared_ptr<geopm::IOGroup> iogroup), (override));
+        MOCK_METHOD(void, register_profileio,
+                    (std::shared_ptr<geopm::ProfileIOGroup> iogroup), (override));
+        MOCK_METHOD(std::shared_ptr<geopm::ProfileIOGroup>, get_profileio, (),
+                    (override));
+        MOCK_METHOD(std::set<std::string>, signal_names, (), (const, override));
+        MOCK_METHOD(std::set<std::string>, control_names, (), (const, override));
+        MOCK_METHOD(int, signal_domain_type, (const std::string &signal_name),
+                    (const, override));
+        MOCK_METHOD(int, control_domain_type, (const std::string &control_name),
+                    (const, override));
+        MOCK_METHOD(int, push_signal,
+                    (const std::string &signal_name, int domain_type, int domain_idx),
+                    (override));
+        MOCK_METHOD(int, push_combined_signal,
+                    (const std::string &signal_name, int domain_type,
+                     int domain_idx, const std::vector<int> &sub_signal_idx),
+                    (override));
+        MOCK_METHOD(int, push_control,
+                    (const std::string &control_name, int domain_type, int domain_idx),
+                    (override));
+        MOCK_METHOD(int, num_signal_pushed, (), (const, override));
+        MOCK_METHOD(int, num_control_pushed, (), (const, override));
+        MOCK_METHOD(double, sample, (int signal_idx), (override));
+        MOCK_METHOD(void, adjust, (int control_idx, double setting), (override));
+        MOCK_METHOD(void, read_batch, (), (override));
+        MOCK_METHOD(void, write_batch, (), (override));
+        MOCK_METHOD(double, read_signal,
+                    (const std::string &signal_name, int domain_type, int domain_idx),
+                    (override));
+        MOCK_METHOD(void, write_control,
+                    (const std::string &control_name, int domain_type,
+                     int domain_idx, double setting),
+                    (override));
+        MOCK_METHOD(void, save_control, (), (override));
+        MOCK_METHOD(void, restore_control, (), (override));
+        MOCK_METHOD(std::function<double, agg_function, (const std::vector<double> &)>(
+                        const std::string &),
+                    (const, override));
+        MOCK_METHOD(std::function<std::string, format_function, (double)>(const std::string &),
+                    (const, override));
+        MOCK_METHOD(std::string, signal_description,
+                    (const std::string &signal_name), (const, override));
+        MOCK_METHOD(std::string, control_description,
+                    (const std::string &control_name), (const, override));
+        MOCK_METHOD(int, signal_behavior, (const std::string &signal_name),
+                    (const, override));
 };
 
 #endif

--- a/test/MockPlatformIO.hpp
+++ b/test/MockPlatformIO.hpp
@@ -35,63 +35,49 @@
 
 #include "gmock/gmock.h"
 
-#include "PlatformIO.hpp"
 #include "IOGroup.hpp"
+#include "PlatformIO.hpp"
 
 class MockPlatformIO : public geopm::PlatformIO
 {
     public:
-        MOCK_METHOD1(register_iogroup,
-                     void(std::shared_ptr<geopm::IOGroup> iogroup));
+        MOCK_METHOD1(register_iogroup, void(std::shared_ptr<geopm::IOGroup> iogroup));
         MOCK_METHOD1(register_profileio,
                      void(std::shared_ptr<geopm::ProfileIOGroup> iogroup));
-        MOCK_METHOD0(get_profileio,
-                     std::shared_ptr<geopm::ProfileIOGroup>(void));
-        MOCK_CONST_METHOD0(signal_names,
-                           std::set<std::string>(void));
-        MOCK_CONST_METHOD0(control_names,
-                           std::set<std::string>(void));
-        MOCK_CONST_METHOD1(signal_domain_type,
-                           int(const std::string &signal_name));
-        MOCK_CONST_METHOD1(control_domain_type,
-                           int(const std::string &control_name));
-        MOCK_METHOD3(push_signal,
-                     int(const std::string &signal_name, int domain_type, int domain_idx));
+        MOCK_METHOD0(get_profileio, std::shared_ptr<geopm::ProfileIOGroup>(void));
+        MOCK_CONST_METHOD0(signal_names, std::set<std::string>(void));
+        MOCK_CONST_METHOD0(control_names, std::set<std::string>(void));
+        MOCK_CONST_METHOD1(signal_domain_type, int(const std::string &signal_name));
+        MOCK_CONST_METHOD1(control_domain_type, int(const std::string &control_name));
+        MOCK_METHOD3(push_signal, int(const std::string &signal_name,
+                                      int domain_type, int domain_idx));
         MOCK_METHOD4(push_combined_signal,
-                     int(const std::string &signal_name, int domain_type, int domain_idx,
-                         const std::vector<int> &sub_signal_idx));
-        MOCK_METHOD3(push_control,
-                     int(const std::string &control_name, int domain_type, int domain_idx));
-        MOCK_CONST_METHOD0(num_signal_pushed,
-                           int(void));
-        MOCK_CONST_METHOD0(num_control_pushed,
-                           int(void));
-        MOCK_METHOD1(sample,
-                     double(int signal_idx));
-        MOCK_METHOD2(adjust,
-                     void(int control_idx, double setting));
-        MOCK_METHOD0(read_batch,
-                     void(void));
-        MOCK_METHOD0(write_batch,
-                     void(void));
-        MOCK_METHOD3(read_signal,
-                     double(const std::string &signal_name, int domain_type, int domain_idx));
-        MOCK_METHOD4(write_control,
-                     void(const std::string &control_name, int domain_type, int domain_idx, double setting));
-        MOCK_METHOD0(save_control,
-                     void(void));
-        MOCK_METHOD0(restore_control,
-                     void(void));
+                     int(const std::string &signal_name, int domain_type,
+                         int domain_idx, const std::vector<int> &sub_signal_idx));
+        MOCK_METHOD3(push_control, int(const std::string &control_name,
+                                       int domain_type, int domain_idx));
+        MOCK_CONST_METHOD0(num_signal_pushed, int(void));
+        MOCK_CONST_METHOD0(num_control_pushed, int(void));
+        MOCK_METHOD1(sample, double(int signal_idx));
+        MOCK_METHOD2(adjust, void(int control_idx, double setting));
+        MOCK_METHOD0(read_batch, void(void));
+        MOCK_METHOD0(write_batch, void(void));
+        MOCK_METHOD3(read_signal, double(const std::string &signal_name,
+                                         int domain_type, int domain_idx));
+        MOCK_METHOD4(write_control, void(const std::string &control_name, int domain_type,
+                                         int domain_idx, double setting));
+        MOCK_METHOD0(save_control, void(void));
+        MOCK_METHOD0(restore_control, void(void));
         MOCK_CONST_METHOD1(agg_function,
-                           std::function<double(const std::vector<double> &)>(const std::string&));
+                           std::function<double(const std::vector<double> &)>(
+                               const std::string &));
         MOCK_CONST_METHOD1(format_function,
-                           std::function<std::string(double)>(const std::string&));
+                           std::function<std::string(double)>(const std::string &));
         MOCK_CONST_METHOD1(signal_description,
                            std::string(const std::string &signal_name));
         MOCK_CONST_METHOD1(control_description,
                            std::string(const std::string &control_name));
-        MOCK_CONST_METHOD1(signal_behavior,
-                           int(const std::string &signal_name));
+        MOCK_CONST_METHOD1(signal_behavior, int(const std::string &signal_name));
 };
 
 #endif

--- a/test/MockPlatformIO.hpp
+++ b/test/MockPlatformIO.hpp
@@ -78,11 +78,10 @@ class MockPlatformIO : public geopm::PlatformIO
                     (override));
         MOCK_METHOD(void, save_control, (), (override));
         MOCK_METHOD(void, restore_control, (), (override));
-        MOCK_METHOD(std::function<double, agg_function, (const std::vector<double> &)>(
-                        const std::string &),
-                    (const, override));
-        MOCK_METHOD(std::function<std::string, format_function, (double)>(const std::string &),
-                    (const, override));
+        MOCK_METHOD(std::function<double(const std::vector<double> &)>, agg_function,
+                    (const std::string &signal_name), (const, override));
+        MOCK_METHOD(std::function<std::string(double)>, format_function,
+                    (const std::string &signal_name), (const, override));
         MOCK_METHOD(std::string, signal_description,
                     (const std::string &signal_name), (const, override));
         MOCK_METHOD(std::string, control_description,

--- a/test/MockPlatformIO.hpp
+++ b/test/MockPlatformIO.hpp
@@ -43,10 +43,6 @@ class MockPlatformIO : public geopm::PlatformIO
     public:
         MOCK_METHOD(void, register_iogroup,
                     (std::shared_ptr<geopm::IOGroup> iogroup), (override));
-        MOCK_METHOD(void, register_profileio,
-                    (std::shared_ptr<geopm::ProfileIOGroup> iogroup), (override));
-        MOCK_METHOD(std::shared_ptr<geopm::ProfileIOGroup>, get_profileio, (),
-                    (override));
         MOCK_METHOD(std::set<std::string>, signal_names, (), (const, override));
         MOCK_METHOD(std::set<std::string>, control_names, (), (const, override));
         MOCK_METHOD(int, signal_domain_type, (const std::string &signal_name),
@@ -56,15 +52,9 @@ class MockPlatformIO : public geopm::PlatformIO
         MOCK_METHOD(int, push_signal,
                     (const std::string &signal_name, int domain_type, int domain_idx),
                     (override));
-        MOCK_METHOD(int, push_combined_signal,
-                    (const std::string &signal_name, int domain_type,
-                     int domain_idx, const std::vector<int> &sub_signal_idx),
-                    (override));
         MOCK_METHOD(int, push_control,
                     (const std::string &control_name, int domain_type, int domain_idx),
                     (override));
-        MOCK_METHOD(int, num_signal_pushed, (), (const, override));
-        MOCK_METHOD(int, num_control_pushed, (), (const, override));
         MOCK_METHOD(double, sample, (int signal_idx), (override));
         MOCK_METHOD(void, adjust, (int control_idx, double setting), (override));
         MOCK_METHOD(void, read_batch, (), (override));

--- a/test/MockPlatformTopo.hpp
+++ b/test/MockPlatformTopo.hpp
@@ -42,19 +42,15 @@
 class MockPlatformTopo : public geopm::PlatformTopo
 {
     public:
-        MOCK_CONST_METHOD1(num_domain,
-                           int(int domain_type));
-        MOCK_CONST_METHOD2(domain_idx,
-                           int(int domain_type, int cpu_idx));
-        MOCK_CONST_METHOD2(is_nested_domain,
-                           bool(int inner_domain, int outer_domain));
-        MOCK_CONST_METHOD3(domain_nested,
-                           std::set<int>(int inner_domain, int outer_domain, int outer_idx));
+        MOCK_CONST_METHOD1(num_domain, int(int domain_type));
+        MOCK_CONST_METHOD2(domain_idx, int(int domain_type, int cpu_idx));
+        MOCK_CONST_METHOD2(is_nested_domain, bool(int inner_domain, int outer_domain));
+        MOCK_CONST_METHOD3(domain_nested, std::set<int>(int inner_domain, int outer_domain,
+                                                        int outer_idx));
 };
 
 /// Create a MockPlatformTopo and set up expectations for the system hierarchy.
 /// Counts for each input component are for the whole board.
 std::shared_ptr<MockPlatformTopo> make_topo(int num_package, int num_core, int num_cpu);
-
 
 #endif

--- a/test/MockPlatformTopo.hpp
+++ b/test/MockPlatformTopo.hpp
@@ -42,11 +42,13 @@
 class MockPlatformTopo : public geopm::PlatformTopo
 {
     public:
-        MOCK_CONST_METHOD1(num_domain, int(int domain_type));
-        MOCK_CONST_METHOD2(domain_idx, int(int domain_type, int cpu_idx));
-        MOCK_CONST_METHOD2(is_nested_domain, bool(int inner_domain, int outer_domain));
-        MOCK_CONST_METHOD3(domain_nested, std::set<int>(int inner_domain, int outer_domain,
-                                                        int outer_idx));
+        MOCK_METHOD(int, num_domain, (int domain_type), (const, override));
+        MOCK_METHOD(int, domain_idx, (int domain_type, int cpu_idx), (const, override));
+        MOCK_METHOD(bool, is_nested_domain,
+                    (int inner_domain, int outer_domain), (const, override));
+        MOCK_METHOD(std::set<int>, domain_nested,
+                    (int inner_domain, int outer_domain, int outer_idx),
+                    (const, override));
 };
 
 /// Create a MockPlatformTopo and set up expectations for the system hierarchy.

--- a/test/MockPolicyStore.hpp
+++ b/test/MockPolicyStore.hpp
@@ -40,14 +40,16 @@
 class MockPolicyStore : public geopm::PolicyStore
 {
     public:
-        MOCK_CONST_METHOD2(get_best,
-                           std::vector<double>(const std::string &profile_name,
-                                               const std::string &agent_name));
-        MOCK_METHOD3(set_best, void(const std::string &profile_name,
-                                    const std::string &agent_name,
-                                    const std::vector<double> &policy));
-        MOCK_METHOD2(set_default, void(const std::string &agent_name,
-                                       const std::vector<double> &policy));
+        MOCK_METHOD(std::vector<double>, get_best,
+                    (const std::string &profile_name, const std::string &agent_name),
+                    (const, override));
+        MOCK_METHOD(void, set_best,
+                    (const std::string &profile_name, const std::string &agent_name,
+                     const std::vector<double> &policy),
+                    (override));
+        MOCK_METHOD(void, set_default,
+                    (const std::string &agent_name, const std::vector<double> &policy),
+                    (override));
 };
 
 #endif

--- a/test/MockPolicyStore.hpp
+++ b/test/MockPolicyStore.hpp
@@ -43,13 +43,11 @@ class MockPolicyStore : public geopm::PolicyStore
         MOCK_CONST_METHOD2(get_best,
                            std::vector<double>(const std::string &profile_name,
                                                const std::string &agent_name));
-        MOCK_METHOD3(set_best,
-                     void(const std::string &profile_name,
-                          const std::string &agent_name,
-                          const std::vector<double> &policy));
-        MOCK_METHOD2(set_default,
-                     void(const std::string &agent_name,
-                          const std::vector<double> &policy));
+        MOCK_METHOD3(set_best, void(const std::string &profile_name,
+                                    const std::string &agent_name,
+                                    const std::vector<double> &policy));
+        MOCK_METHOD2(set_default, void(const std::string &agent_name,
+                                       const std::vector<double> &policy));
 };
 
 #endif

--- a/test/MockPowerBalancer.hpp
+++ b/test/MockPowerBalancer.hpp
@@ -37,30 +37,20 @@
 
 #include "PowerBalancer.hpp"
 
-class MockPowerBalancer : public geopm::PowerBalancer {
+class MockPowerBalancer : public geopm::PowerBalancer
+{
     public:
-        MOCK_METHOD1(power_cap,
-                     void(double cap));
-        MOCK_CONST_METHOD0(power_cap,
-                           double(void));
-        MOCK_CONST_METHOD0(power_limit,
-                           double(void));
-        MOCK_METHOD1(power_limit_adjusted,
-                     void(double limit));
-        MOCK_METHOD1(is_runtime_stable,
-                     bool(double measured_runtime));
-        MOCK_CONST_METHOD0(runtime_sample,
-                           double(void));
-        MOCK_METHOD0(calculate_runtime_sample,
-                     void(void));
-        MOCK_METHOD1(target_runtime,
-                     void(double largest_runtime));
-        MOCK_METHOD1(is_target_met,
-                     bool(double measured_runtime));
-        MOCK_METHOD1(achieved_limit,
-                     void(double achieved));
-        MOCK_METHOD0(power_slack,
-                     double(void));
+        MOCK_METHOD1(power_cap, void(double cap));
+        MOCK_CONST_METHOD0(power_cap, double(void));
+        MOCK_CONST_METHOD0(power_limit, double(void));
+        MOCK_METHOD1(power_limit_adjusted, void(double limit));
+        MOCK_METHOD1(is_runtime_stable, bool(double measured_runtime));
+        MOCK_CONST_METHOD0(runtime_sample, double(void));
+        MOCK_METHOD0(calculate_runtime_sample, void(void));
+        MOCK_METHOD1(target_runtime, void(double largest_runtime));
+        MOCK_METHOD1(is_target_met, bool(double measured_runtime));
+        MOCK_METHOD1(achieved_limit, void(double achieved));
+        MOCK_METHOD0(power_slack, double(void));
 };
 
 #endif

--- a/test/MockPowerBalancer.hpp
+++ b/test/MockPowerBalancer.hpp
@@ -49,7 +49,6 @@ class MockPowerBalancer : public geopm::PowerBalancer
         MOCK_METHOD(void, calculate_runtime_sample, (), (override));
         MOCK_METHOD(void, target_runtime, (double largest_runtime), (override));
         MOCK_METHOD(bool, is_target_met, (double measured_runtime), (override));
-        MOCK_METHOD(void, achieved_limit, (double achieved), (override));
         MOCK_METHOD(double, power_slack, (), (override));
 };
 

--- a/test/MockPowerBalancer.hpp
+++ b/test/MockPowerBalancer.hpp
@@ -40,17 +40,17 @@
 class MockPowerBalancer : public geopm::PowerBalancer
 {
     public:
-        MOCK_METHOD1(power_cap, void(double cap));
-        MOCK_CONST_METHOD0(power_cap, double(void));
-        MOCK_CONST_METHOD0(power_limit, double(void));
-        MOCK_METHOD1(power_limit_adjusted, void(double limit));
-        MOCK_METHOD1(is_runtime_stable, bool(double measured_runtime));
-        MOCK_CONST_METHOD0(runtime_sample, double(void));
-        MOCK_METHOD0(calculate_runtime_sample, void(void));
-        MOCK_METHOD1(target_runtime, void(double largest_runtime));
-        MOCK_METHOD1(is_target_met, bool(double measured_runtime));
-        MOCK_METHOD1(achieved_limit, void(double achieved));
-        MOCK_METHOD0(power_slack, double(void));
+        MOCK_METHOD(void, power_cap, (double cap), (override));
+        MOCK_METHOD(double, power_cap, (), (const, override));
+        MOCK_METHOD(double, power_limit, (), (const, override));
+        MOCK_METHOD(void, power_limit_adjusted, (double limit), (override));
+        MOCK_METHOD(bool, is_runtime_stable, (double measured_runtime), (override));
+        MOCK_METHOD(double, runtime_sample, (), (const, override));
+        MOCK_METHOD(void, calculate_runtime_sample, (), (override));
+        MOCK_METHOD(void, target_runtime, (double largest_runtime), (override));
+        MOCK_METHOD(bool, is_target_met, (double measured_runtime), (override));
+        MOCK_METHOD(void, achieved_limit, (double achieved), (override));
+        MOCK_METHOD(double, power_slack, (), (override));
 };
 
 #endif

--- a/test/MockPowerGovernor.hpp
+++ b/test/MockPowerGovernor.hpp
@@ -40,14 +40,15 @@
 class MockPowerGovernor : public geopm::PowerGovernor
 {
     public:
-        MOCK_METHOD0(init_platform_io, void(void));
-        MOCK_METHOD0(sample_platform, void(void));
-        MOCK_METHOD2(adjust_platform,
-                     void(double node_power_request, double &node_power_actual));
-        MOCK_CONST_METHOD0(do_write_batch, bool());
-        MOCK_METHOD2(set_power_bounds,
-                     void(double min_pkg_power, double max_pkg_power));
-        MOCK_CONST_METHOD0(power_package_time_window, double(void));
+        MOCK_METHOD(void, init_platform_io, (), (override));
+        MOCK_METHOD(void, sample_platform, (), (override));
+        MOCK_METHOD(void, adjust_platform,
+                    (double node_power_request, double &node_power_actual),
+                    (override));
+        MOCK_METHOD(bool, do_write_batch, (), (const, override));
+        MOCK_METHOD(void, set_power_bounds,
+                    (double min_pkg_power, double max_pkg_power), (override));
+        MOCK_METHOD(double, power_package_time_window, (), (const, override));
 };
 
 #endif

--- a/test/MockPowerGovernor.hpp
+++ b/test/MockPowerGovernor.hpp
@@ -40,14 +40,11 @@
 class MockPowerGovernor : public geopm::PowerGovernor
 {
     public:
-        MOCK_METHOD0(init_platform_io,
-                     void(void));
-        MOCK_METHOD0(sample_platform,
-                     void(void));
+        MOCK_METHOD0(init_platform_io, void(void));
+        MOCK_METHOD0(sample_platform, void(void));
         MOCK_METHOD2(adjust_platform,
                      void(double node_power_request, double &node_power_actual));
-        MOCK_CONST_METHOD0(do_write_batch,
-                     bool());
+        MOCK_CONST_METHOD0(do_write_batch, bool());
         MOCK_METHOD2(set_power_bounds,
                      void(double min_pkg_power, double max_pkg_power));
         MOCK_CONST_METHOD0(power_package_time_window, double(void));

--- a/test/MockProcessRegionAggregator.hpp
+++ b/test/MockProcessRegionAggregator.hpp
@@ -40,9 +40,11 @@
 class MockProcessRegionAggregator : public geopm::ProcessRegionAggregator
 {
     public:
-        MOCK_METHOD0(update, void(void));
-        MOCK_CONST_METHOD1(get_runtime_average, double(uint64_t region_hash));
-        MOCK_CONST_METHOD1(get_count_average, double(uint64_t region_hash));
+        MOCK_METHOD(void, update, (), (override));
+        MOCK_METHOD(double, get_runtime_average, (uint64_t region_hash),
+                    (const, override));
+        MOCK_METHOD(double, get_count_average, (uint64_t region_hash),
+                    (const, override));
 };
 
 #endif

--- a/test/MockProcessRegionAggregator.hpp
+++ b/test/MockProcessRegionAggregator.hpp
@@ -40,12 +40,9 @@
 class MockProcessRegionAggregator : public geopm::ProcessRegionAggregator
 {
     public:
-        MOCK_METHOD0(update,
-                     void(void));
-        MOCK_CONST_METHOD1(get_runtime_average,
-                           double(uint64_t region_hash));
-        MOCK_CONST_METHOD1(get_count_average,
-                           double(uint64_t region_hash));
+        MOCK_METHOD0(update, void(void));
+        MOCK_CONST_METHOD1(get_runtime_average, double(uint64_t region_hash));
+        MOCK_CONST_METHOD1(get_count_average, double(uint64_t region_hash));
 };
 
 #endif

--- a/test/MockProfileSampler.hpp
+++ b/test/MockProfileSampler.hpp
@@ -35,38 +35,25 @@
 
 #include "gmock/gmock.h"
 
-#include "ProfileSampler.hpp"
 #include "Comm.hpp"
+#include "ProfileSampler.hpp"
 
 class MockProfileSampler : public geopm::ProfileSampler
 {
     public:
-        MOCK_CONST_METHOD0(do_shutdown,
-                     bool (void));
-        MOCK_CONST_METHOD0(do_report,
-                           bool (void));
-        MOCK_METHOD0(region_names,
-                     void (void));
-        MOCK_METHOD0(initialize,
-                     void (void));
-        MOCK_CONST_METHOD0(rank_per_node,
-                           int (void));
-        MOCK_CONST_METHOD0(cpu_rank,
-                           std::vector<int> (void));
-        MOCK_CONST_METHOD0(name_set,
-                           std::set<std::string> (void));
-        MOCK_CONST_METHOD0(report_name,
-                           std::string (void));
-        MOCK_CONST_METHOD0(profile_name,
-                           std::string (void));
-        MOCK_METHOD0(controller_ready,
-                     void(void));
-        MOCK_METHOD0(abort,
-                     void(void));
-        MOCK_METHOD0(sample_cache,
-                     std::vector<struct geopm_prof_message_s> (void));
-        MOCK_METHOD0(check_sample_end,
-                     void(void));
+        MOCK_CONST_METHOD0(do_shutdown, bool(void));
+        MOCK_CONST_METHOD0(do_report, bool(void));
+        MOCK_METHOD0(region_names, void(void));
+        MOCK_METHOD0(initialize, void(void));
+        MOCK_CONST_METHOD0(rank_per_node, int(void));
+        MOCK_CONST_METHOD0(cpu_rank, std::vector<int>(void));
+        MOCK_CONST_METHOD0(name_set, std::set<std::string>(void));
+        MOCK_CONST_METHOD0(report_name, std::string(void));
+        MOCK_CONST_METHOD0(profile_name, std::string(void));
+        MOCK_METHOD0(controller_ready, void(void));
+        MOCK_METHOD0(abort, void(void));
+        MOCK_METHOD0(sample_cache, std::vector<struct geopm_prof_message_s>(void));
+        MOCK_METHOD0(check_sample_end, void(void));
 };
 
 #endif

--- a/test/MockProfileSampler.hpp
+++ b/test/MockProfileSampler.hpp
@@ -41,19 +41,20 @@
 class MockProfileSampler : public geopm::ProfileSampler
 {
     public:
-        MOCK_CONST_METHOD0(do_shutdown, bool(void));
-        MOCK_CONST_METHOD0(do_report, bool(void));
-        MOCK_METHOD0(region_names, void(void));
-        MOCK_METHOD0(initialize, void(void));
-        MOCK_CONST_METHOD0(rank_per_node, int(void));
-        MOCK_CONST_METHOD0(cpu_rank, std::vector<int>(void));
-        MOCK_CONST_METHOD0(name_set, std::set<std::string>(void));
-        MOCK_CONST_METHOD0(report_name, std::string(void));
-        MOCK_CONST_METHOD0(profile_name, std::string(void));
-        MOCK_METHOD0(controller_ready, void(void));
-        MOCK_METHOD0(abort, void(void));
-        MOCK_METHOD0(sample_cache, std::vector<struct geopm_prof_message_s>(void));
-        MOCK_METHOD0(check_sample_end, void(void));
+        MOCK_METHOD(bool, do_shutdown, (), (const, override));
+        MOCK_METHOD(bool, do_report, (), (const, override));
+        MOCK_METHOD(void, region_names, (), (override));
+        MOCK_METHOD(void, initialize, (), (override));
+        MOCK_METHOD(int, rank_per_node, (), (const, override));
+        MOCK_METHOD(std::vector<int>, cpu_rank, (), (const, override));
+        MOCK_METHOD(std::set<std::string>, name_set, (), (const, override));
+        MOCK_METHOD(std::string, report_name, (), (const, override));
+        MOCK_METHOD(std::string, profile_name, (), (const, override));
+        MOCK_METHOD(void, controller_ready, (), (override));
+        MOCK_METHOD(void, abort, (), (override));
+        MOCK_METHOD(std::vector<struct geopm_prof_message_s>, sample_cache, (),
+                    (override));
+        MOCK_METHOD(void, check_sample_end, (), (override));
 };
 
 #endif

--- a/test/MockProfileTable.hpp
+++ b/test/MockProfileTable.hpp
@@ -46,7 +46,7 @@ class MockProfileTable : public geopm::ProfileTable
         MOCK_METHOD(size_t, capacity, (), (const, override));
         MOCK_METHOD(size_t, size, (), (const, override));
         MOCK_METHOD(void, dump,
-                    (std::vector<std::pair<uint64_t, struct geopm_prof_message_s> >::iterator content,
+                    ((std::vector<std::pair<uint64_t, struct geopm_prof_message_s> >::iterator)content,
                      size_t &length),
                     (override));
         MOCK_METHOD(bool, name_fill, (size_t header_offset), (override));

--- a/test/MockProfileTable.hpp
+++ b/test/MockProfileTable.hpp
@@ -40,15 +40,18 @@
 class MockProfileTable : public geopm::ProfileTable
 {
     public:
-        MOCK_METHOD1(key, uint64_t(const std::string &name));
-        MOCK_METHOD1(insert, void(const struct geopm_prof_message_s &value));
-        MOCK_CONST_METHOD0(capacity, size_t(void));
-        MOCK_CONST_METHOD0(size, size_t(void));
-        MOCK_METHOD2(dump,
-                     void(std::vector<std::pair<uint64_t, struct geopm_prof_message_s> >::iterator content,
-                          size_t &length));
-        MOCK_METHOD1(name_fill, bool(size_t header_offset));
-        MOCK_METHOD2(name_set, bool(size_t header_offset, std::set<std::string> &name));
+        MOCK_METHOD(uint64_t, key, (const std::string &name), (override));
+        MOCK_METHOD(void, insert, (const struct geopm_prof_message_s &value),
+                    (override));
+        MOCK_METHOD(size_t, capacity, (), (const, override));
+        MOCK_METHOD(size_t, size, (), (const, override));
+        MOCK_METHOD(void, dump,
+                    (std::vector<std::pair<uint64_t, struct geopm_prof_message_s> >::iterator content,
+                     size_t &length),
+                    (override));
+        MOCK_METHOD(bool, name_fill, (size_t header_offset), (override));
+        MOCK_METHOD(bool, name_set,
+                    (size_t header_offset, std::set<std::string> &name), (override));
 };
 
 #endif

--- a/test/MockProfileTable.hpp
+++ b/test/MockProfileTable.hpp
@@ -40,21 +40,15 @@
 class MockProfileTable : public geopm::ProfileTable
 {
     public:
-        MOCK_METHOD1(key,
-                     uint64_t (const std::string &name));
-        MOCK_METHOD1(insert,
-                     void (const struct geopm_prof_message_s &value));
-        MOCK_CONST_METHOD0(capacity,
-                           size_t (void));
-        MOCK_CONST_METHOD0(size,
-                           size_t (void));
+        MOCK_METHOD1(key, uint64_t(const std::string &name));
+        MOCK_METHOD1(insert, void(const struct geopm_prof_message_s &value));
+        MOCK_CONST_METHOD0(capacity, size_t(void));
+        MOCK_CONST_METHOD0(size, size_t(void));
         MOCK_METHOD2(dump,
-                     void (std::vector<std::pair<uint64_t, struct geopm_prof_message_s>>::iterator content,
-                           size_t &length));
-        MOCK_METHOD1(name_fill,
-                     bool (size_t header_offset));
-        MOCK_METHOD2(name_set,
-                     bool (size_t header_offset, std::set<std::string> &name));
+                     void(std::vector<std::pair<uint64_t, struct geopm_prof_message_s> >::iterator content,
+                          size_t &length));
+        MOCK_METHOD1(name_fill, bool(size_t header_offset));
+        MOCK_METHOD2(name_set, bool(size_t header_offset, std::set<std::string> &name));
 };
 
 #endif

--- a/test/MockProfileTracer.hpp
+++ b/test/MockProfileTracer.hpp
@@ -40,8 +40,7 @@
 class MockProfileTracer : public geopm::ProfileTracer
 {
     public:
-        MOCK_METHOD1(update,
-                     void(const std::vector<geopm::record_s> &records));
+        MOCK_METHOD1(update, void(const std::vector<geopm::record_s> &records));
 };
 
 #endif

--- a/test/MockProfileTracer.hpp
+++ b/test/MockProfileTracer.hpp
@@ -40,7 +40,8 @@
 class MockProfileTracer : public geopm::ProfileTracer
 {
     public:
-        MOCK_METHOD1(update, void(const std::vector<geopm::record_s> &records));
+        MOCK_METHOD(void, update, (const std::vector<geopm::record_s> &records),
+                    (override));
 };
 
 #endif

--- a/test/MockRecordFilter.hpp
+++ b/test/MockRecordFilter.hpp
@@ -40,8 +40,8 @@
 class MockRecordFilter : public geopm::RecordFilter
 {
     public:
-        MOCK_METHOD1(filter,
-                     std::vector<geopm::record_s>(const geopm::record_s &record));
+        MOCK_METHOD(std::vector<geopm::record_s>, filter,
+                    (const geopm::record_s &record), (override));
 };
 
 #endif

--- a/test/MockReporter.hpp
+++ b/test/MockReporter.hpp
@@ -35,9 +35,9 @@
 
 #include "gmock/gmock.h"
 
-#include "Reporter.hpp"
 #include "ApplicationIO.hpp"
 #include "Comm.hpp"
+#include "Reporter.hpp"
 #include "TreeComm.hpp"
 
 class MockReporter : public geopm::Reporter
@@ -45,14 +45,14 @@ class MockReporter : public geopm::Reporter
     public:
         MOCK_METHOD0(init, void(void));
         MOCK_METHOD0(update, void(void));
-        MOCK_METHOD7(generate,
-                     void(const std::string &agent_name,
-                          const std::vector<std::pair<std::string, std::string> > &agent_report_header,
-                          const std::vector<std::pair<std::string, std::string> > &agent_node_report,
-                          const std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > &agent_region_report,
-                          const geopm::ApplicationIO &application_io,
-                          std::shared_ptr<geopm::Comm> comm,
-                          const geopm::TreeComm &tree_comm));
+        MOCK_METHOD7(
+            generate,
+            void(const std::string &agent_name,
+                 const std::vector<std::pair<std::string, std::string> > &agent_report_header,
+                 const std::vector<std::pair<std::string, std::string> > &agent_node_report,
+                 const std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > &agent_region_report,
+                 const geopm::ApplicationIO &application_io,
+                 std::shared_ptr<geopm::Comm> comm, const geopm::TreeComm &tree_comm));
 };
 
 #endif

--- a/test/MockReporter.hpp
+++ b/test/MockReporter.hpp
@@ -48,9 +48,9 @@ class MockReporter : public geopm::Reporter
         MOCK_METHOD(
             void, generate,
             (const std::string &agent_name,
-             const std::vector<std::pair<std::string, std::string> > &agent_report_header,
-             const std::vector<std::pair<std::string, std::string> > &agent_node_report,
-             const std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > &agent_region_report,
+             (const std::vector<std::pair<std::string, std::string> >)&agent_report_header,
+             (const std::vector<std::pair<std::string, std::string> >)&agent_node_report,
+             (const std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >)&agent_region_report,
              const geopm::ApplicationIO &application_io,
              std::shared_ptr<geopm::Comm> comm, const geopm::TreeComm &tree_comm),
             (override));

--- a/test/MockReporter.hpp
+++ b/test/MockReporter.hpp
@@ -43,16 +43,17 @@
 class MockReporter : public geopm::Reporter
 {
     public:
-        MOCK_METHOD0(init, void(void));
-        MOCK_METHOD0(update, void(void));
-        MOCK_METHOD7(
-            generate,
-            void(const std::string &agent_name,
-                 const std::vector<std::pair<std::string, std::string> > &agent_report_header,
-                 const std::vector<std::pair<std::string, std::string> > &agent_node_report,
-                 const std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > &agent_region_report,
-                 const geopm::ApplicationIO &application_io,
-                 std::shared_ptr<geopm::Comm> comm, const geopm::TreeComm &tree_comm));
+        MOCK_METHOD(void, init, (), (override));
+        MOCK_METHOD(void, update, (), (override));
+        MOCK_METHOD(
+            void, generate,
+            (const std::string &agent_name,
+             const std::vector<std::pair<std::string, std::string> > &agent_report_header,
+             const std::vector<std::pair<std::string, std::string> > &agent_node_report,
+             const std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > &agent_region_report,
+             const geopm::ApplicationIO &application_io,
+             std::shared_ptr<geopm::Comm> comm, const geopm::TreeComm &tree_comm),
+            (override));
 };
 
 #endif

--- a/test/MockSSTIO.hpp
+++ b/test/MockSSTIO.hpp
@@ -37,14 +37,12 @@
 
 #include "SSTIO.hpp"
 
-
 class MockSSTIO : public geopm::SSTIO
 {
     public:
         virtual ~MockSSTIO() = default;
-        MOCK_METHOD4(add_mbox_read,
-                     int(uint32_t cpu_index, uint16_t command,
-                         uint16_t subcommand, uint32_t subcommand_arg));
+        MOCK_METHOD4(add_mbox_read, int(uint32_t cpu_index, uint16_t command,
+                                        uint16_t subcommand, uint32_t subcommand_arg));
         MOCK_METHOD7(add_mbox_write,
                      int(uint32_t cpu_index, uint16_t command, uint16_t subcommand,
                          uint32_t interface_parameter, uint16_t read_subcommand,
@@ -56,19 +54,22 @@ class MockSSTIO : public geopm::SSTIO
         MOCK_METHOD0(read_batch, void(void));
         MOCK_CONST_METHOD1(sample, uint64_t(int batch_idx));
         MOCK_METHOD0(write_batch, void(void));
-        MOCK_METHOD4(read_mbox_once, uint32_t(uint32_t cpu_index, uint16_t command,
-                                              uint16_t subcommand, uint32_t subcommand_arg));
+        MOCK_METHOD4(read_mbox_once,
+                     uint32_t(uint32_t cpu_index, uint16_t command,
+                              uint16_t subcommand, uint32_t subcommand_arg));
         MOCK_METHOD9(write_mbox_once,
                      void(uint32_t cpu_index, uint16_t command, uint16_t subcommand,
                           uint32_t interface_parameter, uint16_t read_subcommand,
                           uint32_t read_interface_parameter, uint32_t read_mask,
                           uint64_t write_value, uint64_t write_mask));
-        MOCK_METHOD2(read_mmio_once, uint32_t(uint32_t cpu_index, uint16_t register_offset));
+        MOCK_METHOD2(read_mmio_once,
+                     uint32_t(uint32_t cpu_index, uint16_t register_offset));
         MOCK_METHOD6(write_mmio_once,
                      void(uint32_t cpu_index, uint16_t register_offset,
                           uint32_t register_value, uint32_t read_mask,
                           uint64_t write_value, uint64_t write_mask));
-        MOCK_METHOD3(adjust, void(int batch_idx, uint64_t write_value, uint64_t write_mask));
+        MOCK_METHOD3(adjust, void(int batch_idx, uint64_t write_value,
+                                  uint64_t write_mask));
         MOCK_METHOD1(get_punit_from_cpu, uint32_t(uint32_t cpu_index));
 };
 

--- a/test/MockSSTIO.hpp
+++ b/test/MockSSTIO.hpp
@@ -41,36 +41,44 @@ class MockSSTIO : public geopm::SSTIO
 {
     public:
         virtual ~MockSSTIO() = default;
-        MOCK_METHOD4(add_mbox_read, int(uint32_t cpu_index, uint16_t command,
-                                        uint16_t subcommand, uint32_t subcommand_arg));
-        MOCK_METHOD7(add_mbox_write,
-                     int(uint32_t cpu_index, uint16_t command, uint16_t subcommand,
-                         uint32_t interface_parameter, uint16_t read_subcommand,
-                         uint32_t read_interface_parameter, uint32_t read_mask));
-        MOCK_METHOD2(add_mmio_read, int(uint32_t cpu_index, uint16_t register_offset));
-        MOCK_METHOD4(add_mmio_write,
-                     int(uint32_t cpu_index, uint16_t register_offset,
-                         uint32_t register_value, uint32_t read_mask));
-        MOCK_METHOD0(read_batch, void(void));
-        MOCK_CONST_METHOD1(sample, uint64_t(int batch_idx));
-        MOCK_METHOD0(write_batch, void(void));
-        MOCK_METHOD4(read_mbox_once,
-                     uint32_t(uint32_t cpu_index, uint16_t command,
-                              uint16_t subcommand, uint32_t subcommand_arg));
-        MOCK_METHOD9(write_mbox_once,
-                     void(uint32_t cpu_index, uint16_t command, uint16_t subcommand,
-                          uint32_t interface_parameter, uint16_t read_subcommand,
-                          uint32_t read_interface_parameter, uint32_t read_mask,
-                          uint64_t write_value, uint64_t write_mask));
-        MOCK_METHOD2(read_mmio_once,
-                     uint32_t(uint32_t cpu_index, uint16_t register_offset));
-        MOCK_METHOD6(write_mmio_once,
-                     void(uint32_t cpu_index, uint16_t register_offset,
-                          uint32_t register_value, uint32_t read_mask,
-                          uint64_t write_value, uint64_t write_mask));
-        MOCK_METHOD3(adjust, void(int batch_idx, uint64_t write_value,
-                                  uint64_t write_mask));
-        MOCK_METHOD1(get_punit_from_cpu, uint32_t(uint32_t cpu_index));
+        MOCK_METHOD(int, add_mbox_read,
+                    (uint32_t cpu_index, uint16_t command, uint16_t subcommand,
+                     uint32_t subcommand_arg),
+                    (override));
+        MOCK_METHOD(int, add_mbox_write,
+                    (uint32_t cpu_index, uint16_t command, uint16_t subcommand,
+                     uint32_t interface_parameter, uint16_t read_subcommand,
+                     uint32_t read_interface_parameter, uint32_t read_mask),
+                    (override));
+        MOCK_METHOD(int, add_mmio_read,
+                    (uint32_t cpu_index, uint16_t register_offset), (override));
+        MOCK_METHOD(int, add_mmio_write,
+                    (uint32_t cpu_index, uint16_t register_offset,
+                     uint32_t register_value, uint32_t read_mask),
+                    (override));
+        MOCK_METHOD(void, read_batch, (), (override));
+        MOCK_METHOD(uint64_t, sample, (int batch_idx), (const, override));
+        MOCK_METHOD(void, write_batch, (), (override));
+        MOCK_METHOD(uint32_t, read_mbox_once,
+                    (uint32_t cpu_index, uint16_t command, uint16_t subcommand,
+                     uint32_t subcommand_arg),
+                    (override));
+        MOCK_METHOD(void, write_mbox_once,
+                    (uint32_t cpu_index, uint16_t command, uint16_t subcommand,
+                     uint32_t interface_parameter, uint16_t read_subcommand,
+                     uint32_t read_interface_parameter, uint32_t read_mask,
+                     uint64_t write_value, uint64_t write_mask),
+                    (override));
+        MOCK_METHOD(uint32_t, read_mmio_once,
+                    (uint32_t cpu_index, uint16_t register_offset), (override));
+        MOCK_METHOD(void, write_mmio_once,
+                    (uint32_t cpu_index, uint16_t register_offset, uint32_t register_value,
+                     uint32_t read_mask, uint64_t write_value, uint64_t write_mask),
+                    (override));
+        MOCK_METHOD(void, adjust,
+                    (int batch_idx, uint64_t write_value, uint64_t write_mask),
+                    (override));
+        MOCK_METHOD(uint32_t, get_punit_from_cpu, (uint32_t cpu_index), (override));
 };
 
 #endif

--- a/test/MockSampleAggregator.hpp
+++ b/test/MockSampleAggregator.hpp
@@ -40,21 +40,26 @@
 class MockSampleAggregator : public geopm::SampleAggregator
 {
     public:
-        MOCK_METHOD3(push_signal_total, int(const std::string &signal_name,
-                                            int domain_type, int domain_idx));
-        MOCK_METHOD3(push_signal_average, int(const std::string &signal_name,
-                                              int domain_type, int domain_idx));
-        MOCK_METHOD3(push_signal, int(const std::string &signal_name,
-                                      int domain_type, int domain_idx));
-        MOCK_METHOD0(update, void(void));
-        MOCK_METHOD1(sample_application, double(int signal_idx));
-        MOCK_METHOD1(sample_epoch, double(int signal_idx));
-        MOCK_METHOD2(sample_region, double(int signal_idx, uint64_t region_hash));
-        MOCK_METHOD1(sample_epoch_last, double(int signal_idx));
-        MOCK_METHOD2(sample_region_last, double(int signal_idx, uint64_t region_hash));
-        MOCK_METHOD1(sample_period_last, double(int signal_idx));
-        MOCK_METHOD1(period_duration, void(double));
-        MOCK_METHOD0(get_period, int(void));
+        MOCK_METHOD(int, push_signal_total,
+                    (const std::string &signal_name, int domain_type, int domain_idx),
+                    (override));
+        MOCK_METHOD(int, push_signal_average,
+                    (const std::string &signal_name, int domain_type, int domain_idx),
+                    (override));
+        MOCK_METHOD(int, push_signal,
+                    (const std::string &signal_name, int domain_type, int domain_idx),
+                    (override));
+        MOCK_METHOD(void, update, (), (override));
+        MOCK_METHOD(double, sample_application, (int signal_idx), (override));
+        MOCK_METHOD(double, sample_epoch, (int signal_idx), (override));
+        MOCK_METHOD(double, sample_region,
+                    (int signal_idx, uint64_t region_hash), (override));
+        MOCK_METHOD(double, sample_epoch_last, (int signal_idx), (override));
+        MOCK_METHOD(double, sample_region_last,
+                    (int signal_idx, uint64_t region_hash), (override));
+        MOCK_METHOD(double, sample_period_last, (int signal_idx), (override));
+        MOCK_METHOD(void, period_duration, (double), (override));
+        MOCK_METHOD(int, get_period, (), (override));
 };
 
 #endif

--- a/test/MockSampleAggregator.hpp
+++ b/test/MockSampleAggregator.hpp
@@ -37,32 +37,24 @@
 
 #include "SampleAggregator.hpp"
 
-class MockSampleAggregator : public geopm::SampleAggregator {
+class MockSampleAggregator : public geopm::SampleAggregator
+{
     public:
-        MOCK_METHOD3(push_signal_total,
-                     int(const std::string &signal_name, int domain_type, int domain_idx));
-        MOCK_METHOD3(push_signal_average,
-                     int(const std::string &signal_name, int domain_type, int domain_idx));
-        MOCK_METHOD3(push_signal,
-                     int(const std::string &signal_name, int domain_type, int domain_idx));
-        MOCK_METHOD0(update,
-                     void(void));
-        MOCK_METHOD1(sample_application,
-                     double(int signal_idx));
-        MOCK_METHOD1(sample_epoch,
-                     double(int signal_idx));
-        MOCK_METHOD2(sample_region,
-                     double(int signal_idx, uint64_t region_hash));
-        MOCK_METHOD1(sample_epoch_last,
-                     double(int signal_idx));
-        MOCK_METHOD2(sample_region_last,
-                     double(int signal_idx, uint64_t region_hash));
-        MOCK_METHOD1(sample_period_last,
-                     double(int signal_idx));
-        MOCK_METHOD1(period_duration,
-                     void(double));
-        MOCK_METHOD0(get_period,
-                     int(void));
+        MOCK_METHOD3(push_signal_total, int(const std::string &signal_name,
+                                            int domain_type, int domain_idx));
+        MOCK_METHOD3(push_signal_average, int(const std::string &signal_name,
+                                              int domain_type, int domain_idx));
+        MOCK_METHOD3(push_signal, int(const std::string &signal_name,
+                                      int domain_type, int domain_idx));
+        MOCK_METHOD0(update, void(void));
+        MOCK_METHOD1(sample_application, double(int signal_idx));
+        MOCK_METHOD1(sample_epoch, double(int signal_idx));
+        MOCK_METHOD2(sample_region, double(int signal_idx, uint64_t region_hash));
+        MOCK_METHOD1(sample_epoch_last, double(int signal_idx));
+        MOCK_METHOD2(sample_region_last, double(int signal_idx, uint64_t region_hash));
+        MOCK_METHOD1(sample_period_last, double(int signal_idx));
+        MOCK_METHOD1(period_duration, void(double));
+        MOCK_METHOD0(get_period, int(void));
 };
 
 #endif

--- a/test/MockSharedMemory.hpp
+++ b/test/MockSharedMemory.hpp
@@ -55,12 +55,12 @@ class MockSharedMemory : public geopm::SharedMemory
         };
         virtual ~MockSharedMemory() = default;
 
-        MOCK_CONST_METHOD0(pointer, void *(void));
-        MOCK_CONST_METHOD0(key, std::string(void));
-        MOCK_CONST_METHOD0(size, size_t(void));
-        MOCK_METHOD0(get_scoped_lock,
-                     std::unique_ptr<geopm::SharedMemoryScopedLock>(void));
-        MOCK_METHOD0(unlink, void(void));
+        MOCK_METHOD(void *, pointer, (), (const, override));
+        MOCK_METHOD(std::string, key, (), (const, override));
+        MOCK_METHOD(size_t, size, (), (const, override));
+        MOCK_METHOD(std::unique_ptr<geopm::SharedMemoryScopedLock>,
+                    get_scoped_lock, (), (override));
+        MOCK_METHOD(void, unlink, (), (override));
 
     protected:
         std::vector<char> m_buffer;

--- a/test/MockSharedMemory.hpp
+++ b/test/MockSharedMemory.hpp
@@ -35,8 +35,8 @@
 
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "SharedMemory.hpp"
 #include "SharedMemoryScopedLock.hpp"
@@ -45,27 +45,23 @@ class MockSharedMemory : public geopm::SharedMemory
 {
     public:
         MockSharedMemory() = delete;
-        MockSharedMemory(size_t size) {
+        MockSharedMemory(size_t size)
+        {
             m_buffer = std::vector<char>(size, '\0');
-            EXPECT_CALL(*this, size())
-                .WillRepeatedly(testing::Return(size));
+            EXPECT_CALL(*this, size()).WillRepeatedly(testing::Return(size));
             EXPECT_CALL(*this, pointer())
                 .WillRepeatedly(testing::Return(m_buffer.data()));
-            EXPECT_CALL(*this, unlink())
-                .WillRepeatedly(testing::Return());
+            EXPECT_CALL(*this, unlink()).WillRepeatedly(testing::Return());
         };
         virtual ~MockSharedMemory() = default;
 
-        MOCK_CONST_METHOD0(pointer,
-                           void *(void));
-        MOCK_CONST_METHOD0(key,
-                           std::string (void));
-        MOCK_CONST_METHOD0(size,
-                           size_t (void));
+        MOCK_CONST_METHOD0(pointer, void *(void));
+        MOCK_CONST_METHOD0(key, std::string(void));
+        MOCK_CONST_METHOD0(size, size_t(void));
         MOCK_METHOD0(get_scoped_lock,
                      std::unique_ptr<geopm::SharedMemoryScopedLock>(void));
-        MOCK_METHOD0(unlink,
-                     void(void));
+        MOCK_METHOD0(unlink, void(void));
+
     protected:
         std::vector<char> m_buffer;
 };

--- a/test/MockSignal.hpp
+++ b/test/MockSignal.hpp
@@ -40,9 +40,9 @@
 class MockSignal : public geopm::Signal
 {
     public:
-        MOCK_METHOD0(setup_batch, void(void));
-        MOCK_METHOD0(sample, double(void));
-        MOCK_CONST_METHOD0(read, double(void));
+        MOCK_METHOD(void, setup_batch, (), (override));
+        MOCK_METHOD(double, sample, (), (override));
+        MOCK_METHOD(double, read, (), (const, override));
 };
 
 #endif

--- a/test/MockSignal.hpp
+++ b/test/MockSignal.hpp
@@ -40,12 +40,9 @@
 class MockSignal : public geopm::Signal
 {
     public:
-        MOCK_METHOD0(setup_batch,
-                     void(void));
-        MOCK_METHOD0(sample,
-                     double(void));
-        MOCK_CONST_METHOD0(read,
-                           double(void));
+        MOCK_METHOD0(setup_batch, void(void));
+        MOCK_METHOD0(sample, double(void));
+        MOCK_CONST_METHOD0(read, double(void));
 };
 
 #endif

--- a/test/MockTracer.hpp
+++ b/test/MockTracer.hpp
@@ -41,11 +41,12 @@
 class MockTracer : public geopm::Tracer
 {
     public:
-        MOCK_METHOD2(columns,
-                     void(const std::vector<std::string> &agent_cols,
-                          const std::vector<std::function<std::string(double)> > &agent_formats));
-        MOCK_METHOD1(update, void(const std::vector<double> &agent_vals));
-        MOCK_METHOD0(flush, void(void));
+        MOCK_METHOD(void, columns,
+                    (const std::vector<std::string> &agent_cols,
+                     const std::vector<std::function<std::string(double)> > &agent_formats),
+                    (override));
+        MOCK_METHOD(void, update, (const std::vector<double> &agent_vals), (override));
+        MOCK_METHOD(void, flush, (), (override));
 };
 
 #endif

--- a/test/MockTracer.hpp
+++ b/test/MockTracer.hpp
@@ -35,8 +35,8 @@
 
 #include "gmock/gmock.h"
 
-#include "geopm.h"
 #include "Tracer.hpp"
+#include "geopm.h"
 
 class MockTracer : public geopm::Tracer
 {
@@ -44,10 +44,8 @@ class MockTracer : public geopm::Tracer
         MOCK_METHOD2(columns,
                      void(const std::vector<std::string> &agent_cols,
                           const std::vector<std::function<std::string(double)> > &agent_formats));
-        MOCK_METHOD1(update,
-                     void(const std::vector<double> &agent_vals));
-        MOCK_METHOD0(flush,
-                     void(void));
+        MOCK_METHOD1(update, void(const std::vector<double> &agent_vals));
+        MOCK_METHOD0(flush, void(void));
 };
 
 #endif

--- a/test/MockTreeComm.hpp
+++ b/test/MockTreeComm.hpp
@@ -102,8 +102,6 @@ class MockTreeComm : public geopm::TreeComm
             return true;
         }
         MOCK_METHOD(size_t, overhead_send, (), (const, override));
-        MOCK_METHOD(void, broadcast_string, (const std::string &str), (override));
-        MOCK_METHOD(std::string, broadcast_string, (), (override));
         int num_send(void)
         {
             return m_num_send;

--- a/test/MockTreeComm.hpp
+++ b/test/MockTreeComm.hpp
@@ -33,8 +33,8 @@
 #ifndef MOCKTREECOMM_HPP_INCLUDE
 #define MOCKTREECOMM_HPP_INCLUDE
 
-#include <set>
 #include <map>
+#include <set>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -44,16 +44,11 @@
 class MockTreeComm : public geopm::TreeComm
 {
     public:
-        MOCK_CONST_METHOD0(num_level_controlled,
-                           int(void));
-        MOCK_CONST_METHOD0(max_level,
-                           int(void));
-        MOCK_CONST_METHOD0(root_level,
-                           int(void));
-        MOCK_CONST_METHOD1(level_rank,
-                           int(int level));
-        MOCK_CONST_METHOD1(level_size,
-                           int(int level));
+        MOCK_CONST_METHOD0(num_level_controlled, int(void));
+        MOCK_CONST_METHOD0(max_level, int(void));
+        MOCK_CONST_METHOD0(root_level, int(void));
+        MOCK_CONST_METHOD1(level_rank, int(int level));
+        MOCK_CONST_METHOD1(level_size, int(int level));
 
         void send_up(int level, const std::vector<double> &sample) override
         {
@@ -61,16 +56,18 @@ class MockTreeComm : public geopm::TreeComm
             m_levels_sent_up.insert(level);
             m_data_sent_up[level] = sample;
         }
-        void send_up_mock_child(int level, int child_idx, const std::vector<double> &sample)
+        void send_up_mock_child(int level, int child_idx,
+                                const std::vector<double> &sample)
         {
-            m_data_sent_up_child[{level, child_idx}] = sample;
+            m_data_sent_up_child[{ level, child_idx }] = sample;
         }
         void send_down(int level, const std::vector<std::vector<double> > &policy) override
         {
             ++m_num_send;
             m_levels_sent_down.insert(level);
             if (policy.size() == 0) {
-                throw std::runtime_error("MockTreeComm::send_down(): policy vector was wrong size");
+                throw std::runtime_error(
+                    "MockTreeComm::send_down(): policy vector was wrong size");
             }
             m_data_sent_down[level] = policy[0]; /// @todo slightly wrong
         }
@@ -83,8 +80,9 @@ class MockTreeComm : public geopm::TreeComm
             m_levels_rcvd_up.insert(level);
             int child_idx = 0;
             for (auto &vec : sample) {
-                if (m_data_sent_up_child.find({level, child_idx}) != m_data_sent_up_child.end()) {
-                    vec = m_data_sent_up_child.at({level, child_idx});
+                if (m_data_sent_up_child.find({ level, child_idx }) !=
+                    m_data_sent_up_child.end()) {
+                    vec = m_data_sent_up_child.at({ level, child_idx });
                 }
                 else {
                     vec = m_data_sent_up.at(level);
@@ -103,12 +101,9 @@ class MockTreeComm : public geopm::TreeComm
             policy = m_data_sent_down.at(level);
             return true;
         }
-        MOCK_CONST_METHOD0(overhead_send,
-                           size_t(void));
-        MOCK_METHOD1(broadcast_string,
-                     void(const std::string &str));
-        MOCK_METHOD0(broadcast_string,
-                     std::string(void));
+        MOCK_CONST_METHOD0(overhead_send, size_t(void));
+        MOCK_METHOD1(broadcast_string, void(const std::string &str));
+        MOCK_METHOD0(broadcast_string, std::string(void));
         int num_send(void)
         {
             return m_num_send;
@@ -142,6 +137,7 @@ class MockTreeComm : public geopm::TreeComm
             m_levels_rcvd_down.clear();
             m_levels_rcvd_up.clear();
         }
+
     private:
         // map from level -> last sent data
         std::map<int, std::vector<double> > m_data_sent_up;

--- a/test/MockTreeComm.hpp
+++ b/test/MockTreeComm.hpp
@@ -44,11 +44,11 @@
 class MockTreeComm : public geopm::TreeComm
 {
     public:
-        MOCK_CONST_METHOD0(num_level_controlled, int(void));
-        MOCK_CONST_METHOD0(max_level, int(void));
-        MOCK_CONST_METHOD0(root_level, int(void));
-        MOCK_CONST_METHOD1(level_rank, int(int level));
-        MOCK_CONST_METHOD1(level_size, int(int level));
+        MOCK_METHOD(int, num_level_controlled, (), (const, override));
+        MOCK_METHOD(int, max_level, (), (const, override));
+        MOCK_METHOD(int, root_level, (), (const, override));
+        MOCK_METHOD(int, level_rank, (int level), (const, override));
+        MOCK_METHOD(int, level_size, (int level), (const, override));
 
         void send_up(int level, const std::vector<double> &sample) override
         {
@@ -101,9 +101,9 @@ class MockTreeComm : public geopm::TreeComm
             policy = m_data_sent_down.at(level);
             return true;
         }
-        MOCK_CONST_METHOD0(overhead_send, size_t(void));
-        MOCK_METHOD1(broadcast_string, void(const std::string &str));
-        MOCK_METHOD0(broadcast_string, std::string(void));
+        MOCK_METHOD(size_t, overhead_send, (), (const, override));
+        MOCK_METHOD(void, broadcast_string, (const std::string &str), (override));
+        MOCK_METHOD(std::string, broadcast_string, (), (override));
         int num_send(void)
         {
             return m_num_send;

--- a/test/MockTreeCommLevel.hpp
+++ b/test/MockTreeCommLevel.hpp
@@ -40,12 +40,14 @@
 class MockTreeCommLevel : public geopm::TreeCommLevel
 {
     public:
-        MOCK_CONST_METHOD0(level_rank, int(void));
-        MOCK_METHOD1(send_up, void(const std::vector<double> &sample));
-        MOCK_METHOD1(send_down, void(const std::vector<std::vector<double> > &policy));
-        MOCK_METHOD1(receive_up, bool(std::vector<std::vector<double> > &sample));
-        MOCK_METHOD1(receive_down, bool(std::vector<double> &policy));
-        MOCK_CONST_METHOD0(overhead_send, size_t(void));
+        MOCK_METHOD(int, level_rank, (), (const, override));
+        MOCK_METHOD(void, send_up, (const std::vector<double> &sample), (override));
+        MOCK_METHOD(void, send_down,
+                    (const std::vector<std::vector<double> > &policy), (override));
+        MOCK_METHOD(bool, receive_up,
+                    (std::vector<std::vector<double> > & sample), (override));
+        MOCK_METHOD(bool, receive_down, (std::vector<double> & policy), (override));
+        MOCK_METHOD(size_t, overhead_send, (), (const, override));
 };
 
 #endif

--- a/test/MockTreeCommLevel.hpp
+++ b/test/MockTreeCommLevel.hpp
@@ -37,20 +37,15 @@
 
 #include "TreeCommLevel.hpp"
 
-class MockTreeCommLevel : public geopm::TreeCommLevel {
+class MockTreeCommLevel : public geopm::TreeCommLevel
+{
     public:
-        MOCK_CONST_METHOD0(level_rank,
-                           int(void));
-        MOCK_METHOD1(send_up,
-                     void(const std::vector<double> &sample));
-        MOCK_METHOD1(send_down,
-                     void(const std::vector<std::vector<double> > &policy));
-        MOCK_METHOD1(receive_up,
-                     bool(std::vector<std::vector<double> > &sample));
-        MOCK_METHOD1(receive_down,
-                     bool(std::vector<double> &policy));
-        MOCK_CONST_METHOD0(overhead_send,
-                           size_t(void));
+        MOCK_CONST_METHOD0(level_rank, int(void));
+        MOCK_METHOD1(send_up, void(const std::vector<double> &sample));
+        MOCK_METHOD1(send_down, void(const std::vector<std::vector<double> > &policy));
+        MOCK_METHOD1(receive_up, bool(std::vector<std::vector<double> > &sample));
+        MOCK_METHOD1(receive_down, bool(std::vector<double> &policy));
+        MOCK_CONST_METHOD0(overhead_send, size_t(void));
 };
 
 #endif


### PR DESCRIPTION
This set of changes updates gmock to use the new-style MOCK_METHOD calls that have been available to us since #1643. 

The second patch in the stack applies the new `MOCK_METHOD` call format, and fixes any formatting inconsistencies by running clang-format. The first patch applies `clang-format` without any other changes, with the intent of making it easier to see non-formatting differences in the second patch.

Migration was performed by the following script:
```
for migration_file in "$@"
do
        perl -0p \
                -e 's/MOCK_METHOD\d\(\s*([^,]+),\s*([^(]+)\s*([^;]*)\);/MOCK_METHOD\($2,$1,$3, (override)\);/gms; \
                    s/MOCK_CONST_METHOD\d\(\s*([^,]+),\s*([^(]+)\s*([^;]*)\);/MOCK_METHOD\($2,$1,$3, (const, override)\);/gms; \
                    s/MOCK_METHOD\(([^;]*)\(void\)([^;]*;)/MOCK_METHOD\($1\(\)$2/gms; ' \
                "$migration_file" \
                | clang-format --style=file \
                > "${migration_file}.tmp"
        mv "${migration_file}.tmp" "$migration_file"
done
```

The script does not handle all cases of gmock macro migration, but it does handle most of the ones that apply for our code. The main case it does not handle is nested types that contain commas (they need to be wrapped by a set of parentheses). The third patch manually addresses those few cases where it impacts our build.

As a result of using the new format, the build can now warn us about inconsistencies between mock code and the interface it implements. The fourth patch fixes some now-reported inconsistencies that started generating build failures. This changes fixes #858.

The last patch removes an ignore option for a warning that we no longer need to ignore since we consistently use `override` qualifiers in our mock code now.