### PR TITLE
Align dudley patch to new Python requirements

### DIFF
--- a/specs/geopm-pyyaml-req.patch
+++ b/specs/geopm-pyyaml-req.patch
@@ -1,6 +1,6 @@
-From 916b85e200455df187259a35db579cd0ec280b3e Mon Sep 17 00:00:00 2001
+From 95973e3b8478a9b8928567d18166fe444950a543 Mon Sep 17 00:00:00 2001
 From: Brad Geltz <brad.geltz@intel.com>
-Date: Mon, 21 Jun 2021 15:40:59 -0700
+Date: Thu, 29 Jul 2021 11:12:55 -0700
 Subject: [PATCH] Use pyyaml 5.1.1
 #
 #  Copyright (c) 2015 - 2021, Intel Corporation
@@ -42,18 +42,17 @@ Signed-off-by: Brad Geltz <brad.geltz@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scripts/requirements.txt b/scripts/requirements.txt
-index 3150aaa1..c4725e26 100644
+index bf78713f..f6553d7d 100644
 --- a/scripts/requirements.txt
 +++ b/scripts/requirements.txt
-@@ -7,7 +7,7 @@ psutil>=5.4.8
+@@ -7,6 +7,6 @@ psutil>=5.4.8
  pandas>=0.23.0
  tables>=3.4.3
  cffi>=1.6.0
 -pyyaml>=5.1.0
 +pyyaml==5.1.1
- mock>=3.0.0
  future>=0.17.1
  pylint>=1.9.5
--- 
+--
 2.26.2
 


### PR DESCRIPTION
Needed because the mock module was removed from the geopmpy requirements.txt.