### PR TITLE
Fix OmpiExecLauncher execution failures

### DIFF
--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -588,7 +588,7 @@ class Launcher(object):
                                   node_list=self.node_list,
                                   exclude_list=self.exclude_list,
                                   reservation=self.reservation,
-                                  partition=self.partition)
+                                  partition=getattr(self, 'partition', None))
         ostream = io.StringIO()
         launcher.run(stdout=ostream)
         out = ostream.getvalue()
@@ -1253,7 +1253,7 @@ class OMPIExecLauncher(Launcher):
 
         if is_geopmctl:
             # add not to warn on fork messge
-            result.append('--mca mpi_warn_on_fork 0')
+            result.extend(['--mca', 'mpi_warn_on_fork', '0'])
         return result
 
     def parse_host_file(self, file_name):

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -341,6 +341,7 @@ class Launcher(object):
         self.environ_ext = dict()
         self.rank_per_node = None
         self.exclude_list = None
+        self.partition = None
         self.reservation = None
         self.quiet = quiet
         self.default_handler = signal.getsignal(signal.SIGINT)
@@ -588,7 +589,7 @@ class Launcher(object):
                                   node_list=self.node_list,
                                   exclude_list=self.exclude_list,
                                   reservation=self.reservation,
-                                  partition=getattr(self, 'partition', None))
+                                  partition=self.partition)
         ostream = io.StringIO()
         launcher.run(stdout=ostream)
         out = ostream.getvalue()


### PR DESCRIPTION
OmpiExecLauncher is currently unable to launch in application mode. These changes make it run again.
- Avoid expecting the absent partition option
- Multiple args were being combined to a single quoted arg when
  launching geopmctl. Split them up.
