### PR TITLE
Add bash autocompletion scripts for geopmlaunch, geopmread, and geopmwrite

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -895,5 +895,6 @@ include test/Makefile.mk
 include integration/Makefile.mk
 include examples/Makefile.mk
 include scripts/Makefile.mk
+include shell_completion/Makefile.mk
 
 .PHONY: $(PHONY_TARGETS)

--- a/configure.ac
+++ b/configure.ac
@@ -231,6 +231,19 @@ if test "x$with_mpif77" != x; then
   MPIF77=$with_mpif77
 fi
 
+AC_ARG_WITH([bash-completion-dir], [AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
+            [Install the bash auto-completion script in this directory. @<:@default=yes@:>@])])
+if test "x$with_bash_completion_dir" = "x"; then
+  bashcompdir=`pkg-config --define-variable=prefix='${prefix}' --variable=completionsdir bash-completion`
+  if test "x$bashcompdir" = "x"; then
+    bashcompdir="$sysconfdir/bash_completion.d"
+  fi
+else
+  bashcompdir="$with_bash_completion_dir"
+fi
+AC_SUBST([bashcompdir])
+AM_CONDITIONAL([ENABLE_BASH_COMPLETION], [test "x$with_bash_completion_dir" != "xno"])
+
 AC_ARG_ENABLE([mpi],
   [AS_HELP_STRING([--disable-mpi], [Do not build components that require MPI])],
 [if test "x$enable_mpi" = "xno" ; then
@@ -625,6 +638,7 @@ AC_MSG_RESULT([libdir             : ${libdir}])
 AC_MSG_RESULT([datarootdir        : ${datarootdir}])
 AC_MSG_RESULT([datadir            : ${datadir}])
 AC_MSG_RESULT([mandir             : ${mandir}])
+AC_MSG_RESULT([bashcompdir        : ${bashcompdir}])
 AC_MSG_RESULT([GEOPM_CONFIG_PATH  : ${GEOPM_CONFIG_PATH}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([debug              : ${enable_debug}])

--- a/copying_headers/MANIFEST.EXEMPT
+++ b/copying_headers/MANIFEST.EXEMPT
@@ -114,6 +114,7 @@ scripts/outlier/README.md
 scripts/outlier/theta_nodelist_broken.txt
 scripts/requirements.txt
 scripts/test/test_io_experiment.report
+shell_completion/README.md
 specs/geopm-dudley.spec.in
 specs/geopm-ohpc.spec.in
 specs/geopm-theta.spec.in

--- a/shell_completion/Makefile.mk
+++ b/shell_completion/Makefile.mk
@@ -1,0 +1,43 @@
+#  Copyright (c) 2015 - 2021, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+EXTRA_DIST += shell_completion/README.md \
+              shell_completion/geopmlaunch.bash \
+              shell_completion/geopmread.bash \
+              shell_completion/geopmwrite.bash \
+              #end
+
+if ENABLE_BASH_COMPLETION
+dist_bashcomp_DATA = shell_completion/geopmlaunch.bash \
+                     shell_completion/geopmread.bash \
+                     shell_completion/geopmwrite.bash \
+                     # end
+endif

--- a/shell_completion/README.md
+++ b/shell_completion/README.md
@@ -1,0 +1,13 @@
+Shell Completion Scripts
+========================
+This directory contains scripts to enable shell completion for GEOPM tools.
+
+The non-extension part of each file name indicates which tool's interface is
+autocompleted by the script. The extension part of the file name indicates the
+target completion environment. For example, geopmlaunch.bash_completion defines
+a Bash autocompletion script for geopmlaunch.
+
+Typically, these scripts can be enabled by sourcing them into your shell
+environment or by installing them to a location where they will be automatically
+sourced. For example, you can add `source /path/to/geopmlaunch.bash_completion`
+to your `.bashrc`.

--- a/shell_completion/geopmlaunch.bash
+++ b/shell_completion/geopmlaunch.bash
@@ -1,0 +1,99 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2021, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# This is a bash completion script for geopmlaunch. Source it in bash,
+# or put it in your bash_completion.d directory
+
+_geopmlaunch_launchers()
+{
+        # Extract the part of the help text (parts separated by empty lines)
+        # that lists the launchers. Strip out quotation marks and replace
+        # commas with newlines
+        geopmlaunch --help 2>/dev/null | awk -F':' -e 'BEGIN { RS="\n\n" } /Possible LAUNCHER values:/ { gsub(/(\"|,|[[:space:]])+/, "\n", $2); print $2 }'
+}
+
+_geopmlaunch_options()
+{
+        # Extract single and double dash options from the help text, dropping equal signs
+        geopmlaunch $1 --help 2>/dev/null | tr ',' '\n' | awk -F '[\t =]+' '/^\s*(--\S+=?)|^\s*-\S/ {print $2}'
+}
+
+_geopmlaunch()
+{
+        COMPREPLY=()
+        local cur
+        local prev
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+        [[ "$prev" == '=' ]] && prev="${COMP_WORDS[COMP_CWORD-2]}"
+
+        case "$prev" in
+                --geopm-agent)
+                        COMPREPLY=( $(compgen -W "$(geopmagent 2>/dev/null)" -- "${cur#=}") )
+                        return 0
+                        ;;
+                --geopm-ctl)
+                        COMPREPLY=( $(compgen -W "process pthread application" -- "${cur#=}") )
+                        return 0
+                        ;;
+                --geopm-trace-signals|--geopm-report-signals)
+                        if [[ "$cur"  == *','* ]]
+                        then
+                                local last rest
+                                last="${cur##*,}"
+                                rest="${cur%,*}"
+                                # There's a comma. Prefix each recommendation with the already-entered list.
+                                COMPREPLY=( $(compgen -P "${rest}," -W "$(geopmread 2>/dev/null)" -- "${last#=}") )
+                        else
+                                COMPREPLY=( $(compgen -W "$(geopmread 2>/dev/null)" -- "${cur#=}") )
+                        fi
+                        return 0
+                        ;;
+                *)
+                        if [ "$COMP_CWORD" -eq 1 ]
+                        then
+                                COMPREPLY=( $(compgen -W "$(_geopmlaunch_launchers)" -- "${cur}") );
+                        else
+                                if [[ ! " ${COMP_WORDS[@]:0:${COMP_CWORD}} " =~ " -- " ]]
+                                then
+                                        # Haven't encountered a -- argument
+                                        local launcher="${COMP_WORDS[1]}"
+                                        COMPREPLY=( $(compgen -W "$(_geopmlaunch_options $launcher)" -- "${cur}") );
+                                fi
+                        fi
+                        [[ $COMPREPLY == *= ]] && compopt -o nospace
+                        return 0
+                        ;;
+        esac
+}
+complete -o default -F _geopmlaunch geopmlaunch

--- a/shell_completion/geopmread.bash
+++ b/shell_completion/geopmread.bash
@@ -1,0 +1,121 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2021, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# This is a bash completion script for geopmread. Source it in bash,
+# or put it in your bash_completion.d directory
+
+_geopmread_signals()
+{
+        cur=$1
+        if [[ "$cur" != *":"* ]]
+        then
+                # If no colons are present in the current signal to complete,
+                # the completion list is going to be way too long to read in
+                # a single screen. Reduce verbosity by only showing signals
+                # that have no prefix, and by showing only the set of prefixes
+                # of other signals.
+                geopmread 2>/dev/null | cut -d':' -f1-2 | sort | uniq
+        else
+                geopmread 2>/dev/null
+        fi
+}
+
+_geopmread_options()
+{
+        # Extract single and double dash options from the help text, dropping equal signs
+        geopmread $1 --help 2>/dev/null | tr ',' '\n' | awk -F '[\t =]+' '/^\s*(--\S+=?)|^\s*-\S/ {print $2}'
+}
+
+_geopmread_domains()
+{
+        signal=$1
+        domains=$(geopmread $signal --info 2>/dev/null | awk '/domain:/ {print $2}')
+
+        if [[ "$domains" == *"cpu"* ]]; then
+                domains="$domains core"
+        fi
+        if [[ "$domains" == *"core"* ]]; then
+                domains="$domains package"
+        fi
+        if [[ "$domains" == *"package"* ]]; then
+                domains="$domains board"
+        fi
+
+        echo "$domains"
+}
+
+_geopmread_domain_index()
+{
+        geopmread -d 2>&1 | awk -v domain="$1" '$0 ~ "^"domain"\\>" { for (i=0; i<$2; i++) print i }'
+}
+
+_geopmread()
+{
+        COMP_WORDBREAKS=${COMP_WORDBREAKS//:} # Let colons exist in a word
+        COMPREPLY=()
+        local cur
+        local prev
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+        case "$prev" in
+                --info)
+                        # The user wants info about a signal. Complete with the list of signals.
+                        COMPREPLY=( $(compgen -W "$(_geopmread_signals $cur)" -- "$cur") )
+                        ;;
+                *)
+                        if [ "$COMP_CWORD" -eq 1 ]
+                        then
+                                # Nothing entered yet. Complete with all options and
+                                # with the list of signals.
+                                COMPREPLY=( $(compgen -W "$(_geopmread_options) $(_geopmread_signals $cur)" -- "$cur") );
+                        elif [ "$COMP_CWORD" -eq 2 ]
+                        then
+                                # An arg has been provided. Let's see if it is a signal.
+                                # Try to complete with its domain or the --info option.
+                                COMPREPLY=( $(compgen -W "$(_geopmread_domains $prev) --info" -- "$cur") );
+                        elif [ "$COMP_CWORD" -eq 3 ]
+                        then
+                                # We have two previous args. Assume it is a signal and a domain.
+                                # Complete with the possible domain indices
+                                COMPREPLY=( $(compgen -W "$(_geopmread_domain_index $prev)" -- "$cur") );
+                        fi
+                        ;;
+        esac
+
+        # If the completion reply ends in a colon, we are probably looking at an
+        # incomplete signal name. Don't auto-insert a space, since there is more
+        # to the name.
+        [[ $COMPREPLY == *':' ]] && compopt -o nospace
+        return 0
+}
+complete -o nosort -F _geopmread geopmread

--- a/shell_completion/geopmwrite.bash
+++ b/shell_completion/geopmwrite.bash
@@ -1,0 +1,121 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2021, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# This is a bash completion script for geopmwrite. Source it in bash,
+# or put it in your bash_completion.d directory
+
+_geopmwrite_controls()
+{
+        cur=$1
+        if [[ "$cur" != *":"* ]]
+        then
+                # If no colons are present in the current control to complete,
+                # the completion list is going to be way too long to write in
+                # a single screen. Reduce verbosity by only showing controls
+                # that have no prefix, and by showing only the set of prefixes
+                # of other controls.
+                geopmwrite 2>/dev/null | cut -d':' -f1-2 | sort | uniq
+        else
+                geopmwrite 2>/dev/null
+        fi
+}
+
+_geopmwrite_options()
+{
+        # Extract single and double dash options from the help text, dropping equal signs
+        geopmwrite $1 --help 2>/dev/null | tr ',' '\n' | awk -F '[\t =]+' '/^\s*(--\S+=?)|^\s*-\S/ {print $2}'
+}
+
+_geopmwrite_domains()
+{
+        control=$1
+        domains=$(geopmwrite $control --info 2>/dev/null | awk '/domain:/ {print $2}')
+
+        if [[ "$domains" == *"cpu"* ]]; then
+                domains="$domains core"
+        fi
+        if [[ "$domains" == *"core"* ]]; then
+                domains="$domains package"
+        fi
+        if [[ "$domains" == *"package"* ]]; then
+                domains="$domains board"
+        fi
+
+        echo "$domains"
+}
+
+_geopmwrite_domain_index()
+{
+        geopmwrite -d 2>&1 | awk -v domain="$1" '$0 ~ "^"domain"\\>" { for (i=0; i<$2; i++) print i }'
+}
+
+_geopmwrite()
+{
+        COMP_WORDBREAKS=${COMP_WORDBREAKS//:} # Let colons exist in a word
+        COMPREPLY=()
+        local cur
+        local prev
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+        case "$prev" in
+                --info)
+                        # The user wants info about a control. Complete with the list of controls.
+                        COMPREPLY=( $(compgen -W "$(_geopmwrite_controls $cur)" -- "$cur") )
+                        ;;
+                *)
+                        if [ "$COMP_CWORD" -eq 1 ]
+                        then
+                                # Nothing entered yet. Complete with all options and
+                                # with the list of controls.
+                                COMPREPLY=( $(compgen -W "$(_geopmwrite_options) $(_geopmwrite_controls $cur)" -- "$cur") );
+                        elif [ "$COMP_CWORD" -eq 2 ]
+                        then
+                                # An arg has been provided. Let's see if it is a control.
+                                # Try to complete with its domain or the --info option.
+                                COMPREPLY=( $(compgen -W "$(_geopmwrite_domains $prev) --info" -- "$cur") );
+                        elif [ "$COMP_CWORD" -eq 3 ]
+                        then
+                                # We have two previous args. Assume it is a control and a domain.
+                                # Complete with the possible domain indices
+                                COMPREPLY=( $(compgen -W "$(_geopmwrite_domain_index $prev)" -- "$cur") );
+                        fi
+                        ;;
+        esac
+
+        # If the completion reply ends in a colon, we are probably looking at an
+        # incomplete control name. Don't auto-insert a space, since there is more
+        # to the name.
+        [[ $COMPREPLY == *':' ]] && compopt -o nospace
+        return 0
+}
+complete -o nosort -F _geopmwrite geopmwrite

--- a/specs/geopm.spec.in
+++ b/specs/geopm.spec.in
@@ -88,6 +88,11 @@ Prefix: %{_prefix}
 %define docdir %{_defaultdocdir}/geopm-%{version}
 %endif
 
+%define compdir %(pkg-config --variable=completionsdir bash-completion)
+%if "x%{compdir}" == "x"
+%define compdir "%{_sysconfdir}/bash_completion.d"
+%endif
+
 %description
 @BLURB@
 
@@ -122,6 +127,7 @@ test -f configure || ./autogen.sh
             --disable-mpi --disable-openmp \
             --disable-fortran \
             --with-python=%{python_bin} \
+            --with-bash-completion-dir=%{compdir} \
             || ( cat config.log && false )
 %else
 ./configure --prefix=%{_prefix} --libdir=%{_libdir} --libexecdir=%{_libexecdir} \
@@ -130,6 +136,7 @@ test -f configure || ./autogen.sh
             --disable-mpi --disable-openmp \
             --disable-fortran \
             --with-python=%{python_bin} \
+            --with-bash-completion-dir=%{compdir} \
             || ( cat config.log && false )
 %endif
 
@@ -170,6 +177,7 @@ rm -f %{buildroot}/%{_bindir}/geopmlaunch
 %{_bindir}/geopmagent
 %{_bindir}/geopmread
 %{_bindir}/geopmwrite
+%{compdir}
 %dir %{docdir}
 %doc %{docdir}/COPYING
 %doc %{docdir}/README


### PR DESCRIPTION
This change adds bash completion scripts for geopmlaunch, geopmread, and geopmwrite. The specfile changes were tested [in OBS](https://build.opensuse.org/project/show/home:dannosliwcd) and on our SLES system along with a separate change set that fixes some python2-related build failures.

The autocompletion scripts add some context-aware completions for a few of our CLIs. General options are pulled in from each interface's `-h` option. Specific choices (e.g., launchers in geopmlaunch, signals/controls and their available domains in read/write) are queried from each interface at the time of completion.