### PR TITLE
Updates to NVMLDevicePool and IOGroup for stricter compilers and signal behavior changes

### DIFF
--- a/src/NVMLDevicePool.cpp
+++ b/src/NVMLDevicePool.cpp
@@ -87,12 +87,12 @@ namespace geopm
     {
         //Shutdown NVML
         nvmlReturn_t nvml_result = nvmlShutdown();
-#ifdef GEOPM_DEBUG
         if (nvml_result != NVML_SUCCESS) {
+#ifdef GEOPM_DEBUG
             std::cerr << "NVMLDevicePool::" << __func__ <<  ": NVML failed to shutdown."
                       << "  Error: " <<  nvmlErrorString(nvml_result) << std::endl;
-        }
 #endif
+        }
     }
 
     void NVMLDevicePoolImp::check_nvml_result(nvmlReturn_t nvml_result, int error, const std::string &message, int line) const
@@ -109,7 +109,7 @@ namespace geopm
 
     void NVMLDevicePoolImp::check_accel_range(int accel_idx) const
     {
-        if (accel_idx < 0 || accel_idx >= m_num_accelerator) {
+        if (accel_idx < 0 || accel_idx >= (int)m_num_accelerator) {
             throw Exception("NVMLDevicePool::" + std::string(__func__) + ": accel_idx " +
                             std::to_string(accel_idx) + "  is out of range",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);

--- a/src/NVMLIOGroup.cpp
+++ b/src/NVMLIOGroup.cpp
@@ -630,8 +630,7 @@ namespace geopm
 
     int NVMLIOGroup::signal_behavior(const std::string &signal_name) const
     {
-        // TODO: fix me
-        return IOGroup::M_SIGNAL_BEHAVIOR_LABEL;
+        return IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE;
     }
 
     // Name used for registration with the IOGroup factory


### PR DESCRIPTION
Fixes for issue #1703 #1704 and #1653 

- Moving GEOPM_DEBUG to exclude the initial 'if (nvml_result' so it is considered used by stricter compilers, casting of unsigned int to int to resolve type mimatch
- Moved all NVML signals from label behavior to variable behavior.