### PR TITLE
Fix issue with ACNT and MCNT msr aggregation

### DIFF
--- a/src/msr_data_arch.cpp
+++ b/src/msr_data_arch.cpp
@@ -68,7 +68,7 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1.0,
                     "behavior":  "monotone",
-                    "writeable": false
+                    "writeable": false,
                     "aggregation": "sum"
                 }
             }
@@ -84,7 +84,7 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1.0,
                     "behavior":  "monotone",
-                    "writeable": false
+                    "writeable": false,
                     "aggregation": "sum"
                 }
             }

--- a/src/msr_data_arch.cpp
+++ b/src/msr_data_arch.cpp
@@ -69,6 +69,7 @@ namespace geopm
                     "scalar":    1.0,
                     "behavior":  "monotone",
                     "writeable": false
+                    "aggregation": "sum"
                 }
             }
         },
@@ -84,6 +85,7 @@ namespace geopm
                     "scalar":    1.0,
                     "behavior":  "monotone",
                     "writeable": false
+                    "aggregation": "sum"
                 }
             }
         },


### PR DESCRIPTION
- Aggregation method was not specified in json description.
- Default is "select_first", which is not correct in this case.
- Set aggration to sum which is the type for all counters.
- Fixes #1737 from github issues.