### PR TITLE
Remove regex reserved characters from version in spec

### DIFF
--- a/specs/geopm-dudley.spec.in
+++ b/specs/geopm-dudley.spec.in
@@ -4,10 +4,11 @@
 %define python_family python3
 %define pip_family pip3
 %define install_prefix /opt/ohpc/pub/libs/%{pname}/%{pname}-%{version}
+%define install_prefix_short /opt/ohpc/pub/libs/%{pname}/%{pname}-
 %define module_prefix /opt/ohpc/pub/modulefiles/%{pname}
 %define module_name %{version}
 %define python_family_lib_dir /lib/python%{expand:%{%{python_family}_version}}/site-packages
-%global __requires_exclude_from ^%{install_prefix}%{python_family_lib_dir}/.*$
+%global __requires_exclude_from ^%{install_prefix_short}.*%{python_family_lib_dir}/.*$
 
 Name:          %{pname}
 Summary:       Global Extensible Open Power Manager


### PR DESCRIPTION
The __requires_exclude_from RPM macro was not functioning properly because of a non-release version string, ```geopm-1.1.0+dev1123g3558ff21```.  There is no way to escape the string (specifically the '+') in such a way that it is passed properly to the exclude macro, so I removed it entirely.

Checking the requirements from the RPM now properly omits all Python module required deps.

Before (when things were not functioning properly):
```
$ rpm -qpR geopm-1.1.0+dev1123g3558ff21-1.x86_64.rpm | grep fort
libgfortran-2e0d59d6.so.5.0.0()(64bit)
libgfortran-2e0d59d6.so.5.0.0(GFORTRAN_8)(64bit)
libmpifort.so.12()(64bit)
```

After the changes in this PR:
```
$ rpm -qpR geopm-1.1.0+dev1122g11cfee1b-1.x86_64.rpm | grep fort
libmpifort.so.12()(64bit)
```

More info:
https://docs.fedoraproject.org/en-US/packaging-guidelines/AutoProvidesAndRequiresFiltering/
