### PR TITLE
Level Zero IOGroup, Device Pool, and Accelerator Topo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -657,11 +657,11 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/NVMLIOGroup.hpp \
                             src/LevelZeroAcceleratorTopo.cpp \
                             src/LevelZeroAcceleratorTopo.hpp \
+                            src/LevelZeroDevicePool.cpp \
                             src/LevelZeroDevicePool.hpp \
+                            src/LevelZeroDevicePoolImp.hpp \
                             src/LevelZeroIOGroup.cpp \
                             src/LevelZeroIOGroup.hpp \
-                            src/LevelZeroShim.cpp \
-                            src/LevelZeroShim.hpp \
                             src/LevelZeroShimImp.hpp \
                             src/LevelZeroSignal.cpp \
                             src/LevelZeroSignal.hpp \
@@ -671,14 +671,14 @@ nvml_source_files = src/NVMLDevicePool.cpp \
                     src/NVMLDevicePoolImp.hpp \
                     #end
 
-levelzero_source_files = src/LevelZeroDevicePool.cpp \
-                         src/LevelZeroDevicePoolImp.hpp \
+levelzero_source_files = src/LevelZeroShim.cpp \
+                         src/LevelZeroShim.hpp \
                          #end
 
 if ENABLE_LEVELZERO
     libgeopmpolicy_la_SOURCES += $(levelzero_source_files)
 else
-    libgeopmpolicy_la_SOURCES += src/LevelZeroDevicePoolThrow.cpp
+    libgeopmpolicy_la_SOURCES += src/LevelZeroShimThrow.cpp
     EXTRA_DIST += $(levelzero_source_files) \
                   #end
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -660,6 +660,9 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/LevelZeroDevicePool.hpp \
                             src/LevelZeroIOGroup.cpp \
                             src/LevelZeroIOGroup.hpp \
+                            src/LevelZeroShim.cpp \
+                            src/LevelZeroShim.hpp \
+                            src/LevelZeroShimImp.hpp \
                             src/LevelZeroSignal.cpp \
                             src/LevelZeroSignal.hpp \
                             # end

--- a/Makefile.am
+++ b/Makefile.am
@@ -655,11 +655,30 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/NVMLDevicePool.hpp \
                             src/NVMLIOGroup.cpp \
                             src/NVMLIOGroup.hpp \
+                            src/LevelZeroAcceleratorTopo.cpp \
+                            src/LevelZeroAcceleratorTopo.hpp \
+                            src/LevelZeroDevicePool.hpp \
+                            src/LevelZeroIOGroup.cpp \
+                            src/LevelZeroIOGroup.hpp \
+                            src/LevelZeroSignal.cpp \
+                            src/LevelZeroSignal.hpp \
                             # end
 
 nvml_source_files = src/NVMLDevicePool.cpp \
                     src/NVMLDevicePoolImp.hpp \
                     #end
+
+levelzero_source_files = src/LevelZeroDevicePool.cpp \
+                         src/LevelZeroDevicePoolImp.hpp \
+                         #end
+
+if ENABLE_LEVELZERO
+    libgeopmpolicy_la_SOURCES += $(levelzero_source_files)
+else
+    libgeopmpolicy_la_SOURCES += src/LevelZeroDevicePoolThrow.cpp
+    EXTRA_DIST += $(levelzero_source_files) \
+                  #end
+endif
 
 if ENABLE_NVML
     libgeopmpolicy_la_SOURCES += $(nvml_source_files)

--- a/configure.ac
+++ b/configure.ac
@@ -302,8 +302,8 @@ AC_ARG_WITH([liblevelzero], [AS_HELP_STRING([--with-liblevelzero=PATH],
             [specify directory for installed liblevelzero package.])])
 if test "x$with_liblevelzero" != x; then
   EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -I$with_liblevelzero/include/level_zero"
-  LD_LIBRARY_PATH="$with_liblevelzero/lib:$LD_LIBRARY_PATH"
-  EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L$with_liblevelzero/lib64" #Chris, is this safe?
+  LD_LIBRARY_PATH="$with_liblevelzero/lib64:$LD_LIBRARY_PATH"
+  EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L$with_liblevelzero/lib64"
 fi
 
 AC_ARG_WITH([libelf], [AS_HELP_STRING([--with-libelf=PATH],

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,19 @@ fi
 [enable_procfs="1"]
 )
 
+AC_ARG_ENABLE([levelzero],
+  [AS_HELP_STRING([--enable-levelzero], [Enables use of the levelzero library to support levelzero board accelerators])],
+[if test "x$enable_levelzero" = "xno" ; then
+  enable_levelzero="0"
+else
+  enable_levelzero="1"
+fi
+],
+[enable_levelzero="0"]
+)
+AC_SUBST([enable_levelzero])
+AM_CONDITIONAL([ENABLE_LEVELZERO], [test "x$enable_levelzero" = "x1"])
+
 AC_ARG_ENABLE([nvml],
   [AS_HELP_STRING([--enable-nvml], [Enables use of the NVML library to support NVML board accelerators])],
 [if test "x$enable_nvml" = "xno" ; then
@@ -166,6 +179,13 @@ if test "x$enable_msrsafe_ioctl_write" = "x1" ; then
   AC_DEFINE([GEOPM_MSRSAFE_IOCTL_WRITE], [ ], [Enables use of msr-safe ioctl feature for writing (broken as of msr-safe version 1.2.0)])
 fi
 AC_SUBST([enable_msrsafe_ioctl_write])
+
+if test "x$enable_levelzero" = "x1" ; then
+  ENABLE_LEVELZERO=True
+  AC_DEFINE([GEOPM_ENABLE_LEVELZERO], [ ], [Enables use of the levelzero library to support levelzero board accelerators])
+else
+  ENABLE_levelzero=False
+fi
 
 if test "x$enable_nvml" = "x1" ; then
   ENABLE_NVML=True
@@ -276,6 +296,14 @@ if test "x$with_libnvml" != x; then
   EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -I$with_libnvml/include"
   LD_LIBRARY_PATH="$with_libnvml/lib:$LD_LIBRARY_PATH"
   EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L$with_libnvml/lib"
+fi
+
+AC_ARG_WITH([liblevelzero], [AS_HELP_STRING([--with-liblevelzero=PATH],
+            [specify directory for installed liblevelzero package.])])
+if test "x$with_liblevelzero" != x; then
+  EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -I$with_liblevelzero/include/level_zero"
+  LD_LIBRARY_PATH="$with_liblevelzero/lib:$LD_LIBRARY_PATH"
+  EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L$with_liblevelzero/lib64" #Chris, is this safe?
 fi
 
 AC_ARG_WITH([libelf], [AS_HELP_STRING([--with-libelf=PATH],
@@ -481,6 +509,16 @@ if test "x$enable_nvml" = "x1" ; then
         exit -1])
 fi
 
+if test "x$enable_levelzero" = "x1" ; then
+    AC_SEARCH_LIBS([zeInit], [ze_loader])
+    AC_CHECK_LIB([ze_loader], [zeInit], [], [
+        echo "missing libze_loader: LevelZero library is required, use --with-liblevelzero to specify location"
+        exit -1])
+    AC_CHECK_HEADER([ze_api.h], [], [
+        echo "missing ze_api.h: LevelZero header is required, use --with-liblevelzero to specify location"
+        exit -1])
+fi
+
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h float.h inttypes.h malloc.h netdb.h stddef.h stdint.h stdlib.h string.h sys/socket.h unistd.h])
 
@@ -651,4 +689,5 @@ AC_MSG_RESULT([ompt               : ${enable_ompt}])
 AC_MSG_RESULT([beta               : ${enable_beta}])
 AC_MSG_RESULT([bloat              : ${enable_bloat}])
 AC_MSG_RESULT([nvml               : ${enable_nvml}])
+AC_MSG_RESULT([levelzero          : ${enable_levelzero}])
 AC_MSG_RESULT([===============================================================================])

--- a/integration/test/Makefile.mk
+++ b/integration/test/Makefile.mk
@@ -63,6 +63,7 @@ include integration/test/test_ompt.mk
 include integration/test/test_geopmio.mk
 include integration/test/test_launch_application.mk
 include integration/test/test_launch_pthread.mk
+include integration/test/test_levelzero_signals.mk
 include integration/test/test_geopmagent.mk
 include integration/test/test_environment.mk
 include integration/test/test_power_governor.mk

--- a/integration/test/test_levelzero_signals.mk
+++ b/integration/test/test_levelzero_signals.mk
@@ -1,0 +1,32 @@
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+EXTRA_DIST += integration/test/test_levelzero_signals.py

--- a/integration/test/test_levelzero_signals.py
+++ b/integration/test/test_levelzero_signals.py
@@ -60,10 +60,11 @@ class TestIntegrationLevelZeroSignals(unittest.TestCase):
         cls._app_exec_path = os.path.join(script_dir, '.libs', 'test_levelzero_signals')
 
     def setUp(self):
-        #TODO: get num accelerators
-        #TODO: verify they're level zero accels and not nvidia
         self._stdout = None
         self._stderr = None
+
+        #TODO: Add query for numnber of devices and subdevices
+        #TODO: Add check for ZES_SYSMAN_ENABLE=1
 
     def tearDown(self):
         pass
@@ -73,18 +74,12 @@ class TestIntegrationLevelZeroSignals(unittest.TestCase):
         power = geopm_test_launcher.geopmread("LEVELZERO::POWER board_accelerator 0")
         power_limit_max = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_MAX board_accelerator 0")
         power_limit_min = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_MIN board_accelerator 0")
-        power_limit_enabled_sustained = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_ENABLED_SUSTAINED board_accelerator 0")
-        power_limit_sustained = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_SUSTAINED board_accelerator 0")
-        power_limit_default = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_DEFAULT board_accelerator 0")
 
         #Info
         sys.stdout.write("Power:\n");
         sys.stdout.write("\tPower: {}\n".format(power));
         sys.stdout.write("\tPower limit max: {}\n".format(power_limit_max));
         sys.stdout.write("\tPower limit min: {}\n".format(power_limit_min));
-        sys.stdout.write("\tPower limit default: {}\n".format(power_limit_default));
-        sys.stdout.write("\tPower limit sustained enable: {}\n".format(power_limit_enabled_sustained));
-        sys.stdout.write("\tPower limit sustained: {}\n".format(power_limit_sustained));
 
         #Check
         self.assertGreater(power, 0)
@@ -94,10 +89,10 @@ class TestIntegrationLevelZeroSignals(unittest.TestCase):
         if(power_limit_max > 0): #Negative value indicates max is not supported
             self.assertLessEqual(power, power_limit_max)
 
-        if(power_limit_enabled_sustained == 1):
-            self.assertLessEqual(power, power_limit_sustained)
+        #TODO: Power limit enabled sustained check
 
     def test_energy(self):
+        sys.stdout.write("Running LevelZero Energy Test\n");
         #Query
         energy_prev = geopm_test_launcher.geopmread("LEVELZERO::ENERGY board_accelerator 0")
         energy_timestamp_prev = geopm_test_launcher.geopmread("LEVELZERO::ENERGY_TIMESTAMP board_accelerator 0")
@@ -105,38 +100,31 @@ class TestIntegrationLevelZeroSignals(unittest.TestCase):
         energy_curr = geopm_test_launcher.geopmread("LEVELZERO::ENERGY board_accelerator 0")
         energy_timestamp_curr = geopm_test_launcher.geopmread("LEVELZERO::ENERGY_TIMESTAMP board_accelerator 0")
 
+        sys.stdout.write("Energy:\n");
+        sys.stdout.write("\tEnergy Sample 0: {}\n".format(energy_prev));
+        sys.stdout.write("\tEnergy Sample 1: {}\n".format(energy_curr));
+
         #Check
         self.assertNotEqual(energy_prev, energy_curr)
         self.assertNotEqual(energy_timestamp_prev, energy_timestamp_curr)
 
     def test_frequency(self):
+        sys.stdout.write("Running LevelZero Frequency Test\n");
         #Query
-        standby_mode = geopm_test_launcher.geopmread("LEVELZERO::STANDBY_MODE board_accelerator 0")
         frequency_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_GPU board_accelerator 0")
         frequency_min_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_MIN_GPU board_accelerator 0")
         frequency_max_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_MAX_GPU board_accelerator 0")
-        frequency_range_min_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_RANGE_MIN_GPU_CONTROL board_accelerator 0")
-        frequency_range_max_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_RANGE_MAX_GPU_CONTROL board_accelerator 0")
 
         #Info
         sys.stdout.write("Frequency:\n");
-        sys.stdout.write("\tStandby Mode: {}\n".format(standby_mode));
         sys.stdout.write("\tFrequency GPU: {}\n".format(frequency_gpu));
         sys.stdout.write("\tFrequency GPU Min: {}\n".format(frequency_min_gpu));
         sys.stdout.write("\tFrequency GPU Max: {}\n".format(frequency_max_gpu));
-        sys.stdout.write("\tFrequency GPU Control Min: {}\n".format(frequency_range_min_gpu));
-        sys.stdout.write("\tFrequency GPU Control Max: {}\n".format(frequency_range_max_gpu));
 
-        #Check
-        if(standby_mode == 0): #We may enter idle and see 0 Hz
-            self.assertGreaterEqual(frequency_gpu, 0)
-        else:
-            self.assertGreaterEqual(frequency_gpu, frequency_min_gpu)
-            self.assertGreaterEqual(frequency_gpu, frequency_range_min_gpu)
-
+        #TODO: standby mode check
+        self.assertGreaterEqual(frequency_gpu, frequency_min_gpu)
         if(frequency_max_gpu > 0): #Negative value indicates max was not supported
             self.assertLessEqual(frequency_gpu, frequency_max_gpu)
-            self.assertLessEqual(frequency_gpu, frequency_range_max_gpu)
 
 
 if __name__ == '__main__':

--- a/integration/test/test_levelzero_signals.py
+++ b/integration/test/test_levelzero_signals.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2015 - 2021, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+from __future__ import absolute_import
+
+import os
+import sys
+import unittest
+import subprocess
+import io
+import json
+
+import geopm_context
+import geopmpy.agent
+import geopm_test_launcher
+import util
+import time
+import geopmpy.topo
+
+
+@util.skip_unless_levelzero()
+@util.skip_unless_levelzero_power()
+class TestIntegrationLevelZeroSignals(unittest.TestCase):
+    """Test the levelzero signals
+
+    """
+    @classmethod
+    def setUpClass(cls):
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        cls._app_exec_path = os.path.join(script_dir, '.libs', 'test_levelzero_signals')
+
+    def setUp(self):
+        #TODO: get num accelerators
+        #TODO: verify they're level zero accels and not nvidia
+        self._stdout = None
+        self._stderr = None
+
+    def tearDown(self):
+        pass
+
+    def test_power(self):
+        #Query
+        power = geopm_test_launcher.geopmread("LEVELZERO::POWER board_accelerator 0")
+        power_limit_max = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_MAX board_accelerator 0")
+        power_limit_min = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_MIN board_accelerator 0")
+        power_limit_enabled_sustained = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_ENABLED_SUSTAINED board_accelerator 0")
+        power_limit_sustained = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_SUSTAINED board_accelerator 0")
+        power_limit_default = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_DEFAULT board_accelerator 0")
+
+        #Info
+        sys.stdout.write("Power:\n");
+        sys.stdout.write("\tPower: {}\n".format(power));
+        sys.stdout.write("\tPower limit max: {}\n".format(power_limit_max));
+        sys.stdout.write("\tPower limit min: {}\n".format(power_limit_min));
+        sys.stdout.write("\tPower limit default: {}\n".format(power_limit_default));
+        sys.stdout.write("\tPower limit sustained enable: {}\n".format(power_limit_enabled_sustained));
+        sys.stdout.write("\tPower limit sustained: {}\n".format(power_limit_sustained));
+
+        #Check
+        self.assertGreater(power, 0)
+        self.assertGreaterEqual(power, power_limit_min)
+
+        self.assertLessEqual(power, power_limit_default)
+        if(power_limit_max > 0): #Negative value indicates max is not supported
+            self.assertLessEqual(power, power_limit_max)
+
+        if(power_limit_enabled_sustained == 1):
+            self.assertLessEqual(power, power_limit_sustained)
+
+    def test_energy(self):
+        #Query
+        energy_prev = geopm_test_launcher.geopmread("LEVELZERO::ENERGY board_accelerator 0")
+        energy_timestamp_prev = geopm_test_launcher.geopmread("LEVELZERO::ENERGY_TIMESTAMP board_accelerator 0")
+        time.sleep(5)
+        energy_curr = geopm_test_launcher.geopmread("LEVELZERO::ENERGY board_accelerator 0")
+        energy_timestamp_curr = geopm_test_launcher.geopmread("LEVELZERO::ENERGY_TIMESTAMP board_accelerator 0")
+
+        #Check
+        self.assertNotEqual(energy_prev, energy_curr)
+        self.assertNotEqual(energy_timestamp_prev, energy_timestamp_curr)
+
+    def test_frequency(self):
+        #Query
+        standby_mode = geopm_test_launcher.geopmread("LEVELZERO::STANDBY_MODE board_accelerator 0")
+        frequency_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_GPU board_accelerator 0")
+        frequency_min_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_MIN_GPU board_accelerator 0")
+        frequency_max_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_MAX_GPU board_accelerator 0")
+        frequency_range_min_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_RANGE_MIN_GPU_CONTROL board_accelerator 0")
+        frequency_range_max_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_RANGE_MAX_GPU_CONTROL board_accelerator 0")
+
+        #Info
+        sys.stdout.write("Frequency:\n");
+        sys.stdout.write("\tStandby Mode: {}\n".format(standby_mode));
+        sys.stdout.write("\tFrequency GPU: {}\n".format(frequency_gpu));
+        sys.stdout.write("\tFrequency GPU Min: {}\n".format(frequency_min_gpu));
+        sys.stdout.write("\tFrequency GPU Max: {}\n".format(frequency_max_gpu));
+        sys.stdout.write("\tFrequency GPU Control Min: {}\n".format(frequency_range_min_gpu));
+        sys.stdout.write("\tFrequency GPU Control Max: {}\n".format(frequency_range_max_gpu));
+
+        #Check
+        if(standby_mode == 0): #We may enter idle and see 0 Hz
+            self.assertGreaterEqual(frequency_gpu, 0)
+        else:
+            self.assertGreaterEqual(frequency_gpu, frequency_min_gpu)
+            self.assertGreaterEqual(frequency_gpu, frequency_range_min_gpu)
+
+        if(frequency_max_gpu > 0): #Negative value indicates max was not supported
+            self.assertLessEqual(frequency_gpu, frequency_max_gpu)
+            self.assertLessEqual(frequency_gpu, frequency_range_max_gpu)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/integration/test/util.py
+++ b/integration/test/util.py
@@ -109,6 +109,16 @@ def skip_unless_do_launch():
         return unittest.skip("Most tests in this suite require launch; do not set --skip-launch.")
     return lambda func: func
 
+def skip_unless_levelzero_power():
+    #try/catch read signal for levelzero
+    try:
+        power = geopm_test_launcher.geopmread("LEVELZERO::POWER board_accelerator 0")
+    except subprocess.CalledProcessError:
+        return unittest.skip("Read of LEVELZERO::POWER not supported, skipping test.")
+    return lambda func: func
+
+def skip_unless_levelzero():
+    return skip_unless_config_enable('levelzero');
 
 def skip_unless_platform_bdx():
     fam, mod = geopm_test_launcher.get_platform()

--- a/src/AcceleratorTopo.hpp
+++ b/src/AcceleratorTopo.hpp
@@ -46,10 +46,16 @@ namespace geopm
             virtual ~AcceleratorTopo() = default;
             /// @brief Number of accelerators on the platform.
             virtual int num_accelerator(void) const = 0;
+            /// @brief Number of accelerator subdevices on the platform.
+            virtual int num_accelerator_subdevice(void) const = 0;
             /// @brief CPU Affinitization set for a particular accelerator
             /// @param [in] domain_idx The index indicating a particular
             ///        accelerator
             virtual std::set<int> cpu_affinity_ideal(int domain_idx) const = 0;
+            /// @brief CPU Affinitization set for a particular accelerator subdevice
+            /// @param [in] domain_idx The index indicating a particular
+            ///        accelerator subdevice
+            virtual std::set<int> cpu_affinity_ideal_subdevice(int domain_idx) const = 0;
     };
 
     const AcceleratorTopo &accelerator_topo(void);

--- a/src/AcceleratorTopoNull.cpp
+++ b/src/AcceleratorTopoNull.cpp
@@ -45,7 +45,17 @@ namespace geopm
         return 0;
     }
 
+    int AcceleratorTopoNull::num_accelerator_subdevice(void) const
+    {
+        return 0;
+    }
+
     std::set<int> AcceleratorTopoNull::cpu_affinity_ideal(int domain_idx) const
+    {
+        return {};
+    }
+
+    std::set<int> AcceleratorTopoNull::cpu_affinity_ideal_subdevice(int domain_idx) const
     {
         return {};
     }

--- a/src/AcceleratorTopoNull.hpp
+++ b/src/AcceleratorTopoNull.hpp
@@ -47,7 +47,9 @@ namespace geopm
             AcceleratorTopoNull() = default ;
             virtual ~AcceleratorTopoNull() = default;
             int num_accelerator(void) const override;
+            int num_accelerator_subdevice(void) const override;
             std::set<int> cpu_affinity_ideal(int accel_idx) const override;
+            std::set<int> cpu_affinity_ideal_subdevice(int accel_idx) const override;
     };
 }
 #endif

--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -42,6 +42,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <iostream>
 
 #include "contrib/json11/json11.hpp"
 
@@ -150,7 +151,8 @@ namespace geopm
                 "GEOPM_FREQUENCY_MAP",
                 "GEOPM_MAX_FAN_OUT",
                 "GEOPM_OMPT_DISABLE",
-                "GEOPM_RECORD_FILTER"};
+                "GEOPM_RECORD_FILTER",
+                "ZES_ENABLE_SYSMAN"};
     }
 
     void EnvironmentImp::parse_environment()
@@ -425,5 +427,22 @@ namespace geopm
     {
         return is_set("GEOPM_RECORD_FILTER");
     }
+
+    bool EnvironmentImp::do_sysman(void) const
+    {
+        bool result = false;
+        if (is_set("ZES_ENABLE_SYSMAN")) {
+            try {
+                if(std::stoi(lookup("ZES_ENABLE_SYSMAN")) == 1) {
+                    result = true;
+                }
+            }
+            catch (const std::exception &) {
+
+            }
+        }
+        return result;
+    }
+
 
 }

--- a/src/Environment.hpp
+++ b/src/Environment.hpp
@@ -74,6 +74,7 @@ namespace geopm
             virtual std::string override_config_path(void) const = 0;
             virtual std::string record_filter(void) const = 0;
             virtual bool do_record_filter(void) const = 0;
+            virtual bool do_sysman(void) const = 0;
             virtual bool do_debug_attach_all(void) const = 0;
             virtual bool do_debug_attach_one(void) const = 0;
             virtual int debug_attach_process(void) const = 0;
@@ -119,6 +120,7 @@ namespace geopm
                                                std::map<std::string, std::string> &name_value_map);
             std::string record_filter(void) const override;
             bool do_record_filter(void) const override;
+            bool do_sysman(void) const override;
             bool do_debug_attach_all(void) const override;
             bool do_debug_attach_one(void) const override;
             int debug_attach_process(void) const override;

--- a/src/IOGroup.cpp
+++ b/src/IOGroup.cpp
@@ -50,6 +50,9 @@
 #ifdef GEOPM_ENABLE_NVML
 #include "NVMLIOGroup.hpp"
 #endif
+#ifdef GEOPM_ENABLE_LEVELZERO
+#include "LevelZeroIOGroup.hpp"
+#endif
 #ifdef GEOPM_DEBUG
 #include <iostream>
 #endif
@@ -113,6 +116,10 @@ namespace geopm
 #ifdef GEOPM_ENABLE_NVML
         register_plugin(NVMLIOGroup::plugin_name(),
                         NVMLIOGroup::make_plugin);
+#endif
+#ifdef GEOPM_ENABLE_LEVELZERO
+        register_plugin(LevelZeroIOGroup::plugin_name(),
+                        LevelZeroIOGroup::make_plugin);
 #endif
     }
 

--- a/src/LevelZeroAcceleratorTopo.cpp
+++ b/src/LevelZeroAcceleratorTopo.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <map>
+
+#include "config.h"
+#include "Exception.hpp"
+#include "LevelZeroDevicePool.hpp"
+#include "LevelZeroAcceleratorTopo.hpp"
+
+namespace geopm
+{
+    LevelZeroAcceleratorTopo::LevelZeroAcceleratorTopo()
+        : LevelZeroAcceleratorTopo(levelzero_device_pool(geopm_sched_num_cpu()), geopm_sched_num_cpu())
+    {
+    }
+
+    LevelZeroAcceleratorTopo::LevelZeroAcceleratorTopo(const LevelZeroDevicePool &device_pool, const int num_cpu)
+        : m_levelzero_device_pool(device_pool)
+        , m_num_accelerator(m_levelzero_device_pool.num_accelerator())
+    {
+        if (m_num_accelerator == 0) {
+            std::cerr << "Warning: <geopm> LevelZeroAcceleratorTopo: No levelZero accelerators detected.\n";
+        }
+        else {
+            m_cpu_affinity_ideal.resize(m_num_accelerator);
+            unsigned int num_cpu_per_accelerator = num_cpu / m_num_accelerator;
+
+            //TODO: Add ideal cpu to accelerator affinitization that isn't a simple split.  This may come from
+            //      a call to oneAPI
+            for (unsigned int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
+                for (unsigned int cpu_idx = accel_idx*num_cpu_per_accelerator;
+                     cpu_idx < (accel_idx+1)*num_cpu_per_accelerator;
+                     cpu_idx++) {
+                    m_cpu_affinity_ideal.at(accel_idx).insert(cpu_idx);
+                }
+            }
+
+            if ((num_cpu % m_num_accelerator) != 0) {
+                unsigned int accel_idx = 0;
+                for (int cpu_idx = num_cpu_per_accelerator*m_num_accelerator; cpu_idx < num_cpu; ++cpu_idx) {
+                    m_cpu_affinity_ideal.at(accel_idx%m_num_accelerator).insert(cpu_idx);
+                    ++accel_idx;
+                }
+            }
+        }
+    }
+
+    int LevelZeroAcceleratorTopo::num_accelerator(void) const
+    {
+        return m_num_accelerator;
+    }
+
+    std::set<int> LevelZeroAcceleratorTopo::cpu_affinity_ideal(int accel_idx) const
+    {
+        if (accel_idx < 0 || (unsigned int)accel_idx >= m_num_accelerator) {
+            throw Exception("LevelZeroAcceleratorTopo::" + std::string(__func__) + ": accel_idx " +
+                            std::to_string(accel_idx) + " is out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return m_cpu_affinity_ideal.at(accel_idx);
+    }
+}

--- a/src/LevelZeroAcceleratorTopo.cpp
+++ b/src/LevelZeroAcceleratorTopo.cpp
@@ -44,23 +44,24 @@
 namespace geopm
 {
     LevelZeroAcceleratorTopo::LevelZeroAcceleratorTopo()
-        : LevelZeroAcceleratorTopo(levelzero_device_pool(geopm_sched_num_cpu()), geopm_sched_num_cpu())
+        : LevelZeroAcceleratorTopo(levelzero_device_pool(), geopm_sched_num_cpu())
     {
     }
 
     LevelZeroAcceleratorTopo::LevelZeroAcceleratorTopo(const LevelZeroDevicePool &device_pool, const int num_cpu)
         : m_levelzero_device_pool(device_pool)
         , m_num_accelerator(m_levelzero_device_pool.num_accelerator())
+        , m_num_accelerator_subdevice(m_levelzero_device_pool.num_accelerator_subdevice())
     {
         if (m_num_accelerator == 0) {
-            std::cerr << "Warning: <geopm> LevelZeroAcceleratorTopo: No levelZero accelerators detected.\n";
+            std::cerr << "Warning: <geopm> LevelZeroAcceleratorTopo: No levelZero devices detected.\n";
         }
         else {
             m_cpu_affinity_ideal.resize(m_num_accelerator);
             unsigned int num_cpu_per_accelerator = num_cpu / m_num_accelerator;
 
-            //TODO: Add ideal cpu to accelerator affinitization that isn't a simple split.  This may come from
-            //      a call to oneAPI
+            // TODO: Add ideal cpu to accelerator affinitization that isn't a simple split if needed.
+            //       This may come from a call to oneAPI, LevelZero, etc
             for (unsigned int accel_idx = 0; accel_idx <  m_num_accelerator; ++accel_idx) {
                 for (unsigned int cpu_idx = accel_idx*num_cpu_per_accelerator;
                      cpu_idx < (accel_idx+1)*num_cpu_per_accelerator;
@@ -68,7 +69,6 @@ namespace geopm
                     m_cpu_affinity_ideal.at(accel_idx).insert(cpu_idx);
                 }
             }
-
             if ((num_cpu % m_num_accelerator) != 0) {
                 unsigned int accel_idx = 0;
                 for (int cpu_idx = num_cpu_per_accelerator*m_num_accelerator; cpu_idx < num_cpu; ++cpu_idx) {
@@ -77,11 +77,42 @@ namespace geopm
                 }
             }
         }
+
+        if (m_num_accelerator_subdevice == 0) {
+            std::cerr << "Warning: <geopm> LevelZeroAcceleratorTopo: No levelZero subdevices detected.\n";
+        }
+        else {
+            m_cpu_affinity_ideal_subdevice.resize(m_num_accelerator_subdevice);
+            unsigned int num_cpu_per_accelerator_subdevice = num_cpu / m_num_accelerator_subdevice;
+
+            // TODO: Add ideal cpu to accelerator subdevice affinitization that isn't a simple split if needed.
+            //       This may come from a call to oneAPI, LevelZero, etc
+            for (unsigned int accel_sub_idx = 0; accel_sub_idx <  m_num_accelerator_subdevice; ++accel_sub_idx) {
+                for (unsigned int cpu_idx = accel_sub_idx*num_cpu_per_accelerator_subdevice;
+                     cpu_idx < (accel_sub_idx+1)*num_cpu_per_accelerator_subdevice;
+                     cpu_idx++) {
+                    m_cpu_affinity_ideal_subdevice.at(accel_sub_idx).insert(cpu_idx);
+                }
+            }
+            if ((num_cpu % m_num_accelerator_subdevice) != 0) {
+                unsigned int accel_sub_idx = 0;
+                for (int cpu_idx = num_cpu_per_accelerator_subdevice*m_num_accelerator_subdevice; cpu_idx < num_cpu; ++cpu_idx) {
+                    m_cpu_affinity_ideal_subdevice.at(accel_sub_idx%m_num_accelerator_subdevice).insert(cpu_idx);
+                    ++accel_sub_idx;
+                }
+            }
+
+        }
     }
 
     int LevelZeroAcceleratorTopo::num_accelerator(void) const
     {
         return m_num_accelerator;
+    }
+
+    int LevelZeroAcceleratorTopo::num_accelerator_subdevice(void) const
+    {
+        return m_num_accelerator_subdevice;
     }
 
     std::set<int> LevelZeroAcceleratorTopo::cpu_affinity_ideal(int accel_idx) const
@@ -92,5 +123,15 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         return m_cpu_affinity_ideal.at(accel_idx);
+    }
+
+    std::set<int> LevelZeroAcceleratorTopo::cpu_affinity_ideal_subdevice(int accel_idx) const
+    {
+        if (accel_idx < 0 || (unsigned int)accel_idx >= m_num_accelerator_subdevice) {
+            throw Exception("LevelZeroAcceleratorTopo::" + std::string(__func__) + ": accel_idx " +
+                            std::to_string(accel_idx) + " is out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return m_cpu_affinity_ideal_subdevice.at(accel_idx);
     }
 }

--- a/src/LevelZeroAcceleratorTopo.hpp
+++ b/src/LevelZeroAcceleratorTopo.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Intel Corporation
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,33 +30,31 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
+#ifndef LEVELZEROACCELERATORTOPO_HPP_INCLUDE
+#define LEVELZEROACCELERATORTOPO_HPP_INCLUDE
 
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <string>
+#include <cstdint>
+#include <vector>
+#include <set>
 
-#include "Exception.hpp"
-#include "AcceleratorTopoNull.hpp"
-
-#ifdef GEOPM_ENABLE_NVML
-#include "NVMLAcceleratorTopo.hpp"
-#elif defined(GEOPM_ENABLE_LEVELZERO)
-#include "LevelZeroAcceleratorTopo.hpp"
-#endif
+#include "AcceleratorTopo.hpp"
 
 namespace geopm
 {
-    const AcceleratorTopo &accelerator_topo(void)
+    class LevelZeroDevicePool;
+
+    class LevelZeroAcceleratorTopo : public AcceleratorTopo
     {
-#ifdef GEOPM_ENABLE_NVML
-        static NVMLAcceleratorTopo instance;
-#elif defined(GEOPM_ENABLE_LEVELZERO)
-        static LevelZeroAcceleratorTopo instance;
-#else
-        static AcceleratorTopoNull instance;
-#endif
-        return instance;
-    }
+        public:
+            LevelZeroAcceleratorTopo();
+            LevelZeroAcceleratorTopo(const LevelZeroDevicePool &device_pool, const int num_cpu);
+            virtual ~LevelZeroAcceleratorTopo() = default;
+            virtual int num_accelerator(void) const override;
+            virtual std::set<int> cpu_affinity_ideal(int accel_idx) const override;
+        private:
+            const LevelZeroDevicePool &m_levelzero_device_pool;
+            std::vector<std::set<int> > m_cpu_affinity_ideal;
+            unsigned int m_num_accelerator;
+    };
 }
+#endif

--- a/src/LevelZeroAcceleratorTopo.hpp
+++ b/src/LevelZeroAcceleratorTopo.hpp
@@ -50,11 +50,15 @@ namespace geopm
             LevelZeroAcceleratorTopo(const LevelZeroDevicePool &device_pool, const int num_cpu);
             virtual ~LevelZeroAcceleratorTopo() = default;
             virtual int num_accelerator(void) const override;
+            virtual int num_accelerator_subdevice(void) const override;
             virtual std::set<int> cpu_affinity_ideal(int accel_idx) const override;
+            virtual std::set<int> cpu_affinity_ideal_subdevice(int accel_idx) const override;
         private:
             const LevelZeroDevicePool &m_levelzero_device_pool;
             std::vector<std::set<int> > m_cpu_affinity_ideal;
+            std::vector<std::set<int> > m_cpu_affinity_ideal_subdevice;
             unsigned int m_num_accelerator;
+            unsigned int m_num_accelerator_subdevice;
     };
 }
 #endif

--- a/src/LevelZeroDevicePool.cpp
+++ b/src/LevelZeroDevicePool.cpp
@@ -61,291 +61,8 @@ namespace geopm
 
     LevelZeroDevicePoolImp::LevelZeroDevicePoolImp(const int num_cpu)
         : M_NUM_CPU(num_cpu)
+        , m_shim(levelzero_shim(num_cpu))
     {
-        //TODO: change to a check and error if not enabled.  All ENV handling goes through environment class
-        char *zes_enable_sysman = getenv("ZES_ENABLE_SYSMAN");
-        if (zes_enable_sysman == NULL || strcmp(zes_enable_sysman, "1") != 0) {
-            std::cout << "GEOPM Debug: ZES_ENABLE_SYSMAN not set to 1.  Forcing to 1" << std::endl;
-            setenv("ZES_ENABLE_SYSMAN", "1", 1);
-        }
-
-        ze_result_t ze_result;
-        //Initialize
-        ze_result = zeInit(0);
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                        ": LevelZero Driver failed to initialize.", __LINE__);
-        // Discover drivers
-        ze_result = zeDriverGet(&m_num_driver, nullptr);
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                        ": LevelZero Driver enumeration failed.", __LINE__);
-        m_levelzero_driver.resize(m_num_driver);
-        ze_result = zeDriverGet(&m_num_driver, m_levelzero_driver.data());
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                        ": LevelZero Driver acquisition failed.", __LINE__);
-
-        for (unsigned int driver = 0; driver < m_num_driver; driver++) {
-            // Discover devices in a driver
-            uint32_t num_device = 0;
-
-            ze_result = zeDeviceGet(m_levelzero_driver.at(driver), &num_device, nullptr);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": LevelZero Device enumeration failed.", __LINE__);
-            std::vector<zes_device_handle_t> device_handle(num_device);
-            ze_result = zeDeviceGet(m_levelzero_driver.at(driver), &num_device, device_handle.data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": LevelZero Device acquisition failed.", __LINE__);
-
-            for(unsigned int dev_idx = 0; dev_idx < num_device; ++dev_idx) {
-                ze_device_properties_t property;
-                ze_result = zeDeviceGetProperties(device_handle.at(dev_idx), &property);
-
-#ifdef GEOPM_DEBUG
-                uint32_t num_sub_device = 0;
-
-                ze_result = zeDeviceGetSubDevices(device_handle.at(dev_idx), &num_sub_device, nullptr);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                                ": LevelZero Sub-Device enumeration failed.", __LINE__);
-                std::cout << "Debug: levelZero sub-devices: " << std::to_string(num_sub_device) << std::endl;
-#endif
-
-
-
-                if (property.type == ZE_DEVICE_TYPE_GPU) {
-                    if ((property.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED) == 0) {
-                        m_sysman_device.push_back(device_handle.at(dev_idx));
-                        ++m_num_board_gpu;
-                    }
-#ifdef GEOPM_DEBUG
-                    else {
-                        std::cerr << "Warning: <geopm> LevelZeroDevicePool: Integrated GPU access is not "
-                                     "currently supported by GEOPM.\n";
-                    }
-#endif
-                }
-#ifdef GEOPM_DEBUG
-                else if (property.type == ZE_DEVICE_TYPE_CPU) {
-                    // All CPU functionality is handled by GEOPM & MSR Safe currently
-                    std::cerr << "Warning: <geopm> LevelZeroDevicePool: CPU access via LevelZero is not "
-                                 "currently supported by GEOPM.\n";
-                }
-                else if (property.type == ZE_DEVICE_TYPE_FPGA) {
-                    // FPGA functionality is not currently supported by GEOPM, but should not cause
-                    // an error if the devices are present
-                    std::cerr << "Warning: <geopm> LevelZeroDevicePool: Field Programmable Gate Arrays are not "
-                                 "currently supported by GEOPM.\n";
-                }
-                else if (property.type == ZE_DEVICE_TYPE_MCA) {
-                    // MCA functionality is not currently supported by GEOPM, but should not cause
-                    // an error if the devices are present
-                    std::cerr << "Warning: <geopm> LevelZeroDevicePool: Memory Copy Accelerators are not "
-                                 "currently supported by GEOPM.\n";
-                }
-#endif
-            }
-            m_num_device = m_num_board_gpu + m_num_integrated_gpu + m_num_fpga + m_num_mca;
-
-            // This approach is far simpler, but does not allow for functioning in systems with multiple
-            // accelerator types but unsupported accel types OR split accel indexes (i.e. BOARD_ACCELERATOR
-            // vs PACKAGE_ACCELERATOR)
-            //m_sysman_device.insert(m_sysman_device.end(), device_handle.begin(), device_handle.end());
-            //m_num_device = m_num_device + num_device;
-        }
-
-        m_fan_domain.resize(m_num_device);
-        m_temperature_domain.resize(m_num_device);
-        m_fabric_domain.resize(m_num_device);
-        m_mem_domain.resize(m_num_device);
-        m_standby_domain.resize(m_num_device);
-        m_freq_domain.resize(m_num_device);
-        m_power_domain.resize(m_num_device);
-        m_engine_domain.resize(m_num_device);
-        m_perf_domain.resize(m_num_device);
-
-        // TODO: When additional device types such as FPGA, MCA, and Integrated GPU are supported by GEOPM
-        // This should be changed to a more general loop iterating over type and caching appropriately
-        for (unsigned int board_gpu_idx = 0; board_gpu_idx < m_num_board_gpu; board_gpu_idx++) {
-            ze_device_properties_t property;
-            ze_result = zeDeviceGetProperties(m_sysman_device.at(board_gpu_idx), &property);
-
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": failed to get device properties.", __LINE__);
-            domain_cache(board_gpu_idx);
-       }
-    }
-
-    void LevelZeroDevicePoolImp::domain_cache(unsigned int accel_idx) {
-        ze_result_t ze_result;
-        uint32_t num_domain = 0;
-
-        //Cache frequency domains
-        ze_result = zesDeviceEnumFrequencyDomains(m_sysman_device.at(accel_idx), &num_domain, nullptr);
-        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Frequency domain detection is "
-                         "not supported.\n";
-        }
-        else {
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains.", __LINE__);
-            m_freq_domain.at(accel_idx).resize(num_domain);
-
-            ze_result = zesDeviceEnumFrequencyDomains(m_sysman_device.at(accel_idx), &num_domain, m_freq_domain.at(accel_idx).data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                        ": Sysman failed to get domain handles.", __LINE__);
-#ifdef GEOPM_DEBUG
-            std::cout << "Debug: levelZero frequency domains: " << std::to_string(num_domain) << std::endl;
-#endif
-        }
-
-        //Cache power domains
-        num_domain = 0;
-        ze_result = zesDeviceEnumPowerDomains(m_sysman_device.at(accel_idx), &num_domain, nullptr);
-        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Power domain detection is "
-                         "not supported.\n";
-        }
-        else {
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-            m_power_domain.at(accel_idx).resize(num_domain);
-            ze_result = zesDeviceEnumPowerDomains(m_sysman_device.at(accel_idx), &num_domain, m_power_domain.at(accel_idx).data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain handle(s).", __LINE__);
-#ifdef GEOPM_DEBUG
-            std::cout << "Debug: levelZero power domains: " << std::to_string(num_domain) << std::endl;
-#endif
-        }
-
-        //Cache engine domains
-        num_domain = 0;
-        ze_result = zesDeviceEnumEngineGroups(m_sysman_device.at(accel_idx), &num_domain, nullptr);
-        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Engine domain detection is "
-                         "not supported.\n";
-        }
-        else {
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-            m_engine_domain.at(accel_idx).resize(num_domain);
-            ze_result = zesDeviceEnumEngineGroups(m_sysman_device.at(accel_idx), &num_domain, m_engine_domain.at(accel_idx).data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-#ifdef GEOPM_DEBUG
-            std::cout << "Debug: levelZero engine domains: " << std::to_string(num_domain) << std::endl;
-#endif
-        }
-
-        //Cache performance domains
-        num_domain = 0;
-        ze_result = zesDeviceEnumPerformanceFactorDomains(m_sysman_device.at(accel_idx), &num_domain, nullptr);
-        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Performance Factor domain detection is "
-                         "not supported.\n";
-        }
-        else {
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-            m_perf_domain.at(accel_idx).resize(num_domain);
-            ze_result = zesDeviceEnumPerformanceFactorDomains(m_sysman_device.at(accel_idx), &num_domain, m_perf_domain.at(accel_idx).data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-#ifdef GEOPM_DEBUG
-            std::cout << "Debug: levelZero performance factor domains: " << std::to_string(num_domain) << std::endl;
-#endif
-        }
-
-        //Standby domain signals
-        num_domain = 0;
-        ze_result = zesDeviceEnumStandbyDomains(m_sysman_device.at(accel_idx), &num_domain, nullptr);
-        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Standby domain detection is "
-                         "not supported.\n";
-        }
-        else {
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-            m_standby_domain.at(accel_idx).resize(num_domain);
-            ze_result = zesDeviceEnumStandbyDomains(m_sysman_device.at(accel_idx), &num_domain, m_standby_domain.at(accel_idx).data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-#ifdef GEOPM_DEBUG
-            std::cout << "Debug: levelZero standby domains: " << std::to_string(num_domain) << std::endl;
-#endif
-        }
-
-        //Memory domain signals
-        num_domain = 0;
-        ze_result = zesDeviceEnumMemoryModules(m_sysman_device.at(accel_idx), &num_domain, nullptr);
-        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Memory module detection is "
-                         "not supported.\n";
-        }
-        else {
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-            m_mem_domain.at(accel_idx).resize(num_domain);
-            ze_result = zesDeviceEnumMemoryModules(m_sysman_device.at(accel_idx), &num_domain, m_mem_domain.at(accel_idx).data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-#ifdef GEOPM_DEBUG
-            std::cout << "Debug: levelZero memory domains: " << std::to_string(num_domain) << std::endl;
-#endif
-        }
-
-        //Fabric domain signals
-        num_domain = 0;
-        ze_result = zesDeviceEnumFabricPorts(m_sysman_device.at(accel_idx), &num_domain, nullptr);
-        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Fabric port detection is not supported.\n";
-        }
-        else {
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-            m_fabric_domain.at(accel_idx).resize(num_domain);
-            ze_result = zesDeviceEnumFabricPorts(m_sysman_device.at(accel_idx), &num_domain, m_fabric_domain.at(accel_idx).data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-#ifdef GEOPM_DEBUG
-            std::cout << "Debug: levelZero fabric domains: " << std::to_string(num_domain) << std::endl;
-#endif
-        }
-
-        //Temperature domain signals
-        num_domain = 0;
-        ze_result = zesDeviceEnumTemperatureSensors(m_sysman_device.at(accel_idx), &num_domain, nullptr);
-        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Temperature sensor domain detection is "
-                         "not supported.\n";
-        }
-        else {
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-            m_temperature_domain.at(accel_idx).resize(num_domain);
-            ze_result = zesDeviceEnumTemperatureSensors(m_sysman_device.at(accel_idx), &num_domain, m_temperature_domain.at(accel_idx).data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-#ifdef GEOPM_DEBUG
-            std::cout << "Debug: levelZero temperature domains: " << std::to_string(num_domain) << std::endl;
-#endif
-        }
-
-        //Fan domain signals
-        num_domain = 0;
-        ze_result = zesDeviceEnumFans(m_sysman_device.at(accel_idx), &num_domain, nullptr);
-        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Fan detection is not supported.\n";
-        }
-        else {
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-            m_fan_domain.at(accel_idx).resize(num_domain);
-            ze_result = zesDeviceEnumFans(m_sysman_device.at(accel_idx), &num_domain, m_fan_domain.at(accel_idx).data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get number of domains", __LINE__);
-#ifdef GEOPM_DEBUG
-            std::cout << "Debug: levelZero fan domains: " << std::to_string(num_domain) << std::endl;
-#endif
-        }
-
     }
 
     LevelZeroDevicePoolImp::~LevelZeroDevicePoolImp()
@@ -354,28 +71,7 @@ namespace geopm
 
     int LevelZeroDevicePoolImp::num_accelerator() const
     {
-        return num_accelerator(ZE_DEVICE_TYPE_GPU);
-    }
-
-    int LevelZeroDevicePoolImp::num_accelerator(ze_device_type_t type) const
-    {
-        if (type == ZE_DEVICE_TYPE_GPU) {
-            // TODO: add Integrated vs Board nuance
-            return m_num_board_gpu;
-        }
-        else if (type == ZE_DEVICE_TYPE_CPU) {
-            return M_NUM_CPU;
-        }
-        else if (type == ZE_DEVICE_TYPE_FPGA) {
-            return m_num_fpga;
-        }
-        else if (type == ZE_DEVICE_TYPE_MCA) {
-            return m_num_mca;
-        }
-        else {
-            throw Exception("LevelZeroDevicePool::" + std::string(__func__) + ": accelerator type " +
-                            std::to_string(type) + "  is unsupported", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
+        return m_shim.num_accelerator();
     }
 
     void LevelZeroDevicePoolImp::check_accel_range(unsigned int accel_idx) const
@@ -387,458 +83,6 @@ namespace geopm
         }
     }
 
-    double LevelZeroDevicePoolImp::frequency_status_gpu(unsigned int accel_idx) const
-    {
-        return std::get<4>(frequency_status(accel_idx, ZES_FREQ_DOMAIN_GPU));
-    }
-
-    uint64_t LevelZeroDevicePoolImp::frequency_status_throttle_reason_gpu(unsigned int accel_idx) const
-    {
-        return std::get<5>(frequency_status(accel_idx, ZES_FREQ_DOMAIN_GPU));
-    }
-
-    double LevelZeroDevicePoolImp::frequency_status_mem(unsigned int accel_idx) const
-    {
-        return std::get<4>(frequency_status(accel_idx, ZES_FREQ_DOMAIN_MEMORY));
-    }
-
-    //TODO: provide frequency: efficient (analogous to sticker?), tdp, and t hrottle
-    //      see: https://spec.oneapi.com/level-zero/latest/sysman/api.html#_CPPv416zes_freq_state_t
-    //TODO: add zesFrequencyGetAvailableClocks for getting all available frequencies?
-    std::tuple<double, double, double, double, double, uint64_t> LevelZeroDevicePoolImp::frequency_status(unsigned int accel_idx, zes_freq_domain_t type) const
-    {
-        check_accel_range(accel_idx);
-        check_domain_range(m_freq_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-        double voltage = 0;
-        double request  = 0;
-        double tdp = 0;
-        double efficient = 0;
-        double actual = 0;
-        uint64_t throttle_reasons = 0;
-        double result_cnt = 0;
-
-        for (auto handle : m_freq_domain.at(accel_idx)) {
-            zes_freq_properties_t property;
-            ze_result = zesFrequencyGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain properties.", __LINE__);
-
-            if (type == property.type) {
-                zes_freq_state_t state;
-                ze_result = zesFrequencyGetState(handle, &state);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                                ": Sysman failed to get frequency state", __LINE__);
-                voltage += state.currentVoltage;
-                request += state.request;
-                tdp += state.tdp;
-                efficient += state.efficient;
-                actual += state.actual;
-                throttle_reasons |= state.throttleReasons;
-                ++result_cnt; //TODO: change for official multi-tile support
-            }
-        }
-
-        return std::make_tuple(voltage/result_cnt, request/result_cnt, tdp/result_cnt, efficient/result_cnt, actual/result_cnt, throttle_reasons);
-    }
-
-
-    double LevelZeroDevicePoolImp::frequency_min_gpu(unsigned int accel_idx) const
-    {
-        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_GPU).first;
-    }
-
-    double LevelZeroDevicePoolImp::frequency_max_gpu(unsigned int accel_idx) const
-    {
-        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_GPU).second;
-    }
-
-    double LevelZeroDevicePoolImp::frequency_min_mem(unsigned int accel_idx) const
-    {
-        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_MEMORY).first;
-    }
-
-    double LevelZeroDevicePoolImp::frequency_max_mem(unsigned int accel_idx) const
-    {
-        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_MEMORY).second;
-    }
-
-    std::pair<double, double> LevelZeroDevicePoolImp::frequency_min_max(unsigned int accel_idx, zes_freq_domain_t type) const
-    {
-        check_accel_range(accel_idx);
-        check_domain_range(m_freq_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-        double result_min = 0;
-        double result_max = 0;
-        double result_cnt = 0;
-
-        for (auto handle : m_freq_domain.at(accel_idx)) {
-            zes_freq_properties_t property;
-            ze_result = zesFrequencyGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain properties.", __LINE__);
-            if (type == property.type) {
-                result_min += property.min;
-                result_max += property.max;
-                ++result_cnt; //TODO: change for official multi-tile support
-            }
-        }
-
-        return {result_min/result_cnt, result_max/result_cnt};
-    }
-
-    double LevelZeroDevicePoolImp::frequency_range_min_gpu(unsigned int accel_idx) const
-    {
-        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_GPU).first;
-    }
-
-    double LevelZeroDevicePoolImp::frequency_range_max_gpu(unsigned int accel_idx) const
-    {
-        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_GPU).second;
-    }
-
-    std::pair<double, double> LevelZeroDevicePoolImp::frequency_range(unsigned int accel_idx, zes_freq_domain_t type) const
-    {
-        check_accel_range(accel_idx);
-        check_domain_range(m_freq_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-        zes_freq_range_t range;
-        double result_min = 0;
-        double result_max = 0;
-        double result_cnt = 0;
-
-        for (auto handle : m_freq_domain.at(accel_idx)) {
-            zes_freq_properties_t property;
-            ze_result = zesFrequencyGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain properties.", __LINE__);
-            if (type == property.type) {
-                ze_result = zesFrequencyGetRange(handle, &range);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                                ": Sysman failed to set frequency.", __LINE__);
-                result_min += range.min;
-                result_max += range.max;
-                ++result_cnt; //TODO: change for official multi-tile support
-            }
-        }
-
-        return {result_min/result_cnt, result_max/result_cnt};
-    }
-
-    uint64_t LevelZeroDevicePoolImp::frequency_throttle_time_gpu(unsigned int accel_idx) const
-    {
-        return frequency_throttle_time(accel_idx, ZES_FREQ_DOMAIN_GPU).first;
-    }
-
-    uint64_t LevelZeroDevicePoolImp::frequency_throttle_time_timestamp_gpu(unsigned int accel_idx) const
-    {
-        return frequency_throttle_time(accel_idx, ZES_FREQ_DOMAIN_GPU).second;
-    }
-
-    std::pair<uint64_t, uint64_t> LevelZeroDevicePoolImp::frequency_throttle_time(unsigned int accel_idx, zes_freq_domain_t type) const
-    {
-        check_accel_range(accel_idx);
-        check_domain_range(m_power_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-        uint64_t result_time = 0;
-        uint64_t result_timestamp = 0;
-
-        for (auto handle : m_freq_domain.at(accel_idx)) {
-            zes_freq_properties_t property;
-            ze_result = zesFrequencyGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain properties.", __LINE__);
-            if (type == property.type) {
-                zes_freq_throttle_time_t throttle_counter;
-                ze_result = zesFrequencyGetThrottleTime(handle,  &throttle_counter);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                                ": Sysman failed to get throttle reasons.", __LINE__);
-
-                result_time += throttle_counter.throttleTime;
-                result_timestamp += throttle_counter.timestamp;
-            }
-        }
-        return {result_time, result_timestamp};
-    }
-
-    double LevelZeroDevicePoolImp::temperature(unsigned int accel_idx) const
-    {
-        return temperature(accel_idx, ZES_TEMP_SENSORS_GLOBAL);
-    }
-
-    double LevelZeroDevicePoolImp::temperature_gpu(unsigned int accel_idx) const
-    {
-        return temperature(accel_idx, ZES_TEMP_SENSORS_GPU);
-    }
-
-    double LevelZeroDevicePoolImp::temperature_memory(unsigned int accel_idx) const
-    {
-        return temperature(accel_idx, ZES_TEMP_SENSORS_MEMORY);
-    }
-
-    double LevelZeroDevicePoolImp::temperature(int accel_idx, zes_temp_sensors_t sensor_type) const
-    {
-        check_accel_range(accel_idx);
-        check_domain_range(m_engine_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-        double result = 0;
-        double temp = 0;
-        double result_cnt = 0;
-        bool domain_match = false;
-
-        zes_temp_properties_t property;
-
-        //for each engine group
-        for (auto handle : m_temperature_domain.at(accel_idx)) {
-            ze_result = zesTemperatureGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get temperature sensor properties.", __LINE__);
-
-            if (sensor_type == property.type) {
-                domain_match = true;
-                ze_result = zesTemperatureGetState(handle, &temp);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                                ": Sysman failed to get temperature sensor reading.", __LINE__);
-                result += temp;
-                ++result_cnt; //TODO: change for official multi-tile support
-            }
-        }
-
-        if (!domain_match) {
-            result = NAN;
-        }
-
-        return result/result_cnt;
-    }
-
-    uint64_t LevelZeroDevicePoolImp::active_time_timestamp(unsigned int accel_idx) const
-    {
-        return active_time(accel_idx, ZES_ENGINE_GROUP_ALL).second;
-    }
-
-    uint64_t LevelZeroDevicePoolImp::active_time_timestamp_compute(unsigned int accel_idx) const
-    {
-        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_GROUP_COMPUTE_ALL)
-        return active_time(accel_idx, ZES_ENGINE_GROUP_COMPUTE_SINGLE).second;
-    }
-
-    uint64_t LevelZeroDevicePoolImp::active_time_timestamp_media_decode(unsigned int accel_idx) const
-    {
-        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_MEDIA_ALL);
-        return active_time(accel_idx, ZES_ENGINE_GROUP_MEDIA_DECODE_SINGLE).second;
-    }
-
-    uint64_t LevelZeroDevicePoolImp::active_time_timestamp_copy(unsigned int accel_idx) const
-    {
-        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_GROUP_COPY_ALL);
-        return active_time(accel_idx, ZES_ENGINE_GROUP_COPY_SINGLE).second;
-    }
-
-    uint64_t LevelZeroDevicePoolImp::active_time(unsigned int accel_idx) const
-    {
-        return active_time(accel_idx, ZES_ENGINE_GROUP_ALL).first;
-    }
-
-    uint64_t LevelZeroDevicePoolImp::active_time_compute(unsigned int accel_idx) const
-    {
-        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_GROUP_COMPUTE_ALL)
-        return active_time(accel_idx, ZES_ENGINE_GROUP_COMPUTE_SINGLE).first;
-    }
-
-    uint64_t LevelZeroDevicePoolImp::active_time_media_decode(unsigned int accel_idx) const
-    {
-        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_MEDIA_ALL);
-        return active_time(accel_idx, ZES_ENGINE_GROUP_MEDIA_DECODE_SINGLE).first;
-    }
-
-    uint64_t LevelZeroDevicePoolImp::active_time_copy(unsigned int accel_idx) const
-    {
-        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_GROUP_COPY_ALL);
-        return active_time(accel_idx, ZES_ENGINE_GROUP_COPY_SINGLE).first;
-    }
-
-    std::pair<uint64_t,uint64_t> LevelZeroDevicePoolImp::active_time(unsigned int accel_idx, zes_engine_group_t engine_type) const
-    {
-        check_accel_range(accel_idx);
-        check_domain_range(m_engine_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-        uint64_t result_active = 0;
-        uint64_t result_timestamp = 0;
-
-        zes_engine_properties_t property;
-        zes_engine_stats_t stats;
-
-        //for each engine group
-        for (auto handle : m_engine_domain.at(accel_idx)) {
-            ze_result = zesEngineGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get engine properties.", __LINE__);
-            if (engine_type == property.type) {
-                ze_result = zesEngineGetActivity(handle, &stats);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                                ": Sysman failed to get engine group activity.", __LINE__);
-                result_active += stats.activeTime;
-                result_timestamp += stats.timestamp;
-            }
-        }
-
-        return {result_active, result_timestamp};
-    }
-
-    int32_t LevelZeroDevicePoolImp::power_limit_min(unsigned int accel_idx) const
-    {
-        return std::get<0>(power_limit_default(accel_idx));
-    }
-
-    int32_t LevelZeroDevicePoolImp::power_limit_max(unsigned int accel_idx) const
-    {
-        return std::get<1>(power_limit_default(accel_idx));
-    }
-
-    int32_t LevelZeroDevicePoolImp::power_limit_tdp(unsigned int accel_idx) const
-    {
-        return std::get<2>(power_limit_default(accel_idx));
-    }
-
-    std::tuple<int32_t, int32_t, int32_t> LevelZeroDevicePoolImp::power_limit_default(unsigned int accel_idx) const
-    {
-        check_accel_range(accel_idx);
-        check_domain_range(m_power_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-
-        zes_power_properties_t property;
-        uint64_t tdp = 0;
-        uint64_t min_power_limit = 0;
-        uint64_t max_power_limit = 0;
-
-        for (auto handle : m_power_domain.at(accel_idx)) {
-            ze_result = zesPowerGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain power properties", __LINE__);
-
-            //For initial GEOPM support we're only providing device level power
-            //finding non-subdevice domain.
-            if (property.onSubdevice == 0) {
-                tdp = property.defaultLimit;
-                min_power_limit = property.minLimit;
-                max_power_limit = property.maxLimit;
-            }
-        }
-
-        return std::make_tuple(min_power_limit, max_power_limit, tdp);
-    }
-
-    int32_t LevelZeroDevicePoolImp::power_limit_peak_ac(unsigned int accel_idx) const
-    {
-        zes_power_peak_limit_t peak = {};
-        peak = std::get<2>(power_limit(accel_idx));
-        return peak.powerAC;
-    }
-
-    bool LevelZeroDevicePoolImp::power_limit_enabled_burst(unsigned int accel_idx) const
-    {
-        zes_power_burst_limit_t burst = {};
-        burst = std::get<1>(power_limit(accel_idx));
-        return (bool)burst.enabled;
-    }
-
-    int32_t LevelZeroDevicePoolImp::power_limit_burst(unsigned int accel_idx) const
-    {
-        zes_power_burst_limit_t burst = {};
-        burst = std::get<1>(power_limit(accel_idx));
-        return burst.power;
-    }
-
-    bool LevelZeroDevicePoolImp::power_limit_enabled_sustained(unsigned int accel_idx) const
-    {
-        zes_power_sustained_limit_t sustained = {};
-        sustained = std::get<0>(power_limit(accel_idx));
-        return (bool)sustained.enabled;
-    }
-
-    int32_t LevelZeroDevicePoolImp::power_limit_sustained(unsigned int accel_idx) const
-    {
-        zes_power_sustained_limit_t sustained = {};
-        sustained = std::get<0>(power_limit(accel_idx));
-        return sustained.power;
-    }
-
-    int32_t LevelZeroDevicePoolImp::power_limit_interval_sustained(unsigned int accel_idx) const
-    {
-        zes_power_sustained_limit_t sustained = {};
-        sustained = std::get<0>(power_limit(accel_idx));
-        return sustained.interval;
-    }
-
-    std::tuple<zes_power_sustained_limit_t, zes_power_burst_limit_t,
-               zes_power_peak_limit_t> LevelZeroDevicePoolImp::power_limit(unsigned int accel_idx) const
-    {
-        check_accel_range(accel_idx);
-        check_domain_range(m_power_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-
-        zes_power_sustained_limit_t sustained = {};
-        zes_power_burst_limit_t burst = {};
-        zes_power_peak_limit_t peak = {};
-
-        for (auto handle : m_power_domain.at(accel_idx)) {
-            zes_power_properties_t property;
-            ze_result = zesPowerGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain power properties", __LINE__);
-
-            //For initial GEOPM support we're only providing device level power
-            //finding non-subdevice domain.
-            if (property.onSubdevice == 0) {
-                ze_result = zesPowerGetLimits(handle, &sustained, &burst, &peak);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get power limits", __LINE__);
-            }
-        }
-
-        return std::make_tuple(sustained, burst, peak);
-    }
-
-    std::pair<uint64_t,uint64_t> LevelZeroDevicePoolImp::energy_pair(unsigned int accel_idx) const
-    {
-        check_accel_range(accel_idx);
-        check_domain_range(m_power_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-        uint64_t result_energy = 0;
-        uint64_t result_timestamp = 0;
-
-        for (auto handle : m_power_domain.at(accel_idx)) {
-            zes_power_energy_counter_t energy_counter;
-            zes_power_properties_t property;
-            ze_result = zesPowerGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain power properties", __LINE__);
-
-            //For initial GEOPM support we're only providing device level power
-            //finding non-subdevice domain.
-            if (property.onSubdevice == 0) {
-                ze_result = zesPowerGetEnergyCounter(handle, &energy_counter);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                                ": Sysman failed to get energy_counter values", __LINE__);
-                result_energy += energy_counter.energy;
-                result_timestamp += energy_counter.timestamp;
-            }
-        }
-        return {result_energy, result_timestamp};
-    }
-
-    uint64_t LevelZeroDevicePoolImp::energy_timestamp(unsigned int accel_idx) const
-    {
-        //TODO: for performance testing we may want to cache either the timestamp or the energy reading
-        return energy_pair(accel_idx).second;
-    }
-
-    uint64_t LevelZeroDevicePoolImp::energy(unsigned int accel_idx) const
-    {
-        //TODO: for performance testing we may want to cache either the timestamp or the energy reading
-        return energy_pair(accel_idx).first;
-    }
-
     void LevelZeroDevicePoolImp::check_domain_range(int size, const char *func, int line) const
     {
         if (size == 0) {
@@ -847,302 +91,159 @@ namespace geopm
         }
     }
 
-    double LevelZeroDevicePoolImp::performance_factor(unsigned int accel_idx) const
+    double LevelZeroDevicePoolImp::frequency_status(unsigned int accel_idx, geopm_levelzero_domain_e domain) const
     {
         check_accel_range(accel_idx);
-        check_domain_range(m_perf_domain.at(accel_idx).size(), __func__, __LINE__);
-
-        ze_result_t ze_result;
-        double performance_factor;
-        double result_cnt = 0;
-        double result = 0;
-
-        for (auto handle : m_perf_domain.at(accel_idx)) {
-            zes_perf_properties_t property;
-            ze_result = zesPerformanceFactorGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain performance factor properties",
-                                                             __LINE__);
-
-            // TODO: Additional splitting of performance factor into type based upon zes_engine_type_flags_t
-            // may be required
-            ze_result = zesPerformanceFactorGetConfig(handle, &performance_factor);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                          ": Sysman failed to get performance factor", __LINE__);
-            result += performance_factor;
-            ++result_cnt; //TODO: change for official multi-tile support
-        }
-
-        return result/result_cnt;
-    }
-
-    std::vector<uint32_t> LevelZeroDevicePoolImp::active_process_list(unsigned int accel_idx) const
-    {
-        check_accel_range(accel_idx);
-        ze_result_t ze_result;
-
-        uint32_t num_process = 0;
-        std::vector<zes_process_state_t> processes = {};
-        std::vector<unsigned int> result;
-
-        ze_result = zesDeviceProcessesGetState(m_sysman_device.at(accel_idx), &num_process, nullptr);
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                        ": Sysman failed to get running process count",
-                                                        __LINE__);
-
-        processes.resize(num_process);
-        ze_result = zesDeviceProcessesGetState(m_sysman_device.at(accel_idx), &num_process, processes.data());
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                        ": Sysman failed to get running processes",
-                                                        __LINE__);
-
-        result.resize(num_process);
-        for (uint32_t i = 0; i < num_process; i++) {
-            result.push_back(processes.at(i).processId);
-        }
-
-        return result;
-    }
-
-    double LevelZeroDevicePoolImp::standby_mode(unsigned int accel_idx) const
-    {
-        check_accel_range(accel_idx);
-        check_domain_range(m_standby_domain.at(accel_idx).size(), __func__, __LINE__);
-        zes_standby_promo_mode_t mode = {};
         double result = 0;
         double result_cnt = 0;
-
-        ze_result_t ze_result;
-        for (auto handle : m_standby_domain.at(accel_idx)) {
-            zes_standby_properties_t property;
-            ze_result = zesStandbyGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain standby properties",
-                                                             __LINE__);
-
-            ze_result = zesStandbyGetMode(handle, &mode);
-            result += mode;
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                          ": Sysman failed to get standby mode", __LINE__);
+        int domain_size = m_shim.frequency_domain_count(accel_idx, domain);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            result += m_shim.frequency_status(accel_idx, domain, domain_idx);
             ++result_cnt; //TODO: change for official multi-tile support
         }
         return result/result_cnt;
     }
 
-    double LevelZeroDevicePoolImp::memory_allocated(unsigned int accel_idx) const
+    double LevelZeroDevicePoolImp::frequency_min(unsigned int accel_idx, geopm_levelzero_domain_e domain) const
     {
         check_accel_range(accel_idx);
-        check_domain_range(m_mem_domain.at(accel_idx).size(), __func__, __LINE__);
-        double allocated_ratio = NAN;
+        double result = 0;
         double result_cnt = 0;
-
-        for (auto handle : m_mem_domain.at(accel_idx)) {
-            ze_result_t ze_result;
-            zes_mem_properties_t property;
-            zes_mem_state_t state = {};
-
-            ze_result = zesMemoryGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain memory properties",
-                                                             __LINE__);
-            //TODO: consider memory location (on device, in system)
-            ze_result = zesMemoryGetState(handle, &state);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                          ": Sysman failed to get memory allocated", __LINE__);
-
-            //TODO: Fix the assumption that there's only a single domain. For now we're assuming 1 or
-            //      taking the last domain basically...could be HBM, DDR3/4/5, LPDDR, SRAM, GRF, ...
-            allocated_ratio += (double)(state.size - state.free) / (double)state.size;
+        int domain_size = m_shim.frequency_domain_count(accel_idx, domain);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            result += m_shim.frequency_min(accel_idx, domain, domain_idx);
             ++result_cnt; //TODO: change for official multi-tile support
         }
-        return allocated_ratio/result_cnt;
+        return result/result_cnt;
     }
 
-    void LevelZeroDevicePoolImp::energy_threshold_control(unsigned int accel_idx, double setting) const
+    double LevelZeroDevicePoolImp::frequency_max(unsigned int accel_idx, geopm_levelzero_domain_e domain) const
     {
         check_accel_range(accel_idx);
-        check_domain_range(m_power_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-
-        for (auto handle : m_power_domain.at(accel_idx)) {
-            zes_power_properties_t property;
-            ze_result = zesPowerGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain power properties", __LINE__);
-            ze_result = zesPowerSetEnergyThreshold(handle, setting);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                        ": Sysman failed to set domain energy threshold", __LINE__);
+        double result = 0;
+        double result_cnt = 0;
+        int domain_size = m_shim.frequency_domain_count(accel_idx, domain);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            result += m_shim.frequency_max(accel_idx, domain, domain_idx);
+            ++result_cnt; //TODO: change for official multi-tile support
         }
+        return result/result_cnt;
     }
 
-
-    void LevelZeroDevicePoolImp::frequency_control_gpu(unsigned int accel_idx, double setting) const
-    {
-        frequency_control(accel_idx, setting, setting, ZES_FREQ_DOMAIN_GPU);
-    }
-
-    void LevelZeroDevicePoolImp::frequency_control(unsigned int accel_idx, double min_freq, double max_freq, zes_freq_domain_t type) const
+    uint64_t LevelZeroDevicePoolImp::active_time_timestamp(unsigned int accel_idx, geopm_levelzero_domain_e domain) const
     {
         check_accel_range(accel_idx);
-        check_domain_range(m_freq_domain.at(accel_idx).size(), __func__, __LINE__);
-        ze_result_t ze_result;
-
-        zes_freq_properties_t property;
-        zes_freq_range_t range;
-        range.min = min_freq;
-        range.max = max_freq;
-        //zes_freq_range_t range_check;
-
-        for (auto handle : m_freq_domain.at(accel_idx)) {
-            //zes_freq_properties_t properts = {ZES_STRUCTURE_TYPE_FREQ_PROPERTIES,
-            ze_result = zesFrequencyGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain properties.", __LINE__);
-
-            if (property.type == type) {
-                if (property.canControl == 0) {
-                    throw Exception("LevelZeroDevicePool::" + std::string(__func__) + ": Attempted to set frequency " +
-                                    "for non controllable domain",
-                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-                }
-                ze_result = zesFrequencySetRange(handle, &range);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                                ": Sysman failed to set frequency.", __LINE__);
-            }
+        double result = 0;
+        double result_cnt = 0;
+        int domain_size = m_shim.engine_domain_count(accel_idx, domain);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            result += m_shim.active_time_timestamp(accel_idx, domain, domain_idx);
+            ++result_cnt; //TODO: change for official multi-tile support
         }
+        return result/result_cnt;
     }
 
-    void LevelZeroDevicePoolImp::standby_mode_control(unsigned int accel_idx, double setting) const
+    uint64_t LevelZeroDevicePoolImp::active_time(unsigned int accel_idx, geopm_levelzero_domain_e domain) const
     {
         check_accel_range(accel_idx);
-        check_domain_range(m_standby_domain.at(accel_idx).size(), __func__, __LINE__);
-
-        ze_result_t ze_result;
-        for (auto handle : m_standby_domain.at(accel_idx)) {
-            zes_standby_properties_t property;
-            ze_result = zesStandbyGetProperties(handle, &property);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                            ": Sysman failed to get domain standby properties",
-                                                             __LINE__);
-
-            ze_result = zesStandbySetMode(handle, (zes_standby_promo_mode_t)setting);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
-                                                          ": Sysman failed to set standby mode", __LINE__);
+        double result = 0;
+        double result_cnt = 0;
+        int domain_size = m_shim.engine_domain_count(accel_idx, domain);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            result += m_shim.active_time(accel_idx, domain, domain_idx);
+            ++result_cnt; //TODO: change for official multi-tile support
         }
+        return result/result_cnt;
     }
 
-    void LevelZeroDevicePoolImp::check_ze_result(ze_result_t ze_result, int error, std::string message, int line) const
+    int32_t LevelZeroDevicePoolImp::power_limit_min(unsigned int accel_idx) const
     {
-        if(ze_result != ZE_RESULT_SUCCESS) {
-            std::string error_string = "Unknown ze_result_t value";
+        check_accel_range(accel_idx);
+        double result = 0;
+        double result_cnt = 0;
 
-            if (ze_result == ZE_RESULT_SUCCESS) {
-                error_string = "ZE_RESULT_SUCCESS";
-            }
-            else if (ze_result == ZE_RESULT_NOT_READY) {
-                error_string = "ZE_RESULT_NOT_READY";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_UNINITIALIZED) {
-                error_string = "ZE_RESULT_ERROR_UNINITIALIZED";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_DEVICE_LOST) {
-                error_string = "ZE_RESULT_ERROR_DEVICE_LOST";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_ARGUMENT) {
-                error_string = "ZE_RESULT_ERROR_INVALID_ARGUMENT";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY) {
-                error_string = "ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY) {
-                error_string = "ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_MODULE_BUILD_FAILURE) {
-                error_string = "ZE_RESULT_ERROR_MODULE_BUILD_FAILURE";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS) {
-                error_string = "ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_NOT_AVAILABLE) {
-                error_string = "ZE_RESULT_ERROR_NOT_AVAILABLE";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_VERSION) {
-                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_VERSION";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_FEATURE";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_NULL_HANDLE) {
-                error_string = "ZE_RESULT_ERROR_INVALID_NULL_HANDLE";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE) {
-                error_string = "ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_NULL_POINTER) {
-                error_string = "ZE_RESULT_ERROR_INVALID_NULL_POINTER";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_SIZE) {
-                error_string = "ZE_RESULT_ERROR_INVALID_SIZE";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_SIZE) {
-                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_SIZE";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT) {
-                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT) {
-                error_string = "ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_ENUMERATION) {
-                error_string = "ZE_RESULT_ERROR_INVALID_ENUMERATION";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_ENUMERATION) {
-                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_ENUMERATION";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT) {
-                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_NATIVE_BINARY) {
-                error_string = "ZE_RESULT_ERROR_INVALID_NATIVE_BINARY";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_GLOBAL_NAME) {
-                error_string = "ZE_RESULT_ERROR_INVALID_GLOBAL_NAME";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_NAME) {
-                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_NAME";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_FUNCTION_NAME) {
-                error_string = "ZE_RESULT_ERROR_INVALID_FUNCTION_NAME";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION) {
-                error_string = "ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION) {
-                error_string = "ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX) {
-                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE) {
-                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE) {
-                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE) {
-                error_string = "ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_OVERLAPPING_REGIONS) {
-                error_string = "ZE_RESULT_ERROR_OVERLAPPING_REGIONS";
-            }
-            else if (ze_result == ZE_RESULT_ERROR_UNKNOWN) {
-                error_string = "ZE_RESULT_ERROR_UNKNOWN";
-            }
-
-            throw Exception(message + "  Error: " + error_string, error, __FILE__, line);
+        int domain_size = m_shim.energy_domain_count_device(accel_idx);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            result += m_shim.power_limit_min(accel_idx, domain_idx);
+            ++result_cnt; //TODO: change for official multi-tile support
         }
+        return result/result_cnt;
     }
 
+    int32_t LevelZeroDevicePoolImp::power_limit_max(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        double result = 0;
+        double result_cnt = 0;
 
+        int domain_size = m_shim.energy_domain_count_device(accel_idx);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            result += m_shim.power_limit_max(accel_idx, domain_idx);
+            ++result_cnt; //TODO: change for official multi-tile support
+        }
+        return result/result_cnt;
+    }
+
+    int32_t LevelZeroDevicePoolImp::power_limit_tdp(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        double result = 0;
+        double result_cnt = 0;
+
+        int domain_size = m_shim.energy_domain_count_device(accel_idx);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            result += m_shim.power_limit_tdp(accel_idx, domain_idx);
+            ++result_cnt; //TODO: change for official multi-tile support
+        }
+        return result/result_cnt;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::energy_timestamp(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        double result = 0;
+        double result_cnt = 0;
+
+        int domain_size = m_shim.energy_domain_count_device(accel_idx);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            result += m_shim.energy_timestamp(accel_idx, domain_idx);
+            ++result_cnt; //TODO: change for official multi-tile support
+        }
+        return result/result_cnt;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::energy(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        double result = 0;
+        double result_cnt = 0;
+
+        int domain_size = m_shim.energy_domain_count_device(accel_idx);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            result += m_shim.energy(accel_idx, domain_idx);
+            ++result_cnt; //TODO: change for official multi-tile support
+        }
+        return result/result_cnt;
+    }
+
+    void LevelZeroDevicePoolImp::frequency_control(unsigned int accel_idx, geopm_levelzero_domain_e domain, double setting) const
+    {
+        check_accel_range(accel_idx);
+        int domain_size = m_shim.frequency_domain_count(accel_idx, domain);
+        check_domain_range(domain_size, __func__, __LINE__);
+        for (int domain_idx = 0; domain_idx < domain_size; domain_idx++){
+            m_shim.frequency_control(accel_idx, domain, domain_idx, setting);
+        }
+    }
 
 }

--- a/src/LevelZeroDevicePool.cpp
+++ b/src/LevelZeroDevicePool.cpp
@@ -1,0 +1,1148 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <cmath>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <thread>
+#include <chrono>
+#include <time.h>
+
+#include "Exception.hpp"
+#include "Agg.hpp"
+#include "Helper.hpp"
+#include "geopm_sched.h"
+
+#include "LevelZeroDevicePoolImp.hpp"
+
+namespace geopm
+{
+
+    const LevelZeroDevicePool &levelzero_device_pool(const int num_cpu)
+    {
+        static LevelZeroDevicePoolImp instance(num_cpu);
+        return instance;
+    }
+
+    LevelZeroDevicePoolImp::LevelZeroDevicePoolImp(const int num_cpu)
+        : M_NUM_CPU(num_cpu)
+    {
+        //TODO: change to a check and error if not enabled.  All ENV handling goes through environment class
+        char *zes_enable_sysman = getenv("ZES_ENABLE_SYSMAN");
+        if (zes_enable_sysman == NULL || strcmp(zes_enable_sysman, "1") != 0) {
+            std::cout << "GEOPM Debug: ZES_ENABLE_SYSMAN not set to 1.  Forcing to 1" << std::endl;
+            setenv("ZES_ENABLE_SYSMAN", "1", 1);
+        }
+
+        ze_result_t ze_result;
+        //Initialize
+        ze_result = zeInit(0);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                        ": LevelZero Driver failed to initialize.", __LINE__);
+        // Discover drivers
+        ze_result = zeDriverGet(&m_num_driver, nullptr);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                        ": LevelZero Driver enumeration failed.", __LINE__);
+        m_levelzero_driver.resize(m_num_driver);
+        ze_result = zeDriverGet(&m_num_driver, m_levelzero_driver.data());
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                        ": LevelZero Driver acquisition failed.", __LINE__);
+
+        for (unsigned int driver = 0; driver < m_num_driver; driver++) {
+            // Discover devices in a driver
+            uint32_t num_device = 0;
+
+            ze_result = zeDeviceGet(m_levelzero_driver.at(driver), &num_device, nullptr);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": LevelZero Device enumeration failed.", __LINE__);
+            std::vector<zes_device_handle_t> device_handle(num_device);
+            ze_result = zeDeviceGet(m_levelzero_driver.at(driver), &num_device, device_handle.data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": LevelZero Device acquisition failed.", __LINE__);
+
+            for(unsigned int dev_idx = 0; dev_idx < num_device; ++dev_idx) {
+                ze_device_properties_t property;
+                ze_result = zeDeviceGetProperties(device_handle.at(dev_idx), &property);
+
+#ifdef GEOPM_DEBUG
+                uint32_t num_sub_device = 0;
+
+                ze_result = zeDeviceGetSubDevices(device_handle.at(dev_idx), &num_sub_device, nullptr);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                                ": LevelZero Sub-Device enumeration failed.", __LINE__);
+                std::cout << "Debug: levelZero sub-devices: " << std::to_string(num_sub_device) << std::endl;
+#endif
+
+
+
+                if (property.type == ZE_DEVICE_TYPE_GPU) {
+                    if ((property.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED) == 0) {
+                        m_sysman_device.push_back(device_handle.at(dev_idx));
+                        ++m_num_board_gpu;
+                    }
+#ifdef GEOPM_DEBUG
+                    else {
+                        std::cerr << "Warning: <geopm> LevelZeroDevicePool: Integrated GPU access is not "
+                                     "currently supported by GEOPM.\n";
+                    }
+#endif
+                }
+#ifdef GEOPM_DEBUG
+                else if (property.type == ZE_DEVICE_TYPE_CPU) {
+                    // All CPU functionality is handled by GEOPM & MSR Safe currently
+                    std::cerr << "Warning: <geopm> LevelZeroDevicePool: CPU access via LevelZero is not "
+                                 "currently supported by GEOPM.\n";
+                }
+                else if (property.type == ZE_DEVICE_TYPE_FPGA) {
+                    // FPGA functionality is not currently supported by GEOPM, but should not cause
+                    // an error if the devices are present
+                    std::cerr << "Warning: <geopm> LevelZeroDevicePool: Field Programmable Gate Arrays are not "
+                                 "currently supported by GEOPM.\n";
+                }
+                else if (property.type == ZE_DEVICE_TYPE_MCA) {
+                    // MCA functionality is not currently supported by GEOPM, but should not cause
+                    // an error if the devices are present
+                    std::cerr << "Warning: <geopm> LevelZeroDevicePool: Memory Copy Accelerators are not "
+                                 "currently supported by GEOPM.\n";
+                }
+#endif
+            }
+            m_num_device = m_num_board_gpu + m_num_integrated_gpu + m_num_fpga + m_num_mca;
+
+            // This approach is far simpler, but does not allow for functioning in systems with multiple
+            // accelerator types but unsupported accel types OR split accel indexes (i.e. BOARD_ACCELERATOR
+            // vs PACKAGE_ACCELERATOR)
+            //m_sysman_device.insert(m_sysman_device.end(), device_handle.begin(), device_handle.end());
+            //m_num_device = m_num_device + num_device;
+        }
+
+        m_fan_domain.resize(m_num_device);
+        m_temperature_domain.resize(m_num_device);
+        m_fabric_domain.resize(m_num_device);
+        m_mem_domain.resize(m_num_device);
+        m_standby_domain.resize(m_num_device);
+        m_freq_domain.resize(m_num_device);
+        m_power_domain.resize(m_num_device);
+        m_engine_domain.resize(m_num_device);
+        m_perf_domain.resize(m_num_device);
+
+        // TODO: When additional device types such as FPGA, MCA, and Integrated GPU are supported by GEOPM
+        // This should be changed to a more general loop iterating over type and caching appropriately
+        for (unsigned int board_gpu_idx = 0; board_gpu_idx < m_num_board_gpu; board_gpu_idx++) {
+            ze_device_properties_t property;
+            ze_result = zeDeviceGetProperties(m_sysman_device.at(board_gpu_idx), &property);
+
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": failed to get device properties.", __LINE__);
+            domain_cache(board_gpu_idx);
+       }
+    }
+
+    void LevelZeroDevicePoolImp::domain_cache(unsigned int accel_idx) {
+        ze_result_t ze_result;
+        uint32_t num_domain = 0;
+
+        //Cache frequency domains
+        ze_result = zesDeviceEnumFrequencyDomains(m_sysman_device.at(accel_idx), &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Frequency domain detection is "
+                         "not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains.", __LINE__);
+            m_freq_domain.at(accel_idx).resize(num_domain);
+
+            ze_result = zesDeviceEnumFrequencyDomains(m_sysman_device.at(accel_idx), &num_domain, m_freq_domain.at(accel_idx).data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                        ": Sysman failed to get domain handles.", __LINE__);
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero frequency domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+        //Cache power domains
+        num_domain = 0;
+        ze_result = zesDeviceEnumPowerDomains(m_sysman_device.at(accel_idx), &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Power domain detection is "
+                         "not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+            m_power_domain.at(accel_idx).resize(num_domain);
+            ze_result = zesDeviceEnumPowerDomains(m_sysman_device.at(accel_idx), &num_domain, m_power_domain.at(accel_idx).data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain handle(s).", __LINE__);
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero power domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+        //Cache engine domains
+        num_domain = 0;
+        ze_result = zesDeviceEnumEngineGroups(m_sysman_device.at(accel_idx), &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Engine domain detection is "
+                         "not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+            m_engine_domain.at(accel_idx).resize(num_domain);
+            ze_result = zesDeviceEnumEngineGroups(m_sysman_device.at(accel_idx), &num_domain, m_engine_domain.at(accel_idx).data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero engine domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+        //Cache performance domains
+        num_domain = 0;
+        ze_result = zesDeviceEnumPerformanceFactorDomains(m_sysman_device.at(accel_idx), &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Performance Factor domain detection is "
+                         "not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+            m_perf_domain.at(accel_idx).resize(num_domain);
+            ze_result = zesDeviceEnumPerformanceFactorDomains(m_sysman_device.at(accel_idx), &num_domain, m_perf_domain.at(accel_idx).data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero performance factor domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+        //Standby domain signals
+        num_domain = 0;
+        ze_result = zesDeviceEnumStandbyDomains(m_sysman_device.at(accel_idx), &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Standby domain detection is "
+                         "not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+            m_standby_domain.at(accel_idx).resize(num_domain);
+            ze_result = zesDeviceEnumStandbyDomains(m_sysman_device.at(accel_idx), &num_domain, m_standby_domain.at(accel_idx).data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero standby domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+        //Memory domain signals
+        num_domain = 0;
+        ze_result = zesDeviceEnumMemoryModules(m_sysman_device.at(accel_idx), &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Memory module detection is "
+                         "not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+            m_mem_domain.at(accel_idx).resize(num_domain);
+            ze_result = zesDeviceEnumMemoryModules(m_sysman_device.at(accel_idx), &num_domain, m_mem_domain.at(accel_idx).data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero memory domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+        //Fabric domain signals
+        num_domain = 0;
+        ze_result = zesDeviceEnumFabricPorts(m_sysman_device.at(accel_idx), &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Fabric port detection is not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+            m_fabric_domain.at(accel_idx).resize(num_domain);
+            ze_result = zesDeviceEnumFabricPorts(m_sysman_device.at(accel_idx), &num_domain, m_fabric_domain.at(accel_idx).data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero fabric domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+        //Temperature domain signals
+        num_domain = 0;
+        ze_result = zesDeviceEnumTemperatureSensors(m_sysman_device.at(accel_idx), &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Temperature sensor domain detection is "
+                         "not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+            m_temperature_domain.at(accel_idx).resize(num_domain);
+            ze_result = zesDeviceEnumTemperatureSensors(m_sysman_device.at(accel_idx), &num_domain, m_temperature_domain.at(accel_idx).data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero temperature domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+        //Fan domain signals
+        num_domain = 0;
+        ze_result = zesDeviceEnumFans(m_sysman_device.at(accel_idx), &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroDevicePool: Fan detection is not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+            m_fan_domain.at(accel_idx).resize(num_domain);
+            ze_result = zesDeviceEnumFans(m_sysman_device.at(accel_idx), &num_domain, m_fan_domain.at(accel_idx).data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero fan domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+    }
+
+    LevelZeroDevicePoolImp::~LevelZeroDevicePoolImp()
+    {
+    }
+
+    int LevelZeroDevicePoolImp::num_accelerator() const
+    {
+        return num_accelerator(ZE_DEVICE_TYPE_GPU);
+    }
+
+    int LevelZeroDevicePoolImp::num_accelerator(ze_device_type_t type) const
+    {
+        if (type == ZE_DEVICE_TYPE_GPU) {
+            // TODO: add Integrated vs Board nuance
+            return m_num_board_gpu;
+        }
+        else if (type == ZE_DEVICE_TYPE_CPU) {
+            return M_NUM_CPU;
+        }
+        else if (type == ZE_DEVICE_TYPE_FPGA) {
+            return m_num_fpga;
+        }
+        else if (type == ZE_DEVICE_TYPE_MCA) {
+            return m_num_mca;
+        }
+        else {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) + ": accelerator type " +
+                            std::to_string(type) + "  is unsupported", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+
+    void LevelZeroDevicePoolImp::check_accel_range(unsigned int accel_idx) const
+    {
+        if (accel_idx >= (unsigned int) num_accelerator()) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) + ": accel_idx " +
+                            std::to_string(accel_idx) + "  is out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+
+    double LevelZeroDevicePoolImp::frequency_status_gpu(unsigned int accel_idx) const
+    {
+        return std::get<4>(frequency_status(accel_idx, ZES_FREQ_DOMAIN_GPU));
+    }
+
+    uint64_t LevelZeroDevicePoolImp::frequency_status_throttle_reason_gpu(unsigned int accel_idx) const
+    {
+        return std::get<5>(frequency_status(accel_idx, ZES_FREQ_DOMAIN_GPU));
+    }
+
+    double LevelZeroDevicePoolImp::frequency_status_mem(unsigned int accel_idx) const
+    {
+        return std::get<4>(frequency_status(accel_idx, ZES_FREQ_DOMAIN_MEMORY));
+    }
+
+    //TODO: provide frequency: efficient (analogous to sticker?), tdp, and t hrottle
+    //      see: https://spec.oneapi.com/level-zero/latest/sysman/api.html#_CPPv416zes_freq_state_t
+    //TODO: add zesFrequencyGetAvailableClocks for getting all available frequencies?
+    std::tuple<double, double, double, double, double, uint64_t> LevelZeroDevicePoolImp::frequency_status(unsigned int accel_idx, zes_freq_domain_t type) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_freq_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+        double voltage = 0;
+        double request  = 0;
+        double tdp = 0;
+        double efficient = 0;
+        double actual = 0;
+        uint64_t throttle_reasons = 0;
+        double result_cnt = 0;
+
+        for (auto handle : m_freq_domain.at(accel_idx)) {
+            zes_freq_properties_t property;
+            ze_result = zesFrequencyGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain properties.", __LINE__);
+
+            if (type == property.type) {
+                zes_freq_state_t state;
+                ze_result = zesFrequencyGetState(handle, &state);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                                ": Sysman failed to get frequency state", __LINE__);
+                voltage += state.currentVoltage;
+                request += state.request;
+                tdp += state.tdp;
+                efficient += state.efficient;
+                actual += state.actual;
+                throttle_reasons |= state.throttleReasons;
+                ++result_cnt; //TODO: change for official multi-tile support
+            }
+        }
+
+        return std::make_tuple(voltage/result_cnt, request/result_cnt, tdp/result_cnt, efficient/result_cnt, actual/result_cnt, throttle_reasons);
+    }
+
+
+    double LevelZeroDevicePoolImp::frequency_min_gpu(unsigned int accel_idx) const
+    {
+        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_GPU).first;
+    }
+
+    double LevelZeroDevicePoolImp::frequency_max_gpu(unsigned int accel_idx) const
+    {
+        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_GPU).second;
+    }
+
+    double LevelZeroDevicePoolImp::frequency_min_mem(unsigned int accel_idx) const
+    {
+        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_MEMORY).first;
+    }
+
+    double LevelZeroDevicePoolImp::frequency_max_mem(unsigned int accel_idx) const
+    {
+        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_MEMORY).second;
+    }
+
+    std::pair<double, double> LevelZeroDevicePoolImp::frequency_min_max(unsigned int accel_idx, zes_freq_domain_t type) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_freq_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+        double result_min = 0;
+        double result_max = 0;
+        double result_cnt = 0;
+
+        for (auto handle : m_freq_domain.at(accel_idx)) {
+            zes_freq_properties_t property;
+            ze_result = zesFrequencyGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain properties.", __LINE__);
+            if (type == property.type) {
+                result_min += property.min;
+                result_max += property.max;
+                ++result_cnt; //TODO: change for official multi-tile support
+            }
+        }
+
+        return {result_min/result_cnt, result_max/result_cnt};
+    }
+
+    double LevelZeroDevicePoolImp::frequency_range_min_gpu(unsigned int accel_idx) const
+    {
+        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_GPU).first;
+    }
+
+    double LevelZeroDevicePoolImp::frequency_range_max_gpu(unsigned int accel_idx) const
+    {
+        return frequency_min_max(accel_idx, ZES_FREQ_DOMAIN_GPU).second;
+    }
+
+    std::pair<double, double> LevelZeroDevicePoolImp::frequency_range(unsigned int accel_idx, zes_freq_domain_t type) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_freq_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+        zes_freq_range_t range;
+        double result_min = 0;
+        double result_max = 0;
+        double result_cnt = 0;
+
+        for (auto handle : m_freq_domain.at(accel_idx)) {
+            zes_freq_properties_t property;
+            ze_result = zesFrequencyGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain properties.", __LINE__);
+            if (type == property.type) {
+                ze_result = zesFrequencyGetRange(handle, &range);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                                ": Sysman failed to set frequency.", __LINE__);
+                result_min += range.min;
+                result_max += range.max;
+                ++result_cnt; //TODO: change for official multi-tile support
+            }
+        }
+
+        return {result_min/result_cnt, result_max/result_cnt};
+    }
+
+    uint64_t LevelZeroDevicePoolImp::frequency_throttle_time_gpu(unsigned int accel_idx) const
+    {
+        return frequency_throttle_time(accel_idx, ZES_FREQ_DOMAIN_GPU).first;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::frequency_throttle_time_timestamp_gpu(unsigned int accel_idx) const
+    {
+        return frequency_throttle_time(accel_idx, ZES_FREQ_DOMAIN_GPU).second;
+    }
+
+    std::pair<uint64_t, uint64_t> LevelZeroDevicePoolImp::frequency_throttle_time(unsigned int accel_idx, zes_freq_domain_t type) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_power_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+        uint64_t result_time = 0;
+        uint64_t result_timestamp = 0;
+
+        for (auto handle : m_freq_domain.at(accel_idx)) {
+            zes_freq_properties_t property;
+            ze_result = zesFrequencyGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain properties.", __LINE__);
+            if (type == property.type) {
+                zes_freq_throttle_time_t throttle_counter;
+                ze_result = zesFrequencyGetThrottleTime(handle,  &throttle_counter);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                                ": Sysman failed to get throttle reasons.", __LINE__);
+
+                result_time += throttle_counter.throttleTime;
+                result_timestamp += throttle_counter.timestamp;
+            }
+        }
+        return {result_time, result_timestamp};
+    }
+
+    double LevelZeroDevicePoolImp::temperature(unsigned int accel_idx) const
+    {
+        return temperature(accel_idx, ZES_TEMP_SENSORS_GLOBAL);
+    }
+
+    double LevelZeroDevicePoolImp::temperature_gpu(unsigned int accel_idx) const
+    {
+        return temperature(accel_idx, ZES_TEMP_SENSORS_GPU);
+    }
+
+    double LevelZeroDevicePoolImp::temperature_memory(unsigned int accel_idx) const
+    {
+        return temperature(accel_idx, ZES_TEMP_SENSORS_MEMORY);
+    }
+
+    double LevelZeroDevicePoolImp::temperature(int accel_idx, zes_temp_sensors_t sensor_type) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_engine_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+        double result = 0;
+        double temp = 0;
+        double result_cnt = 0;
+        bool domain_match = false;
+
+        zes_temp_properties_t property;
+
+        //for each engine group
+        for (auto handle : m_temperature_domain.at(accel_idx)) {
+            ze_result = zesTemperatureGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get temperature sensor properties.", __LINE__);
+
+            if (sensor_type == property.type) {
+                domain_match = true;
+                ze_result = zesTemperatureGetState(handle, &temp);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                                ": Sysman failed to get temperature sensor reading.", __LINE__);
+                result += temp;
+                ++result_cnt; //TODO: change for official multi-tile support
+            }
+        }
+
+        if (!domain_match) {
+            result = NAN;
+        }
+
+        return result/result_cnt;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::active_time_timestamp(unsigned int accel_idx) const
+    {
+        return active_time(accel_idx, ZES_ENGINE_GROUP_ALL).second;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::active_time_timestamp_compute(unsigned int accel_idx) const
+    {
+        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_GROUP_COMPUTE_ALL)
+        return active_time(accel_idx, ZES_ENGINE_GROUP_COMPUTE_SINGLE).second;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::active_time_timestamp_media_decode(unsigned int accel_idx) const
+    {
+        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_MEDIA_ALL);
+        return active_time(accel_idx, ZES_ENGINE_GROUP_MEDIA_DECODE_SINGLE).second;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::active_time_timestamp_copy(unsigned int accel_idx) const
+    {
+        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_GROUP_COPY_ALL);
+        return active_time(accel_idx, ZES_ENGINE_GROUP_COPY_SINGLE).second;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::active_time(unsigned int accel_idx) const
+    {
+        return active_time(accel_idx, ZES_ENGINE_GROUP_ALL).first;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::active_time_compute(unsigned int accel_idx) const
+    {
+        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_GROUP_COMPUTE_ALL)
+        return active_time(accel_idx, ZES_ENGINE_GROUP_COMPUTE_SINGLE).first;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::active_time_media_decode(unsigned int accel_idx) const
+    {
+        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_MEDIA_ALL);
+        return active_time(accel_idx, ZES_ENGINE_GROUP_MEDIA_DECODE_SINGLE).first;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::active_time_copy(unsigned int accel_idx) const
+    {
+        //TODO: transition to return active_time(accel_idx, ZES_ENGINE_GROUP_COPY_ALL);
+        return active_time(accel_idx, ZES_ENGINE_GROUP_COPY_SINGLE).first;
+    }
+
+    std::pair<uint64_t,uint64_t> LevelZeroDevicePoolImp::active_time(unsigned int accel_idx, zes_engine_group_t engine_type) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_engine_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+        uint64_t result_active = 0;
+        uint64_t result_timestamp = 0;
+
+        zes_engine_properties_t property;
+        zes_engine_stats_t stats;
+
+        //for each engine group
+        for (auto handle : m_engine_domain.at(accel_idx)) {
+            ze_result = zesEngineGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get engine properties.", __LINE__);
+            if (engine_type == property.type) {
+                ze_result = zesEngineGetActivity(handle, &stats);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                                ": Sysman failed to get engine group activity.", __LINE__);
+                result_active += stats.activeTime;
+                result_timestamp += stats.timestamp;
+            }
+        }
+
+        return {result_active, result_timestamp};
+    }
+
+    int32_t LevelZeroDevicePoolImp::power_limit_min(unsigned int accel_idx) const
+    {
+        return std::get<0>(power_limit_default(accel_idx));
+    }
+
+    int32_t LevelZeroDevicePoolImp::power_limit_max(unsigned int accel_idx) const
+    {
+        return std::get<1>(power_limit_default(accel_idx));
+    }
+
+    int32_t LevelZeroDevicePoolImp::power_limit_tdp(unsigned int accel_idx) const
+    {
+        return std::get<2>(power_limit_default(accel_idx));
+    }
+
+    std::tuple<int32_t, int32_t, int32_t> LevelZeroDevicePoolImp::power_limit_default(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_power_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+
+        zes_power_properties_t property;
+        uint64_t tdp = 0;
+        uint64_t min_power_limit = 0;
+        uint64_t max_power_limit = 0;
+
+        for (auto handle : m_power_domain.at(accel_idx)) {
+            ze_result = zesPowerGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain power properties", __LINE__);
+
+            //For initial GEOPM support we're only providing device level power
+            //finding non-subdevice domain.
+            if (property.onSubdevice == 0) {
+                tdp = property.defaultLimit;
+                min_power_limit = property.minLimit;
+                max_power_limit = property.maxLimit;
+            }
+        }
+
+        return std::make_tuple(min_power_limit, max_power_limit, tdp);
+    }
+
+    int32_t LevelZeroDevicePoolImp::power_limit_peak_ac(unsigned int accel_idx) const
+    {
+        zes_power_peak_limit_t peak = {};
+        peak = std::get<2>(power_limit(accel_idx));
+        return peak.powerAC;
+    }
+
+    bool LevelZeroDevicePoolImp::power_limit_enabled_burst(unsigned int accel_idx) const
+    {
+        zes_power_burst_limit_t burst = {};
+        burst = std::get<1>(power_limit(accel_idx));
+        return (bool)burst.enabled;
+    }
+
+    int32_t LevelZeroDevicePoolImp::power_limit_burst(unsigned int accel_idx) const
+    {
+        zes_power_burst_limit_t burst = {};
+        burst = std::get<1>(power_limit(accel_idx));
+        return burst.power;
+    }
+
+    bool LevelZeroDevicePoolImp::power_limit_enabled_sustained(unsigned int accel_idx) const
+    {
+        zes_power_sustained_limit_t sustained = {};
+        sustained = std::get<0>(power_limit(accel_idx));
+        return (bool)sustained.enabled;
+    }
+
+    int32_t LevelZeroDevicePoolImp::power_limit_sustained(unsigned int accel_idx) const
+    {
+        zes_power_sustained_limit_t sustained = {};
+        sustained = std::get<0>(power_limit(accel_idx));
+        return sustained.power;
+    }
+
+    int32_t LevelZeroDevicePoolImp::power_limit_interval_sustained(unsigned int accel_idx) const
+    {
+        zes_power_sustained_limit_t sustained = {};
+        sustained = std::get<0>(power_limit(accel_idx));
+        return sustained.interval;
+    }
+
+    std::tuple<zes_power_sustained_limit_t, zes_power_burst_limit_t,
+               zes_power_peak_limit_t> LevelZeroDevicePoolImp::power_limit(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_power_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+
+        zes_power_sustained_limit_t sustained = {};
+        zes_power_burst_limit_t burst = {};
+        zes_power_peak_limit_t peak = {};
+
+        for (auto handle : m_power_domain.at(accel_idx)) {
+            zes_power_properties_t property;
+            ze_result = zesPowerGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain power properties", __LINE__);
+
+            //For initial GEOPM support we're only providing device level power
+            //finding non-subdevice domain.
+            if (property.onSubdevice == 0) {
+                ze_result = zesPowerGetLimits(handle, &sustained, &burst, &peak);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get power limits", __LINE__);
+            }
+        }
+
+        return std::make_tuple(sustained, burst, peak);
+    }
+
+    std::pair<uint64_t,uint64_t> LevelZeroDevicePoolImp::energy_pair(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_power_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+        uint64_t result_energy = 0;
+        uint64_t result_timestamp = 0;
+
+        for (auto handle : m_power_domain.at(accel_idx)) {
+            zes_power_energy_counter_t energy_counter;
+            zes_power_properties_t property;
+            ze_result = zesPowerGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain power properties", __LINE__);
+
+            //For initial GEOPM support we're only providing device level power
+            //finding non-subdevice domain.
+            if (property.onSubdevice == 0) {
+                ze_result = zesPowerGetEnergyCounter(handle, &energy_counter);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                                ": Sysman failed to get energy_counter values", __LINE__);
+                result_energy += energy_counter.energy;
+                result_timestamp += energy_counter.timestamp;
+            }
+        }
+        return {result_energy, result_timestamp};
+    }
+
+    uint64_t LevelZeroDevicePoolImp::energy_timestamp(unsigned int accel_idx) const
+    {
+        //TODO: for performance testing we may want to cache either the timestamp or the energy reading
+        return energy_pair(accel_idx).second;
+    }
+
+    uint64_t LevelZeroDevicePoolImp::energy(unsigned int accel_idx) const
+    {
+        //TODO: for performance testing we may want to cache either the timestamp or the energy reading
+        return energy_pair(accel_idx).first;
+    }
+
+    void LevelZeroDevicePoolImp::check_domain_range(int size, const char *func, int line) const
+    {
+        if (size == 0) {
+            throw Exception("LevelZeroDevicePool::" + std::string(func) + ": Not supported on this hardware",
+                             GEOPM_ERROR_INVALID, __FILE__, line);
+        }
+    }
+
+    double LevelZeroDevicePoolImp::performance_factor(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_perf_domain.at(accel_idx).size(), __func__, __LINE__);
+
+        ze_result_t ze_result;
+        double performance_factor;
+        double result_cnt = 0;
+        double result = 0;
+
+        for (auto handle : m_perf_domain.at(accel_idx)) {
+            zes_perf_properties_t property;
+            ze_result = zesPerformanceFactorGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain performance factor properties",
+                                                             __LINE__);
+
+            // TODO: Additional splitting of performance factor into type based upon zes_engine_type_flags_t
+            // may be required
+            ze_result = zesPerformanceFactorGetConfig(handle, &performance_factor);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                          ": Sysman failed to get performance factor", __LINE__);
+            result += performance_factor;
+            ++result_cnt; //TODO: change for official multi-tile support
+        }
+
+        return result/result_cnt;
+    }
+
+    std::vector<uint32_t> LevelZeroDevicePoolImp::active_process_list(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        ze_result_t ze_result;
+
+        uint32_t num_process = 0;
+        std::vector<zes_process_state_t> processes = {};
+        std::vector<unsigned int> result;
+
+        ze_result = zesDeviceProcessesGetState(m_sysman_device.at(accel_idx), &num_process, nullptr);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                        ": Sysman failed to get running process count",
+                                                        __LINE__);
+
+        processes.resize(num_process);
+        ze_result = zesDeviceProcessesGetState(m_sysman_device.at(accel_idx), &num_process, processes.data());
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                        ": Sysman failed to get running processes",
+                                                        __LINE__);
+
+        result.resize(num_process);
+        for (uint32_t i = 0; i < num_process; i++) {
+            result.push_back(processes.at(i).processId);
+        }
+
+        return result;
+    }
+
+    double LevelZeroDevicePoolImp::standby_mode(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_standby_domain.at(accel_idx).size(), __func__, __LINE__);
+        zes_standby_promo_mode_t mode = {};
+        double result = 0;
+        double result_cnt = 0;
+
+        ze_result_t ze_result;
+        for (auto handle : m_standby_domain.at(accel_idx)) {
+            zes_standby_properties_t property;
+            ze_result = zesStandbyGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain standby properties",
+                                                             __LINE__);
+
+            ze_result = zesStandbyGetMode(handle, &mode);
+            result += mode;
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                          ": Sysman failed to get standby mode", __LINE__);
+            ++result_cnt; //TODO: change for official multi-tile support
+        }
+        return result/result_cnt;
+    }
+
+    double LevelZeroDevicePoolImp::memory_allocated(unsigned int accel_idx) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_mem_domain.at(accel_idx).size(), __func__, __LINE__);
+        double allocated_ratio = NAN;
+        double result_cnt = 0;
+
+        for (auto handle : m_mem_domain.at(accel_idx)) {
+            ze_result_t ze_result;
+            zes_mem_properties_t property;
+            zes_mem_state_t state = {};
+
+            ze_result = zesMemoryGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain memory properties",
+                                                             __LINE__);
+            //TODO: consider memory location (on device, in system)
+            ze_result = zesMemoryGetState(handle, &state);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                          ": Sysman failed to get memory allocated", __LINE__);
+
+            //TODO: Fix the assumption that there's only a single domain. For now we're assuming 1 or
+            //      taking the last domain basically...could be HBM, DDR3/4/5, LPDDR, SRAM, GRF, ...
+            allocated_ratio += (double)(state.size - state.free) / (double)state.size;
+            ++result_cnt; //TODO: change for official multi-tile support
+        }
+        return allocated_ratio/result_cnt;
+    }
+
+    void LevelZeroDevicePoolImp::energy_threshold_control(unsigned int accel_idx, double setting) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_power_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+
+        for (auto handle : m_power_domain.at(accel_idx)) {
+            zes_power_properties_t property;
+            ze_result = zesPowerGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain power properties", __LINE__);
+            ze_result = zesPowerSetEnergyThreshold(handle, setting);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                        ": Sysman failed to set domain energy threshold", __LINE__);
+        }
+    }
+
+
+    void LevelZeroDevicePoolImp::frequency_control_gpu(unsigned int accel_idx, double setting) const
+    {
+        frequency_control(accel_idx, setting, setting, ZES_FREQ_DOMAIN_GPU);
+    }
+
+    void LevelZeroDevicePoolImp::frequency_control(unsigned int accel_idx, double min_freq, double max_freq, zes_freq_domain_t type) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_freq_domain.at(accel_idx).size(), __func__, __LINE__);
+        ze_result_t ze_result;
+
+        zes_freq_properties_t property;
+        zes_freq_range_t range;
+        range.min = min_freq;
+        range.max = max_freq;
+        //zes_freq_range_t range_check;
+
+        for (auto handle : m_freq_domain.at(accel_idx)) {
+            //zes_freq_properties_t properts = {ZES_STRUCTURE_TYPE_FREQ_PROPERTIES,
+            ze_result = zesFrequencyGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain properties.", __LINE__);
+
+            if (property.type == type) {
+                if (property.canControl == 0) {
+                    throw Exception("LevelZeroDevicePool::" + std::string(__func__) + ": Attempted to set frequency " +
+                                    "for non controllable domain",
+                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                }
+                ze_result = zesFrequencySetRange(handle, &range);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                                ": Sysman failed to set frequency.", __LINE__);
+            }
+        }
+    }
+
+    void LevelZeroDevicePoolImp::standby_mode_control(unsigned int accel_idx, double setting) const
+    {
+        check_accel_range(accel_idx);
+        check_domain_range(m_standby_domain.at(accel_idx).size(), __func__, __LINE__);
+
+        ze_result_t ze_result;
+        for (auto handle : m_standby_domain.at(accel_idx)) {
+            zes_standby_properties_t property;
+            ze_result = zesStandbyGetProperties(handle, &property);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain standby properties",
+                                                             __LINE__);
+
+            ze_result = zesStandbySetMode(handle, (zes_standby_promo_mode_t)setting);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                          ": Sysman failed to set standby mode", __LINE__);
+        }
+    }
+
+    void LevelZeroDevicePoolImp::check_ze_result(ze_result_t ze_result, int error, std::string message, int line) const
+    {
+        if(ze_result != ZE_RESULT_SUCCESS) {
+            std::string error_string = "Unknown ze_result_t value";
+
+            if (ze_result == ZE_RESULT_SUCCESS) {
+                error_string = "ZE_RESULT_SUCCESS";
+            }
+            else if (ze_result == ZE_RESULT_NOT_READY) {
+                error_string = "ZE_RESULT_NOT_READY";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNINITIALIZED) {
+                error_string = "ZE_RESULT_ERROR_UNINITIALIZED";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_DEVICE_LOST) {
+                error_string = "ZE_RESULT_ERROR_DEVICE_LOST";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_ARGUMENT) {
+                error_string = "ZE_RESULT_ERROR_INVALID_ARGUMENT";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY) {
+                error_string = "ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY) {
+                error_string = "ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_MODULE_BUILD_FAILURE) {
+                error_string = "ZE_RESULT_ERROR_MODULE_BUILD_FAILURE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS) {
+                error_string = "ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_NOT_AVAILABLE) {
+                error_string = "ZE_RESULT_ERROR_NOT_AVAILABLE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_VERSION) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_VERSION";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_FEATURE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_NULL_HANDLE) {
+                error_string = "ZE_RESULT_ERROR_INVALID_NULL_HANDLE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE) {
+                error_string = "ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_NULL_POINTER) {
+                error_string = "ZE_RESULT_ERROR_INVALID_NULL_POINTER";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_SIZE) {
+                error_string = "ZE_RESULT_ERROR_INVALID_SIZE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_SIZE) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_SIZE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT) {
+                error_string = "ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_ENUMERATION) {
+                error_string = "ZE_RESULT_ERROR_INVALID_ENUMERATION";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_ENUMERATION) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_ENUMERATION";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_NATIVE_BINARY) {
+                error_string = "ZE_RESULT_ERROR_INVALID_NATIVE_BINARY";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_GLOBAL_NAME) {
+                error_string = "ZE_RESULT_ERROR_INVALID_GLOBAL_NAME";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_NAME) {
+                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_NAME";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_FUNCTION_NAME) {
+                error_string = "ZE_RESULT_ERROR_INVALID_FUNCTION_NAME";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION) {
+                error_string = "ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION) {
+                error_string = "ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX) {
+                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE) {
+                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE) {
+                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE) {
+                error_string = "ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_OVERLAPPING_REGIONS) {
+                error_string = "ZE_RESULT_ERROR_OVERLAPPING_REGIONS";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNKNOWN) {
+                error_string = "ZE_RESULT_ERROR_UNKNOWN";
+            }
+
+            throw Exception(message + "  Error: " + error_string, error, __FILE__, line);
+        }
+    }
+
+
+
+}

--- a/src/LevelZeroDevicePool.hpp
+++ b/src/LevelZeroDevicePool.hpp
@@ -50,79 +50,83 @@ namespace geopm
             /// @brief Number of accelerators on the platform.
             /// @return Number of LevelZero accelerators.
             virtual int num_accelerator(void) const = 0;
+            /// @brief Number of accelerator subdevices on the platform.
+            /// @return Number of LevelZero accelerator subdevices.
+            virtual int num_accelerator_subdevice(void) const = 0;
+
             /// @brief Get the LevelZero device actual frequency in MHz
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The LevelZero domain type being targeted
             /// @return Accelerator device core clock rate in MHz.
-            virtual double frequency_status(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual double frequency_status(unsigned int subdevice_idx, int l0_domain) const = 0;
             /// @brief Get the LevelZero device mininmum frequency in MHz
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The LevelZero domain type being targeted
             /// @return Accelerator minimum frequency in MHz.
-            virtual double frequency_min(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual double frequency_min(unsigned int subdevice_idx, int l0_domain) const = 0;
             /// @brief Get the LevelZero device maximum frequency in MHz
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The LevelZero domain type being targeted
             /// @return Accelerator maximum frequency in MHz.
-            virtual double frequency_max(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual double frequency_max(unsigned int subdevice_idx, int l0_domain) const = 0;
 
             /// @brief Get the LevelZero device active time in microseconds
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The LevelZero domain type being targeted
             /// @return Accelerator active time in microseconds.
-            virtual uint64_t active_time(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual uint64_t active_time(unsigned int subdevice_idx, int l0_domain) const = 0;
             /// @brief Get the LevelZero device timestamp for the active time value in microseconds
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The LevelZero domain type being targeted
             /// @return Accelerator device timestamp for the active time value in microseconds.
-            virtual uint64_t active_time_timestamp(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual uint64_t active_time_timestamp(unsigned int subdevice_idx, int l0_domain) const = 0;
 
             /// @brief Get the LevelZero device default power limit in milliwatts
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator default power limit in milliwatts
-            virtual int32_t power_limit_tdp(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_tdp(unsigned int idx) const = 0;
             /// @brief Get the LevelZero device minimum power limit in milliwatts
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain_idx The index indicating a particular
             ///        domain of the accelerator.
             /// @return Accelerator minimum power limit in milliwatts
-            virtual int32_t power_limit_min(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_min(unsigned int idx) const = 0;
             /// @brief Get the LevelZero device maximum power limit in milliwatts
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain_idx The index indicating a particular
             ///        domain of the accelerator.
             /// @return Accelerator maximum power limit in milliwatts
-            virtual int32_t power_limit_max(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_max(unsigned int idx) const = 0;
 
             /// @brief Get the LevelZero device energy in microjoules.
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator energy in microjoules.
-            virtual uint64_t energy(unsigned int accel_idx) const = 0;
+            virtual uint64_t energy(unsigned int idx) const = 0;
             /// @brief Get the LevelZero device energy timestamp in microseconds
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator energy timestamp in microseconds
-            virtual uint64_t energy_timestamp(unsigned int accel_idx) const = 0;
+            virtual uint64_t energy_timestamp(unsigned int idx) const = 0;
 
             /// @brief Set min and max frequency for LevelZero device.
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The LevelZero domain type being targeted
             /// @param [in] setting Target frequency in MHz.
-            virtual void frequency_control(unsigned int accel_idx, geopm_levelzero_domain_e domain, double setting) const = 0;
+            virtual void frequency_control(unsigned int idx, int l0_domain, double setting) const = 0;
 
         private:
     };
 
-    const LevelZeroDevicePool &levelzero_device_pool(int num_cpu);
+    const LevelZeroDevicePool &levelzero_device_pool();
 }
 #endif

--- a/src/LevelZeroDevicePool.hpp
+++ b/src/LevelZeroDevicePool.hpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LEVELZERODEVICEPOOL_HPP_INCLUDE
+#define LEVELZERODEVICEPOOL_HPP_INCLUDE
+
+#include <vector>
+#include <string>
+#include <cstdint>
+
+#include "geopm_sched.h"
+
+namespace geopm
+{
+
+    class LevelZeroDevicePool
+    {
+        public:
+            LevelZeroDevicePool() = default;
+            virtual ~LevelZeroDevicePool() = default;
+            /// @brief Number of accelerators on the platform.
+            /// @return Number of LevelZero accelerators.
+            virtual int num_accelerator(void) const = 0;
+            /// @brief Get the LevelZero device core clock rate
+            ///        in MHz.
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator.
+            /// @return Accelerator device core clock rate in MHz.
+            virtual double frequency_status_gpu(unsigned int accel_idx) const = 0;
+            virtual double frequency_status_mem(unsigned int accel_idx) const = 0;
+            virtual double frequency_min_gpu(unsigned int accel_idx) const = 0;
+            virtual double frequency_max_gpu(unsigned int accel_idx) const = 0;
+            virtual double frequency_min_mem(unsigned int accel_idx) const = 0;
+            virtual double frequency_max_mem(unsigned int accel_idx) const = 0;
+            virtual double frequency_range_min_gpu(unsigned int accel_idx) const = 0;
+            virtual double frequency_range_max_gpu(unsigned int accel_idx) const = 0;
+            virtual uint64_t frequency_status_throttle_reason_gpu(unsigned int accel_idx) const = 0;
+            virtual uint64_t frequency_throttle_time_gpu(unsigned int accel_idx) const = 0;
+            virtual uint64_t frequency_throttle_time_timestamp_gpu(unsigned int accel_idx) const = 0;
+
+            /// @brief Get the LevelZero device temperature.
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator.
+            /// @return temperature in degrees Celsius
+            virtual double temperature(unsigned int accel_idx) const = 0;
+            virtual double temperature_gpu(unsigned int accel_idx) const = 0;
+            virtual double temperature_memory(unsigned int accel_idx) const = 0;
+
+            virtual uint64_t active_time(unsigned int accel_idx) const = 0;
+            virtual uint64_t active_time_compute(unsigned int accel_idx) const = 0;
+            virtual uint64_t active_time_copy(unsigned int accel_idx) const = 0;
+            virtual uint64_t active_time_media_decode(unsigned int accel_idx) const = 0;
+            virtual uint64_t active_time_timestamp(unsigned int accel_idx) const = 0;
+            virtual uint64_t active_time_timestamp_compute(unsigned int accel_idx) const = 0;
+            virtual uint64_t active_time_timestamp_copy(unsigned int accel_idx) const = 0;
+            virtual uint64_t active_time_timestamp_media_decode(unsigned int accel_idx) const = 0;
+            /// @brief Get the LevelZero device power in Watts.
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator.
+            /// @return Accelerator power consumption in milliwatts.
+            virtual int32_t power_limit_tdp(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_min(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_max(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_sustained(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_interval_sustained(unsigned int accel_idx) const = 0;
+            virtual bool  power_limit_enabled_sustained(unsigned int accel_idx) const = 0;
+            virtual bool  power_limit_enabled_burst(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_burst(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_peak_ac(unsigned int accel_idx) const = 0;
+
+            /// @brief Get the LevelZero device energy in microjoules.
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator.
+            /// @return Accelerator power consumption in milliwatts.
+            virtual uint64_t energy (unsigned int accel_idx) const = 0;
+            virtual uint64_t energy_timestamp (unsigned int accel_idx) const = 0;
+            virtual double performance_factor(unsigned int accel_idx) const = 0;
+            virtual std::vector<uint32_t> active_process_list(unsigned int accel_idx) const = 0;
+            virtual double standby_mode(unsigned int accel_idx) const = 0;
+            virtual double memory_allocated(unsigned int accel_idx) const = 0;
+
+            /// @brief Set min and max frequency for LevelZero device.
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator.
+            /// @param [in] min_freq Target min frequency in MHz.
+            /// @param [in] max_freq Target max frequency in MHz.
+            virtual void energy_threshold_control(unsigned int accel_idx, double setting) const = 0;
+            virtual void frequency_control_gpu(unsigned int accel_idx, double setting) const = 0;
+            virtual void standby_mode_control(unsigned int accel_idx, double setting) const = 0;
+
+        private:
+    };
+
+    const LevelZeroDevicePool &levelzero_device_pool(int num_cpu);
+}
+#endif

--- a/src/LevelZeroDevicePoolImp.hpp
+++ b/src/LevelZeroDevicePoolImp.hpp
@@ -35,9 +35,6 @@
 
 #include <string>
 
-#include <level_zero/ze_api.h>
-#include <level_zero/zes_api.h>
-
 #include "LevelZeroDevicePool.hpp"
 #include "LevelZeroShim.hpp"
 
@@ -45,32 +42,35 @@
 
 namespace geopm
 {
-
     class LevelZeroDevicePoolImp : public LevelZeroDevicePool
     {
         public:
-            LevelZeroDevicePoolImp(const int num_cpu);
-            virtual ~LevelZeroDevicePoolImp();
+            LevelZeroDevicePoolImp();
+            LevelZeroDevicePoolImp(const LevelZeroShim &device_shim);
+            virtual ~LevelZeroDevicePoolImp() = default;
             virtual int num_accelerator(void) const override;
-            virtual double frequency_status(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
-            virtual double frequency_min(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
-            virtual double frequency_max(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
-            virtual uint64_t active_time(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
-            virtual uint64_t active_time_timestamp(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
-            virtual int32_t power_limit_tdp(unsigned int accel_idx) const override;
-            virtual int32_t power_limit_min(unsigned int accel_idx) const override;
-            virtual int32_t power_limit_max(unsigned int accel_idx) const override;
-            virtual uint64_t energy(unsigned int accel_idx) const override;
-            virtual uint64_t energy_timestamp(unsigned int accel_idx) const override;
+            virtual int num_accelerator_subdevice(void) const override;
 
-            virtual void frequency_control(unsigned int accel_idx, geopm_levelzero_domain_e domain, double setting) const override;
+            virtual double frequency_status(unsigned int subdevice_idx, int l0_domain) const override;
+            virtual double frequency_min(unsigned int subdevice_idx, int l0_domain) const override;
+            virtual double frequency_max(unsigned int subdevice_idx, int l0_domain) const override;
+            virtual uint64_t active_time(unsigned int device_idx, int l0_domain) const override;
+            virtual uint64_t active_time_timestamp(unsigned int device_idx, int l0_domain) const override;
+            virtual int32_t power_limit_tdp(unsigned int idx) const override;
+            virtual int32_t power_limit_min(unsigned int idx) const override;
+            virtual int32_t power_limit_max(unsigned int idx) const override;
+            virtual uint64_t energy(unsigned int idx) const override;
+            virtual uint64_t energy_timestamp(unsigned int idx) const override;
+
+            virtual void frequency_control(unsigned int subdevice_idx, int l0_domain, double setting) const override;
 
         private:
-            const unsigned int M_NUM_CPU;
             const LevelZeroShim &m_shim;
 
-            virtual void check_accel_range(unsigned int accel_idx) const;
-            virtual void check_domain_range(int size, const char *func, int line) const;
+            virtual void check_device_range(unsigned int dev_idx) const;
+            virtual void check_subdevice_range(unsigned int sub_idx) const;
+            virtual void check_domain_exists(int size, const char *func, int line) const;
+            virtual std::pair<unsigned int, unsigned int> subdevice_device_conversion(unsigned int idx) const;
     };
 }
 #endif

--- a/src/LevelZeroDevicePoolImp.hpp
+++ b/src/LevelZeroDevicePoolImp.hpp
@@ -39,6 +39,7 @@
 #include <level_zero/zes_api.h>
 
 #include "LevelZeroDevicePool.hpp"
+#include "LevelZeroShim.hpp"
 
 #include "geopm_time.h"
 
@@ -51,96 +52,25 @@ namespace geopm
             LevelZeroDevicePoolImp(const int num_cpu);
             virtual ~LevelZeroDevicePoolImp();
             virtual int num_accelerator(void) const override;
-            virtual double frequency_status_gpu(unsigned int accel_idx) const override;
-            virtual double frequency_status_mem(unsigned int accel_idx) const override;
-            virtual double frequency_min_gpu(unsigned int accel_idx) const override;
-            virtual double frequency_max_gpu(unsigned int accel_idx) const override;
-            virtual double frequency_min_mem(unsigned int accel_idx) const override;
-            virtual double frequency_max_mem(unsigned int accel_idx) const override;
-            virtual double frequency_range_min_gpu(unsigned int accel_idx) const override;
-            virtual double frequency_range_max_gpu(unsigned int accel_idx) const override;
-            virtual uint64_t frequency_status_throttle_reason_gpu(unsigned int accel_idx) const override;
-            virtual uint64_t frequency_throttle_time_gpu(unsigned int accel_idx) const override;
-            virtual uint64_t frequency_throttle_time_timestamp_gpu(unsigned int accel_idx) const override;
-            virtual double temperature(unsigned int accel_idx) const override;
-            virtual double temperature_gpu(unsigned int accel_idx) const override;
-            virtual double temperature_memory(unsigned int accel_idx) const override;
-            virtual uint64_t active_time(unsigned int accel_idx) const override;
-            virtual uint64_t active_time_compute(unsigned int accel_idx) const override;
-            virtual uint64_t active_time_copy(unsigned int accel_idx) const override;
-            virtual uint64_t active_time_media_decode(unsigned int accel_idx) const override;
-            virtual uint64_t active_time_timestamp(unsigned int accel_idx) const override;
-            virtual uint64_t active_time_timestamp_compute(unsigned int accel_idx) const override;
-            virtual uint64_t active_time_timestamp_copy(unsigned int accel_idx) const override;
-            virtual uint64_t active_time_timestamp_media_decode(unsigned int accel_idx) const override;
-
+            virtual double frequency_status(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
+            virtual double frequency_min(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
+            virtual double frequency_max(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
+            virtual uint64_t active_time(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
+            virtual uint64_t active_time_timestamp(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
             virtual int32_t power_limit_tdp(unsigned int accel_idx) const override;
             virtual int32_t power_limit_min(unsigned int accel_idx) const override;
             virtual int32_t power_limit_max(unsigned int accel_idx) const override;
-            virtual bool power_limit_enabled_sustained(unsigned int accel_idx) const override;
-            virtual bool power_limit_enabled_burst(unsigned int accel_idx) const override;
-            virtual int32_t power_limit_interval_sustained(unsigned int accel_idx) const override;
-            virtual int32_t power_limit_sustained(unsigned int accel_idx) const override;
-            virtual int32_t power_limit_burst(unsigned int accel_idx) const override;
-            virtual int32_t power_limit_peak_ac(unsigned int accel_idx) const override;
             virtual uint64_t energy(unsigned int accel_idx) const override;
             virtual uint64_t energy_timestamp(unsigned int accel_idx) const override;
-            virtual double performance_factor(unsigned int accel_idx) const override;
-            virtual std::vector<uint32_t> active_process_list(unsigned int accel_idx) const override;
-            virtual double standby_mode(unsigned int accel_idx) const override;
-            virtual double memory_allocated(unsigned int accel_idx) const override;
-            virtual void energy_threshold_control(unsigned int accel_idx, double setting) const override;
-            virtual void frequency_control_gpu(unsigned int accel_idx,  double setting) const override;
-            virtual void standby_mode_control(unsigned int accel_idx, double setting) const override;
+
+            virtual void frequency_control(unsigned int accel_idx, geopm_levelzero_domain_e domain, double setting) const override;
 
         private:
             const unsigned int M_NUM_CPU;
-            virtual void domain_cache(unsigned int accel_idx);
+            const LevelZeroShim &m_shim;
+
             virtual void check_accel_range(unsigned int accel_idx) const;
             virtual void check_domain_range(int size, const char *func, int line) const;
-            virtual void check_ze_result(ze_result_t ze_result, int error, std::string message, int line) const;
-            virtual int num_accelerator(ze_device_type_t type) const;
-
-            virtual std::tuple<zes_power_sustained_limit_t,
-                               zes_power_burst_limit_t,
-                               zes_power_peak_limit_t> power_limit(unsigned int accel_idx) const;
-
-            virtual std::tuple<int32_t, int32_t, int32_t> power_limit_default(unsigned int accel_idx) const;
-            virtual std::tuple<double, double, double, double, double, uint64_t> frequency_status(unsigned int accel_idx, zes_freq_domain_t) const;
-            virtual std::pair<double, double> frequency_min_max(unsigned int accel_idx, zes_freq_domain_t type) const;
-            virtual std::pair<double, double> frequency_range(unsigned int accel_idx, zes_freq_domain_t type) const;
-            virtual std::pair<uint64_t, uint64_t> frequency_throttle_time(unsigned int accel_idx, zes_freq_domain_t type) const;
-            virtual std::pair<uint64_t, uint64_t> energy_pair(unsigned int accel_idx) const;
-            virtual std::pair<uint64_t, uint64_t> active_time(unsigned int accel_idx, zes_engine_group_t engine_type) const;
-            virtual double temperature(int accel_idx, zes_temp_sensors_t sensor_type) const;
-            virtual void frequency_control(unsigned int accel_idx, double min_freq, double max_freq, zes_freq_domain_t) const;
-
-            std::string ze_error_string(ze_result_t result);
-
-            uint32_t m_num_driver;
-            uint32_t m_num_device;
-            uint32_t m_num_integrated_gpu;
-            uint32_t m_num_board_gpu;
-            uint32_t m_num_fpga;
-            uint32_t m_num_mca;
-
-            std::vector<ze_driver_handle_t> m_levelzero_driver;
-            // TODO: This will need to be a map or vector of vectors if we're supporting multiple
-            //       types of sysman devices such as <BOARD GPU devices, PACKAGE GPU device, FPGA device>
-            std::vector<zes_device_handle_t> m_sysman_device;
-
-            // TODO: These will need to be something like a map of vector of vectors if we're supporting multiple
-            //       types of sysman devices such as <Temperature<device<Board GPU, Package GPU, FPGA>>>
-            std::vector<std::vector<zes_freq_handle_t> > m_freq_domain;
-            std::vector<std::vector<zes_pwr_handle_t> > m_power_domain;
-            std::vector<std::vector<zes_engine_handle_t> > m_engine_domain;
-            std::vector<std::vector<zes_perf_handle_t> > m_perf_domain;
-            std::vector<std::vector<zes_standby_handle_t> > m_standby_domain;
-            std::vector<std::vector<zes_mem_handle_t> > m_mem_domain;
-            std::vector<std::vector<zes_fabric_port_handle_t> > m_fabric_domain;
-            std::vector<std::vector<zes_temp_handle_t> > m_temperature_domain;
-            std::vector<std::vector<zes_fan_handle_t> > m_fan_domain;
-
     };
 }
 #endif

--- a/src/LevelZeroDevicePoolImp.hpp
+++ b/src/LevelZeroDevicePoolImp.hpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LEVELZERODEVICEPOOLIMP_HPP_INCLUDE
+#define LEVELZERODEVICEPOOLIMP_HPP_INCLUDE
+
+#include <string>
+
+#include <level_zero/ze_api.h>
+#include <level_zero/zes_api.h>
+
+#include "LevelZeroDevicePool.hpp"
+
+#include "geopm_time.h"
+
+namespace geopm
+{
+
+    class LevelZeroDevicePoolImp : public LevelZeroDevicePool
+    {
+        public:
+            LevelZeroDevicePoolImp(const int num_cpu);
+            virtual ~LevelZeroDevicePoolImp();
+            virtual int num_accelerator(void) const override;
+            virtual double frequency_status_gpu(unsigned int accel_idx) const override;
+            virtual double frequency_status_mem(unsigned int accel_idx) const override;
+            virtual double frequency_min_gpu(unsigned int accel_idx) const override;
+            virtual double frequency_max_gpu(unsigned int accel_idx) const override;
+            virtual double frequency_min_mem(unsigned int accel_idx) const override;
+            virtual double frequency_max_mem(unsigned int accel_idx) const override;
+            virtual double frequency_range_min_gpu(unsigned int accel_idx) const override;
+            virtual double frequency_range_max_gpu(unsigned int accel_idx) const override;
+            virtual uint64_t frequency_status_throttle_reason_gpu(unsigned int accel_idx) const override;
+            virtual uint64_t frequency_throttle_time_gpu(unsigned int accel_idx) const override;
+            virtual uint64_t frequency_throttle_time_timestamp_gpu(unsigned int accel_idx) const override;
+            virtual double temperature(unsigned int accel_idx) const override;
+            virtual double temperature_gpu(unsigned int accel_idx) const override;
+            virtual double temperature_memory(unsigned int accel_idx) const override;
+            virtual uint64_t active_time(unsigned int accel_idx) const override;
+            virtual uint64_t active_time_compute(unsigned int accel_idx) const override;
+            virtual uint64_t active_time_copy(unsigned int accel_idx) const override;
+            virtual uint64_t active_time_media_decode(unsigned int accel_idx) const override;
+            virtual uint64_t active_time_timestamp(unsigned int accel_idx) const override;
+            virtual uint64_t active_time_timestamp_compute(unsigned int accel_idx) const override;
+            virtual uint64_t active_time_timestamp_copy(unsigned int accel_idx) const override;
+            virtual uint64_t active_time_timestamp_media_decode(unsigned int accel_idx) const override;
+
+            virtual int32_t power_limit_tdp(unsigned int accel_idx) const override;
+            virtual int32_t power_limit_min(unsigned int accel_idx) const override;
+            virtual int32_t power_limit_max(unsigned int accel_idx) const override;
+            virtual bool power_limit_enabled_sustained(unsigned int accel_idx) const override;
+            virtual bool power_limit_enabled_burst(unsigned int accel_idx) const override;
+            virtual int32_t power_limit_interval_sustained(unsigned int accel_idx) const override;
+            virtual int32_t power_limit_sustained(unsigned int accel_idx) const override;
+            virtual int32_t power_limit_burst(unsigned int accel_idx) const override;
+            virtual int32_t power_limit_peak_ac(unsigned int accel_idx) const override;
+            virtual uint64_t energy(unsigned int accel_idx) const override;
+            virtual uint64_t energy_timestamp(unsigned int accel_idx) const override;
+            virtual double performance_factor(unsigned int accel_idx) const override;
+            virtual std::vector<uint32_t> active_process_list(unsigned int accel_idx) const override;
+            virtual double standby_mode(unsigned int accel_idx) const override;
+            virtual double memory_allocated(unsigned int accel_idx) const override;
+            virtual void energy_threshold_control(unsigned int accel_idx, double setting) const override;
+            virtual void frequency_control_gpu(unsigned int accel_idx,  double setting) const override;
+            virtual void standby_mode_control(unsigned int accel_idx, double setting) const override;
+
+        private:
+            const unsigned int M_NUM_CPU;
+            virtual void domain_cache(unsigned int accel_idx);
+            virtual void check_accel_range(unsigned int accel_idx) const;
+            virtual void check_domain_range(int size, const char *func, int line) const;
+            virtual void check_ze_result(ze_result_t ze_result, int error, std::string message, int line) const;
+            virtual int num_accelerator(ze_device_type_t type) const;
+
+            virtual std::tuple<zes_power_sustained_limit_t,
+                               zes_power_burst_limit_t,
+                               zes_power_peak_limit_t> power_limit(unsigned int accel_idx) const;
+
+            virtual std::tuple<int32_t, int32_t, int32_t> power_limit_default(unsigned int accel_idx) const;
+            virtual std::tuple<double, double, double, double, double, uint64_t> frequency_status(unsigned int accel_idx, zes_freq_domain_t) const;
+            virtual std::pair<double, double> frequency_min_max(unsigned int accel_idx, zes_freq_domain_t type) const;
+            virtual std::pair<double, double> frequency_range(unsigned int accel_idx, zes_freq_domain_t type) const;
+            virtual std::pair<uint64_t, uint64_t> frequency_throttle_time(unsigned int accel_idx, zes_freq_domain_t type) const;
+            virtual std::pair<uint64_t, uint64_t> energy_pair(unsigned int accel_idx) const;
+            virtual std::pair<uint64_t, uint64_t> active_time(unsigned int accel_idx, zes_engine_group_t engine_type) const;
+            virtual double temperature(int accel_idx, zes_temp_sensors_t sensor_type) const;
+            virtual void frequency_control(unsigned int accel_idx, double min_freq, double max_freq, zes_freq_domain_t) const;
+
+            std::string ze_error_string(ze_result_t result);
+
+            uint32_t m_num_driver;
+            uint32_t m_num_device;
+            uint32_t m_num_integrated_gpu;
+            uint32_t m_num_board_gpu;
+            uint32_t m_num_fpga;
+            uint32_t m_num_mca;
+
+            std::vector<ze_driver_handle_t> m_levelzero_driver;
+            // TODO: This will need to be a map or vector of vectors if we're supporting multiple
+            //       types of sysman devices such as <BOARD GPU devices, PACKAGE GPU device, FPGA device>
+            std::vector<zes_device_handle_t> m_sysman_device;
+
+            // TODO: These will need to be something like a map of vector of vectors if we're supporting multiple
+            //       types of sysman devices such as <Temperature<device<Board GPU, Package GPU, FPGA>>>
+            std::vector<std::vector<zes_freq_handle_t> > m_freq_domain;
+            std::vector<std::vector<zes_pwr_handle_t> > m_power_domain;
+            std::vector<std::vector<zes_engine_handle_t> > m_engine_domain;
+            std::vector<std::vector<zes_perf_handle_t> > m_perf_domain;
+            std::vector<std::vector<zes_standby_handle_t> > m_standby_domain;
+            std::vector<std::vector<zes_mem_handle_t> > m_mem_domain;
+            std::vector<std::vector<zes_fabric_port_handle_t> > m_fabric_domain;
+            std::vector<std::vector<zes_temp_handle_t> > m_temperature_domain;
+            std::vector<std::vector<zes_fan_handle_t> > m_fan_domain;
+
+    };
+}
+#endif

--- a/src/LevelZeroDevicePoolThrow.cpp
+++ b/src/LevelZeroDevicePoolThrow.cpp
@@ -32,31 +32,28 @@
 
 #include "config.h"
 
+#include <cmath>
+
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
 
 #include "Exception.hpp"
-#include "AcceleratorTopoNull.hpp"
+#include "Agg.hpp"
+#include "Helper.hpp"
+#include "geopm_sched.h"
 
-#ifdef GEOPM_ENABLE_NVML
-#include "NVMLAcceleratorTopo.hpp"
-#elif defined(GEOPM_ENABLE_LEVELZERO)
-#include "LevelZeroAcceleratorTopo.hpp"
-#endif
+#include "LevelZeroDevicePool.hpp"
 
 namespace geopm
 {
-    const AcceleratorTopo &accelerator_topo(void)
+
+    const LevelZeroDevicePool &levelzero_device_pool(const int num_cpu)
     {
-#ifdef GEOPM_ENABLE_NVML
-        static NVMLAcceleratorTopo instance;
-#elif defined(GEOPM_ENABLE_LEVELZERO)
-        static LevelZeroAcceleratorTopo instance;
-#else
-        static AcceleratorTopoNull instance;
-#endif
-        return instance;
+        throw Exception("LevelZeroDevicePoolThrow::" + std::string(__func__) +
+                        ": GEOPM configured without Level Zero library support.  Please configure with --enable-levelzero",
+                        GEOPM_ERROR_INVALID, __FILE__, __LINE__);
     }
+
 }

--- a/src/LevelZeroIOGroup.cpp
+++ b/src/LevelZeroIOGroup.cpp
@@ -1,0 +1,1015 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "LevelZeroIOGroup.hpp"
+
+#include <cmath>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <numeric>
+#include <sched.h>
+#include <errno.h>
+
+#include "IOGroup.hpp"
+#include "Signal.hpp"
+#include "DerivativeSignal.hpp"
+#include "PlatformTopo.hpp"
+#include "LevelZeroDevicePool.hpp"
+#include "Exception.hpp"
+#include "Agg.hpp"
+#include "Helper.hpp"
+#include "geopm_debug.hpp"
+
+namespace geopm
+{
+
+    LevelZeroIOGroup::LevelZeroIOGroup()
+        : LevelZeroIOGroup(platform_topo(), levelzero_device_pool(platform_topo().num_domain(GEOPM_DOMAIN_CPU)))
+    {
+    }
+
+    // Set up mapping between signal and control names and corresponding indices
+    LevelZeroIOGroup::LevelZeroIOGroup(const PlatformTopo &platform_topo, const LevelZeroDevicePool &device_pool)
+        : m_platform_topo(platform_topo)
+        , m_levelzero_device_pool(device_pool)
+        , m_is_batch_read(false)
+        , m_signal_available({{"LEVELZERO::FREQUENCY_GPU", {
+                                  "Accelerator compute/GPU domain frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_status_gpu(domain_idx);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_MAX_GPU", {
+                                  "Accelerator compute/GPU domain maximum frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_max_gpu(domain_idx);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_MIN_GPU", {
+                                  "Accelerator compute/GPU domain minimum frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_min_gpu(domain_idx);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::ENERGY", {
+                                  "Accelerator energy in Joules",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.energy(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::ENERGY_TIMESTAMP", {
+                                  "Accelerator energy timestamp in seconds",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.energy_timestamp(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_RANGE_MIN_GPU_CONTROL", {
+                                  "Accelerator compute/GPU domain user specified min frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_range_min_gpu(domain_idx);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_RANGE_MAX_GPU_CONTROL", {
+                                  "Accelerator compute/GPU domain user specified max frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_range_max_gpu(domain_idx);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_MEMORY", {
+                                  "Accelerator memory domain frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_status_mem(domain_idx);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_MAX_MEMORY", {
+                                  "Accelerator memory domain maximum frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_max_mem(domain_idx);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_MIN_MEMORY", {
+                                  "Accelerator memory domain minimum frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_min_mem(domain_idx);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::MEMORY_ALLOCATED", {
+                                  "Memory usage as a ratio of total memory",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.memory_allocated(domain_idx);
+                                  },
+                                  1
+                                  }},
+                              {"LEVELZERO::TEMPERATURE", {
+                                  "Device Temperature in Celsius",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.temperature(domain_idx);
+                                  },
+                                  1
+                                  }},
+                              {"LEVELZERO::TEMPERATURE_GPU", {
+                                  "Device GPU Temperature in Celsius",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.temperature_gpu(domain_idx);
+                                  },
+                                  1
+                                  }},
+                              {"LEVELZERO::TEMPERATURE_MEMORY", {
+                                  "Device Memory Temperature in Celsius",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.temperature_memory(domain_idx);
+                                  },
+                                  1
+                                  }},
+                              {"LEVELZERO::STANDBY_MODE", {
+                                  "Accelerator Standby Mode."
+                                  "\n  0 indicates the device may go into standby"
+                                  "\n  1 indicates the device will never go into standby",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.standby_mode(domain_idx);
+                                  },
+                                  1
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_ENABLED_SUSTAINED", {
+                                  "Accelerator sustained power limit enable value",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_enabled_sustained(domain_idx);
+                                  },
+                                  1
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_SUSTAINED", {
+                                  "Accelerator sustained power limit in Watts",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_sustained(domain_idx);
+                                  },
+                                  1/1e3
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_INTERVAL_SUSTAINED", {
+                                  "Accelerator sustained power limit interval in seconds",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_interval_sustained(domain_idx);
+                                  },
+                                  1/1e3
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_BURST", {
+                                  "Accelerator burst power limit in Watts",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_burst(domain_idx);
+                                  },
+                                  1/1e3
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_ENABLED_BURST", {
+                                  "Accelerator burst power limit enable value",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_enabled_burst(domain_idx);
+                                  },
+                                  1
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_PEAK_AC", {
+                                  "Accelerator peak AC power limit in Watts",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_peak_ac(domain_idx);
+                                  },
+                                  1/1e3
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_DEFAULT", {
+                                  "Default power limit in Watts",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_tdp(domain_idx);
+                                  },
+                                  1/1e3
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_MIN", {
+                                  "Minimum power limit in Watts",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_min(domain_idx);
+                                  },
+                                  1/1e3
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_MAX", {
+                                  "Maximum power limit in Watts",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_max(domain_idx);
+                                  },
+                                  1/1e3
+                                  }},
+                              {"LEVELZERO::THROTTLE_REASONS_GPU", {
+                                  "GPU throttle reasons",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_status_throttle_reason_gpu(domain_idx);
+                                  },
+                                  1
+                                  }},
+                              {"LEVELZERO::THROTTLE_TIME_GPU", {
+                                  "GPU throttle time",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_throttle_time_gpu(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::THROTTLE_TIME_TIMESTAMP_GPU", {
+                                  "GPU throttle time reading timestamp",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_throttle_time_timestamp_gpu(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME", {
+                                  "GPU active time",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_TIMESTAMP", {
+                                  "GPU active time reading timestamp",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time_timestamp(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_COMPUTE", {
+                                  "GPU Compute engine active time",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time_compute(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_TIMESTAMP_COMPUTE", {
+                                  "GPU Compute engine active time reading timestamp",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time_timestamp_compute(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_COPY", {
+                                  "GPU Copy engine active time",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time_copy(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_TIMESTAMP_COPY", {
+                                  "GPU Copy engine active time timestamp",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time_timestamp_copy(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_MEDIA_DECODE", {
+                                  "GPU Media Decode engine active time",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time_media_decode(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_TIMESTAMP_MEDIA_DECODE", {
+                                  "GPU Media Decode engine active time",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time_timestamp_media_decode(domain_idx);
+                                  },
+                                  1/1e6
+                                  }},
+                              {"LEVELZERO::PERFORMANCE_FACTOR", {
+                                  "Perofrmance Factor of the domain",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.performance_factor(domain_idx);
+                                  },
+                                  1
+                                  }},
+                             })
+        , m_control_available({{"LEVELZERO::FREQUENCY_GPU_CONTROL", {
+                                    "Sets accelerator frequency (in hertz)",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                    Agg::average,
+                                    string_format_double
+                                    }},
+                                {"LEVELZERO::STANDBY_MODE_CONTROL", {
+                                    "Accelerator Standby Mode."
+                                    "\n  0 indicates the device may go into standby"
+                                    "\n  1 indicates the device will never go into standby",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                    Agg::average,
+                                    string_format_double
+                                    }}
+                              })
+    {
+        // populate signals for each domain
+        for (auto &sv : m_signal_available) {
+            std::vector<std::shared_ptr<Signal> > result;
+            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(signal_domain_type(sv.first)); ++domain_idx) {
+                std::shared_ptr<Signal> signal =
+                        std::make_shared<LevelZeroSignal>(sv.second.m_devpool_func, domain_idx, sv.second.scalar);
+                result.push_back(signal);
+            }
+            sv.second.m_signals = result;
+        }
+
+        register_derivative_signals();
+
+        register_signal_alias("FREQUENCY_ACCELERATOR", "LEVELZERO::FREQUENCY_GPU");
+        register_signal_alias("POWER_ACCELERATOR", "LEVELZERO::POWER");
+        register_control_alias("FREQUENCY_ACCELERATOR_CONTROL", "LEVELZERO::FREQUENCY_GPU_CONTROL");
+
+        // populate controls for each domain
+        for (auto &sv : m_control_available) {
+            std::vector<std::shared_ptr<control_s> > result;
+            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(control_domain_type(sv.first)); ++domain_idx) {
+                std::shared_ptr<control_s> ctrl = std::make_shared<control_s>(control_s{0, false});
+                result.push_back(ctrl);
+            }
+            sv.second.controls = result;
+        }
+    }
+
+    void LevelZeroIOGroup::register_derivative_signals(void) {
+        int derivative_window = 8;
+        double sleep_time = 0.005;
+
+        struct signal_data
+        {
+            std::string name;
+            std::string description;
+            std::string base_name;
+            std::string time_name;
+        };
+
+        std::vector<signal_data> derivative_signals {
+            {"LEVELZERO::POWER",
+                    "Average accelerator power over 40 ms or 8 control loop iterations",
+                    "LEVELZERO::ENERGY",
+                    "LEVELZERO::ENERGY_TIMESTAMP"},
+            {"LEVELZERO::UTILIZATION",
+                    "GPU utilization"
+                        "n  Level Zero logical engines may may to the same hardware"
+                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
+                    "LEVELZERO::ACTIVE_TIME",
+                    "LEVELZERO::ACTIVE_TIME_TIMESTAMP"},
+            {"LEVELZERO::THROTTLE_RATIO_GPU",
+                    "Ratio of time the GPU domains were throttled",
+                    "LEVELZERO::THROTTLE_TIME_GPU",
+                    "LEVELZERO::THROTTLE_TIME_TIMESTAMP_GPU"},
+            {"LEVELZERO::UTILIZATION_COMPUTE",
+                    "Compute engine utilization"
+                        "n  Level Zero logical engines may may to the same hardware"
+                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
+                    "LEVELZERO::ACTIVE_TIME_COMPUTE",
+                    "LEVELZERO::ACTIVE_TIME_TIMESTAMP_COMPUTE"},
+            {"LEVELZERO::UTILIZATION_COPY",
+                    "Copy engine utilization"
+                        "n  Level Zero logical engines may may to the same hardware"
+                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
+                    "LEVELZERO::ACTIVE_TIME_COPY",
+                    "LEVELZERO::ACTIVE_TIME_TIMESTAMP_COPY"},
+            {"LEVELZERO::UTILIZATION_MEDIA_DECODE",
+                    "Media decode engine utilization"
+                        "n  Level Zero logical engines may may to the same hardware"
+                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
+                    "LEVELZERO::ACTIVE_TIME_MEDIA_DECODE",
+                    "LEVELZERO::ACTIVE_TIME_TIMESTAMP_MEDIA_DECODE"}
+        };
+        //std::shared_ptr<Signal> time_sig = std::make_shared<TimeSignal>(m_time_zero, m_time_batch);
+        //m_signal_available[time_name] = {std::vector<std::shared_ptr<Signal> >({time_sig}),
+        for (const auto &ds : derivative_signals) {
+            auto read_it = m_signal_available.find(ds.base_name);
+            auto time_it = m_signal_available.find(ds.time_name);
+            if (read_it != m_signal_available.end() && time_it != m_signal_available.end()) {
+                auto readings = read_it->second.m_signals;
+                int domain = read_it->second.domain_type;
+                int num_domain = m_platform_topo.num_domain(domain);
+                GEOPM_DEBUG_ASSERT(num_domain == (int)readings.size(),
+                                   "size of domain for " + ds.base_name +
+                                   " does not match number of signals available.");
+
+                auto time_sig = time_it->second.m_signals;
+                GEOPM_DEBUG_ASSERT(time_it->second.domain_type == domain,
+                                   "domain for " + ds.time_name +
+                                   " does not match " + ds.base_name);
+
+                std::vector<std::shared_ptr<Signal> > result(num_domain);
+                for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+                    auto read = readings[domain_idx];
+                    auto time = time_sig[domain_idx];
+                    result[domain_idx] =
+                        std::make_shared<DerivativeSignal>(time, read,
+                                                           derivative_window,
+                                                           sleep_time);
+                }
+                m_signal_available[ds.name] = {ds.description + "\n    alias_for: " + ds.base_name + " rate of change",
+                                                   domain,
+                                                   agg_function(ds.base_name),
+                                                   format_function(ds.base_name),
+                                                   result,
+                                                   nullptr,
+                                                   1
+                                                   };
+            }
+        }
+
+    }
+
+    // Extract the set of all signal names from the index map
+    std::set<std::string> LevelZeroIOGroup::signal_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &sv : m_signal_available) {
+            result.insert(sv.first);
+        }
+        return result;
+    }
+
+    // Extract the set of all control names from the index map
+    std::set<std::string> LevelZeroIOGroup::control_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &sv : m_control_available) {
+            result.insert(sv.first);
+        }
+        return result;
+    }
+
+    // Check signal name using index map
+    bool LevelZeroIOGroup::is_valid_signal(const std::string &signal_name) const
+    {
+        return m_signal_available.find(signal_name) != m_signal_available.end();
+    }
+
+    // Check control name using index map
+    bool LevelZeroIOGroup::is_valid_control(const std::string &control_name) const
+    {
+        return m_control_available.find(control_name) != m_control_available.end();
+    }
+
+    // Return domain for all valid signals
+    int LevelZeroIOGroup::signal_domain_type(const std::string &signal_name) const
+    {
+        int result = GEOPM_DOMAIN_INVALID;
+        auto it = m_signal_available.find(signal_name);
+        if (it != m_signal_available.end()) {
+            result = it->second.domain_type;
+        }
+        return result;
+    }
+
+    // Return domain for all valid controls
+    int LevelZeroIOGroup::control_domain_type(const std::string &control_name) const
+    {
+        int result = GEOPM_DOMAIN_INVALID;
+        auto it = m_control_available.find(control_name);
+        if (it != m_control_available.end()) {
+            result = it->second.domain_type;
+        }
+        return result;
+    }
+
+    // Mark the given signal to be read by read_batch()
+    int LevelZeroIOGroup::push_signal(const std::string &signal_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": signal_name " + signal_name +
+                            " not valid for LevelZeroIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != signal_domain_type(signal_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": " + signal_name + ": domain_type must be " +
+                            std::to_string(signal_domain_type(signal_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(signal_domain_type(signal_name))) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (m_is_batch_read) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": cannot push signal after call to read_batch().",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        int result = -1;
+        bool is_found = false;
+        std::shared_ptr<Signal> signal = m_signal_available.at(signal_name).m_signals.at(domain_idx);
+
+        // Check if signal was already pushed.
+        for (size_t ii = 0; !is_found && ii < m_signal_pushed.size(); ++ii) {
+            if (m_signal_pushed[ii] == signal) {
+                result = ii;
+                is_found = true;
+            }
+        }
+        if (!is_found) {
+            // If not pushed, add to pushed signals and configure for batch reads
+            result = m_signal_pushed.size();
+            m_signal_pushed.push_back(signal);
+            signal->setup_batch();
+        }
+
+        return result;
+    }
+
+    // Mark the given control to be written by write_batch()
+    int LevelZeroIOGroup::push_control(const std::string &control_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": control_name " + control_name +
+                            " not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != control_domain_type(control_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": " + control_name + ": domain_type must be " +
+                            std::to_string(control_domain_type(control_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(domain_type)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        int result = -1;
+        bool is_found = false;
+        std::shared_ptr<control_s> control = m_control_available.at(control_name).controls.at(domain_idx);
+
+        // Check if control was already pushed
+        for (size_t ii = 0; !is_found && ii < m_control_pushed.size(); ++ii) {
+            // same location means this control or its alias was already pushed
+            if (m_control_pushed[ii] == control) {
+                result = ii;
+                is_found = true;
+            }
+        }
+        if (!is_found) {
+            // If not pushed, add to pushed control
+            result = m_control_pushed.size();
+            m_control_pushed.push_back(control);
+        }
+
+        return result;
+    }
+
+    // Parse and update saved values for signals
+    void LevelZeroIOGroup::read_batch(void)
+    {
+        m_is_batch_read = true;
+    }
+
+    // Write all controls that have been pushed and adjusted
+    void LevelZeroIOGroup::write_batch(void)
+    {
+        for (auto &sv : m_control_available) {
+            for (unsigned int domain_idx = 0; domain_idx < sv.second.controls.size(); ++domain_idx) {
+                if (sv.second.controls.at(domain_idx)->m_is_adjusted) {
+                    // TODO: numerous optimizations are possible, including:
+                    //          grouped power limit writes
+                    //          grouped freqeuncy writes (with device pool modification)
+                    //
+                    //  The majority of these require more in-depth level zero data types being understood by the
+                    //  IOGroup, OR new data structures
+                    write_control(sv.first, sv.second.domain_type, domain_idx, sv.second.controls.at(domain_idx)->m_setting);
+                }
+            }
+        }
+    }
+
+    // Return the latest value read by read_batch()
+    double LevelZeroIOGroup::sample(int batch_idx)
+    {
+        if (batch_idx < 0 || batch_idx >= (int)m_signal_pushed.size()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": batch_idx " +std::to_string(batch_idx)+ " out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (!m_is_batch_read) { //Not strictly necessary, but keeping to enforce general flow of read_batch followed by sample.
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": signal has not been read.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_signal_pushed[batch_idx]->sample();
+    }
+
+    // Save a setting to be written by a future write_batch()
+    void LevelZeroIOGroup::adjust(int batch_idx, double setting)
+    {
+        if (batch_idx < 0 || (unsigned)batch_idx >= m_control_pushed.size()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + "(): batch_idx " +std::to_string(batch_idx)+ " out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        m_control_pushed.at(batch_idx)->m_setting = setting;
+        m_control_pushed.at(batch_idx)->m_is_adjusted = true;
+    }
+
+    // Read the value of a signal immediately, bypassing read_batch().  Should not modify m_signal_value
+    double LevelZeroIOGroup::read_signal(const std::string &signal_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            " not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != signal_domain_type(signal_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": " + signal_name + ": domain_type must be " +
+                            std::to_string(signal_domain_type(signal_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(signal_domain_type(signal_name))) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        double result = NAN;
+        auto it = m_signal_available.find(signal_name);
+        if (it != m_signal_available.end()) {
+            result = (it->second.m_signals.at(domain_idx))->read();
+        }
+        else {
+    #ifdef GEOPM_DEBUG
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": Handling not defined for " +
+                            signal_name, GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+
+    #endif
+        }
+        return result;
+    }
+
+    // Write to the control immediately, bypassing write_batch()
+    void LevelZeroIOGroup::write_control(const std::string &control_name, int domain_type, int domain_idx, double setting)
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": " + control_name +
+                            " not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": " + control_name + ": domain_type must be " +
+                            std::to_string(control_domain_type(control_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (control_name == "LEVELZERO::FREQUENCY_GPU_CONTROL" || control_name == "FREQUENCY_ACCELERATOR_CONTROL") {
+            m_levelzero_device_pool.frequency_control_gpu(domain_idx, setting/1e6);
+        }
+        else if (control_name == "LEVELZERO::STANDBY_MODE_CONTROL") {
+            m_levelzero_device_pool.standby_mode_control(domain_idx, setting);
+        }
+        else {
+    #ifdef GEOPM_DEBUG
+                throw Exception("LevelZeroIOGroup::" + std::string(__func__) + "Handling not defined for "
+                                + control_name, GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+    #endif
+        }
+    }
+
+    // Implemented to allow an IOGroup to save platform settings before starting
+    // to adjust them
+    void LevelZeroIOGroup::save_control(void)
+    {
+        // TODO: Read ALL LEVELZERO Power Limits, frequency settings, etc
+        for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR); ++domain_idx) {
+            //Frequency Control Settings
+            m_initial_freq_range_min_gpu_limit.push_back(read_signal("LEVELZERO::FREQUENCY_RANGE_MIN_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+            m_initial_freq_range_max_gpu_limit.push_back(read_signal("LEVELZERO::FREQUENCY_RANGE_MAX_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+            //Power Control Settings
+            m_initial_power_limit_sustained.push_back(read_signal("LEVELZERO::POWER_LIMIT_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+            m_initial_power_limit_enabled_sustained.push_back(read_signal("LEVELZERO::POWER_LIMIT_ENABLED_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+            m_initial_power_limit_interval_sustained.push_back(read_signal("LEVELZERO::POWER_LIMIT_INTERVAL_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+            m_initial_power_limit_burst.push_back(read_signal("LEVELZERO::POWER_LIMIT_BURST", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+            m_initial_power_limit_enabled_burst.push_back(read_signal("LEVELZERO::POWER_LIMIT_ENABLED_BURST", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+        }
+    }
+
+    // Implemented to allow an IOGroup to restore previously saved
+    // platform settings
+    void LevelZeroIOGroup::restore_control(void)
+    {
+        /// @todo: Usage of the LEVELZERO API for setting frequency, power, etc requires root privileges.
+        ///        As such several unit tests will fail when calling restore_control.  Once a non-
+        ///        privileged solution is available this code may be restored
+    }
+
+    // Hint to Agent about how to aggregate signals from this IOGroup
+    std::function<double(const std::vector<double> &)> LevelZeroIOGroup::agg_function(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            "not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return it->second.m_agg_function;
+    }
+
+    // Specifies how to print signals from this IOGroup
+    std::function<std::string(double)> LevelZeroIOGroup::format_function(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            "not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return it->second.m_format_function;
+    }
+
+    // A user-friendly description of each signal
+    std::string LevelZeroIOGroup::signal_description(const std::string &signal_name) const
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": signal_name " + signal_name +
+                            " not valid for LevelZeroIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return m_signal_available.at(signal_name).m_description;
+    }
+
+    // A user-friendly description of each control
+    std::string LevelZeroIOGroup::control_description(const std::string &control_name) const
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": " + control_name +
+                            "not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_control_available.at(control_name).m_description;
+    }
+
+    // Name used for registration with the IOGroup factory
+    std::string LevelZeroIOGroup::plugin_name(void)
+    {
+        return "levelzero";
+    }
+
+    int LevelZeroIOGroup::signal_behavior(const std::string &signal_name) const
+    {
+        return IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE;
+    }
+
+    // Function used by the factory to create objects of this type
+    std::unique_ptr<IOGroup> LevelZeroIOGroup::make_plugin(void)
+    {
+        return geopm::make_unique<LevelZeroIOGroup>();
+    }
+
+    void LevelZeroIOGroup::register_signal_alias(const std::string &alias_name,
+                                            const std::string &signal_name)
+    {
+        if (m_signal_available.find(alias_name) != m_signal_available.end()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": signal_name " + alias_name +
+                            " was previously registered.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            // skip adding an alias if underlying signal is not found
+            return;
+        }
+        // copy signal info but append to description
+        m_signal_available[alias_name] = it->second;
+        m_signal_available[alias_name].m_description =
+            m_signal_available[signal_name].m_description + '\n' + "    alias_for: " + signal_name;
+    }
+
+    void LevelZeroIOGroup::register_control_alias(const std::string &alias_name,
+                                           const std::string &control_name)
+    {
+        if (m_control_available.find(alias_name) != m_control_available.end()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": contro1_name " + alias_name +
+                            " was previously registered.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto it = m_control_available.find(control_name);
+        if (it == m_control_available.end()) {
+            // skip adding an alias if underlying control is not found
+            return;
+        }
+        // copy control info but append to description
+        m_control_available[alias_name] = it->second;
+        m_control_available[alias_name].m_description =
+        m_control_available[control_name].m_description + '\n' + "    alias_for: " + control_name;
+    }
+}

--- a/src/LevelZeroIOGroup.cpp
+++ b/src/LevelZeroIOGroup.cpp
@@ -73,7 +73,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.frequency_status_gpu(domain_idx);
+                                      return this->m_levelzero_device_pool.frequency_status(domain_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE);
                                   },
                                   1e6
                                   }},
@@ -85,7 +85,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.frequency_max_gpu(domain_idx);
+                                      return this->m_levelzero_device_pool.frequency_max(domain_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE);
                                   },
                                   1e6
                                   }},
@@ -97,7 +97,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.frequency_min_gpu(domain_idx);
+                                      return this->m_levelzero_device_pool.frequency_min(domain_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE);
                                   },
                                   1e6
                                   }},
@@ -125,30 +125,6 @@ namespace geopm
                                   },
                                   1/1e6
                                   }},
-                              {"LEVELZERO::FREQUENCY_RANGE_MIN_GPU_CONTROL", {
-                                  "Accelerator compute/GPU domain user specified min frequency in hertz",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.frequency_range_min_gpu(domain_idx);
-                                  },
-                                  1e6
-                                  }},
-                              {"LEVELZERO::FREQUENCY_RANGE_MAX_GPU_CONTROL", {
-                                  "Accelerator compute/GPU domain user specified max frequency in hertz",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.frequency_range_max_gpu(domain_idx);
-                                  },
-                                  1e6
-                                  }},
                               {"LEVELZERO::FREQUENCY_MEMORY", {
                                   "Accelerator memory domain frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
@@ -157,7 +133,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.frequency_status_mem(domain_idx);
+                                      return this->m_levelzero_device_pool.frequency_status(domain_idx, GEOPM_LEVELZERO_DOMAIN_MEMORY);
                                   },
                                   1e6
                                   }},
@@ -169,7 +145,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.frequency_max_mem(domain_idx);
+                                      return this->m_levelzero_device_pool.frequency_max(domain_idx, GEOPM_LEVELZERO_DOMAIN_MEMORY);
                                   },
                                   1e6
                                   }},
@@ -181,143 +157,9 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.frequency_min_mem(domain_idx);
+                                      return this->m_levelzero_device_pool.frequency_min(domain_idx, GEOPM_LEVELZERO_DOMAIN_MEMORY);
                                   },
                                   1e6
-                                  }},
-                              {"LEVELZERO::MEMORY_ALLOCATED", {
-                                  "Memory usage as a ratio of total memory",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.memory_allocated(domain_idx);
-                                  },
-                                  1
-                                  }},
-                              {"LEVELZERO::TEMPERATURE", {
-                                  "Device Temperature in Celsius",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.temperature(domain_idx);
-                                  },
-                                  1
-                                  }},
-                              {"LEVELZERO::TEMPERATURE_GPU", {
-                                  "Device GPU Temperature in Celsius",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.temperature_gpu(domain_idx);
-                                  },
-                                  1
-                                  }},
-                              {"LEVELZERO::TEMPERATURE_MEMORY", {
-                                  "Device Memory Temperature in Celsius",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.temperature_memory(domain_idx);
-                                  },
-                                  1
-                                  }},
-                              {"LEVELZERO::STANDBY_MODE", {
-                                  "Accelerator Standby Mode."
-                                  "\n  0 indicates the device may go into standby"
-                                  "\n  1 indicates the device will never go into standby",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.standby_mode(domain_idx);
-                                  },
-                                  1
-                                  }},
-                              {"LEVELZERO::POWER_LIMIT_ENABLED_SUSTAINED", {
-                                  "Accelerator sustained power limit enable value",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.power_limit_enabled_sustained(domain_idx);
-                                  },
-                                  1
-                                  }},
-                              {"LEVELZERO::POWER_LIMIT_SUSTAINED", {
-                                  "Accelerator sustained power limit in Watts",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.power_limit_sustained(domain_idx);
-                                  },
-                                  1/1e3
-                                  }},
-                              {"LEVELZERO::POWER_LIMIT_INTERVAL_SUSTAINED", {
-                                  "Accelerator sustained power limit interval in seconds",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.power_limit_interval_sustained(domain_idx);
-                                  },
-                                  1/1e3
-                                  }},
-                              {"LEVELZERO::POWER_LIMIT_BURST", {
-                                  "Accelerator burst power limit in Watts",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.power_limit_burst(domain_idx);
-                                  },
-                                  1/1e3
-                                  }},
-                              {"LEVELZERO::POWER_LIMIT_ENABLED_BURST", {
-                                  "Accelerator burst power limit enable value",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.power_limit_enabled_burst(domain_idx);
-                                  },
-                                  1
-                                  }},
-                              {"LEVELZERO::POWER_LIMIT_PEAK_AC", {
-                                  "Accelerator peak AC power limit in Watts",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.power_limit_peak_ac(domain_idx);
-                                  },
-                                  1/1e3
                                   }},
                               {"LEVELZERO::POWER_LIMIT_DEFAULT", {
                                   "Default power limit in Watts",
@@ -355,42 +197,6 @@ namespace geopm
                                   },
                                   1/1e3
                                   }},
-                              {"LEVELZERO::THROTTLE_REASONS_GPU", {
-                                  "GPU throttle reasons",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.frequency_status_throttle_reason_gpu(domain_idx);
-                                  },
-                                  1
-                                  }},
-                              {"LEVELZERO::THROTTLE_TIME_GPU", {
-                                  "GPU throttle time",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.frequency_throttle_time_gpu(domain_idx);
-                                  },
-                                  1/1e6
-                                  }},
-                              {"LEVELZERO::THROTTLE_TIME_TIMESTAMP_GPU", {
-                                  "GPU throttle time reading timestamp",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.frequency_throttle_time_timestamp_gpu(domain_idx);
-                                  },
-                                  1/1e6
-                                  }},
                               {"LEVELZERO::ACTIVE_TIME", {
                                   "GPU active time",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
@@ -399,7 +205,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.active_time(domain_idx);
+                                      return this->m_levelzero_device_pool.active_time(domain_idx, GEOPM_LEVELZERO_DOMAIN_ALL);
                                   },
                                   1/1e6
                                   }},
@@ -411,7 +217,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.active_time_timestamp(domain_idx);
+                                      return this->m_levelzero_device_pool.active_time_timestamp(domain_idx, GEOPM_LEVELZERO_DOMAIN_ALL);
                                   },
                                   1/1e6
                                   }},
@@ -423,7 +229,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.active_time_compute(domain_idx);
+                                      return this->m_levelzero_device_pool.active_time(domain_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE);
                                   },
                                   1/1e6
                                   }},
@@ -435,7 +241,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.active_time_timestamp_compute(domain_idx);
+                                      return this->m_levelzero_device_pool.active_time_timestamp(domain_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE);
                                   },
                                   1/1e6
                                   }},
@@ -447,7 +253,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.active_time_copy(domain_idx);
+                                      return this->m_levelzero_device_pool.active_time(domain_idx, GEOPM_LEVELZERO_DOMAIN_MEMORY);
                                   },
                                   1/1e6
                                   }},
@@ -459,58 +265,13 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_levelzero_device_pool.active_time_timestamp_copy(domain_idx);
+                                      return this->m_levelzero_device_pool.active_time_timestamp(domain_idx, GEOPM_LEVELZERO_DOMAIN_MEMORY);
                                   },
                                   1/1e6
-                                  }},
-                              {"LEVELZERO::ACTIVE_TIME_MEDIA_DECODE", {
-                                  "GPU Media Decode engine active time",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.active_time_media_decode(domain_idx);
-                                  },
-                                  1/1e6
-                                  }},
-                              {"LEVELZERO::ACTIVE_TIME_TIMESTAMP_MEDIA_DECODE", {
-                                  "GPU Media Decode engine active time",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.active_time_timestamp_media_decode(domain_idx);
-                                  },
-                                  1/1e6
-                                  }},
-                              {"LEVELZERO::PERFORMANCE_FACTOR", {
-                                  "Perofrmance Factor of the domain",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                  Agg::average,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.performance_factor(domain_idx);
-                                  },
-                                  1
-                                  }},
+                                  }}
                              })
         , m_control_available({{"LEVELZERO::FREQUENCY_GPU_CONTROL", {
                                     "Sets accelerator frequency (in hertz)",
-                                    {},
-                                    GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                    Agg::average,
-                                    string_format_double
-                                    }},
-                                {"LEVELZERO::STANDBY_MODE_CONTROL", {
-                                    "Accelerator Standby Mode."
-                                    "\n  0 indicates the device may go into standby"
-                                    "\n  1 indicates the device will never go into standby",
                                     {},
                                     GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                     Agg::average,
@@ -569,10 +330,6 @@ namespace geopm
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
                     "LEVELZERO::ACTIVE_TIME",
                     "LEVELZERO::ACTIVE_TIME_TIMESTAMP"},
-            {"LEVELZERO::THROTTLE_RATIO_GPU",
-                    "Ratio of time the GPU domains were throttled",
-                    "LEVELZERO::THROTTLE_TIME_GPU",
-                    "LEVELZERO::THROTTLE_TIME_TIMESTAMP_GPU"},
             {"LEVELZERO::UTILIZATION_COMPUTE",
                     "Compute engine utilization"
                         "n  Level Zero logical engines may may to the same hardware"
@@ -585,12 +342,6 @@ namespace geopm
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
                     "LEVELZERO::ACTIVE_TIME_COPY",
                     "LEVELZERO::ACTIVE_TIME_TIMESTAMP_COPY"},
-            {"LEVELZERO::UTILIZATION_MEDIA_DECODE",
-                    "Media decode engine utilization"
-                        "n  Level Zero logical engines may may to the same hardware"
-                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
-                    "LEVELZERO::ACTIVE_TIME_MEDIA_DECODE",
-                    "LEVELZERO::ACTIVE_TIME_TIMESTAMP_MEDIA_DECODE"}
         };
         //std::shared_ptr<Signal> time_sig = std::make_shared<TimeSignal>(m_time_zero, m_time_batch);
         //m_signal_available[time_name] = {std::vector<std::shared_ptr<Signal> >({time_sig}),
@@ -871,10 +622,7 @@ namespace geopm
         }
 
         if (control_name == "LEVELZERO::FREQUENCY_GPU_CONTROL" || control_name == "FREQUENCY_ACCELERATOR_CONTROL") {
-            m_levelzero_device_pool.frequency_control_gpu(domain_idx, setting/1e6);
-        }
-        else if (control_name == "LEVELZERO::STANDBY_MODE_CONTROL") {
-            m_levelzero_device_pool.standby_mode_control(domain_idx, setting);
+            m_levelzero_device_pool.frequency_control(domain_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE, setting/1e6);
         }
         else {
     #ifdef GEOPM_DEBUG
@@ -890,15 +638,15 @@ namespace geopm
     {
         // TODO: Read ALL LEVELZERO Power Limits, frequency settings, etc
         for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR); ++domain_idx) {
-            //Frequency Control Settings
-            m_initial_freq_range_min_gpu_limit.push_back(read_signal("LEVELZERO::FREQUENCY_RANGE_MIN_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
-            m_initial_freq_range_max_gpu_limit.push_back(read_signal("LEVELZERO::FREQUENCY_RANGE_MAX_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
-            //Power Control Settings
-            m_initial_power_limit_sustained.push_back(read_signal("LEVELZERO::POWER_LIMIT_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
-            m_initial_power_limit_enabled_sustained.push_back(read_signal("LEVELZERO::POWER_LIMIT_ENABLED_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
-            m_initial_power_limit_interval_sustained.push_back(read_signal("LEVELZERO::POWER_LIMIT_INTERVAL_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
-            m_initial_power_limit_burst.push_back(read_signal("LEVELZERO::POWER_LIMIT_BURST", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
-            m_initial_power_limit_enabled_burst.push_back(read_signal("LEVELZERO::POWER_LIMIT_ENABLED_BURST", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+//            //Frequency Control Settings
+//            m_initial_freq_range_min_gpu_limit.push_back(read_signal("LEVELZERO::FREQUENCY_RANGE_MIN_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+//            m_initial_freq_range_max_gpu_limit.push_back(read_signal("LEVELZERO::FREQUENCY_RANGE_MAX_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+//            //Power Control Settings
+//            m_initial_power_limit_sustained.push_back(read_signal("LEVELZERO::POWER_LIMIT_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+//            m_initial_power_limit_enabled_sustained.push_back(read_signal("LEVELZERO::POWER_LIMIT_ENABLED_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+//            m_initial_power_limit_interval_sustained.push_back(read_signal("LEVELZERO::POWER_LIMIT_INTERVAL_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+//            m_initial_power_limit_burst.push_back(read_signal("LEVELZERO::POWER_LIMIT_BURST", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
+//            m_initial_power_limit_enabled_burst.push_back(read_signal("LEVELZERO::POWER_LIMIT_ENABLED_BURST", GEOPM_DOMAIN_BOARD_ACCELERATOR, domain_idx));
         }
     }
 

--- a/src/LevelZeroIOGroup.hpp
+++ b/src/LevelZeroIOGroup.hpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LEVELZEROIOGROUP_HPP_INCLUDE
+#define LEVELZEROIOGROUP_HPP_INCLUDE
+
+#include <map>
+#include <vector>
+#include <string>
+#include <memory>
+#include <functional>
+
+#include "IOGroup.hpp"
+#include "LevelZeroSignal.hpp"
+
+namespace geopm
+{
+    class PlatformTopo;
+    class LevelZeroDevicePool;
+
+    /// @brief IOGroup that provides signals and controls for Accelerators
+    class LevelZeroIOGroup : public IOGroup
+    {
+        public:
+            LevelZeroIOGroup();
+            LevelZeroIOGroup(const PlatformTopo &platform_topo, const LevelZeroDevicePool &device_pool);
+            virtual ~LevelZeroIOGroup() = default;
+            std::set<std::string> signal_names(void) const override;
+            std::set<std::string> control_names(void) const override;
+            bool is_valid_signal(const std::string &signal_name) const override;
+            bool is_valid_control(const std::string &control_name) const override;
+            int signal_domain_type(const std::string &signal_name) const override;
+            int control_domain_type(const std::string &control_name) const override;
+            int push_signal(const std::string &signal_name, int domain_type, int domain_idx)  override;
+            int push_control(const std::string &control_name, int domain_type, int domain_idx) override;
+            void read_batch(void) override;
+            void write_batch(void) override;
+            double sample(int batch_idx) override;
+            void adjust(int batch_idx, double setting) override;
+            double read_signal(const std::string &signal_name, int domain_type, int domain_idx) override;
+            void write_control(const std::string &control_name, int domain_type, int domain_idx, double setting) override;
+            void save_control(void) override;
+            void restore_control(void) override;
+            std::function<double(const std::vector<double> &)> agg_function(const std::string &signal_name) const override;
+            std::function<std::string(double)> format_function(const std::string &signal_name) const override;
+            std::string signal_description(const std::string &signal_name) const override;
+            std::string control_description(const std::string &control_name) const override;
+            int signal_behavior(const std::string &signal_name) const override;
+            static std::string plugin_name(void);
+            static std::unique_ptr<IOGroup> make_plugin(void);
+        private:
+            void init(void);
+
+            void register_derivative_signals(void);
+            void register_signal_alias(const std::string &alias_name, const std::string &signal_name);
+            void register_control_alias(const std::string &alias_name, const std::string &control_name);
+
+            const PlatformTopo &m_platform_topo;
+            const LevelZeroDevicePool &m_levelzero_device_pool;
+            bool m_is_batch_read;
+            std::vector<uint64_t> m_initial_freq_range_max_gpu_limit;
+            std::vector<uint64_t> m_initial_freq_range_min_gpu_limit;
+            std::vector<uint64_t> m_initial_power_limit_sustained;
+            std::vector<uint64_t> m_initial_power_limit_enabled_sustained;
+            std::vector<uint64_t> m_initial_power_limit_interval_sustained;
+            std::vector<uint64_t> m_initial_power_limit_burst;
+            std::vector<uint64_t> m_initial_power_limit_enabled_burst;
+
+            struct control_s
+            {
+                double m_setting;
+                bool m_is_adjusted;
+            };
+
+            struct signal_info {
+                std::string m_description;
+                int domain_type;
+                std::function<double(const std::vector<double> &)> m_agg_function;
+                std::function<std::string(double)> m_format_function;
+                std::vector<std::shared_ptr<Signal> > m_signals;
+                std::function<double (unsigned int)> m_devpool_func;
+                double scalar;
+            };
+
+            struct control_info {
+                std::string m_description;
+                std::vector<std::shared_ptr<control_s> > controls;
+                int domain_type;
+                std::function<double(const std::vector<double> &)> m_agg_function;
+                std::function<std::string(double)> m_format_function;
+            };
+
+            std::map<std::string, signal_info> m_signal_available;
+            std::map<std::string, control_info> m_control_available;
+            std::vector<std::shared_ptr<Signal> > m_signal_pushed;
+            std::vector<std::shared_ptr<control_s> > m_control_pushed;
+    };
+}
+#endif

--- a/src/LevelZeroShim.cpp
+++ b/src/LevelZeroShim.cpp
@@ -1,0 +1,666 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <cmath>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <thread>
+#include <chrono>
+#include <time.h>
+
+#include "Exception.hpp"
+#include "Agg.hpp"
+#include "Helper.hpp"
+#include "geopm_sched.h"
+
+#include "LevelZeroShimImp.hpp"
+
+namespace geopm
+{
+    const LevelZeroShim &levelzero_shim(const int num_cpu)
+    {
+        static LevelZeroShimImp instance(num_cpu);
+        return instance;
+    }
+
+    LevelZeroShimImp::LevelZeroShimImp(const int num_cpu)
+        : M_NUM_CPU(num_cpu)
+    {
+        //TODO: change to a check and error if not enabled.  All ENV handling goes through environment class
+        char *zes_enable_sysman = getenv("ZES_ENABLE_SYSMAN");
+        if (zes_enable_sysman == NULL || strcmp(zes_enable_sysman, "1") != 0) {
+            std::cout << "GEOPM Debug: ZES_ENABLE_SYSMAN not set to 1.  Forcing to 1" << std::endl;
+            setenv("ZES_ENABLE_SYSMAN", "1", 1);
+        }
+
+        ze_result_t ze_result;
+        //Initialize
+        ze_result = zeInit(0);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                        ": LevelZero Driver failed to initialize.", __LINE__);
+        // Discover drivers
+        ze_result = zeDriverGet(&m_num_driver, nullptr);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                        ": LevelZero Driver enumeration failed.", __LINE__);
+        m_levelzero_driver.resize(m_num_driver);
+        ze_result = zeDriverGet(&m_num_driver, m_levelzero_driver.data());
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                        ": LevelZero Driver acquisition failed.", __LINE__);
+
+        for (unsigned int driver = 0; driver < m_num_driver; driver++) {
+            // Discover devices in a driver
+            uint32_t num_device = 0;
+
+            ze_result = zeDeviceGet(m_levelzero_driver.at(driver), &num_device, nullptr);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                            ": LevelZero Device enumeration failed.", __LINE__);
+            std::vector<zes_device_handle_t> device_handle(num_device);
+            ze_result = zeDeviceGet(m_levelzero_driver.at(driver), &num_device, device_handle.data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                            ": LevelZero Device acquisition failed.", __LINE__);
+
+
+            for(unsigned int accel_idx = 0; accel_idx < num_device; ++accel_idx) {
+                ze_device_properties_t property;
+                ze_result = zeDeviceGetProperties(device_handle.at(accel_idx), &property);
+
+                uint32_t num_subdevice = 0;
+
+                ze_result = zeDeviceGetSubDevices(device_handle.at(accel_idx), &num_subdevice, nullptr);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                                ": LevelZero Sub-Device enumeration failed.", __LINE__);
+
+                std::vector<zes_device_handle_t> subdevice_handle(num_subdevice);
+                ze_result = zeDeviceGetSubDevices(device_handle.at(accel_idx), &num_subdevice, subdevice_handle.data());
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                                ": LevelZero Sub-Device acquisition failed.", __LINE__);
+
+#ifdef GEOPM_DEBUG
+                std::cout << "Debug: levelZero sub-devices: " << std::to_string(num_subdevice) << std::endl;
+#endif
+
+                if (property.type == ZE_DEVICE_TYPE_GPU) {
+                    if ((property.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED) == 0) {
+                        ++m_num_board_gpu;
+
+                        //NOTE: We're only supporting Board GPUs to start with
+                        m_devices.push_back({
+                            device_handle.at(accel_idx),
+                            property,
+                            num_subdevice,
+                            subdevice_handle,
+                            {}, //subdevice
+                            {}, //power domain
+                            {}  //temp domain
+                        });
+                    }
+#ifdef GEOPM_DEBUG
+                    else {
+                        std::cerr << "Warning: <geopm> LevelZeroShim: Integrated GPU access is not "
+                                     "currently supported by GEOPM.\n";
+                    }
+#endif
+                }
+#ifdef GEOPM_DEBUG
+                else if (property.type == ZE_DEVICE_TYPE_CPU) {
+                    // All CPU functionality is handled by GEOPM & MSR Safe currently
+                    std::cerr << "Warning: <geopm> LevelZeroShim: CPU access via LevelZero is not "
+                                 "currently supported by GEOPM.\n";
+                }
+                else if (property.type == ZE_DEVICE_TYPE_FPGA) {
+                    // FPGA functionality is not currently supported by GEOPM, but should not cause
+                    // an error if the devices are present
+                    std::cerr << "Warning: <geopm> LevelZeroShim: Field Programmable Gate Arrays are not "
+                                 "currently supported by GEOPM.\n";
+                }
+                else if (property.type == ZE_DEVICE_TYPE_MCA) {
+                    // MCA functionality is not currently supported by GEOPM, but should not cause
+                    // an error if the devices are present
+                    std::cerr << "Warning: <geopm> LevelZeroShim: Memory Copy Accelerators are not "
+                                 "currently supported by GEOPM.\n";
+                }
+#endif
+            }
+            m_num_device = m_num_board_gpu + m_num_integrated_gpu + m_num_fpga + m_num_mca;
+
+            // This approach is far simpler, but does not allow for functioning in systems with multiple
+            // accelerator types but unsupported accel types OR split accel indexes (i.e. BOARD_ACCELERATOR
+            // vs PACKAGE_ACCELERATOR)
+            //m_sysman_device.insert(m_sysman_device.end(), device_handle.begin(), device_handle.end());
+            //m_num_device = m_num_device + num_device;
+        }
+
+        // TODO: When additional device types such as FPGA, MCA, and Integrated GPU are supported by GEOPM
+        // This should be changed to a more general loop iterating over type and caching appropriately
+        for (unsigned int board_gpu_idx = 0; board_gpu_idx < m_num_board_gpu; board_gpu_idx++) {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                            ": failed to get device properties.", __LINE__);
+            domain_cache(board_gpu_idx);
+       }
+    }
+
+    void LevelZeroShimImp::domain_cache(unsigned int accel_idx) {
+        ze_result_t ze_result;
+        uint32_t num_domain = 0;
+
+        //Cache frequency domains
+        ze_result = zesDeviceEnumFrequencyDomains(m_devices.at(accel_idx).device_handle, &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroShim: Frequency domain detection is "
+                         "not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains.", __LINE__);
+            //make temp var
+            std::vector<zes_freq_handle_t> freq_domain;
+            freq_domain.resize(num_domain);
+
+            ze_result = zesDeviceEnumFrequencyDomains(m_devices.at(accel_idx).device_handle, &num_domain, freq_domain.data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                        ": Sysman failed to get domain handles.", __LINE__);
+
+            m_devices.at(accel_idx).subdevice.m_freq_domain.resize(GEOPM_LEVELZERO_DOMAIN_SIZE);
+
+            for (auto handle : freq_domain) {
+                zes_freq_properties_t property;
+                ze_result = zesFrequencyGetProperties(handle, &property);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                                ": Sysman failed to get domain properties.", __LINE__);
+
+                if (property.type == ZES_FREQ_DOMAIN_GPU) {
+                    m_devices.at(accel_idx).subdevice.m_freq_domain.at(GEOPM_LEVELZERO_DOMAIN_COMPUTE).push_back(handle);
+                }
+                else if (property.type == ZES_FREQ_DOMAIN_MEMORY) {
+                    m_devices.at(accel_idx).subdevice.m_freq_domain.at(GEOPM_LEVELZERO_DOMAIN_MEMORY).push_back(handle);
+                }
+            }
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero frequency domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+        //Cache power domains
+        num_domain = 0;
+        ze_result = zesDeviceEnumPowerDomains(m_devices.at(accel_idx).device_handle, &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroShim: Power domain detection is "
+                         "not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+            std::vector<zes_pwr_handle_t> power_domain;
+            power_domain.resize(num_domain);
+
+            ze_result = zesDeviceEnumPowerDomains(m_devices.at(accel_idx).device_handle, &num_domain, power_domain.data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                            ": Sysman failed to get domain handle(s).", __LINE__);
+
+            for (auto handle : power_domain) {
+                zes_power_properties_t property;
+                ze_result = zesPowerGetProperties(handle, &property);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                                ": Sysman failed to get domain power properties", __LINE__);
+
+                //For initial GEOPM support we're only providing device level power, but are tracking sub-device
+                //for future use
+                //finding non-subdevice domain.
+                if (property.onSubdevice == 0) {
+                    m_devices.at(accel_idx).m_power_domain.push_back(handle);
+                }
+                else {
+                    m_devices.at(accel_idx).subdevice.m_power_domain.push_back(handle);
+                }
+            }
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero power domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+        //Cache engine domains
+        num_domain = 0;
+        ze_result = zesDeviceEnumEngineGroups(m_devices.at(accel_idx).device_handle, &num_domain, nullptr);
+        if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            std::cerr << "Warning: <geopm> LevelZeroShim: Engine domain detection is "
+                         "not supported.\n";
+        }
+        else {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+            std::vector<zes_engine_handle_t> engine_domain;
+            engine_domain.resize(num_domain);
+
+            ze_result = zesDeviceEnumEngineGroups(m_devices.at(accel_idx).device_handle, &num_domain, engine_domain.data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                            ": Sysman failed to get number of domains", __LINE__);
+
+            m_devices.at(accel_idx).subdevice.m_engine_domain.resize(GEOPM_LEVELZERO_DOMAIN_SIZE);
+
+            for (auto handle : engine_domain) {
+                zes_engine_properties_t property;
+                ze_result = zesEngineGetProperties(handle, &property);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                                ": Sysman failed to get domain engine properties", __LINE__);
+                if (property.type == ZES_ENGINE_GROUP_ALL) {
+                    m_devices.at(accel_idx).subdevice.m_engine_domain.at(GEOPM_LEVELZERO_DOMAIN_ALL).push_back(handle);
+                }
+                //TODO: change to ZES_ENGINE_GROUP_COMPUTE_ALL?  Or check for COMPUTE_ALL and then do _SINGLE
+                else if (property.type == ZES_ENGINE_GROUP_COMPUTE_SINGLE) {
+                    m_devices.at(accel_idx).subdevice.m_engine_domain.at(GEOPM_LEVELZERO_DOMAIN_COMPUTE).push_back(handle);
+                }
+                //TODO: change to ZES_ENGINE_GROUP_COPY_ALL?  Or check for COMPUTE_ALL and then do _SINGLE
+                else if (property.type == ZES_ENGINE_GROUP_COPY_SINGLE) {
+                    m_devices.at(accel_idx).subdevice.m_engine_domain.at(GEOPM_LEVELZERO_DOMAIN_MEMORY).push_back(handle);
+                }
+            }
+#ifdef GEOPM_DEBUG
+            std::cout << "Debug: levelZero engine domains: " << std::to_string(num_domain) << std::endl;
+#endif
+        }
+
+    }
+
+    LevelZeroShimImp::~LevelZeroShimImp()
+    {
+    }
+
+    int LevelZeroShimImp::num_accelerator() const
+    {
+        return num_accelerator(ZE_DEVICE_TYPE_GPU);
+    }
+
+    int LevelZeroShimImp::num_accelerator(ze_device_type_t type) const
+    {
+        //switch/case
+        if (type == ZE_DEVICE_TYPE_GPU) {
+            // TODO: add Integrated vs Board nuance
+            return m_num_board_gpu;
+        }
+        else if (type == ZE_DEVICE_TYPE_CPU) {
+            return M_NUM_CPU;
+        }
+        else if (type == ZE_DEVICE_TYPE_FPGA) {
+            return m_num_fpga;
+        }
+        else if (type == ZE_DEVICE_TYPE_MCA) {
+            return m_num_mca;
+        }
+        else {
+            throw Exception("LevelZeroShim::" + std::string(__func__) + ": accelerator type " +
+                            std::to_string(type) + "  is unsupported", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+
+    int LevelZeroShimImp::frequency_domain_count(unsigned int accel_idx, geopm_levelzero_domain_e domain) const
+    {
+        return m_devices.at(accel_idx).subdevice.m_freq_domain.at(domain).size();
+    }
+
+    int LevelZeroShimImp::engine_domain_count(unsigned int accel_idx, geopm_levelzero_domain_e domain) const
+    {
+        return m_devices.at(accel_idx).subdevice.m_engine_domain.at(domain).size();
+    }
+
+    int LevelZeroShimImp::energy_domain_count_device(unsigned int accel_idx) const
+    {
+        return m_devices.at(accel_idx).m_power_domain.size();
+    }
+
+    int LevelZeroShimImp::energy_domain_count_subdevice(unsigned int accel_idx, int domain_idx) const
+    {
+        return m_devices.at(accel_idx).subdevice.m_power_domain.size();
+    }
+
+    double LevelZeroShimImp::frequency_status(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    {
+        return frequency_status_shim(accel_idx, domain, domain_idx).actual;
+    }
+
+    //double LevelZeroShimImp::frequency_tdp(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    //{
+    //    return frequency_status_shim(accel_idx, domain, domain_idx).tdp;
+    //}
+
+    //double LevelZeroShimImp::frequency_efficient(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    //{
+    //    return frequency_status_shim(accel_idx, domain, domain_idx).efficient;
+    //}
+
+    //uint64_t LevelZeroShimImp::frequency_throttle_reasons(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    //{
+    //    return frequency_status_shim(accel_idx, domain, domain_idx).throttle_reasons;
+    //}
+
+    //std::tuple<double, double, double, double, double, uint64_t> LevelZeroShimImp::frequency_status_shim(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    LevelZeroShimImp::frequency_s LevelZeroShimImp::frequency_status_shim(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    {
+        ze_result_t ze_result;
+        zes_freq_domain_t type;
+
+        frequency_s result;
+
+        zes_freq_handle_t handle = m_devices.at(accel_idx).subdevice.m_freq_domain.at(domain).at(domain_idx);
+        zes_freq_state_t state;
+        ze_result = zesFrequencyGetState(handle, &state);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                            ": Sysman failed to get frequency state", __LINE__);
+
+        result.voltage = state.currentVoltage;
+        result.request = state.request;
+        result.tdp = state.tdp;
+        result.efficient = state.efficient;
+        result.actual = state.actual;
+        result.throttle_reasons = state.throttleReasons;
+
+        return result;
+    }
+
+    double LevelZeroShimImp::frequency_min(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    {
+        return frequency_min_max(accel_idx, domain, domain_idx).first;
+    }
+
+    double LevelZeroShimImp::frequency_max(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    {
+        return frequency_min_max(accel_idx, domain, domain_idx).second;
+    }
+
+    std::pair<double, double> LevelZeroShimImp::frequency_min_max(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    {
+        ze_result_t ze_result;
+        double result_min = 0;
+        double result_max = 0;
+
+        zes_freq_handle_t handle = m_devices.at(accel_idx).subdevice.m_freq_domain.at(domain).at(domain_idx);
+        zes_freq_properties_t property;
+        ze_result = zesFrequencyGetProperties(handle, &property);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                        ": Sysman failed to get domain properties.", __LINE__);
+        result_min += property.min;
+        result_max += property.max;
+
+        return {result_min, result_max};
+    }
+
+    uint64_t LevelZeroShimImp::active_time_timestamp(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    {
+        return active_time_pair(accel_idx, domain, domain_idx).second;
+    }
+
+    uint64_t LevelZeroShimImp::active_time(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    {
+        return active_time_pair(accel_idx, domain, domain_idx).first;
+    }
+
+    std::pair<uint64_t,uint64_t> LevelZeroShimImp::active_time_pair(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const
+    {
+        ze_result_t ze_result;
+        uint64_t result_active = 0;
+        uint64_t result_timestamp = 0;
+
+        zes_engine_properties_t property;
+        zes_engine_stats_t stats;
+
+        zes_engine_handle_t handle = m_devices.at(accel_idx).subdevice.m_engine_domain.at(domain).at(domain_idx);
+        ze_result = zesEngineGetActivity(handle, &stats);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                        ": Sysman failed to get engine group activity.", __LINE__);
+        result_active += stats.activeTime;
+        result_timestamp += stats.timestamp;
+
+        return {result_active, result_timestamp};
+    }
+
+    std::pair<uint64_t,uint64_t> LevelZeroShimImp::energy_pair(unsigned int accel_idx, int domain_idx) const
+    {
+        ze_result_t ze_result;
+        uint64_t result_energy = 0;
+        uint64_t result_timestamp = 0;
+
+        zes_pwr_handle_t handle = m_devices.at(accel_idx).m_power_domain.at(domain_idx);
+        //For initial GEOPM support we're only providing device level power.  Eventually we'll want to
+        //choose between these two
+        //zes_power_handle_t subdevice_handle = m_devices.at(accel_idx).subdevice.m_power_domain.at(domain).at(domain_idx);
+
+        zes_power_energy_counter_t energy_counter;
+        ze_result = zesPowerGetEnergyCounter(handle, &energy_counter);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                        ": Sysman failed to get energy_counter values", __LINE__);
+        result_energy += energy_counter.energy;
+        result_timestamp += energy_counter.timestamp;
+        return {result_energy, result_timestamp};
+    }
+
+    uint64_t LevelZeroShimImp::energy_timestamp(unsigned int accel_idx, int domain_idx) const
+    {
+        //TODO: for performance testing we may want to cache either the timestamp or the energy reading
+        return energy_pair(accel_idx, domain_idx).second;
+    }
+
+    uint64_t LevelZeroShimImp::energy(unsigned int accel_idx, int domain_idx) const
+    {
+        //TODO: for performance testing we may want to cache either the timestamp or the energy reading
+        return energy_pair(accel_idx, domain_idx).first;
+    }
+
+    int32_t LevelZeroShimImp::power_limit_tdp(unsigned int accel_idx, int domain_idx) const
+    {
+        //return std::get<2>(power_limit_default(accel_idx, domain_idx));
+        return power_limit_default(accel_idx, domain_idx).tdp;
+    }
+
+    int32_t LevelZeroShimImp::power_limit_min(unsigned int accel_idx, int domain_idx) const
+    {
+        //return std::get<0>(power_limit_default(accel_idx, domain_idx));
+        return power_limit_default(accel_idx, domain_idx).min;
+    }
+
+    int32_t LevelZeroShimImp::power_limit_max(unsigned int accel_idx, int domain_idx) const
+    {
+        //return std::get<1>(power_limit_default(accel_idx, domain_idx));
+        return power_limit_default(accel_idx, domain_idx).max;
+    }
+
+    //std::tuple<int32_t, int32_t, int32_t> LevelZeroShimImp::power_limit_default(unsigned int accel_idx, int domain_idx) const
+    LevelZeroShimImp::power_limit_s LevelZeroShimImp::power_limit_default(unsigned int accel_idx, int domain_idx) const
+    {
+        ze_result_t ze_result;
+
+        zes_power_properties_t property;
+        uint64_t tdp = 0;
+        uint64_t min_power_limit = 0;
+        uint64_t max_power_limit = 0;
+        power_limit_s result_power;
+
+        //For initial GEOPM support we're only providing device level power.  Eventually we'll want to
+        //choose between these two
+        //zes_power_handle_t subdevice_handle = m_devices.at(accel_idx).subdevice.m_power_domain.at(domain).at(domain_idx);
+        zes_pwr_handle_t handle = m_devices.at(accel_idx).m_power_domain.at(domain_idx);
+
+        //TODO: these could cached at init time
+        ze_result = zesPowerGetProperties(handle, &property);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroDevicePool::" + std::string(__func__) +
+                                                        ": Sysman failed to get domain power properties", __LINE__);
+        tdp = property.defaultLimit;
+        min_power_limit = property.minLimit;
+        max_power_limit = property.maxLimit;
+        result_power.tdp = property.defaultLimit;
+        result_power.min = property.minLimit;
+        result_power.max = property.maxLimit;
+
+        //return std::make_tuple(min_power_limit, max_power_limit, tdp);
+        return result_power;
+    }
+
+    void LevelZeroShimImp::frequency_control(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx, double setting) const
+    {
+        ze_result_t ze_result;
+        zes_freq_properties_t property;
+        zes_freq_range_t range;
+        range.min = setting;
+        range.max = setting;
+
+        zes_freq_handle_t handle = m_devices.at(accel_idx).subdevice.m_freq_domain.at(domain).at(domain_idx);
+
+        ze_result = zesFrequencyGetProperties(handle, &property);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                        ": Sysman failed to get domain properties.", __LINE__);
+
+        if (property.canControl == 0) {
+            throw Exception("LevelZeroShim::" + std::string(__func__) + ": Attempted to set frequency " +
+                            "for non controllable domain",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        ze_result = zesFrequencySetRange(handle, &range);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZeroShim::" + std::string(__func__) +
+                                                        ": Sysman failed to set frequency.", __LINE__);
+    }
+
+    void LevelZeroShimImp::check_ze_result(ze_result_t ze_result, int error, std::string message, int line) const
+    {
+        if(ze_result != ZE_RESULT_SUCCESS) {
+            std::string error_string = "Unknown ze_result_t value";
+
+            if (ze_result == ZE_RESULT_SUCCESS) {
+                error_string = "ZE_RESULT_SUCCESS";
+            }
+            else if (ze_result == ZE_RESULT_NOT_READY) {
+                error_string = "ZE_RESULT_NOT_READY";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNINITIALIZED) {
+                error_string = "ZE_RESULT_ERROR_UNINITIALIZED";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_DEVICE_LOST) {
+                error_string = "ZE_RESULT_ERROR_DEVICE_LOST";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_ARGUMENT) {
+                error_string = "ZE_RESULT_ERROR_INVALID_ARGUMENT";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY) {
+                error_string = "ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY) {
+                error_string = "ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_MODULE_BUILD_FAILURE) {
+                error_string = "ZE_RESULT_ERROR_MODULE_BUILD_FAILURE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS) {
+                error_string = "ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_NOT_AVAILABLE) {
+                error_string = "ZE_RESULT_ERROR_NOT_AVAILABLE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_VERSION) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_VERSION";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_FEATURE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_NULL_HANDLE) {
+                error_string = "ZE_RESULT_ERROR_INVALID_NULL_HANDLE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE) {
+                error_string = "ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_NULL_POINTER) {
+                error_string = "ZE_RESULT_ERROR_INVALID_NULL_POINTER";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_SIZE) {
+                error_string = "ZE_RESULT_ERROR_INVALID_SIZE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_SIZE) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_SIZE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT) {
+                error_string = "ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_ENUMERATION) {
+                error_string = "ZE_RESULT_ERROR_INVALID_ENUMERATION";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_ENUMERATION) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_ENUMERATION";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT) {
+                error_string = "ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_NATIVE_BINARY) {
+                error_string = "ZE_RESULT_ERROR_INVALID_NATIVE_BINARY";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_GLOBAL_NAME) {
+                error_string = "ZE_RESULT_ERROR_INVALID_GLOBAL_NAME";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_NAME) {
+                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_NAME";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_FUNCTION_NAME) {
+                error_string = "ZE_RESULT_ERROR_INVALID_FUNCTION_NAME";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION) {
+                error_string = "ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION) {
+                error_string = "ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX) {
+                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE) {
+                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE) {
+                error_string = "ZE_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE) {
+                error_string = "ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_OVERLAPPING_REGIONS) {
+                error_string = "ZE_RESULT_ERROR_OVERLAPPING_REGIONS";
+            }
+            else if (ze_result == ZE_RESULT_ERROR_UNKNOWN) {
+                error_string = "ZE_RESULT_ERROR_UNKNOWN";
+            }
+
+            throw Exception(message + "  Error: " + error_string, error, __FILE__, line);
+        }
+    }
+}

--- a/src/LevelZeroShim.hpp
+++ b/src/LevelZeroShim.hpp
@@ -51,111 +51,97 @@ namespace geopm
             /// @return Number of LevelZero accelerators.
             virtual int num_accelerator(void) const = 0;
 
+            /// @brief Number of accelerator subdevices on the platform.
+            /// @return Number of LevelZero accelerator subdevices.
+            virtual int num_accelerator_subdevice(void) const = 0;
+
             /// @brief Get the number of LevelZero frequency domains of a certain type
             /// @param [in] domain The domain type being targeted
             /// @return Accelerator frequency domain count.
-            virtual int frequency_domain_count(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual int frequency_domain_count(unsigned int device_idx, int domain) const = 0;
             /// @brief Get the LevelZero device actual frequency in MHz
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The domain type being targeted
             /// @param [in] domain_idx The index indicating a particular
             ///        domain of the accelerator.
             /// @return Accelerator device core clock rate in MHz.
-            virtual double frequency_status(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const = 0;
+            virtual double frequency_status(unsigned int device_idx, int domain, int domain_idx) const = 0;
             /// @brief Get the LevelZero device mininmum frequency in MHz
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The domain type being targeted
             /// @param [in] domain_idx The index indicating a particular
             ///        domain of the accelerator.
             /// @return Accelerator minimum frequency in MHz.
-            virtual double frequency_min(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const = 0;
+            virtual double frequency_min(unsigned int device_idx, int domain, int domain_idx) const = 0;
             /// @brief Get the LevelZero device maximum frequency in MHz
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The domain type being targeted
             /// @param [in] domain_idx The index indicating a particular
             ///        domain of the accelerator.
             /// @return Accelerator maximum frequency in MHz.
-            virtual double frequency_max(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const = 0;
+            virtual double frequency_max(unsigned int device_idx, int domain, int domain_idx) const = 0;
 
             /// @brief Get the number of LevelZero engine domains
             /// @param [in] domain The domain type being targeted
             /// @return Accelerator engine domain count.
-            virtual int engine_domain_count(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual int engine_domain_count(unsigned int device_idx, int domain) const = 0;
             /// @brief Get the LevelZero device active time in microseconds
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The domain type being targeted
             /// @param [in] domain_idx The index indicating a particular
             ///        domain of the accelerator.
             /// @return Accelerator active time in microseconds.
-            virtual uint64_t active_time(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const = 0;
+            virtual uint64_t active_time(unsigned int device_idx, int domain, int domain_idx) const = 0;
             /// @brief Get the LevelZero device timestamp for the active time value in microseconds
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The domain type being targeted
             /// @param [in] domain_idx The index indicating a particular
             ///        domain of the accelerator.
             /// @return Accelerator device timestamp for the active time value in microseconds.
-            virtual uint64_t active_time_timestamp(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const = 0;
+            virtual uint64_t active_time_timestamp(unsigned int device_idx, int domain, int domain_idx) const = 0;
 
             /// @brief Get the LevelZero device default power limit in milliwatts
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
-            /// @param [in] domain_idx The index indicating a particular
-            ///        domain of the accelerator.
             /// @return Accelerator default power limit in milliwatts
-            virtual int32_t power_limit_tdp(unsigned int accel_idx, int domain_idx) const = 0;
+            virtual int32_t power_limit_tdp(unsigned int device_idx) const = 0;
             /// @brief Get the LevelZero device minimum power limit in milliwatts
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
-            /// @param [in] domain_idx The index indicating a particular
-            ///        domain of the accelerator.
             /// @return Accelerator minimum power limit in milliwatts
-            virtual int32_t power_limit_min(unsigned int accel_idx, int domain_idx) const = 0;
+            virtual int32_t power_limit_min(unsigned int device_idx) const = 0;
             /// @brief Get the LevelZero device maximum power limit in milliwatts
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
-            /// @param [in] domain_idx The index indicating a particular
-            ///        domain of the accelerator.
             /// @return Accelerator maximum power limit in milliwatts
-            virtual int32_t power_limit_max(unsigned int accel_idx, int domain_idx) const = 0;
+            virtual int32_t power_limit_max(unsigned int device_idx) const = 0;
 
-            /// @brief Get the number of LevelZero device energy domains
-            /// @param [in] domain The domain type being targeted
-            /// @return Accelerator device energy domain count.
-            virtual int energy_domain_count_device(unsigned int accel_idx) const = 0;
-            /// @brief Get the number of LevelZero subdevice energy domains
-            /// @param [in] accel_idx The index indicating a particular
-            ///        accelerator.
-            /// @param [in] domain_idx The index indicating a particular
-            ///        domain of the accelerator.
-            /// @return Accelerator sub-device energy domain count.
-            virtual int energy_domain_count_subdevice(unsigned int accel_idx, int domain_idx) const = 0;
             /// @brief Get the LevelZero device energy in microjoules.
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator energy in microjoules.
-            virtual uint64_t energy(unsigned int accel_idx, int domain_idx) const = 0;
+            virtual uint64_t energy(unsigned int device_idx) const = 0;
             /// @brief Get the LevelZero device energy timestamp in microseconds
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
-            /// @param [in] domain_idx The index indicating a particular
-            ///        domain of the accelerator.
             /// @return Accelerator energy timestamp in microseconds
-            virtual uint64_t energy_timestamp(unsigned int accel_idx, int domain_idx) const = 0;
+            virtual uint64_t energy_timestamp(unsigned int device_idx) const = 0;
 
             /// @brief Set min and max frequency for LevelZero device.
-            /// @param [in] accel_idx The index indicating a particular
+            /// @param [in] device_idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain The domain type being targeted
             /// @param [in] setting Target frequency in MHz.
-            virtual void frequency_control(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx, double setting) const = 0;
+            virtual void frequency_control(unsigned int device_idx, int domain, int domain_idx, double setting) const = 0;
 
         private:
     };
-    const LevelZeroShim &levelzero_shim(int num_cpu);
+
+    const LevelZeroShim &levelzero_shim();
 }
 #endif

--- a/src/LevelZeroShim.hpp
+++ b/src/LevelZeroShim.hpp
@@ -30,8 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef LEVELZERODEVICEPOOL_HPP_INCLUDE
-#define LEVELZERODEVICEPOOL_HPP_INCLUDE
+#ifndef LEVELZEROSHIM_HPP_INCLUDE
+#define LEVELZEROSHIM_HPP_INCLUDE
 
 #include <vector>
 #include <string>
@@ -42,87 +42,120 @@
 
 namespace geopm
 {
-    class LevelZeroDevicePool
+    class LevelZeroShim
     {
         public:
-            LevelZeroDevicePool() = default;
-            virtual ~LevelZeroDevicePool() = default;
+            LevelZeroShim() = default;
+            virtual ~LevelZeroShim() = default;
             /// @brief Number of accelerators on the platform.
             /// @return Number of LevelZero accelerators.
             virtual int num_accelerator(void) const = 0;
+
+            /// @brief Get the number of LevelZero frequency domains of a certain type
+            /// @param [in] domain The domain type being targeted
+            /// @return Accelerator frequency domain count.
+            virtual int frequency_domain_count(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
             /// @brief Get the LevelZero device actual frequency in MHz
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
-            /// @param [in] domain The LevelZero domain type being targeted
+            /// @param [in] domain The domain type being targeted
+            /// @param [in] domain_idx The index indicating a particular
+            ///        domain of the accelerator.
             /// @return Accelerator device core clock rate in MHz.
-            virtual double frequency_status(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual double frequency_status(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const = 0;
             /// @brief Get the LevelZero device mininmum frequency in MHz
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
-            /// @param [in] domain The LevelZero domain type being targeted
+            /// @param [in] domain The domain type being targeted
+            /// @param [in] domain_idx The index indicating a particular
+            ///        domain of the accelerator.
             /// @return Accelerator minimum frequency in MHz.
-            virtual double frequency_min(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual double frequency_min(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const = 0;
             /// @brief Get the LevelZero device maximum frequency in MHz
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
-            /// @param [in] domain The LevelZero domain type being targeted
+            /// @param [in] domain The domain type being targeted
+            /// @param [in] domain_idx The index indicating a particular
+            ///        domain of the accelerator.
             /// @return Accelerator maximum frequency in MHz.
-            virtual double frequency_max(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual double frequency_max(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const = 0;
 
+            /// @brief Get the number of LevelZero engine domains
+            /// @param [in] domain The domain type being targeted
+            /// @return Accelerator engine domain count.
+            virtual int engine_domain_count(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
             /// @brief Get the LevelZero device active time in microseconds
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
-            /// @param [in] domain The LevelZero domain type being targeted
+            /// @param [in] domain The domain type being targeted
+            /// @param [in] domain_idx The index indicating a particular
+            ///        domain of the accelerator.
             /// @return Accelerator active time in microseconds.
-            virtual uint64_t active_time(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual uint64_t active_time(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const = 0;
             /// @brief Get the LevelZero device timestamp for the active time value in microseconds
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
-            /// @param [in] domain The LevelZero domain type being targeted
+            /// @param [in] domain The domain type being targeted
+            /// @param [in] domain_idx The index indicating a particular
+            ///        domain of the accelerator.
             /// @return Accelerator device timestamp for the active time value in microseconds.
-            virtual uint64_t active_time_timestamp(unsigned int accel_idx, geopm_levelzero_domain_e domain) const = 0;
+            virtual uint64_t active_time_timestamp(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const = 0;
 
             /// @brief Get the LevelZero device default power limit in milliwatts
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
+            /// @param [in] domain_idx The index indicating a particular
+            ///        domain of the accelerator.
             /// @return Accelerator default power limit in milliwatts
-            virtual int32_t power_limit_tdp(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_tdp(unsigned int accel_idx, int domain_idx) const = 0;
             /// @brief Get the LevelZero device minimum power limit in milliwatts
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain_idx The index indicating a particular
             ///        domain of the accelerator.
             /// @return Accelerator minimum power limit in milliwatts
-            virtual int32_t power_limit_min(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_min(unsigned int accel_idx, int domain_idx) const = 0;
             /// @brief Get the LevelZero device maximum power limit in milliwatts
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @param [in] domain_idx The index indicating a particular
             ///        domain of the accelerator.
             /// @return Accelerator maximum power limit in milliwatts
-            virtual int32_t power_limit_max(unsigned int accel_idx) const = 0;
+            virtual int32_t power_limit_max(unsigned int accel_idx, int domain_idx) const = 0;
 
+            /// @brief Get the number of LevelZero device energy domains
+            /// @param [in] domain The domain type being targeted
+            /// @return Accelerator device energy domain count.
+            virtual int energy_domain_count_device(unsigned int accel_idx) const = 0;
+            /// @brief Get the number of LevelZero subdevice energy domains
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator.
+            /// @param [in] domain_idx The index indicating a particular
+            ///        domain of the accelerator.
+            /// @return Accelerator sub-device energy domain count.
+            virtual int energy_domain_count_subdevice(unsigned int accel_idx, int domain_idx) const = 0;
             /// @brief Get the LevelZero device energy in microjoules.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator energy in microjoules.
-            virtual uint64_t energy(unsigned int accel_idx) const = 0;
+            virtual uint64_t energy(unsigned int accel_idx, int domain_idx) const = 0;
             /// @brief Get the LevelZero device energy timestamp in microseconds
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
+            /// @param [in] domain_idx The index indicating a particular
+            ///        domain of the accelerator.
             /// @return Accelerator energy timestamp in microseconds
-            virtual uint64_t energy_timestamp(unsigned int accel_idx) const = 0;
+            virtual uint64_t energy_timestamp(unsigned int accel_idx, int domain_idx) const = 0;
 
             /// @brief Set min and max frequency for LevelZero device.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
-            /// @param [in] domain The LevelZero domain type being targeted
+            /// @param [in] domain The domain type being targeted
             /// @param [in] setting Target frequency in MHz.
-            virtual void frequency_control(unsigned int accel_idx, geopm_levelzero_domain_e domain, double setting) const = 0;
+            virtual void frequency_control(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx, double setting) const = 0;
 
         private:
     };
-
-    const LevelZeroDevicePool &levelzero_device_pool(int num_cpu);
+    const LevelZeroShim &levelzero_shim(int num_cpu);
 }
 #endif

--- a/src/LevelZeroShimImp.hpp
+++ b/src/LevelZeroShimImp.hpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LEVELZEROSHIMIMP_HPP_INCLUDE
+#define LEVELZEROSHIMIMP_HPP_INCLUDE
+
+#include <string>
+
+#include <level_zero/ze_api.h>
+#include <level_zero/zes_api.h>
+
+#include "LevelZeroShim.hpp"
+
+#include "geopm_time.h"
+
+namespace geopm
+{
+    class LevelZeroShimImp : public LevelZeroShim
+    {
+        public:
+            LevelZeroShimImp(const int num_cpu);
+            virtual ~LevelZeroShimImp();
+            virtual int num_accelerator(void) const override;
+            virtual int frequency_domain_count(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
+            virtual double frequency_status(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const override;
+            virtual double frequency_min(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const override;
+            virtual double frequency_max(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const override;
+
+            virtual int engine_domain_count(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
+            virtual uint64_t active_time(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const override;
+            virtual uint64_t active_time_timestamp(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const override;
+
+            virtual int energy_domain_count_device(unsigned int accel_idx) const override;
+            virtual int energy_domain_count_subdevice(unsigned int accel_idx, int domain_idx) const override;
+            virtual uint64_t energy(unsigned int accel_idx, int domain_idx) const override;
+            virtual uint64_t energy_timestamp(unsigned int accel_idx, int domain_idx) const override;
+            virtual int32_t power_limit_tdp(unsigned int accel_idx, int domain_idx) const override;
+            virtual int32_t power_limit_min(unsigned int accel_idx, int domain_idx) const override;
+            virtual int32_t power_limit_max(unsigned int accel_idx, int domain_idx) const override;
+
+            virtual void frequency_control(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx, double setting) const override;
+
+        private:
+            const unsigned int M_NUM_CPU;
+
+            struct frequency_s {
+                double voltage = 0;
+                double request  = 0;
+                double tdp = 0;
+                double efficient = 0;
+                double actual = 0;
+                uint64_t throttle_reasons = 0;
+            };
+            struct power_limit_s {
+                int32_t tdp = 0;
+                int32_t min= 0;
+                int32_t max = 0;
+            };
+
+            virtual void domain_cache(unsigned int accel_idx);
+            virtual void check_ze_result(ze_result_t ze_result, int error, std::string message, int line) const;
+            virtual int num_accelerator(ze_device_type_t type) const;
+
+            virtual std::pair<double, double> frequency_min_max(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const;
+            virtual std::pair<uint64_t, uint64_t> energy_pair(unsigned int accel_idx, int domain_idx) const;
+            virtual std::pair<uint64_t, uint64_t> active_time_pair(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const;
+
+            virtual power_limit_s power_limit_default(unsigned int accel_idx, int domain_idx) const;
+            virtual frequency_s frequency_status_shim(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const;
+
+            uint32_t m_num_driver;
+            uint32_t m_num_device;
+            uint32_t m_num_integrated_gpu;
+            uint32_t m_num_board_gpu;
+            uint32_t m_num_fpga;
+            uint32_t m_num_mca;
+
+            std::vector<ze_driver_handle_t> m_levelzero_driver;
+            // TODO: This will need to be a map or vector of vectors if we're supporting multiple
+            //       types of sysman devices such as <BOARD GPU devices, PACKAGE GPU device, FPGA device>
+            std::vector<zes_device_handle_t> m_sysman_device;
+
+            struct subdevice_s {
+                // Could treat this like the other domains to be consistent, but it does not
+                // have GPU and MEM domains
+                std::vector<zes_pwr_handle_t> m_power_domain;
+                //These are enum geopm_levelzero_domain_e indexed
+                std::vector<std::vector<zes_freq_handle_t> > m_freq_domain;
+                std::vector<std::vector<zes_engine_handle_t> > m_engine_domain;
+                //std::vector<std::vector<zes_perf_handle_t> > m_perf_domain;
+                //std::vector<std::vector<zes_standby_handle_t> > m_standby_domain;
+                //std::vector<std::vector<zes_mem_handle_t> > m_mem_domain;
+                //std::vector<std::vector<zes_temp_handle_t> > m_temperature_domain;
+                //std::vector<std::vector<zes_fabric_port_handle_t> > m_fabric_domain;
+            };
+
+            struct device_info_s {
+                zes_device_handle_t device_handle; // likely not needed
+                ze_device_properties_t property;
+                //ze_device_type_t device_type; // already a part of property above
+                uint32_t m_num_subdevice;
+                // device type doesn't tell us board vs integrated GPU.  So we have our own
+                //geopm_levelzero_type_e geopm_device_type;
+                std::vector<zes_device_handle_t> subdevice_handle;
+
+                // Sub-Device domain tracking
+                // Currently tracking all sub-devices together
+                // until we move to expose GEOPM_BOARD_ACCELERATOR_SUBDEVICE
+                subdevice_s subdevice;
+                //std::vector<subdevice_s> subdevice;
+
+                // Device/Package domain
+                std::vector<zes_pwr_handle_t> m_power_domain;
+                std::vector<zes_temp_handle_t> m_temperature_domain;
+            };
+            std::vector<device_info_s> m_devices;
+    };
+}
+#endif

--- a/src/LevelZeroShimImp.hpp
+++ b/src/LevelZeroShimImp.hpp
@@ -47,31 +47,29 @@ namespace geopm
     class LevelZeroShimImp : public LevelZeroShim
     {
         public:
-            LevelZeroShimImp(const int num_cpu);
-            virtual ~LevelZeroShimImp();
+            LevelZeroShimImp();
+            virtual ~LevelZeroShimImp() = default;
             virtual int num_accelerator(void) const override;
-            virtual int frequency_domain_count(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
-            virtual double frequency_status(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const override;
-            virtual double frequency_min(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const override;
-            virtual double frequency_max(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const override;
+            virtual int num_accelerator_subdevice(void) const override;
 
-            virtual int engine_domain_count(unsigned int accel_idx, geopm_levelzero_domain_e domain) const override;
-            virtual uint64_t active_time(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const override;
-            virtual uint64_t active_time_timestamp(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const override;
+            virtual int frequency_domain_count(unsigned int device_idx, int domain) const override;
+            virtual double frequency_status(unsigned int device_idx, int domain, int domain_idx) const override;
+            virtual double frequency_min(unsigned int device_idx, int domain, int domain_idx) const override;
+            virtual double frequency_max(unsigned int device_idx, int domain, int domain_idx) const override;
 
-            virtual int energy_domain_count_device(unsigned int accel_idx) const override;
-            virtual int energy_domain_count_subdevice(unsigned int accel_idx, int domain_idx) const override;
-            virtual uint64_t energy(unsigned int accel_idx, int domain_idx) const override;
-            virtual uint64_t energy_timestamp(unsigned int accel_idx, int domain_idx) const override;
-            virtual int32_t power_limit_tdp(unsigned int accel_idx, int domain_idx) const override;
-            virtual int32_t power_limit_min(unsigned int accel_idx, int domain_idx) const override;
-            virtual int32_t power_limit_max(unsigned int accel_idx, int domain_idx) const override;
+            virtual int engine_domain_count(unsigned int device_idx, int domain) const override;
+            virtual uint64_t active_time(unsigned int device_idx, int domain, int domain_idx) const override;
+            virtual uint64_t active_time_timestamp(unsigned int device_idx, int domain, int domain_idx) const override;
 
-            virtual void frequency_control(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx, double setting) const override;
+            virtual uint64_t energy(unsigned int device_idx) const override;
+            virtual uint64_t energy_timestamp(unsigned int device_idx) const override;
+            virtual int32_t power_limit_tdp(unsigned int device_idx) const override;
+            virtual int32_t power_limit_min(unsigned int device_idx) const override;
+            virtual int32_t power_limit_max(unsigned int device_idx) const override;
+
+            virtual void frequency_control(unsigned int device_idx, int domain, int domain_idx, double setting) const override;
 
         private:
-            const unsigned int M_NUM_CPU;
-
             struct frequency_s {
                 double voltage = 0;
                 double request  = 0;
@@ -86,60 +84,50 @@ namespace geopm
                 int32_t max = 0;
             };
 
-            virtual void domain_cache(unsigned int accel_idx);
+            virtual void domain_cache(unsigned int device_idx);
             virtual void check_ze_result(ze_result_t ze_result, int error, std::string message, int line) const;
-            virtual int num_accelerator(ze_device_type_t type) const;
 
-            virtual std::pair<double, double> frequency_min_max(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const;
-            virtual std::pair<uint64_t, uint64_t> energy_pair(unsigned int accel_idx, int domain_idx) const;
-            virtual std::pair<uint64_t, uint64_t> active_time_pair(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const;
+            virtual std::pair<double, double> frequency_min_max(unsigned int device_idx, int domain, int domain_idx) const;
+            virtual std::pair<uint64_t, uint64_t> energy_pair(unsigned int device_idx) const;
+            virtual std::pair<uint64_t, uint64_t> active_time_pair(unsigned int device_idx, int domain, int domain_idx) const;
 
-            virtual power_limit_s power_limit_default(unsigned int accel_idx, int domain_idx) const;
-            virtual frequency_s frequency_status_shim(unsigned int accel_idx, geopm_levelzero_domain_e domain, int domain_idx) const;
+            virtual power_limit_s power_limit_default(unsigned int device_idx) const;
+            virtual frequency_s frequency_status_shim(unsigned int device_idx, int domain, int domain_idx) const;
 
-            uint32_t m_num_driver;
-            uint32_t m_num_device;
-            uint32_t m_num_integrated_gpu;
             uint32_t m_num_board_gpu;
-            uint32_t m_num_fpga;
-            uint32_t m_num_mca;
+            uint32_t m_num_board_gpu_subdevice;
 
             std::vector<ze_driver_handle_t> m_levelzero_driver;
-            // TODO: This will need to be a map or vector of vectors if we're supporting multiple
-            //       types of sysman devices such as <BOARD GPU devices, PACKAGE GPU device, FPGA device>
-            std::vector<zes_device_handle_t> m_sysman_device;
 
             struct subdevice_s {
                 // Could treat this like the other domains to be consistent, but it does not
                 // have GPU and MEM domains
                 std::vector<zes_pwr_handle_t> m_power_domain;
-                //These are enum geopm_levelzero_domain_e indexed
+                //These are enum geopm_levelzero_domain_e indexed, then subdevice indexed
                 std::vector<std::vector<zes_freq_handle_t> > m_freq_domain;
                 std::vector<std::vector<zes_engine_handle_t> > m_engine_domain;
-                //std::vector<std::vector<zes_perf_handle_t> > m_perf_domain;
-                //std::vector<std::vector<zes_standby_handle_t> > m_standby_domain;
-                //std::vector<std::vector<zes_mem_handle_t> > m_mem_domain;
-                //std::vector<std::vector<zes_temp_handle_t> > m_temperature_domain;
-                //std::vector<std::vector<zes_fabric_port_handle_t> > m_fabric_domain;
+                std::vector<std::vector<zes_perf_handle_t> > m_perf_domain;
+                std::vector<std::vector<zes_standby_handle_t> > m_standby_domain;
+                std::vector<std::vector<zes_mem_handle_t> > m_mem_domain;
+                std::vector<std::vector<zes_temp_handle_t> > m_temperature_domain;
+                std::vector<std::vector<zes_fabric_port_handle_t> > m_fabric_domain;
             };
 
             struct device_info_s {
-                zes_device_handle_t device_handle; // likely not needed
+                zes_device_handle_t device_handle;
                 ze_device_properties_t property;
-                //ze_device_type_t device_type; // already a part of property above
                 uint32_t m_num_subdevice;
-                // device type doesn't tell us board vs integrated GPU.  So we have our own
-                //geopm_levelzero_type_e geopm_device_type;
                 std::vector<zes_device_handle_t> subdevice_handle;
 
-                // Sub-Device domain tracking
-                // Currently tracking all sub-devices together
-                // until we move to expose GEOPM_BOARD_ACCELERATOR_SUBDEVICE
+                // Sub-Device domain tracking.  Because levelzero returns ALL handles for a
+                // 'class' (freq, power, etc) regardless of subdevice it is easier to track
+                // this as class.domain.subdevice where domain is compute/memory.  This avoids
+                // an additional step of sorting handles to determine how many per subdevice
                 subdevice_s subdevice;
-                //std::vector<subdevice_s> subdevice;
 
-                // Device/Package domain
-                std::vector<zes_pwr_handle_t> m_power_domain;
+                // Device/Package domains
+                zes_pwr_handle_t m_power_domain;
+                //This is enum geopm_levelzero_domain_e indexed
                 std::vector<zes_temp_handle_t> m_temperature_domain;
             };
             std::vector<device_info_s> m_devices;

--- a/src/LevelZeroShimThrow.cpp
+++ b/src/LevelZeroShimThrow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Intel Corporation
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,21 +39,24 @@
 #include <sstream>
 #include <string>
 
+#include <thread>
+#include <chrono>
+#include <time.h>
+
 #include "Exception.hpp"
+#include "Environment.hpp"
 #include "Agg.hpp"
 #include "Helper.hpp"
 #include "geopm_sched.h"
 
-#include "LevelZeroDevicePool.hpp"
+#include "LevelZeroShim.hpp"
 
 namespace geopm
 {
-
-    const LevelZeroDevicePool &levelzero_device_pool(const int num_cpu)
+    const LevelZeroShim &levelzero_shim()
     {
-        throw Exception("LevelZeroDevicePoolThrow::" + std::string(__func__) +
+        throw Exception("LevelZeroShimThrow::" + std::string(__func__) +
                         ": GEOPM configured without Level Zero library support.  Please configure with --enable-levelzero",
                         GEOPM_ERROR_INVALID, __FILE__, __LINE__);
     }
-
 }

--- a/src/LevelZeroSignal.hpp
+++ b/src/LevelZeroSignal.hpp
@@ -30,33 +30,40 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
+#ifndef LEVELZEROSIGNAL_HPP_INCLUDE
+#define LEVELZEROSIGNAL_HPP_INCLUDE
 
-#include <fstream>
-#include <iostream>
-#include <sstream>
+#include <cstdint>
+#include <cmath>
+
 #include <string>
+#include <memory>
+#include <functional>
 
-#include "Exception.hpp"
-#include "AcceleratorTopoNull.hpp"
+#include "Signal.hpp"
+#include "LevelZeroDevicePool.hpp"
 
-#ifdef GEOPM_ENABLE_NVML
-#include "NVMLAcceleratorTopo.hpp"
-#elif defined(GEOPM_ENABLE_LEVELZERO)
-#include "LevelZeroAcceleratorTopo.hpp"
-#endif
 
 namespace geopm
 {
-    const AcceleratorTopo &accelerator_topo(void)
+    class LevelZeroDevicePool;
+
+    class LevelZeroSignal : public Signal
     {
-#ifdef GEOPM_ENABLE_NVML
-        static NVMLAcceleratorTopo instance;
-#elif defined(GEOPM_ENABLE_LEVELZERO)
-        static LevelZeroAcceleratorTopo instance;
-#else
-        static AcceleratorTopoNull instance;
-#endif
-        return instance;
-    }
+        public:
+            virtual ~LevelZeroSignal() = default;
+            LevelZeroSignal(std::function<double (unsigned int)> devpool_func,
+                         unsigned int accelerator, double scalar);
+            LevelZeroSignal(const LevelZeroSignal &other) = delete;
+            void setup_batch(void) override;
+            double sample(void) override;
+            double read(void) const override;
+        private:
+            std::function<double (unsigned int)> m_devpool_func;
+            unsigned int m_accel;
+            double m_scalar;
+            bool m_is_batch_ready;
+    };
 }
+
+#endif

--- a/src/NVMLAcceleratorTopo.cpp
+++ b/src/NVMLAcceleratorTopo.cpp
@@ -130,6 +130,13 @@ namespace geopm
         return m_num_accelerator;
     }
 
+    int NVMLAcceleratorTopo::num_accelerator_subdevice(void) const
+    {
+        // At this time sub-devices are not supported separate from sub-devices on NVIDIA
+        // As such we are reporting a single sub-device per device for mapping purposes
+        return m_num_accelerator;
+    }
+
     std::set<int> NVMLAcceleratorTopo::cpu_affinity_ideal(int accel_idx) const
     {
         if (accel_idx < 0 || (unsigned int) accel_idx >= m_num_accelerator) {
@@ -138,5 +145,12 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         return m_cpu_affinity_ideal.at(accel_idx);
+    }
+
+    std::set<int> NVMLAcceleratorTopo::cpu_affinity_ideal_subdevice(int accel_idx) const
+    {
+        // At this time sub-devices are not supported separate from sub-devices on NVIDIA
+        // As such we are reporting a single sub-device per device for mapping purposes
+        return cpu_affinity_ideal(accel_idx);
     }
 }

--- a/src/NVMLAcceleratorTopo.hpp
+++ b/src/NVMLAcceleratorTopo.hpp
@@ -50,7 +50,9 @@ namespace geopm
             NVMLAcceleratorTopo(const NVMLDevicePool &device_pool, const int num_cpu);
             virtual ~NVMLAcceleratorTopo() = default;
             virtual int num_accelerator(void) const override;
+            virtual int num_accelerator_subdevice(void) const override;
             virtual std::set<int> cpu_affinity_ideal(int accel_idx) const override;
+            virtual std::set<int> cpu_affinity_ideal_subdevice(int domain_idx) const override;
         private:
             const NVMLDevicePool &m_nvml_device_pool;
             std::vector<std::set<int> > m_cpu_affinity_ideal;

--- a/src/PlatformTopo.cpp
+++ b/src/PlatformTopo.cpp
@@ -155,6 +155,9 @@ namespace geopm
             case GEOPM_DOMAIN_BOARD_ACCELERATOR:
                 result = m_accelerator_topo.num_accelerator();
                 break;
+            case GEOPM_DOMAIN_BOARD_ACCELERATOR_SUBDEVICE:
+                result = m_accelerator_topo.num_accelerator_subdevice();
+                break;
             case GEOPM_DOMAIN_PACKAGE_ACCELERATOR:
                 // @todo Add support for package accelerators to PlatformTopo.
                 result = 0;
@@ -193,6 +196,9 @@ namespace geopm
                 break;
             case GEOPM_DOMAIN_BOARD_ACCELERATOR:
                 cpu_idx = m_accelerator_topo.cpu_affinity_ideal(domain_idx);
+                break;
+            case GEOPM_DOMAIN_BOARD_ACCELERATOR_SUBDEVICE:
+                cpu_idx = m_accelerator_topo.cpu_affinity_ideal_subdevice(domain_idx);
                 break;
             case GEOPM_DOMAIN_PACKAGE:
                 for (int thread_idx = 0;
@@ -285,6 +291,14 @@ namespace geopm
                         }
                     }
                     break;
+                case GEOPM_DOMAIN_BOARD_ACCELERATOR_SUBDEVICE:
+                    for(int accel_sub_idx = 0; (accel_sub_idx <  m_accelerator_topo.num_accelerator_subdevice()) && (result == -1); ++accel_sub_idx) {
+                        std::set<int> affin = m_accelerator_topo.cpu_affinity_ideal_subdevice(accel_sub_idx);
+                        if (affin.find(cpu_idx) != affin.end()) {
+                            result = accel_sub_idx;
+                        }
+                    }
+                    break;
                 case GEOPM_DOMAIN_PACKAGE_MEMORY:
                 case GEOPM_DOMAIN_BOARD_NIC:
                 case GEOPM_DOMAIN_PACKAGE_NIC:
@@ -344,6 +358,16 @@ namespace geopm
             // To support mapping CPU signals to ACCELERATOR domain
             result = true;
         }
+        else if (outer_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR &&
+                 inner_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR_SUBDEVICE) {
+            // To support mapping ACCELERATOR SUBDEVICE signals to ACCELERATOR domain
+            result = true;
+        }
+        else if (outer_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR_SUBDEVICE &&
+                 inner_domain == GEOPM_DOMAIN_CPU) {
+            // To support mapping CPU signals to ACCELERATOR SUBDEVICE domain
+            result = true;
+        }
         return result;
     }
 
@@ -383,7 +407,8 @@ namespace geopm
             {"board_nic", GEOPM_DOMAIN_BOARD_NIC},
             {"package_nic", GEOPM_DOMAIN_PACKAGE_NIC},
             {"board_accelerator", GEOPM_DOMAIN_BOARD_ACCELERATOR},
-            {"package_accelerator", GEOPM_DOMAIN_PACKAGE_ACCELERATOR}
+            {"package_accelerator", GEOPM_DOMAIN_PACKAGE_ACCELERATOR},
+            {"board_accelerator_subdevice", GEOPM_DOMAIN_BOARD_ACCELERATOR_SUBDEVICE}
         };
     }
 

--- a/src/geopm_topo.h
+++ b/src/geopm_topo.h
@@ -91,6 +91,14 @@ enum geopm_domain_e {
     GEOPM_NUM_DOMAIN = 10,
 };
 
+enum geopm_levelzero_domain_e {
+    GEOPM_LEVELZERO_DOMAIN_ALL = 0,
+    GEOPM_LEVELZERO_DOMAIN_COMPUTE = 1,
+    GEOPM_LEVELZERO_DOMAIN_MEMORY = 2,
+    GEOPM_LEVELZERO_DOMAIN_SIZE = 3
+};
+
+
 int geopm_topo_num_domain(int domain_type);
 
 int geopm_topo_domain_idx(int domain_type,

--- a/src/geopm_topo.h
+++ b/src/geopm_topo.h
@@ -86,9 +86,14 @@ enum geopm_domain_e {
      */
     GEOPM_DOMAIN_PACKAGE_ACCELERATOR = 9,
     /*!
+     * @brief Accelerator card subdevices on the PCI Bus (e.g
+     *        Level Zero subdevices)
+     */
+    GEOPM_DOMAIN_BOARD_ACCELERATOR_SUBDEVICE = 10,
+    /*!
      * @brief Number of valid domains.
      */
-    GEOPM_NUM_DOMAIN = 10,
+    GEOPM_NUM_DOMAIN = 11,
 };
 
 enum geopm_levelzero_domain_e {
@@ -97,7 +102,6 @@ enum geopm_levelzero_domain_e {
     GEOPM_LEVELZERO_DOMAIN_MEMORY = 2,
     GEOPM_LEVELZERO_DOMAIN_SIZE = 3
 };
-
 
 int geopm_topo_num_domain(int domain_type);
 

--- a/test/AcceleratorTopoNullTest.cpp
+++ b/test/AcceleratorTopoNullTest.cpp
@@ -54,5 +54,7 @@ TEST(AcceleratorTopoNullTest, default_config)
     std::unique_ptr<AcceleratorTopoNull> topo;
     topo = geopm::make_unique<AcceleratorTopoNull>();
     EXPECT_EQ(0, topo->num_accelerator());
+    EXPECT_EQ(0, topo->num_accelerator_subdevice());
     EXPECT_EQ(topo->cpu_affinity_ideal(0), std::set<int>{});
+    EXPECT_EQ(topo->cpu_affinity_ideal_subdevice(0), std::set<int>{});
 }

--- a/test/LevelZeroAcceleratorTopoTest.cpp
+++ b/test/LevelZeroAcceleratorTopoTest.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <unistd.h>
+#include <limits.h>
+
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "config.h"
+#include "Helper.hpp"
+#include "Exception.hpp"
+#include "MockLevelZeroDevicePool.hpp"
+#include "LevelZeroAcceleratorTopo.hpp"
+#include "geopm_test.hpp"
+
+using geopm::LevelZeroAcceleratorTopo;
+using geopm::Exception;
+using testing::Return;
+
+class LevelZeroAcceleratorTopoTest : public :: testing :: Test
+{
+    protected:
+        void SetUp();
+        void TearDown();
+
+        std::shared_ptr<MockLevelZeroDevicePool> m_device_pool;
+};
+
+void LevelZeroAcceleratorTopoTest::SetUp()
+{
+    m_device_pool = std::make_shared<MockLevelZeroDevicePool>();
+}
+
+void LevelZeroAcceleratorTopoTest::TearDown()
+{
+}
+
+//Test case: Mock num_accelerator = 0 so we hit the appropriate warning and throw on affinitization requests.
+TEST_F(LevelZeroAcceleratorTopoTest, no_gpu_config)
+{
+    const int num_accelerator = 0;
+    const int num_cpu = 40;
+
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    LevelZeroAcceleratorTopo topo(*m_device_pool, num_cpu);
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+
+    GEOPM_EXPECT_THROW_MESSAGE(topo.cpu_affinity_ideal(num_accelerator), GEOPM_ERROR_INVALID, "accel_idx 0 is out of range");
+}
+
+TEST_F(LevelZeroAcceleratorTopoTest, four_forty_config)
+{
+    const int num_accelerator = 4;
+    const int num_cpu = 40;
+
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    LevelZeroAcceleratorTopo topo(*m_device_pool, num_cpu);
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
+    cpus_allowed_set[0] = {0,1,2,3,4,5,6,7,8,9};
+    cpus_allowed_set[1] = {10,11,12,13,14,15,16,17,18,19};
+    cpus_allowed_set[2] = {20,21,22,23,24,25,26,27,28,29};
+    cpus_allowed_set[3] = {30,31,32,33,34,35,36,37,38,39};
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}
+
+//Test case: Different GPU/CPU count, with 8 GPUs and 28 cores per socket.
+TEST_F(LevelZeroAcceleratorTopoTest, eight_fiftysix_affinitization_config)
+{
+    const int num_accelerator = 8;
+    const int num_cpu = 56;
+
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    LevelZeroAcceleratorTopo topo(*m_device_pool, num_cpu);
+
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
+    cpus_allowed_set[0] = {0 ,1 ,2 ,3 ,4 ,5 ,6 };
+    cpus_allowed_set[1] = {7 ,8 ,9 ,10,11,12,13};
+    cpus_allowed_set[2] = {14,15,16,17,18,19,20};
+    cpus_allowed_set[3] = {21,22,23,24,25,26,27};
+    cpus_allowed_set[4] = {28,29,30,31,32,33,34};
+    cpus_allowed_set[5] = {35,36,37,38,39,40,41};
+    cpus_allowed_set[6] = {42,43,44,45,46,47,48};
+    cpus_allowed_set[7] = {49,50,51,52,53,54,55};
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}
+
+//Test case: CPU count that is not evenly divisible by the accelerator count
+TEST_F(LevelZeroAcceleratorTopoTest, uneven_affinitization_config)
+{
+    const int num_accelerator = 3;
+    const int num_cpu =20;
+
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    LevelZeroAcceleratorTopo topo(*m_device_pool, num_cpu);
+
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
+    cpus_allowed_set[0] = {0 ,1 ,2 ,3 ,4 ,5 ,18};
+    cpus_allowed_set[1] = {6 ,7 ,8 ,9 ,10,11,19};
+    cpus_allowed_set[2] = {12,13,14,15,16,17};
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}
+
+//Test case: High Core count, theoretical system to test large CPU SETS.
+//           This represents a system with 64 cores and 8 GPUs
+TEST_F(LevelZeroAcceleratorTopoTest, high_cpu_count_config)
+{
+    const int num_accelerator = 8;
+    const int num_cpu = 128;
+
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillOnce(Return(num_accelerator));
+
+    LevelZeroAcceleratorTopo topo(*m_device_pool, num_cpu);
+
+    EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    std::set<int> cpus_allowed_set[num_accelerator];
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        for (int cpu_idx = 0; cpu_idx < num_cpu/num_accelerator; ++cpu_idx) {
+            cpus_allowed_set[accel_idx].insert(cpu_idx+(accel_idx*16));
+        }
+
+        ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
+    }
+}

--- a/test/LevelZeroDevicePoolTest.cpp
+++ b/test/LevelZeroDevicePoolTest.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <unistd.h>
+#include <limits.h>
+
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "config.h"
+#include "Helper.hpp"
+#include "Exception.hpp"
+#include "MockLevelZeroShim.hpp"
+#include "LevelZeroDevicePoolImp.hpp"
+#include "geopm_test.hpp"
+
+using geopm::LevelZeroDevicePoolImp;
+using geopm::Exception;
+using testing::Return;
+
+class LevelZeroDevicePoolTest : public :: testing :: Test
+{
+    protected:
+        void SetUp();
+        void TearDown();
+
+        std::shared_ptr<MockLevelZeroShim> m_shim;
+};
+
+void LevelZeroDevicePoolTest::SetUp()
+{
+    m_shim = std::make_shared<MockLevelZeroShim>();
+}
+
+void LevelZeroDevicePoolTest::TearDown()
+{
+}
+
+TEST_F(LevelZeroDevicePoolTest, device_count)
+{
+    const int num_accelerator = 4;
+    const int num_accelerator_subdevice = 8;
+    EXPECT_CALL(*m_shim, num_accelerator()).WillRepeatedly(Return(num_accelerator));
+    EXPECT_CALL(*m_shim, num_accelerator_subdevice()).WillRepeatedly(Return(num_accelerator_subdevice));
+
+    LevelZeroDevicePoolImp m_device_pool(*m_shim);
+
+    EXPECT_EQ(num_accelerator, m_device_pool.num_accelerator());
+    EXPECT_EQ(num_accelerator_subdevice, m_device_pool.num_accelerator_subdevice());
+}
+
+TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
+{
+    const int num_accelerator = 4;
+    const int num_accelerator_subdevice = 8;
+    const int num_subdevice_per_device = num_accelerator_subdevice/num_accelerator;
+
+    EXPECT_CALL(*m_shim, num_accelerator()).WillRepeatedly(Return(num_accelerator));
+    EXPECT_CALL(*m_shim, num_accelerator_subdevice()).WillRepeatedly(Return(num_accelerator_subdevice));
+
+    int value = 1500;
+    int offset = 0;
+    int domain_count = 1; //any non-zero number to ensure we don't throw
+    for (int dev_idx = 0; dev_idx < num_accelerator; ++dev_idx) {
+        EXPECT_CALL(*m_shim, frequency_domain_count(dev_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
+        EXPECT_CALL(*m_shim, engine_domain_count(dev_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
+        for (int sub_idx = 0; sub_idx < num_subdevice_per_device; ++sub_idx) {
+            EXPECT_CALL(*m_shim, frequency_status(dev_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset));
+            EXPECT_CALL(*m_shim, frequency_min(dev_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_accelerator_subdevice*10));
+            EXPECT_CALL(*m_shim, frequency_max(dev_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_accelerator_subdevice*20));
+
+            EXPECT_CALL(*m_shim, active_time(dev_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_accelerator_subdevice*30));
+            EXPECT_CALL(*m_shim, active_time_timestamp(dev_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_accelerator_subdevice*40));
+            ++offset;
+        }
+    }
+    LevelZeroDevicePoolImp m_device_pool(*m_shim);
+
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        EXPECT_EQ(value+sub_idx, m_device_pool.frequency_status(sub_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE));
+        EXPECT_EQ(value+sub_idx+num_accelerator_subdevice*10, m_device_pool.frequency_min(sub_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE));
+        EXPECT_EQ(value+sub_idx+num_accelerator_subdevice*20, m_device_pool.frequency_max(sub_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE));
+
+        EXPECT_EQ((uint64_t)(value+sub_idx+num_accelerator_subdevice*30), m_device_pool.active_time(sub_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE));
+        EXPECT_EQ((uint64_t)(value+sub_idx+num_accelerator_subdevice*40), m_device_pool.active_time_timestamp(sub_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE));
+
+        EXPECT_NO_THROW(m_device_pool.frequency_control(sub_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE,value));
+    }
+}
+
+TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_error)
+{
+    const int num_accelerator = 4;
+    const int num_accelerator_subdevice = 9;
+
+    EXPECT_CALL(*m_shim, num_accelerator()).WillRepeatedly(Return(num_accelerator));
+    EXPECT_CALL(*m_shim, num_accelerator_subdevice()).WillRepeatedly(Return(num_accelerator_subdevice));
+
+    LevelZeroDevicePoolImp m_device_pool(*m_shim);
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_status(0, GEOPM_LEVELZERO_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "GEOPM Requires the number of subdevices to be evenly divisible by the number of devices");
+}
+
+TEST_F(LevelZeroDevicePoolTest, domain_error)
+{
+    const int num_accelerator = 4;
+    const int num_accelerator_subdevice = 8;
+    const int num_subdevice_per_device = num_accelerator_subdevice/num_accelerator;
+
+    EXPECT_CALL(*m_shim, num_accelerator()).WillRepeatedly(Return(num_accelerator));
+    EXPECT_CALL(*m_shim, num_accelerator_subdevice()).WillRepeatedly(Return(num_accelerator_subdevice));
+
+    int value = 1500;
+    int offset = 0;
+    int domain_count = 0; //zero to cause a throw
+    for (int dev_idx = 0; dev_idx < num_accelerator; ++dev_idx) {
+        EXPECT_CALL(*m_shim, frequency_domain_count(dev_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
+        for (int sub_idx = 0; sub_idx < num_subdevice_per_device; ++sub_idx) {
+            EXPECT_CALL(*m_shim, frequency_status(dev_idx, GEOPM_LEVELZERO_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset));
+            ++offset;
+        }
+    }
+    LevelZeroDevicePoolImp m_device_pool(*m_shim);
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_status(0, GEOPM_LEVELZERO_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "Not supported on this hardware");
+}
+
+TEST_F(LevelZeroDevicePoolTest, subdevice_range_check)
+{
+    const int num_accelerator = 4;
+    const int num_accelerator_subdevice = 8;
+
+    EXPECT_CALL(*m_shim, num_accelerator()).WillRepeatedly(Return(num_accelerator));
+    EXPECT_CALL(*m_shim, num_accelerator_subdevice()).WillRepeatedly(Return(num_accelerator_subdevice));
+
+    LevelZeroDevicePoolImp m_device_pool(*m_shim);
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_status(num_accelerator_subdevice, GEOPM_LEVELZERO_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "subdevice idx "+std::to_string(num_accelerator_subdevice)+" is out of range");
+}
+
+TEST_F(LevelZeroDevicePoolTest, device_range_check)
+{
+    const int num_accelerator = 4;
+
+    EXPECT_CALL(*m_shim, num_accelerator()).WillRepeatedly(Return(num_accelerator));
+
+    LevelZeroDevicePoolImp m_device_pool(*m_shim);
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.energy(num_accelerator), GEOPM_ERROR_INVALID, "device idx "+std::to_string(num_accelerator)+" is out of range");
+}
+
+TEST_F(LevelZeroDevicePoolTest, device_function_check)
+{
+    const int num_accelerator = 4;
+
+    EXPECT_CALL(*m_shim, num_accelerator()).WillRepeatedly(Return(num_accelerator));
+
+    int value = 1500;
+    int offset = 0;
+    for (int dev_idx = 0; dev_idx < num_accelerator; ++dev_idx) {
+        EXPECT_CALL(*m_shim, power_limit_tdp(dev_idx)).WillOnce(Return(value+offset));
+        EXPECT_CALL(*m_shim, power_limit_min(dev_idx)).WillOnce(Return(value+offset+num_accelerator*10));
+        EXPECT_CALL(*m_shim, power_limit_max(dev_idx)).WillOnce(Return(value+offset+num_accelerator*20));
+        EXPECT_CALL(*m_shim, energy(dev_idx)).WillOnce(Return(value+offset+num_accelerator*30));
+        EXPECT_CALL(*m_shim, energy_timestamp(dev_idx)).WillOnce(Return(value+offset+num_accelerator*40));
+        ++offset;
+    }
+    LevelZeroDevicePoolImp m_device_pool(*m_shim);
+
+    for (int dev_idx = 0; dev_idx < num_accelerator; ++dev_idx) {
+        EXPECT_EQ(value+dev_idx, m_device_pool.power_limit_tdp(dev_idx));
+        EXPECT_EQ(value+dev_idx+num_accelerator*10, m_device_pool.power_limit_min(dev_idx));
+        EXPECT_EQ(value+dev_idx+num_accelerator*20, m_device_pool.power_limit_max(dev_idx));
+        EXPECT_EQ((uint64_t)(value+dev_idx+num_accelerator*30), m_device_pool.energy(dev_idx));
+        EXPECT_EQ((uint64_t)(value+dev_idx+num_accelerator*40), m_device_pool.energy_timestamp(dev_idx));
+    }
+}

--- a/test/LevelZeroIOGroupTest.cpp
+++ b/test/LevelZeroIOGroupTest.cpp
@@ -1,0 +1,485 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <unistd.h>
+#include <limits.h>
+
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "config.h"
+#include "Helper.hpp"
+#include "Exception.hpp"
+#include "PlatformTopo.hpp"
+#include "PluginFactory.hpp"
+#include "LevelZeroIOGroup.hpp"
+#include "geopm_test.hpp"
+#include "MockLevelZeroDevicePool.hpp"
+#include "MockPlatformTopo.hpp"
+
+using geopm::LevelZeroIOGroup;
+using geopm::PlatformTopo;
+using geopm::Exception;
+using testing::Return;
+
+class LevelZeroIOGroupTest : public :: testing :: Test
+{
+    protected:
+        void SetUp();
+        void TearDown();
+        void write_affinitization(const std::string &affinitization_str);
+
+        std::shared_ptr<MockLevelZeroDevicePool> m_device_pool;
+        std::unique_ptr<MockPlatformTopo> m_platform_topo;
+};
+
+void LevelZeroIOGroupTest::SetUp()
+{
+    const int num_board = 1;
+    const int num_package = 2;
+    const int num_board_accelerator = 4;
+    const int num_core = 20;
+    const int num_cpu = 40;
+
+    m_device_pool = std::make_shared<MockLevelZeroDevicePool>();
+    m_platform_topo = geopm::make_unique<MockPlatformTopo>();
+
+    //Platform Topo prep
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD))
+        .WillByDefault(Return(num_board));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .WillByDefault(Return(num_package));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR))
+        .WillByDefault(Return(num_board_accelerator));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_CPU))
+        .WillByDefault(Return(num_cpu));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_CORE))
+        .WillByDefault(Return(num_core));
+
+    for (int cpu_idx = 0; cpu_idx < num_cpu; ++cpu_idx) {
+        if (cpu_idx < 10) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(0));
+        }
+        else if (cpu_idx < 20) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(1));
+        }
+        else if (cpu_idx < 30) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(2));
+        }
+        else {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(3));
+        }
+    }
+
+    EXPECT_CALL(*m_device_pool, num_accelerator()).WillRepeatedly(Return(num_board_accelerator));
+}
+
+void LevelZeroIOGroupTest::TearDown()
+{
+}
+
+TEST_F(LevelZeroIOGroupTest, valid_signals)
+{
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+    for (const auto &sig : levelzero_io.signal_names()) {
+        EXPECT_TRUE(levelzero_io.is_valid_signal(sig));
+        EXPECT_NE(GEOPM_DOMAIN_INVALID, levelzero_io.signal_domain_type(sig));
+        EXPECT_LT(-1, levelzero_io.signal_behavior(sig));
+    }
+}
+
+TEST_F(LevelZeroIOGroupTest, push_control_adjust_write_batch)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+    std::map<int, double> batch_value;
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    std::vector<double> mock_freq = {1530, 1320, 420, 135};
+    std::vector<double> mock_standby_control = {1, 0, 1, 0};
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        batch_value[(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL",
+                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_freq.at(accel_idx)*1e6;
+        batch_value[(levelzero_io.push_control("FREQUENCY_ACCELERATOR_CONTROL",
+                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_freq.at(accel_idx)*1e6;
+        EXPECT_CALL(*m_device_pool,
+                    frequency_control_gpu(accel_idx, mock_freq.at(accel_idx))).Times(2);
+
+        batch_value[(levelzero_io.push_control("LEVELZERO::STANDBY_MODE_CONTROL",
+                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_standby_control.at(accel_idx);
+        EXPECT_CALL(*m_device_pool, standby_mode_control(accel_idx,
+                                                         mock_standby_control.at(accel_idx))).Times(1);
+    }
+
+    for (auto& sv: batch_value) {
+        // Given that we are mocking LEVELZERODevicePool the actual setting here doesn't matter
+        EXPECT_NO_THROW(levelzero_io.adjust(sv.first, sv.second));
+    }
+    EXPECT_NO_THROW(levelzero_io.write_batch());
+}
+
+TEST_F(LevelZeroIOGroupTest, write_control)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    std::vector<double> mock_freq = {1530, 1320, 420, 135};
+    std::vector<double> mock_standby_control = {1, 0, 1, 0};
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool,
+                    frequency_control_gpu(accel_idx, mock_freq.at(accel_idx))).Times(2);
+
+        EXPECT_NO_THROW(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL",
+                                              GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx,
+                                              mock_freq.at(accel_idx)*1e6));
+
+        EXPECT_NO_THROW(levelzero_io.write_control("FREQUENCY_ACCELERATOR_CONTROL",
+                                              GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx,
+                                              mock_freq.at(accel_idx)*1e6));
+
+        EXPECT_CALL(*m_device_pool, standby_mode_control(accel_idx,
+                                                         mock_standby_control.at(accel_idx))).Times(1);
+
+        EXPECT_NO_THROW(levelzero_io.write_control("LEVELZERO::STANDBY_MODE_CONTROL",
+                                              GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx,
+                                              mock_standby_control.at(accel_idx)));
+    }
+}
+
+TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+
+    std::vector<double> mock_freq = {1530, 1320, 420, 135};
+    std::vector<int> batch_idx;
+
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_status_gpu(accel_idx)).WillRepeatedly(Return(mock_freq.at(accel_idx)));
+    }
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+    }
+    levelzero_io.read_batch();
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_batch = levelzero_io.sample(batch_idx.at(accel_idx));
+
+        EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx)*1e6);
+        EXPECT_DOUBLE_EQ(frequency, frequency_batch);
+    }
+
+    mock_freq = {1630, 1420, 520, 235};
+    //second round of testing with a modified value
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_status_gpu(accel_idx)).WillRepeatedly(Return(mock_freq.at(accel_idx)));
+    }
+    levelzero_io.read_batch();
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_batch = levelzero_io.sample(batch_idx.at(accel_idx));
+
+        EXPECT_DOUBLE_EQ(frequency, (mock_freq.at(accel_idx))*1e6);
+        EXPECT_DOUBLE_EQ(frequency, frequency_batch);
+    }
+}
+
+TEST_F(LevelZeroIOGroupTest, read_signal)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+
+    //Frequency
+    std::vector<double> mock_freq_gpu = {1530, 1320, 420, 135};
+    std::vector<double> mock_freq_mem = {130, 1020, 200, 150};
+    std::vector<double> mock_freq_min_gpu = {200, 320, 400, 350};
+    std::vector<double> mock_freq_max_gpu = {2000, 3200, 4200, 1350};
+    std::vector<double> mock_freq_min_mem = {100, 220, 300, 450};
+    std::vector<double> mock_freq_max_mem = {1000, 2200, 3200, 1450};
+    std::vector<double> mock_freq_range_min_gpu = {1200, 620, 500, 530};
+    std::vector<double> mock_freq_range_max_gpu = {3120, 900, 5200, 3500};
+    std::vector<double> mock_freq_throttle_time = {200000, 600020, 100500, 101530};
+    std::vector<double> mock_freq_throttle_time_timestamp = {314520, 901000, 58200, 303500};
+    std::vector<double> mock_freq_throttle_reason = {3, 0, 0xFF, 0xA};
+    //Active time
+    std::vector<uint64_t> mock_active_time = {123, 970, 550, 20};
+    std::vector<uint64_t> mock_active_time_timestamp = {182, 970, 650, 33};
+    std::vector<uint64_t> mock_active_time_compute = {1, 90, 50, 0};
+    std::vector<uint64_t> mock_active_time_timestamp_compute = {12, 90, 150, 3};
+    std::vector<uint64_t> mock_active_time_copy = {12, 20, 30, 40};
+    std::vector<uint64_t> mock_active_time_timestamp_copy = {50, 60, 53, 55};
+    std::vector<uint64_t> mock_active_time_media_decode = {21, 24, 35, 46};
+    std::vector<uint64_t> mock_active_time_timestamp_media_decode = {51, 62, 55, 53};
+    //Temperature
+    std::vector<double> mock_temperature = {45, 60, 68, 92};
+    std::vector<double> mock_temperature_gpu = {50, 65, 78, 99};
+    std::vector<double> mock_temperature_mem = {4, 63, 60, 90};
+    //Power & energy
+    std::vector<int32_t> mock_power_limit_min = {30000, 80000, 20000, 70000};
+    std::vector<int32_t> mock_power_limit_max = {310000, 280000, 320000, 270000};
+    std::vector<int32_t> mock_power_limit_tdp = {320000, 290000, 330000, 280000};
+    std::vector<int32_t> mock_power_limit_interval_sustained = {30000, 26000, 34000, 70000};
+    std::vector<int32_t> mock_power_limit_sustained = {310000, 280000, 320000, 270000};
+    std::vector<bool> mock_power_limit_enabled_sustained = {0, 1, 1, 1};
+    std::vector<int32_t> mock_power_limit_burst = {300000, 270000, 300000, 250000};
+    std::vector<bool> mock_power_limit_enabled_burst = {1, 1, 0, 1};
+    std::vector<int32_t> mock_power_limit_peak_ac = {100000, 730000, 600000, 450000};
+    std::vector<uint64_t> mock_energy = {630000000, 280000000, 470000000, 950000000};
+    std::vector<uint64_t> mock_energy_timestamp = {153, 70, 300, 50};
+
+    std::vector<double> mock_performance_factor = {0, 100, 50, 72};
+    std::vector<double> mock_standby_mode = {0, 1, 0, 1};
+    std::vector<double> mock_memory_allocated = {0, 1, 0.5, 0.21};
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+
+        //Frequency
+        EXPECT_CALL(*m_device_pool, frequency_status_gpu(accel_idx)).WillRepeatedly(Return(mock_freq_gpu.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_status_mem(accel_idx)).WillRepeatedly(Return(mock_freq_mem.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_min_gpu(accel_idx)).WillRepeatedly(Return(mock_freq_min_gpu.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_max_gpu(accel_idx)).WillRepeatedly(Return(mock_freq_max_gpu.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_min_mem(accel_idx)).WillRepeatedly(Return(mock_freq_min_mem.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_max_mem(accel_idx)).WillRepeatedly(Return(mock_freq_max_mem.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_range_min_gpu(accel_idx)).WillRepeatedly(Return(mock_freq_range_min_gpu.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_range_max_gpu(accel_idx)).WillRepeatedly(Return(mock_freq_range_max_gpu.at(accel_idx)));
+
+        EXPECT_CALL(*m_device_pool, frequency_throttle_time_gpu(accel_idx)).WillRepeatedly(Return(mock_freq_throttle_time.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_throttle_time_timestamp_gpu(accel_idx)).WillRepeatedly(Return(mock_freq_throttle_time_timestamp.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_status_throttle_reason_gpu(accel_idx)).WillRepeatedly(Return(mock_freq_throttle_reason.at(accel_idx)));
+
+        //Active time
+        EXPECT_CALL(*m_device_pool, active_time(accel_idx)).WillRepeatedly(Return(mock_active_time.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp(accel_idx)).WillRepeatedly(Return(mock_active_time_timestamp.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_compute(accel_idx)).WillRepeatedly(Return(mock_active_time_compute.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp_compute(accel_idx)).WillRepeatedly(Return(mock_active_time_timestamp_compute.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_copy(accel_idx)).WillRepeatedly(Return(mock_active_time_copy.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp_copy(accel_idx)).WillRepeatedly(Return(mock_active_time_timestamp_copy.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_media_decode(accel_idx)).WillRepeatedly(Return(mock_active_time_media_decode.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp_media_decode(accel_idx)).WillRepeatedly(Return(mock_active_time_timestamp_media_decode.at(accel_idx)));
+
+        //Temperature
+        EXPECT_CALL(*m_device_pool, temperature(accel_idx)).WillRepeatedly(Return(mock_temperature.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, temperature_gpu(accel_idx)).WillRepeatedly(Return(mock_temperature_gpu.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, temperature_memory(accel_idx)).WillRepeatedly(Return(mock_temperature_mem.at(accel_idx)));
+
+        //Power & energy
+        EXPECT_CALL(*m_device_pool, power_limit_min(accel_idx)).WillRepeatedly(Return(mock_power_limit_min.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power_limit_max(accel_idx)).WillRepeatedly(Return(mock_power_limit_max.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power_limit_tdp(accel_idx)).WillRepeatedly(Return(mock_power_limit_tdp.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power_limit_enabled_sustained(accel_idx)).WillRepeatedly(Return(mock_power_limit_enabled_sustained.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power_limit_sustained(accel_idx)).WillRepeatedly(Return(mock_power_limit_sustained.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power_limit_interval_sustained(accel_idx)).WillRepeatedly(Return(mock_power_limit_interval_sustained.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power_limit_enabled_burst(accel_idx)).WillRepeatedly(Return(mock_power_limit_enabled_burst.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power_limit_burst(accel_idx)).WillRepeatedly(Return(mock_power_limit_burst.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power_limit_peak_ac(accel_idx)).WillRepeatedly(Return(mock_power_limit_peak_ac.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, energy(accel_idx)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, energy_timestamp(accel_idx)).WillRepeatedly(Return(mock_energy_timestamp.at(accel_idx)));
+
+        //Misc
+        EXPECT_CALL(*m_device_pool, performance_factor(accel_idx)).WillRepeatedly(Return(mock_performance_factor.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, standby_mode(accel_idx)).WillRepeatedly(Return(mock_standby_mode.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, memory_allocated(accel_idx)).WillRepeatedly(Return(mock_memory_allocated.at(accel_idx)));
+    }
+
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        //Frequency
+        double frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_alias = levelzero_io.read_signal("FREQUENCY_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, frequency_alias);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_gpu.at(accel_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_mem.at(accel_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MIN_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_min_gpu.at(accel_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MAX_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_max_gpu.at(accel_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MIN_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_min_mem.at(accel_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MAX_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_max_mem.at(accel_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_RANGE_MIN_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_range_min_gpu.at(accel_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_RANGE_MAX_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_range_max_gpu.at(accel_idx)*1e6);
+
+        frequency = levelzero_io.read_signal("LEVELZERO::THROTTLE_TIME_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_throttle_time.at(accel_idx)/1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::THROTTLE_TIME_TIMESTAMP_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_throttle_time_timestamp.at(accel_idx)/1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::THROTTLE_REASONS_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_throttle_reason.at(accel_idx));
+
+
+        //Active time
+        double active_time = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(accel_idx)/1e6);
+        double active_time_timestamp = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(active_time_timestamp, mock_active_time_timestamp.at(accel_idx)/1e6);
+        double active_time_compute = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(active_time_compute, mock_active_time_compute.at(accel_idx)/1e6);
+        double active_time_timestamp_compute = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(active_time_timestamp_compute, mock_active_time_timestamp_compute.at(accel_idx)/1e6);
+        double active_time_copy = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time_copy.at(accel_idx)/1e6);
+        double active_time_timestamp_copy = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(active_time_timestamp_copy, mock_active_time_timestamp_copy.at(accel_idx)/1e6);
+        double active_time_media_decode = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_MEDIA_DECODE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(active_time_media_decode, mock_active_time_media_decode.at(accel_idx)/1e6);
+        double active_time_timestamp_media_decode = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP_MEDIA_DECODE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(active_time_timestamp_media_decode, mock_active_time_timestamp_media_decode.at(accel_idx)/1e6);
+
+        //Temperature
+        double temperature = levelzero_io.read_signal("LEVELZERO::TEMPERATURE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(temperature, mock_temperature.at(accel_idx));
+        temperature = levelzero_io.read_signal("LEVELZERO::TEMPERATURE_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(temperature, mock_temperature_gpu.at(accel_idx));
+        temperature = levelzero_io.read_signal("LEVELZERO::TEMPERATURE_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(temperature, mock_temperature_mem.at(accel_idx));
+
+        //Power & energy
+        double power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_MIN", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_min.at(accel_idx)/1e3);
+        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_MAX", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_max.at(accel_idx)/1e3);
+        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_DEFAULT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_tdp.at(accel_idx)/1e3);
+        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_ENABLED_BURST", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_enabled_burst.at(accel_idx));
+        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_ENABLED_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_enabled_sustained.at(accel_idx));
+        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_INTERVAL_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_interval_sustained.at(accel_idx)/1e3);
+        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_BURST", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_burst.at(accel_idx)/1e3);
+        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_SUSTAINED", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_sustained.at(accel_idx)/1e3);
+        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_PEAK_AC", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_peak_ac.at(accel_idx)/1e3);
+
+        double energy = levelzero_io.read_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(energy, mock_energy.at(accel_idx)/1e6);
+        double energy_timestamp = levelzero_io.read_signal("LEVELZERO::ENERGY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(energy_timestamp, mock_energy_timestamp.at(accel_idx)/1e6);
+
+        //Misc
+        double misc = levelzero_io.read_signal("LEVELZERO::PERFORMANCE_FACTOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(misc, mock_performance_factor.at(accel_idx));
+        misc = levelzero_io.read_signal("LEVELZERO::STANDBY_MODE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(misc, mock_standby_mode.at(accel_idx));
+        misc = levelzero_io.read_signal("LEVELZERO::MEMORY_ALLOCATED", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(misc, mock_memory_allocated.at(accel_idx));
+    }
+
+    // Assume DerivativeSignals class functions as expected
+    // Just check validity of derived signals
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::POWER"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::UTILIZATION"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::UTILIZATION_COMPUTE"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::UTILIZATION_COPY"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::UTILIZATION_MEDIA_DECODE"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::THROTTLE_RATIO_GPU"));
+
+}
+
+//Test case: Error path testing including:
+//              - Attempt to push a signal at an invalid domain level
+//              - Attempt to push an invalid signal
+//              - Attempt to sample without a read_batch prior
+//              - Attempt to read a signal at an invalid domain level
+//              - Attempt to push a control at an invalid domain level
+//              - Attempt to adjust a non-existent batch index
+//              - Attempt to write a control at an invalid domain level
+TEST_F(LevelZeroIOGroupTest, error_path)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+
+    std::vector<int> batch_idx;
+
+    std::vector<double> mock_freq = {1530, 1320, 420, 135};
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_status_gpu(accel_idx)).WillRepeatedly(Return(mock_freq.at(accel_idx)));
+    }
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.sample(0),
+                               GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "signal_name LEVELZERO::INVALID not valid for LevelZeroIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "LEVELZERO::INVALID not valid for LevelZeroIOGroup");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.adjust(0, 12345.6),
+                               GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD, 0, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "control_name LEVELZERO::INVALID not valid for LevelZeroIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0, 1530000000),
+                               GEOPM_ERROR_INVALID, "LEVELZERO::INVALID not valid for LevelZeroIOGroup");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+}

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -285,11 +285,19 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/LevelZeroAcceleratorTopoTest.eight_fiftysix_affinitization_config \
               test/gtest_links/LevelZeroAcceleratorTopoTest.uneven_affinitization_config \
               test/gtest_links/LevelZeroAcceleratorTopoTest.high_cpu_count_config \
-              test/gtest_links/LevelZeroIOGroupTest.read_signal_and_batch \
+              test/gtest_links/LevelZeroDevicePoolTest.device_count \
+              test/gtest_links/LevelZeroDevicePoolTest.subdevice_conversion_and_function \
+              test/gtest_links/LevelZeroDevicePoolTest.subdevice_conversion_error \
+              test/gtest_links/LevelZeroDevicePoolTest.subdevice_domain_error \
+              test/gtest_links/LevelZeroDevicePoolTest.subdevice_range_check \
+              test/gtest_links/LevelZeroDevicePoolTest.device_range_check \
+              test/gtest_links/LevelZeroDevicePoolTest.device_function_check \
+              test/gtest_links/LevelZeroIOGroupTest.valid_signals \
               test/gtest_links/LevelZeroIOGroupTest.read_signal \
               test/gtest_links/LevelZeroIOGroupTest.error_path \
               test/gtest_links/LevelZeroIOGroupTest.write_control \
               test/gtest_links/LevelZeroIOGroupTest.push_control_adjust_write_batch \
+              test/gtest_links/LevelZeroIOGroupTest.read_signal_and_batch \
               test/gtest_links/MSRIOGroupTest.adjust \
               test/gtest_links/MSRIOGroupTest.control_error \
               test/gtest_links/MSRIOGroupTest.cpuid \
@@ -632,6 +640,8 @@ test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/FrequencyMapAgentTest.cpp \
                           test/HelperTest.cpp \
                           test/IOGroupTest.cpp \
+                          test/LevelZeroDevicePoolTest.cpp \
+                          test/LevelZeroIOGroupTest.cpp \
                           test/MSRIOGroupTest.cpp \
                           test/MSRIOTest.cpp \
                           test/MSRFieldControlTest.cpp \
@@ -655,6 +665,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/MockMSRIO.hpp \
                           test/MockNVMLDevicePool.hpp \
                           test/MockLevelZeroDevicePool.hpp \
+                          test/MockLevelZeroShim.hpp \
                           test/MockPlatformIO.hpp \
                           test/MockPlatformTopo.cpp \
                           test/MockPlatformTopo.hpp \
@@ -678,7 +689,6 @@ test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/MonitorAgentTest.cpp \
                           test/NVMLAcceleratorTopoTest.cpp \
                           test/LevelZeroAcceleratorTopoTest.cpp \
-                          test/LevelZeroIOGroupTest.cpp \
                           test/NVMLIOGroupTest.cpp \
                           test/OptionParserTest.cpp \
                           test/PlatformIOTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -280,6 +280,16 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/IOGroupTest.signals_have_descriptions \
               test/gtest_links/IOGroupTest.signals_have_format_functions \
               test/gtest_links/IOGroupTest.string_to_behavior \
+              test/gtest_links/LevelZeroAcceleratorTopoTest.no_gpu_config \
+              test/gtest_links/LevelZeroAcceleratorTopoTest.four_forty_config \
+              test/gtest_links/LevelZeroAcceleratorTopoTest.eight_fiftysix_affinitization_config \
+              test/gtest_links/LevelZeroAcceleratorTopoTest.uneven_affinitization_config \
+              test/gtest_links/LevelZeroAcceleratorTopoTest.high_cpu_count_config \
+              test/gtest_links/LevelZeroIOGroupTest.read_signal_and_batch \
+              test/gtest_links/LevelZeroIOGroupTest.read_signal \
+              test/gtest_links/LevelZeroIOGroupTest.error_path \
+              test/gtest_links/LevelZeroIOGroupTest.write_control \
+              test/gtest_links/LevelZeroIOGroupTest.push_control_adjust_write_batch \
               test/gtest_links/MSRIOGroupTest.adjust \
               test/gtest_links/MSRIOGroupTest.control_error \
               test/gtest_links/MSRIOGroupTest.cpuid \
@@ -644,6 +654,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/MockIOGroup.hpp \
                           test/MockMSRIO.hpp \
                           test/MockNVMLDevicePool.hpp \
+                          test/MockLevelZeroDevicePool.hpp \
                           test/MockPlatformIO.hpp \
                           test/MockPlatformTopo.cpp \
                           test/MockPlatformTopo.hpp \
@@ -666,6 +677,8 @@ test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/ModelApplicationTest.cpp \
                           test/MonitorAgentTest.cpp \
                           test/NVMLAcceleratorTopoTest.cpp \
+                          test/LevelZeroAcceleratorTopoTest.cpp \
+                          test/LevelZeroIOGroupTest.cpp \
                           test/NVMLIOGroupTest.cpp \
                           test/OptionParserTest.cpp \
                           test/PlatformIOTest.cpp \

--- a/test/MockLevelZeroDevicePool.hpp
+++ b/test/MockLevelZeroDevicePool.hpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MOCKLEVELZERODEVICEPOOL_HPP_INCLUDE
+#define MOCKLEVELZERODEVICEPOOL_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "LevelZeroDevicePool.hpp"
+
+class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
+{
+    public:
+        MOCK_CONST_METHOD0(num_accelerator,
+                           int(void));
+        MOCK_CONST_METHOD1(frequency_status_gpu,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(frequency_status_mem,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(frequency_min_gpu,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(frequency_max_gpu,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(frequency_min_mem,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(frequency_max_mem,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(frequency_range_min_gpu,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(frequency_range_max_gpu,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(frequency_status_throttle_reason_gpu,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(frequency_throttle_time_gpu,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(frequency_throttle_time_timestamp_gpu,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(active_time,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(active_time_timestamp,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(active_time_compute,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(active_time_timestamp_compute,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(active_time_copy,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(active_time_timestamp_copy,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(active_time_media_decode,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(active_time_timestamp_media_decode,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(temperature,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(temperature_gpu,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(temperature_memory,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_tdp,
+                           int32_t(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_min,
+                           int32_t(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_max,
+                           int32_t(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_enabled_sustained,
+                           bool(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_sustained,
+                           int32_t(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_interval_sustained,
+                           int32_t(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_enabled_burst,
+                           bool(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_burst,
+                           int32_t(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_peak_ac,
+                           int32_t(unsigned int));
+        MOCK_CONST_METHOD1(energy,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(energy_timestamp,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(performance_factor,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(active_process_list,
+                           std::vector<uint32_t>(unsigned int));
+        MOCK_CONST_METHOD1(standby_mode,
+                           double(unsigned int));
+        MOCK_CONST_METHOD1(memory_allocated,
+                           double(unsigned int));
+        MOCK_CONST_METHOD2(energy_threshold_control,
+                           void(unsigned int, double));
+        MOCK_CONST_METHOD2(frequency_control_gpu,
+                           void(unsigned int, double));
+        MOCK_CONST_METHOD2(standby_mode_control,
+                           void(unsigned int, double));
+};
+
+#endif

--- a/test/MockLevelZeroDevicePool.hpp
+++ b/test/MockLevelZeroDevicePool.hpp
@@ -42,86 +42,34 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
     public:
         MOCK_CONST_METHOD0(num_accelerator,
                            int(void));
-        MOCK_CONST_METHOD1(frequency_status_gpu,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(frequency_status_mem,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(frequency_min_gpu,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(frequency_max_gpu,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(frequency_min_mem,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(frequency_max_mem,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(frequency_range_min_gpu,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(frequency_range_max_gpu,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(frequency_status_throttle_reason_gpu,
+        MOCK_CONST_METHOD0(num_accelerator_subdevice,
+                           int(void));
+
+        MOCK_CONST_METHOD2(frequency_status,
+                           double(unsigned int, int));
+        MOCK_CONST_METHOD2(frequency_min,
+                           double(unsigned int, int));
+        MOCK_CONST_METHOD2(frequency_max,
+                           double(unsigned int, int));
+
+        MOCK_CONST_METHOD2(active_time,
+                           uint64_t(unsigned int, int));
+        MOCK_CONST_METHOD2(active_time_timestamp,
+                           uint64_t(unsigned int, int));
+
+        MOCK_CONST_METHOD1(energy,
                            uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(frequency_throttle_time_gpu,
+        MOCK_CONST_METHOD1(energy_timestamp,
                            uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(frequency_throttle_time_timestamp_gpu,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(active_time,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(active_time_timestamp,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(active_time_compute,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(active_time_timestamp_compute,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(active_time_copy,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(active_time_timestamp_copy,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(active_time_media_decode,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(active_time_timestamp_media_decode,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(temperature,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(temperature_gpu,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(temperature_memory,
-                           double(unsigned int));
         MOCK_CONST_METHOD1(power_limit_tdp,
                            int32_t(unsigned int));
         MOCK_CONST_METHOD1(power_limit_min,
                            int32_t(unsigned int));
         MOCK_CONST_METHOD1(power_limit_max,
                            int32_t(unsigned int));
-        MOCK_CONST_METHOD1(power_limit_enabled_sustained,
-                           bool(unsigned int));
-        MOCK_CONST_METHOD1(power_limit_sustained,
-                           int32_t(unsigned int));
-        MOCK_CONST_METHOD1(power_limit_interval_sustained,
-                           int32_t(unsigned int));
-        MOCK_CONST_METHOD1(power_limit_enabled_burst,
-                           bool(unsigned int));
-        MOCK_CONST_METHOD1(power_limit_burst,
-                           int32_t(unsigned int));
-        MOCK_CONST_METHOD1(power_limit_peak_ac,
-                           int32_t(unsigned int));
-        MOCK_CONST_METHOD1(energy,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(energy_timestamp,
-                           uint64_t(unsigned int));
-        MOCK_CONST_METHOD1(performance_factor,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(active_process_list,
-                           std::vector<uint32_t>(unsigned int));
-        MOCK_CONST_METHOD1(standby_mode,
-                           double(unsigned int));
-        MOCK_CONST_METHOD1(memory_allocated,
-                           double(unsigned int));
-        MOCK_CONST_METHOD2(energy_threshold_control,
-                           void(unsigned int, double));
-        MOCK_CONST_METHOD2(frequency_control_gpu,
-                           void(unsigned int, double));
-        MOCK_CONST_METHOD2(standby_mode_control,
-                           void(unsigned int, double));
+
+        MOCK_CONST_METHOD3(frequency_control,
+                           void(unsigned int, int, double));
 };
 
 #endif

--- a/test/MockLevelZeroShim.hpp
+++ b/test/MockLevelZeroShim.hpp
@@ -30,20 +30,50 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef MOCKACCELERATORTOPO_HPP_INCLUDE
-#define MOCKACCELERATORTOPO_HPP_INCLUDE
+#ifndef MOCKLEVELZEROSHIM_HPP_INCLUDE
+#define MOCKLEVELZEROSHIM_HPP_INCLUDE
 
 #include "gmock/gmock.h"
 
-#include "AcceleratorTopo.hpp"
+#include "LevelZeroShim.hpp"
 
-class MockAcceleratorTopo : public geopm::AcceleratorTopo
+class MockLevelZeroShim : public geopm::LevelZeroShim
 {
     public:
-        MOCK_METHOD(int, num_accelerator, (), (const, override));
-        MOCK_METHOD(int, num_accelerator_subdevice, (), (const, override));
-        MOCK_METHOD(std::set<int>, cpu_affinity_ideal, (int), (const, override));
-        MOCK_METHOD(std::set<int>, cpu_affinity_ideal_subdevice, (int), (const, override));
+        MOCK_CONST_METHOD0(num_accelerator,
+                           int(void));
+        MOCK_CONST_METHOD0(num_accelerator_subdevice,
+                           int(void));
+
+        MOCK_CONST_METHOD2(frequency_domain_count,
+                           int(unsigned int, int));
+        MOCK_CONST_METHOD3(frequency_status,
+                           double(unsigned int, int, int));
+        MOCK_CONST_METHOD3(frequency_min,
+                           double(unsigned int, int, int));
+        MOCK_CONST_METHOD3(frequency_max,
+                           double(unsigned int, int, int));
+
+        MOCK_CONST_METHOD2(engine_domain_count,
+                           int(unsigned int, int));
+        MOCK_CONST_METHOD3(active_time,
+                           uint64_t(unsigned int, int, int));
+        MOCK_CONST_METHOD3(active_time_timestamp,
+                           uint64_t(unsigned int, int, int));
+
+        MOCK_CONST_METHOD1(energy,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(energy_timestamp,
+                           uint64_t(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_tdp,
+                           int32_t(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_min,
+                           int32_t(unsigned int));
+        MOCK_CONST_METHOD1(power_limit_max,
+                           int32_t(unsigned int));
+
+        MOCK_CONST_METHOD4(frequency_control,
+                           void(unsigned int, int, int, double));
 };
 
 #endif

--- a/test/NVMLAcceleratorTopoTest.cpp
+++ b/test/NVMLAcceleratorTopoTest.cpp
@@ -80,6 +80,7 @@ TEST_F(NVMLAcceleratorTopoTest, no_gpu_config)
     EXPECT_EQ(num_accelerator, topo.num_accelerator());
 
     GEOPM_EXPECT_THROW_MESSAGE(topo.cpu_affinity_ideal(num_accelerator), GEOPM_ERROR_INVALID, "accel_idx 0 is out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(topo.cpu_affinity_ideal_subdevice(num_accelerator), GEOPM_ERROR_INVALID, "accel_idx 0 is out of range");
 }
 
 //Test case: The HPE SX40 default system configuration
@@ -102,6 +103,7 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_sx40_default_config)
 
     NVMLAcceleratorTopo topo(*m_device_pool, num_cpu);
     EXPECT_EQ(num_accelerator, topo.num_accelerator());
+    EXPECT_EQ(num_accelerator, topo.num_accelerator_subdevice());
     std::set<int> cpus_allowed_set[num_accelerator];
     cpus_allowed_set[0] = {0,1,2,3,4,5,6,7,8,9};
     cpus_allowed_set[1] = {10,11,12,13,14,15,16,17,18,19};
@@ -110,6 +112,7 @@ TEST_F(NVMLAcceleratorTopoTest, hpe_sx40_default_config)
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         ASSERT_THAT(topo.cpu_affinity_ideal(accel_idx), cpus_allowed_set[accel_idx]);
+        ASSERT_THAT(topo.cpu_affinity_ideal_subdevice(accel_idx), cpus_allowed_set[accel_idx]);
     }
 }
 


### PR DESCRIPTION
This PR is intended to provide basic support of the [Intel Level Zero Specification v1.1.2](https://spec.oneapi.com/level-zero/1.1.2/sysman/PROG.html) for monitoring and controlling Intel GPUs.  It follows the architecture implemented for NVIDIA support provided in PR#1229 and PR#1246.  

This PR Provides:
- The ability to discover and enumerate Level Zero devices through the Sysman interface 
- Reporting of devices and a rudimentary static CPU to GPU mapping to PlatformTopo
- A device pool to control and monitor Level Zero devices
- An IO Group that uses the above to provide users with the ability to monitor and control Level Zero devices via geopmread/write and agents.
- Testing of the above features, with the exception of agent capabilities

Summary of Change: 
- Addition of LevelZeroAcceleratorTopo implementation of AcceleratorTopo.
- Addition of LevelZeroDevicePool to act as an interface to the LevelZero API.  See Known issues and future work 2 & 3.
- Addition of LevelZeroIOGroup to provide interface to the LevelZeroDevicePool.  
- Addition of LevelZeroSignal to allow leveraging existing the DerivativeSignal class.
- Modifications to IOGroup and AcceleratorTopo to include Level Zero code when needed.
- Modifications to the configure.ac to provide --enable-levelzero and --with-liblevelzero options for enabling functionality.
- Addition of Unit tests and mock object to test basic Device Pool, Accelerator Topo, and IO Group Functions.
- Addition of Integration tests to test IOGroup and Device Pool functionality on supported systems.

Known Issues & Future work:
1. Addition of signals: frequency throttle reasons, frequency tdp, frequency efficient, as describe [here](https://spec.oneapi.com/level-zero/latest/sysman/api.html#_CPPv416zes_freq_state_t)
2. Refactor of LevelZeroDevicePool to enable testability and provide an actual 'thin' wrapper.  Right now it's functional but too complex.
3. Addition of per device domain tracking to reduce requirement to iterate over number of domains in LevelZeroDevicePool

The devicepool is already slated for a refactor, so focusing on the IOGroup, signals names, and Topo is likely higher priority.  Regardless any feedback is appreciated.