### PR TITLE
Revert changes to endeavor_env.sh

### DIFF
--- a/integration/config/endeavor_env.sh
+++ b/integration/config/endeavor_env.sh
@@ -37,11 +37,8 @@
 # It is NOT intended to be ./ executed.
 
 
-if [ "${SETVARS_COMPLETED:-}" = "1" ] ; then
-    echo "INFO: One API setvars.sh is already sourced. Skipped sourcing again."
-else
-    source /opt/intel/oneAPI/latest/setvars.sh
-fi
+source /opt/intel/compiler/latest/bin/compilervars.sh intel64
+source /opt/intel/impi/latest/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh
 
 export GEOPM_LAUNCHER=impi
 export CC=icc
@@ -55,3 +52,4 @@ export MPIFORT=mpiifort
 export MPIFC=mpiifort
 export MPIF77=mpiifort
 export MPIF90=mpiifort
+


### PR DESCRIPTION
The last change to OneAPI has broken performance of GADGET. Reverting back to the old toolchain with the addition of compiler variables to endeavor_env.sh seems to be working.