### PR TITLE
Fix possible segmentation fault

### DIFF
--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -180,11 +180,10 @@ namespace geopm
 
     void ApplicationSamplerImp::update(const geopm_time_s &curr_time)
     {
-        if (!m_status) {
+        if (!m_status || !m_sampler) {
             throw Exception("ApplicationSamplerImp::" + std::string(__func__) + "(): cannot read process info before connect().",
                             GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
         }
-
         // TODO: temporary until handshake fixed
         m_sampler->check_sample_end();
 
@@ -326,7 +325,12 @@ namespace geopm
 
     std::vector<int> ApplicationSamplerImp::per_cpu_process(void) const
     {
-        return m_sampler->cpu_rank();
+        std::vector<int> result(m_num_cpu, -1);
+        if (m_sampler) {
+            result = m_sampler->cpu_rank();
+        }
+        return result;
+#if 0
         /// @todo code below will work *after* the handshake is complete
         if (!m_status) {
             throw Exception("ApplicationSamplerImp::" + std::string(__func__) + "(): cannot read process info before connect().",
@@ -337,6 +341,7 @@ namespace geopm
             result[cpu_idx] = m_status->get_process(cpu_idx);
         }
         return result;
+#endif
     }
 
     void ApplicationSamplerImp::connect(const std::string &shm_key)

--- a/test/ApplicationSamplerTest.cpp
+++ b/test/ApplicationSamplerTest.cpp
@@ -590,3 +590,12 @@ TEST_F(ApplicationSamplerTest, sampler_cpu)
     EXPECT_EQ(1, CPU_ISSET(2, cpu_set.get()));
     EXPECT_EQ(0, CPU_ISSET(3, cpu_set.get()));
 }
+
+TEST_F(ApplicationSamplerTest, per_cpu_process_no_sampler)
+{
+    m_app_sampler->set_sampler(nullptr);
+    auto process_actual = m_app_sampler->per_cpu_process();
+    EXPECT_EQ((size_t)m_num_cpu, process_actual.size());
+    std::vector<int> process_expect(m_num_cpu, -1);
+    EXPECT_EQ(process_expect, process_actual);
+}

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -86,6 +86,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/ApplicationSamplerTest.cpu_process \
               test/gtest_links/ApplicationSamplerTest.cpu_progress \
               test/gtest_links/ApplicationSamplerTest.sampler_cpu \
+              test/gtest_links/ApplicationSamplerTest.per_cpu_process_no_sampler \
               test/gtest_links/ApplicationStatusTest.bad_shmem \
               test/gtest_links/ApplicationStatusTest.hash \
               test/gtest_links/ApplicationStatusTest.hints \


### PR DESCRIPTION
- The ProfileIOGroup is loaded by PlatformIO even if the
  Controller is not present (e.g. when the geopmread CLI
  is used).
- There were no checks to protect the null pointer from use
  which could lead to a segmentation fault.
- Fixes #1740 from github issues.
