### PR TITLE
Changed the order that CLI arguments are passed to the launch function.

### DIFF
--- a/integration/experiment/frequency_sweep/frequency_sweep.py
+++ b/integration/experiment/frequency_sweep/frequency_sweep.py
@@ -119,9 +119,9 @@ def launch(app_conf, args, experiment_cli_args):
                                         args.step_frequency,
                                         args.run_max_turbo)
     targets = launch_configs(output_dir, app_conf, freq_range)
-    extra_cli_args = list(experiment_cli_args)
-    extra_cli_args += launch_util.geopm_signal_args(report_signals=report_signals(),
+    extra_cli_args = launch_util.geopm_signal_args(report_signals=report_signals(),
                                                     trace_signals=trace_signals())
+    extra_cli_args += list(experiment_cli_args)
     launch_util.launch_all_runs(targets=targets,
                                 num_nodes=args.node_count,
                                 iterations=args.trial_count,

--- a/integration/experiment/uncore_frequency_sweep/uncore_frequency_sweep.py
+++ b/integration/experiment/uncore_frequency_sweep/uncore_frequency_sweep.py
@@ -129,9 +129,10 @@ def launch(app_conf, args, experiment_cli_args):
                                                       args.max_uncore_frequency,
                                                       args.step_uncore_frequency)
     targets = launch_configs(app_conf, core_freq_range, uncore_freq_range)
-    extra_cli_args = list(experiment_cli_args)
-    extra_cli_args += launch_util.geopm_signal_args(report_signals=report_signals(),
+    extra_cli_args = launch_util.geopm_signal_args(report_signals=report_signals(),
                                                     trace_signals=trace_signals())
+    extra_cli_args += list(experiment_cli_args)
+
     launch_util.launch_all_runs(targets=targets,
                                 num_nodes=args.node_count,
                                 iterations=args.trial_count,


### PR DESCRIPTION
GEOPM allows user to pass the same command line arguments multiple times with different values and the last value will be the effective one (due to how Python argparse works). We use this property to override the default trace/report signals defined in integration experiments from experiment command line. However the experiment command line should be added to the end of the internal command line definition that will be passed to GEOPM from inside the integration test script. This is currently the case for all the experiments except for uncore/core frequency sweeps. This PR fixes that inconsistency.
