### PR TITLE
Address issue 1720: ompi failure with undefined exclude_list_options()

### DIFF
--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -1314,6 +1314,9 @@ class OMPIExecLauncher(Launcher):
         """
         return ','
 
+    def exclude_list_option(self):
+        return []
+
 class IMPIExecLauncher(Launcher):
     """
     Launcher derived object for use with the Intel(R) MPI Library job launch


### PR DESCRIPTION
Signed-off-by: lowren.h.lawson@intel.com <lowren.h.lawson@intel.com>

Add an OMPI exclude_list_option() function similar to the impilaunch function

- Issue hit when running a geopmlaunch ompi -np -n resolved with this change
- Fixes #1720 from github issues.
