### PR TITLE
Fixed PCNT aggregation method

### DIFF
--- a/src/msr_data_skx.cpp
+++ b/src/msr_data_skx.cpp
@@ -620,7 +620,8 @@ namespace geopm
                     "units": "none",
                     "scalar": 1.0,
                     "behavior":  "monotone",
-                    "writeable": false
+                    "writeable": false,
+                    "aggregation": "sum"
                 }
             }
         },


### PR DESCRIPTION
Add the missing PCNT metric fix to #1738 PR.
- Aggregation method was not specified in json description.
- Default is "select_first", which is not correct in this case.
- Set aggregation to sum which is the type for all counters.
- Fixes #1737 from github issues.
