### PR TITLE
Use python3 everywhere

### DIFF
--- a/copying_headers/test-license
+++ b/copying_headers/test-license
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/integration/experiment/energy_efficiency/barrier_frequency_sweep.py
+++ b/integration/experiment/energy_efficiency/barrier_frequency_sweep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/energy_efficiency/gen_plot_profile_comparison.py
+++ b/integration/experiment/energy_efficiency/gen_plot_profile_comparison.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/energy_efficiency/power_balancer_energy.py
+++ b/integration/experiment/energy_efficiency/power_balancer_energy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/energy_efficiency/run_barrier_frequency_sweep_nekbone.py
+++ b/integration/experiment/energy_efficiency/run_barrier_frequency_sweep_nekbone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/energy_efficiency/run_power_balancer_energy_amg.py
+++ b/integration/experiment/energy_efficiency/run_power_balancer_energy_amg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/energy_efficiency/run_power_balancer_energy_dgemm.py
+++ b/integration/experiment/energy_efficiency/run_power_balancer_energy_dgemm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/energy_efficiency/run_power_balancer_energy_hpcg.py
+++ b/integration/experiment/energy_efficiency/run_power_balancer_energy_hpcg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/energy_efficiency/run_power_balancer_energy_minife.py
+++ b/integration/experiment/energy_efficiency/run_power_balancer_energy_minife.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/energy_efficiency/run_power_balancer_energy_nasft.py
+++ b/integration/experiment/energy_efficiency/run_power_balancer_energy_nasft.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/energy_efficiency/run_power_balancer_energy_nekbone.py
+++ b/integration/experiment/energy_efficiency/run_power_balancer_energy_nekbone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/frequency_sweep.py
+++ b/integration/experiment/frequency_sweep/frequency_sweep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/gen_frequency_map.py
+++ b/integration/experiment/frequency_sweep/gen_frequency_map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/gen_plot_runtime_energy.py
+++ b/integration/experiment/frequency_sweep/gen_plot_runtime_energy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/gen_region_summary.py
+++ b/integration/experiment/frequency_sweep/gen_region_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_amg.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_amg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_arithmetic_intensity.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_arithmetic_intensity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_dgemm.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_dgemm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_dgemm_tiny.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_dgemm_tiny.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_hpcg.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_hpcg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_minife.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_minife.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_nasft.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_nasft.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_nekbone.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_nekbone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_pennant.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_pennant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/frequency_sweep/run_frequency_sweep_qe.py
+++ b/integration/experiment/frequency_sweep/run_frequency_sweep_qe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/gen_plot_achieved_power.py
+++ b/integration/experiment/monitor/gen_plot_achieved_power.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_amg.py
+++ b/integration/experiment/monitor/run_monitor_amg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_arithmetic_intensity.py
+++ b/integration/experiment/monitor/run_monitor_arithmetic_intensity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_dgemm.py
+++ b/integration/experiment/monitor/run_monitor_dgemm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_dgemm_tiny.py
+++ b/integration/experiment/monitor/run_monitor_dgemm_tiny.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_hpcg.py
+++ b/integration/experiment/monitor/run_monitor_hpcg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_hpl_mkl.py
+++ b/integration/experiment/monitor/run_monitor_hpl_mkl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_hpl_netlib.py
+++ b/integration/experiment/monitor/run_monitor_hpl_netlib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_minife.py
+++ b/integration/experiment/monitor/run_monitor_minife.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_nasft.py
+++ b/integration/experiment/monitor/run_monitor_nasft.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_nekbone.py
+++ b/integration/experiment/monitor/run_monitor_nekbone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_pennant.py
+++ b/integration/experiment/monitor/run_monitor_pennant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/monitor/run_monitor_qe.py
+++ b/integration/experiment/monitor/run_monitor_qe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/gen_balancer_comparison.py
+++ b/integration/experiment/power_sweep/gen_balancer_comparison.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/gen_governor_balancer_comparison.py
+++ b/integration/experiment/power_sweep/gen_governor_balancer_comparison.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/gen_governor_summary.py
+++ b/integration/experiment/power_sweep/gen_governor_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/gen_plot_balancer_comparison.py
+++ b/integration/experiment/power_sweep/gen_plot_balancer_comparison.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/gen_plot_node_efficiency.py
+++ b/integration/experiment/power_sweep/gen_plot_node_efficiency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/gen_plot_power_limit.py
+++ b/integration/experiment/power_sweep/gen_plot_power_limit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/gen_policy_recommendation.py
+++ b/integration/experiment/power_sweep/gen_policy_recommendation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/gen_power_sweep_summary.py
+++ b/integration/experiment/power_sweep/gen_power_sweep_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/power_sweep.py
+++ b/integration/experiment/power_sweep/power_sweep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/run_power_sweep_amg.py
+++ b/integration/experiment/power_sweep/run_power_sweep_amg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/run_power_sweep_arithmetic_intensity.py
+++ b/integration/experiment/power_sweep/run_power_sweep_arithmetic_intensity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/run_power_sweep_dgemm.py
+++ b/integration/experiment/power_sweep/run_power_sweep_dgemm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/run_power_sweep_dgemm_tiny.py
+++ b/integration/experiment/power_sweep/run_power_sweep_dgemm_tiny.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/run_power_sweep_hpcg.py
+++ b/integration/experiment/power_sweep/run_power_sweep_hpcg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/run_power_sweep_minife.py
+++ b/integration/experiment/power_sweep/run_power_sweep_minife.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/run_power_sweep_nekbone.py
+++ b/integration/experiment/power_sweep/run_power_sweep_nekbone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/run_power_sweep_pennant.py
+++ b/integration/experiment/power_sweep/run_power_sweep_pennant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/power_sweep/test_gen_policy_recommendation.py
+++ b/integration/experiment/power_sweep/test_gen_policy_recommendation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/trace_analysis/gen_rate_hist.py
+++ b/integration/experiment/trace_analysis/gen_rate_hist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/uncore_frequency_sweep/gen_plot_heatmap.py
+++ b/integration/experiment/uncore_frequency_sweep/gen_plot_heatmap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/uncore_frequency_sweep/gen_region_summary.py
+++ b/integration/experiment/uncore_frequency_sweep/gen_region_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/uncore_frequency_sweep/run_uncore_frequency_sweep_arithmetic_intensity.py
+++ b/integration/experiment/uncore_frequency_sweep/run_uncore_frequency_sweep_arithmetic_intensity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/uncore_frequency_sweep/run_uncore_frequency_sweep_dgemm.py
+++ b/integration/experiment/uncore_frequency_sweep/run_uncore_frequency_sweep_dgemm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/uncore_frequency_sweep/run_uncore_frequency_sweep_dgemm_tiny.py
+++ b/integration/experiment/uncore_frequency_sweep/run_uncore_frequency_sweep_dgemm_tiny.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/uncore_frequency_sweep/run_uncore_frequency_sweep_pennant.py
+++ b/integration/experiment/uncore_frequency_sweep/run_uncore_frequency_sweep_pennant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/uncore_frequency_sweep/test.py
+++ b/integration/experiment/uncore_frequency_sweep/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/experiment/uncore_frequency_sweep/uncore_frequency_sweep.py
+++ b/integration/experiment/uncore_frequency_sweep/uncore_frequency_sweep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/__main__.py
+++ b/integration/test/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/check_trace.py
+++ b/integration/test/check_trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/short_region/plot_margin_sweep.py
+++ b/integration/test/short_region/plot_margin_sweep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #
@@ -46,7 +46,7 @@ import subprocess
 import os
 try:
     with open(os.devnull, 'w') as FNULL:
-        subprocess.check_call("python -c 'import matplotlib.pyplot'", stdout=FNULL, stderr=FNULL, shell=True)
+        subprocess.check_call("python3 -c 'import matplotlib.pyplot'", stdout=FNULL, stderr=FNULL, shell=True)
 except subprocess.CalledProcessError:
     sys.stderr.write('Warning: Unable to use default matplotlib backend ({}).  For interactive plotting,'
                      ' please install Tkinter support in the OS.  '

--- a/integration/test/test_ee_short_region_slop.py
+++ b/integration/test/test_ee_short_region_slop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_ee_timed_scaling_mix.py
+++ b/integration/test/test_ee_timed_scaling_mix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_enforce_policy.py
+++ b/integration/test/test_enforce_policy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_environment.py
+++ b/integration/test/test_environment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_epoch_inference.py
+++ b/integration/test/test_epoch_inference.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_frequency_hint_usage.py
+++ b/integration/test/test_frequency_hint_usage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_frequency_map.py
+++ b/integration/test/test_frequency_map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_geopmagent.py
+++ b/integration/test/test_geopmagent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_geopmio.py
+++ b/integration/test/test_geopmio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_hint_time.py
+++ b/integration/test/test_hint_time.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_launch_application.py
+++ b/integration/test/test_launch_application.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_launch_pthread.py
+++ b/integration/test/test_launch_pthread.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_monitor.py
+++ b/integration/test/test_monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_omp_outer_loop.py
+++ b/integration/test/test_omp_outer_loop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_ompt.py
+++ b/integration/test/test_ompt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_plugin_static_policy.py
+++ b/integration/test/test_plugin_static_policy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_power_balancer.py
+++ b/integration/test/test_power_balancer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_power_governor.py
+++ b/integration/test/test_power_governor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_profile_overflow.py
+++ b/integration/test/test_profile_overflow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_profile_policy.py
+++ b/integration/test/test_profile_policy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_progress.py
+++ b/integration/test/test_progress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_scaling_region.py
+++ b/integration/test/test_scaling_region.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_template.py.in
+++ b/integration/test/test_template.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_timed_scaling_region.py
+++ b/integration/test/test_timed_scaling_region.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_trace.py
+++ b/integration/test/test_trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/integration/test/test_tutorial_base.py
+++ b/integration/test/test_tutorial_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmconvertreport
+++ b/scripts/geopmconvertreport
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmlaunch
+++ b/scripts/geopmlaunch
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmplotter
+++ b/scripts/geopmplotter
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmpy/__init__.py
+++ b/scripts/geopmpy/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmpy/agent.py
+++ b/scripts/geopmpy/agent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmpy/error.py
+++ b/scripts/geopmpy/error.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmpy/hash.py
+++ b/scripts/geopmpy/hash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmpy/pio.py
+++ b/scripts/geopmpy/pio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmpy/policy_store.py
+++ b/scripts/geopmpy/policy_store.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmpy/topo.py
+++ b/scripts/geopmpy/topo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/geopmpy/update_report.py
+++ b/scripts/geopmpy/update_report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/outlier/outlier_detection.py
+++ b/scripts/outlier/outlier_detection.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/test/TestAffinity.py
+++ b/scripts/test/TestAffinity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/test/TestAgent.py
+++ b/scripts/test/TestAgent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/test/TestError.py
+++ b/scripts/test/TestError.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/test/TestHash.py
+++ b/scripts/test/TestHash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/test/TestIO.py
+++ b/scripts/test/TestIO.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/test/TestLauncher.py
+++ b/scripts/test/TestLauncher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/test/TestPIO.py
+++ b/scripts/test/TestPIO.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/test/TestPolicyStore.py
+++ b/scripts/test/TestPolicyStore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/test/TestPolicyStoreIntegration.py
+++ b/scripts/test/TestPolicyStoreIntegration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/scripts/test/TestTopo.py
+++ b/scripts/test/TestTopo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #

--- a/test_hw/rapl_pkg_limit_plot.py
+++ b/test_hw/rapl_pkg_limit_plot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  Copyright (c) 2015 - 2021, Intel Corporation
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/tutorial/tutorial_build_intel.sh
+++ b/tutorial/tutorial_build_intel.sh
@@ -39,7 +39,7 @@ if [ ! "$OMP_FLAGS" ]; then
 fi
 
 make \
-CC=icc CXX=icpc MPICC=mpiicc MPICXX=mpiicpc MPIFC=mpiifort MPIF77=mpiifort \
+CC=${CC:-icc} CXX=${CXX:-icpc} MPICC=${MPICC:-mpiicc} MPICXX=${MPICXX:-mpiicpc} MPIFC=${MPIFC:-mpiifort} MPIF77=${MPIF77:-mpiifort} \
 CFLAGS="$GEOPM_CFLAGS $OMP_FLAGS -DTUTORIAL_ENABLE_MKL -D_GNU_SOURCE -std=c99 -xAVX $CFLAGS" \
 CXXFLAGS="$GEOPM_CFLAGS $OMP_FLAGS -DTUTORIAL_ENABLE_MKL -D_GNU_SOURCE -std=c++11 -xAVX $CXXFLAGS" \
 LDFLAGS="$GEOPM_LDFLAGS $OMP_FLAGS -lm -lrt -mkl -xAVX $LDFLAGS"


### PR DESCRIPTION
Updates all Python shebangs to use python3.
Updates tutorial build script to not override compilers if they're already set.

Note that there are still a few Python 2 backwards compatibility routines that can be removed (e.g. exc_clear() in error.py, and all usages).
