### PR TITLE
Remove python2 from the geopm specfile

### DIFF
--- a/specs/geopm.spec.in
+++ b/specs/geopm.spec.in
@@ -53,29 +53,27 @@ BuildRequires: elfutils-libelf-devel
 BuildRequires: gdb-headless
 %endif
 
-%if ((%{defined suse_version}) && (0%{?suse_version} < 1500)) || ((%{defined rhel}) && (0%{?rhel} < 8))
-# The version of python 3 available in these versions is not supported for all
-# of our package dependencies, but they do support 2.7 and newer versions of 3
-# We originally released to these distributions with an implicit python 2
-# dependency, so keep it that way for existing compatibility.
-%define python_major_version %{nil}
-BuildRequires: python
-BuildRequires: python-devel
-%define python_bin /usr/bin/python
-%else
 %define python_major_version 3
 %if %{defined rhel}
-# We should depend on python36, but that package is implemented as a module.
-# The enterprise Linux repos on opensuse's OBS instance don't expose modules
-# at this time, so the build fails due to a seemingly invalid dependency.
-# For now, depend on platform-python instead, which is a bare package.
-BuildRequires: platform-python
-BuildRequires: platform-python-devel
-%else
+%if 0%{?rhel} < 8
+BuildRequires: python3-rpm-macros
 BuildRequires: python3
 BuildRequires: python3-devel
+%else
+BuildRequires: python36-rpm-macros
+BuildRequires: python36
+BuildRequires: python36-devel
 %endif
 %define python_bin %{__python3}
+%else
+%if ((%{defined suse_version}) && (0%{?suse_version} < 1500))
+%define python_bin /usr/bin/python3
+%else
+BuildRequires: python-rpm-macros
+%define python_bin %{__python3}
+%endif
+BuildRequires: python3
+BuildRequires: python3-devel
 %endif
 
 %if 0%{?suse_version} >= 1320


### PR DESCRIPTION
Since we have dropped python2 support, the rpm build variants that require python2 no longer succeed in OBS. This change gets them all working again except for RHEL7. I am unable to find a python3 package option for OBS+RHEL7.

Build output: https://build.opensuse.org/project/show/home:dannosliwcd
