### PR TITLE
Fix the muliplier for the MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_2 skx definition

### DIFF
--- a/src/msr_data_skx.cpp
+++ b/src/msr_data_skx.cpp
@@ -255,7 +255,7 @@ namespace geopm
                     "end_bit":   23,
                     "function":  "scale",
                     "units":     "none",
-                    "scalar":    1e8,
+                    "scalar":    1,
                     "behavior":  "constant",
                     "writeable": false
                 },


### PR DESCRIPTION
The current definition reports millions of active cores for the third frequency point on a package that has far fewer than a million cores.