### PR TITLE
Addition of levelzero IO Group and integration tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -661,6 +661,10 @@ libgeopmpolicy_la_SOURCES = contrib/json11/json11.cpp \
                             src/LevelZeroDevicePool.hpp \
                             src/LevelZeroDevicePoolImp.hpp \
                             src/LevelZeroImp.hpp \
+                            src/LevelZeroIOGroup.cpp \
+                            src/LevelZeroIOGroup.hpp \
+                            src/LevelZeroSignal.cpp \
+                            src/LevelZeroSignal.hpp \
                             # end
 
 nvml_source_files = src/NVMLDevicePool.cpp \

--- a/integration/test/Makefile.mk
+++ b/integration/test/Makefile.mk
@@ -63,6 +63,7 @@ include integration/test/test_ompt.mk
 include integration/test/test_geopmio.mk
 include integration/test/test_launch_application.mk
 include integration/test/test_launch_pthread.mk
+include integration/test/test_levelzero_signals.mk
 include integration/test/test_geopmagent.mk
 include integration/test/test_environment.mk
 include integration/test/test_power_governor.mk

--- a/integration/test/test_levelzero_signals.mk
+++ b/integration/test/test_levelzero_signals.mk
@@ -1,0 +1,32 @@
+#  Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+EXTRA_DIST += integration/test/test_levelzero_signals.py

--- a/integration/test/test_levelzero_signals.py
+++ b/integration/test/test_levelzero_signals.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2015 - 2021, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+from __future__ import absolute_import
+
+import os
+import sys
+import unittest
+import subprocess
+import io
+import json
+
+import geopm_context
+import geopmpy.agent
+import geopm_test_launcher
+import util
+import time
+import geopmpy.topo
+
+
+@util.skip_unless_levelzero()
+@util.skip_unless_levelzero_power()
+class TestIntegrationLevelZeroSignals(unittest.TestCase):
+    """Test the levelzero signals
+
+    """
+    @classmethod
+    def setUpClass(cls):
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        cls._app_exec_path = os.path.join(script_dir, '.libs', 'test_levelzero_signals')
+
+    def setUp(self):
+        self._stdout = None
+        self._stderr = None
+
+        #TODO: Add query for numnber of devices and subdevices
+        #TODO: Add check for ZES_SYSMAN_ENABLE=1
+
+    def tearDown(self):
+        pass
+
+    def test_power(self):
+        #Query
+        power = geopm_test_launcher.geopmread("LEVELZERO::POWER board_accelerator 0")
+        power_limit_max = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_MAX board_accelerator 0")
+        power_limit_min = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_MIN board_accelerator 0")
+
+        #Info
+        sys.stdout.write("Power:\n");
+        sys.stdout.write("\tPower: {}\n".format(power));
+        sys.stdout.write("\tPower limit max: {}\n".format(power_limit_max));
+        sys.stdout.write("\tPower limit min: {}\n".format(power_limit_min));
+
+        #Check
+        self.assertGreater(power, 0)
+        self.assertGreaterEqual(power, power_limit_min)
+
+        self.assertLessEqual(power, power_limit_default)
+        if(power_limit_max > 0): #Negative value indicates max is not supported
+            self.assertLessEqual(power, power_limit_max)
+
+        #TODO: Power limit enabled sustained check
+
+    def test_energy(self):
+        sys.stdout.write("Running LevelZero Energy Test\n");
+        #Query
+        energy_prev = geopm_test_launcher.geopmread("LEVELZERO::ENERGY board_accelerator 0")
+        energy_timestamp_prev = geopm_test_launcher.geopmread("LEVELZERO::ENERGY_TIMESTAMP board_accelerator 0")
+        time.sleep(5)
+        energy_curr = geopm_test_launcher.geopmread("LEVELZERO::ENERGY board_accelerator 0")
+        energy_timestamp_curr = geopm_test_launcher.geopmread("LEVELZERO::ENERGY_TIMESTAMP board_accelerator 0")
+
+        sys.stdout.write("Energy:\n");
+        sys.stdout.write("\tEnergy Sample 0: {}\n".format(energy_prev));
+        sys.stdout.write("\tEnergy Sample 1: {}\n".format(energy_curr));
+
+        #Check
+        self.assertNotEqual(energy_prev, energy_curr)
+        self.assertNotEqual(energy_timestamp_prev, energy_timestamp_curr)
+
+    def test_frequency(self):
+        sys.stdout.write("Running LevelZero Frequency Test\n");
+        #Query
+        frequency_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_GPU board_accelerator 0")
+        frequency_min_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_MIN_GPU board_accelerator 0")
+        frequency_max_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_MAX_GPU board_accelerator 0")
+
+        #Info
+        sys.stdout.write("Frequency:\n");
+        sys.stdout.write("\tFrequency GPU: {}\n".format(frequency_gpu));
+        sys.stdout.write("\tFrequency GPU Min: {}\n".format(frequency_min_gpu));
+        sys.stdout.write("\tFrequency GPU Max: {}\n".format(frequency_max_gpu));
+
+        #TODO: standby mode check
+        self.assertGreaterEqual(frequency_gpu, frequency_min_gpu)
+        if(frequency_max_gpu > 0): #Negative value indicates max was not supported
+            self.assertLessEqual(frequency_gpu, frequency_max_gpu)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/integration/test/util.py
+++ b/integration/test/util.py
@@ -109,6 +109,16 @@ def skip_unless_do_launch():
         return unittest.skip("Most tests in this suite require launch; do not set --skip-launch.")
     return lambda func: func
 
+def skip_unless_levelzero_power():
+    #try/catch read signal for levelzero
+    try:
+        power = geopm_test_launcher.geopmread("LEVELZERO::POWER board_accelerator 0")
+    except subprocess.CalledProcessError:
+        return unittest.skip("Read of LEVELZERO::POWER not supported, skipping test.")
+    return lambda func: func
+
+def skip_unless_levelzero():
+    return skip_unless_config_enable('levelzero');
 
 def skip_unless_platform_bdx():
     fam, mod = geopm_test_launcher.get_platform()

--- a/src/IOGroup.cpp
+++ b/src/IOGroup.cpp
@@ -50,6 +50,9 @@
 #ifdef GEOPM_ENABLE_NVML
 #include "NVMLIOGroup.hpp"
 #endif
+#ifdef GEOPM_ENABLE_LEVELZERO
+#include "LevelZeroIOGroup.hpp"
+#endif
 #ifdef GEOPM_DEBUG
 #include <iostream>
 #endif
@@ -113,6 +116,10 @@ namespace geopm
 #ifdef GEOPM_ENABLE_NVML
         register_plugin(NVMLIOGroup::plugin_name(),
                         NVMLIOGroup::make_plugin);
+#endif
+#ifdef GEOPM_ENABLE_LEVELZERO
+        register_plugin(LevelZeroIOGroup::plugin_name(),
+                        LevelZeroIOGroup::make_plugin);
 #endif
     }
 

--- a/src/LevelZero.hpp
+++ b/src/LevelZero.hpp
@@ -94,6 +94,17 @@ namespace geopm
             /// @return Accelerator maximum frequency in MHz.
             virtual double frequency_max(unsigned int l0_device_idx, int l0_domain,
                                          int l0_domain_idx) const = 0;
+            /// @brief Get the LevelZero device mininum and maximum frequency
+            ///        control range in MHz
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero accelerator.
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @param [in] l0_domain_idx The LevelZero index indicating a particular
+            ///        domain of the accelerator.
+            /// @return Accelerator minimum and maximum frequency range in MHz.
+            virtual std::pair<double, double> frequency_range(unsigned int l0_device_idx,
+                                                              int l0_domain,
+                                                              int l0_domain_idx) const = 0;
 
             /// @brief Get the number of LevelZero engine domains
             /// @param [in] l0_domain The LevelZero domain type being targeted
@@ -118,7 +129,8 @@ namespace geopm
             /// @return Accelerator active time in microseconds.
             virtual uint64_t active_time(unsigned int l0_device_idx, int l0_domain,
                                          int l0_domain_idx) const = 0;
-            /// @brief Get the LevelZero device timestamp for the active time value in microseconds
+            /// @brief Get the cachced LevelZero device timestamp for the
+            ///        active time value in microseconds
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero accelerator.
             /// @param [in] l0_domain The LevelZero domain type being targeted
@@ -155,7 +167,7 @@ namespace geopm
             ///        Level Zero accelerator.
             /// @return Accelerator energy in microjoules.
             virtual uint64_t energy(unsigned int l0_device_idx) const = 0;
-            /// @brief Get the LevelZero device energy timestamp in microseconds
+            /// @brief Get the LevelZero device energy cached timestamp in microseconds
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero accelerator.
             /// @return Accelerator energy timestamp in microseconds
@@ -165,9 +177,11 @@ namespace geopm
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero accelerator.
             /// @param [in] domain The domain type being targeted
-            /// @param [in] setting Target frequency in MHz.
+            /// @param [in] range_min Min target frequency in MHz.
+            /// @param [in] range_max Max target frequency in MHz.
             virtual void frequency_control(unsigned int l0_device_idx, int l0_domain,
-                                           int l0_domain_idx, double setting) const = 0;
+                                           int l0_domain_idx, double range_min,
+                                           double range_max) const = 0;
     };
 
     const LevelZero &levelzero();

--- a/src/LevelZeroDevicePool.cpp
+++ b/src/LevelZeroDevicePool.cpp
@@ -175,7 +175,7 @@ namespace geopm
     {
         if (domain != GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP) {
             throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
-                             ": domain " + std::to_string(domain) +
+                            ": domain " + std::to_string(domain) +
                             " is not supported for the frequency domain.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }

--- a/src/LevelZeroDevicePool.cpp
+++ b/src/LevelZeroDevicePool.cpp
@@ -84,7 +84,8 @@ namespace geopm
     {
         if (size == 0) {
             throw Exception("LevelZeroDevicePool::" + std::string(func) +
-                            ":Not supported on this hardware",
+                            ": Not supported on this hardware for the specified "
+                            "LevelZero domain",
                             GEOPM_ERROR_INVALID, __FILE__, line);
         }
     }
@@ -166,6 +167,26 @@ namespace geopm
 
         return m_levelzero.frequency_max(dev_subdev_idx_pair.first, l0_domain,
                                          dev_subdev_idx_pair.second);
+    }
+
+    std::pair<double, double> LevelZeroDevicePoolImp::frequency_range(int domain,
+                                                                      unsigned int domain_idx,
+                                                                      int l0_domain) const
+    {
+        if (domain != GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                             ": domain " + std::to_string(domain) +
+                            " is not supported for the frequency domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        check_domain_exists(m_levelzero.frequency_domain_count(
+                                        dev_subdev_idx_pair.first, l0_domain), __func__, __LINE__);
+
+        return m_levelzero.frequency_range(dev_subdev_idx_pair.first, l0_domain,
+                                           dev_subdev_idx_pair.second);
+
     }
 
     std::pair<uint64_t, uint64_t> LevelZeroDevicePoolImp::active_time_pair(int domain,
@@ -315,7 +336,8 @@ namespace geopm
     }
 
     void LevelZeroDevicePoolImp::frequency_control(int domain, unsigned int domain_idx,
-                                                   int l0_domain, double setting) const
+                                                   int l0_domain, double range_min,
+                                                   double range_max) const
     {
         if (domain != GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP) {
             throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
@@ -330,6 +352,7 @@ namespace geopm
                                         __func__, __LINE__);
 
         m_levelzero.frequency_control(dev_subdev_idx_pair.first, l0_domain,
-                                      dev_subdev_idx_pair.second, setting);
+                                      dev_subdev_idx_pair.second, range_min,
+                                      range_max);
     }
 }

--- a/src/LevelZeroDevicePool.hpp
+++ b/src/LevelZeroDevicePool.hpp
@@ -77,6 +77,9 @@ namespace geopm
             /// @return Accelerator maximum frequency in MHz.
             virtual double frequency_max(int domain, unsigned int domain_idx,
                                          int l0_domain) const = 0;
+            virtual std::pair<double, double> frequency_range(int domain,
+                                                              unsigned int domain_idx,
+                                                              int l0_domain) const = 0;
 
             // UTILIZATION SIGNAL FUNCTIONS
             /// @brief Get the LevelZero device active time and timestamp in microseconds
@@ -160,9 +163,11 @@ namespace geopm
             /// @param [in] domain_idx The GEOPM domain index
             ///             (i.e. accelerator being targeted)
             /// @param [in] l0_domain The LevelZero domain type being targeted
-            /// @param [in] setting Target frequency in MHz.
+            /// @param [in] range_min Min target frequency in MHz.
+            /// @param [in] range_max Max target frequency in MHz.
             virtual void frequency_control(int domain, unsigned int domain_idx,
-                                           int l0_domain, double setting) const = 0;
+                                           int l0_domain, double range_min,
+                                           double range_max) const = 0;
 
         private:
     };

--- a/src/LevelZeroDevicePoolImp.hpp
+++ b/src/LevelZeroDevicePoolImp.hpp
@@ -57,6 +57,9 @@ namespace geopm
                                  int l0_domain) const override;
             double frequency_max(int domain, unsigned int domain_idx,
                                  int l0_domain) const override;
+            std::pair <double, double> frequency_range(int domain,
+                                                       unsigned int domain_idx,
+                                                       int l0_domain) const override;
             std::pair<uint64_t, uint64_t> active_time_pair(int domain,
                                                            unsigned int device_idx,
                                                            int l0_domain) const override;
@@ -78,7 +81,8 @@ namespace geopm
                                       int l0_domain) const override;
 
             void frequency_control(int domain, unsigned int domain_idx,
-                                           int l0_domain, double setting) const override;
+                                   int l0_domain, double range_min,
+                                   double range_max) const override;
 
         private:
             const LevelZero &m_levelzero;

--- a/src/LevelZeroIOGroup.cpp
+++ b/src/LevelZeroIOGroup.cpp
@@ -453,7 +453,6 @@ namespace geopm
                                                    };
             }
         }
-
     }
 
     // Extract the set of all signal names from the index map
@@ -893,7 +892,7 @@ namespace geopm
     }
 
     void LevelZeroIOGroup::register_signal_alias(const std::string &alias_name,
-                                            const std::string &signal_name)
+                                                 const std::string &signal_name)
     {
         if (m_signal_available.find(alias_name) != m_signal_available.end()) {
             throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
@@ -909,12 +908,12 @@ namespace geopm
         // copy signal info but append to description
         m_signal_available[alias_name] = it->second;
         m_signal_available[alias_name].m_description =
-            m_signal_available[signal_name].m_description + '\n' +
-                                            "    alias_for: " + signal_name;
+            m_signal_available[signal_name].m_description +
+            "\n    alias_for: " + signal_name;
     }
 
     void LevelZeroIOGroup::register_control_alias(const std::string &alias_name,
-                                           const std::string &control_name)
+                                                  const std::string &control_name)
     {
         if (m_control_available.find(alias_name) != m_control_available.end()) {
             throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
@@ -930,7 +929,7 @@ namespace geopm
         // copy control info but append to description
         m_control_available[alias_name] = it->second;
         m_control_available[alias_name].m_description =
-       m_control_available[control_name].m_description + '\n' +
-                                         "    alias_for: " + control_name;
+            m_control_available[control_name].m_description +
+            "\n    alias_for: " + control_name;
     }
 }

--- a/src/LevelZeroIOGroup.cpp
+++ b/src/LevelZeroIOGroup.cpp
@@ -641,8 +641,7 @@ namespace geopm
     {
         m_is_batch_read = true;
         for (size_t ii = 0; ii < m_signal_pushed.size(); ++ii) {
-            std::dynamic_pointer_cast<LevelZeroSignal>(m_signal_pushed[ii])->
-                set_sample(m_signal_pushed[ii]->read());
+            m_signal_pushed[ii]->set_sample(m_signal_pushed[ii]->read());
         }
     }
 

--- a/src/LevelZeroIOGroup.cpp
+++ b/src/LevelZeroIOGroup.cpp
@@ -1,0 +1,862 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "LevelZeroIOGroup.hpp"
+
+#include <cmath>
+
+#include <iostream>
+#include <string>
+#include <numeric>
+#include <sched.h>
+#include <errno.h>
+
+#include "IOGroup.hpp"
+#include "Signal.hpp"
+#include "DerivativeSignal.hpp"
+#include "PlatformTopo.hpp"
+#include "LevelZeroDevicePool.hpp"
+#include "LevelZero.hpp"
+#include "Exception.hpp"
+#include "Agg.hpp"
+#include "Helper.hpp"
+#include "geopm_debug.hpp"
+
+namespace geopm
+{
+
+    LevelZeroIOGroup::LevelZeroIOGroup()
+        : LevelZeroIOGroup(platform_topo(), levelzero_device_pool())
+    {
+    }
+
+    // Set up mapping between signal and control names and corresponding indices
+    LevelZeroIOGroup::LevelZeroIOGroup(const PlatformTopo &platform_topo,
+                                       const LevelZeroDevicePool &device_pool)
+        : m_platform_topo(platform_topo)
+        , m_levelzero_device_pool(device_pool)
+        , m_is_batch_read(false)
+        , m_signal_available({{"LEVELZERO::FREQUENCY_GPU", {
+                                  "Accelerator compute/GPU domain frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      // Note: Only the domain index is changing
+                                      //       here when signals are generated in
+                                      //       the init function. Everything else
+                                      //       is provided as part of this initial
+                                      //       declaration and does not change per
+                                      //       signal.
+                                      return this->m_levelzero_device_pool.frequency_status(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_MAX_GPU", {
+                                  "Accelerator compute/GPU domain maximum frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_max(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_MIN_GPU", {
+                                  "Accelerator compute/GPU domain minimum frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_min(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::ENERGY", {
+                                  "Accelerator energy in Joules",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.energy(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_ALL);
+                                  },
+                                  1 / 1e6
+                                  }},
+                              {"LEVELZERO::ENERGY_TIMESTAMP", {
+                                  "Accelerator energy timestamp in seconds",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.energy_timestamp(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_ALL);
+                                  },
+                                  1 / 1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_MEMORY", {
+                                  "Accelerator memory domain frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_status(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_MEMORY);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_MAX_MEMORY", {
+                                  "Accelerator memory domain maximum frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_max(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_MEMORY);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::FREQUENCY_MIN_MEMORY", {
+                                  "Accelerator memory domain minimum frequency in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_min(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_MEMORY);
+                                  },
+                                  1e6
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_DEFAULT", {
+                                  "Default power limit in Watts",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_tdp(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_ALL);
+                                  },
+                                  1 / 1e3
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_MIN", {
+                                  "Minimum power limit in Watts",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_min(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_ALL);
+                                  },
+                                  1 / 1e3
+                                  }},
+                              {"LEVELZERO::POWER_LIMIT_MAX", {
+                                  "Maximum power limit in Watts",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.power_limit_max(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_ALL);
+                                  },
+                                  1 / 1e3
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME", {
+                                  "GPU active time",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_ALL);
+                                  },
+                                  1 / 1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_TIMESTAMP", {
+                                  "GPU active time reading timestamp",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time_timestamp(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_ALL);
+                                  },
+                                  1 / 1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_COMPUTE", {
+                                  "GPU Compute engine active time",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  1 / 1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_TIMESTAMP_COMPUTE", {
+                                  "GPU Compute engine active time reading timestamp",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time_timestamp(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  1 / 1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_COPY", {
+                                  "GPU Copy engine active time",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_MEMORY);
+                                  },
+                                  1 / 1e6
+                                  }},
+                              {"LEVELZERO::ACTIVE_TIME_TIMESTAMP_COPY", {
+                                  "GPU Copy engine active time timestamp",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.active_time_timestamp(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_MEMORY);
+                                  },
+                                  1 / 1e6
+                                  }}
+                             })
+        , m_control_available({{"LEVELZERO::FREQUENCY_GPU_CONTROL", {
+                                    "Sets accelerator frequency (in hertz)",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                    Agg::average,
+                                    string_format_double
+                                    }}
+                              })
+    {
+        // populate signals for each domain
+        for (auto &sv : m_signal_available) {
+            std::vector<std::shared_ptr<Signal> > result;
+            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(
+                                     signal_domain_type(sv.first)); ++domain_idx) {
+                std::shared_ptr<Signal> signal =
+                        std::make_shared<LevelZeroSignal>(sv.second.m_devpool_func,
+                                                          domain_idx,
+                                                          sv.second.scalar);
+                result.push_back(signal);
+            }
+            sv.second.m_signals = result;
+        }
+
+        register_derivative_signals();
+
+        register_signal_alias("FREQUENCY_ACCELERATOR", "LEVELZERO::FREQUENCY_GPU");
+        register_signal_alias("POWER_ACCELERATOR", "LEVELZERO::POWER");
+        register_control_alias("FREQUENCY_ACCELERATOR_CONTROL",
+                               "LEVELZERO::FREQUENCY_GPU_CONTROL");
+
+        // populate controls for each domain
+        for (auto &sv : m_control_available) {
+            std::vector<std::shared_ptr<control_s> > result;
+            for (int domain_idx = 0;
+                 domain_idx < m_platform_topo.num_domain(control_domain_type(sv.first));
+                 ++domain_idx) {
+                std::shared_ptr<control_s> ctrl = std::make_shared<control_s>(control_s{0, false});
+                result.push_back(ctrl);
+            }
+            sv.second.controls = result;
+        }
+    }
+
+    void LevelZeroIOGroup::register_derivative_signals(void) {
+        int derivative_window = 8;
+        double sleep_time = 0.005;
+
+        struct signal_data
+        {
+            std::string name;
+            std::string description;
+            std::string base_name;
+            std::string time_name;
+        };
+
+        std::vector<signal_data> derivative_signals {
+            {"LEVELZERO::POWER",
+                    "Average accelerator power over 40 ms or 8 control loop iterations",
+                    "LEVELZERO::ENERGY",
+                    "LEVELZERO::ENERGY_TIMESTAMP"},
+            {"LEVELZERO::UTILIZATION",
+                    "GPU utilization"
+                        "n  Level Zero logical engines may may to the same hardware"
+                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
+                    "LEVELZERO::ACTIVE_TIME",
+                    "LEVELZERO::ACTIVE_TIME_TIMESTAMP"},
+            {"LEVELZERO::UTILIZATION_COMPUTE",
+                    "Compute engine utilization"
+                        "n  Level Zero logical engines may may to the same hardware"
+                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
+                    "LEVELZERO::ACTIVE_TIME_COMPUTE",
+                    "LEVELZERO::ACTIVE_TIME_TIMESTAMP_COMPUTE"},
+            {"LEVELZERO::UTILIZATION_COPY",
+                    "Copy engine utilization"
+                        "n  Level Zero logical engines may may to the same hardware"
+                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
+                    "LEVELZERO::ACTIVE_TIME_COPY",
+                    "LEVELZERO::ACTIVE_TIME_TIMESTAMP_COPY"},
+        };
+        for (const auto &ds : derivative_signals) {
+            auto read_it = m_signal_available.find(ds.base_name);
+            auto time_it = m_signal_available.find(ds.time_name);
+            if (read_it != m_signal_available.end()
+                && time_it != m_signal_available.end()) {
+                auto readings = read_it->second.m_signals;
+                int domain = read_it->second.domain_type;
+                int num_domain = m_platform_topo.num_domain(domain);
+                GEOPM_DEBUG_ASSERT(num_domain == (int)readings.size(),
+                                   "size of domain for " + ds.base_name +
+                                   " does not match number of signals available.");
+
+                auto time_sig = time_it->second.m_signals;
+                GEOPM_DEBUG_ASSERT(time_it->second.domain_type == domain,
+                                   "domain for " + ds.time_name +
+                                   " does not match " + ds.base_name);
+
+                std::vector<std::shared_ptr<Signal> > result(num_domain);
+                for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+                    auto read = readings[domain_idx];
+                    auto time = time_sig[domain_idx];
+                    result[domain_idx] =
+                        std::make_shared<DerivativeSignal>(time, read,
+                                                           derivative_window,
+                                                           sleep_time);
+                }
+                m_signal_available[ds.name] = {ds.description + "\n    alias_for: " +
+                                               ds.base_name + " rate of change",
+                                                   domain,
+                                                   agg_function(ds.base_name),
+                                                   format_function(ds.base_name),
+                                                   result,
+                                                   nullptr,
+                                                   1
+                                                   };
+            }
+        }
+
+    }
+
+    // Extract the set of all signal names from the index map
+    std::set<std::string> LevelZeroIOGroup::signal_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &sv : m_signal_available) {
+            result.insert(sv.first);
+        }
+        return result;
+    }
+
+    // Extract the set of all control names from the index map
+    std::set<std::string> LevelZeroIOGroup::control_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &sv : m_control_available) {
+            result.insert(sv.first);
+        }
+        return result;
+    }
+
+    // Check signal name using index map
+    bool LevelZeroIOGroup::is_valid_signal(const std::string &signal_name) const
+    {
+        return m_signal_available.find(signal_name) != m_signal_available.end();
+    }
+
+    // Check control name using index map
+    bool LevelZeroIOGroup::is_valid_control(const std::string &control_name) const
+    {
+        return m_control_available.find(control_name) != m_control_available.end();
+    }
+
+    // Return domain for all valid signals
+    int LevelZeroIOGroup::signal_domain_type(const std::string &signal_name) const
+    {
+        int result = GEOPM_DOMAIN_INVALID;
+        auto it = m_signal_available.find(signal_name);
+        if (it != m_signal_available.end()) {
+            result = it->second.domain_type;
+        }
+        return result;
+    }
+
+    // Return domain for all valid controls
+    int LevelZeroIOGroup::control_domain_type(const std::string &control_name) const
+    {
+        int result = GEOPM_DOMAIN_INVALID;
+        auto it = m_control_available.find(control_name);
+        if (it != m_control_available.end()) {
+            result = it->second.domain_type;
+        }
+        return result;
+    }
+
+    // Mark the given signal to be read by read_batch()
+    int LevelZeroIOGroup::push_signal(const std::string &signal_name,
+                                      int domain_type, int domain_idx)
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": signal_name " + signal_name +
+                            " not valid for LevelZeroIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != signal_domain_type(signal_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": " + signal_name + ": domain_type must be " +
+                            std::to_string(signal_domain_type(signal_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 ||
+            domain_idx >= m_platform_topo.num_domain(
+                                          signal_domain_type(signal_name))) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (m_is_batch_read) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": cannot push signal after call to read_batch().",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        int result = -1;
+        bool is_found = false;
+        std::shared_ptr<Signal> signal = m_signal_available.at(
+                                         signal_name).m_signals.at(domain_idx);
+
+        // Check if signal was already pushed.
+        for (size_t ii = 0; !is_found && ii < m_signal_pushed.size(); ++ii) {
+            if (m_signal_pushed[ii] == signal) {
+                result = ii;
+                is_found = true;
+            }
+        }
+        if (!is_found) {
+            // If not pushed, add to pushed signals and configure for batch reads
+            result = m_signal_pushed.size();
+            m_signal_pushed.push_back(signal);
+            signal->setup_batch();
+        }
+
+        return result;
+    }
+
+    // Mark the given control to be written by write_batch()
+    int LevelZeroIOGroup::push_control(const std::string &control_name,
+                                       int domain_type, int domain_idx)
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": control_name " + control_name +
+                            " not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != control_domain_type(control_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": " + control_name + ": domain_type must be " +
+                            std::to_string(control_domain_type(control_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 ||
+            domain_idx >= m_platform_topo.num_domain(domain_type)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        int result = -1;
+        bool is_found = false;
+        std::shared_ptr<control_s> control = m_control_available.at(
+                                             control_name).controls.at(domain_idx);
+
+        // Check if control was already pushed
+        for (size_t ii = 0; !is_found && ii < m_control_pushed.size(); ++ii) {
+            // same location means this control or its alias was already pushed
+            if (m_control_pushed[ii] == control) {
+                result = ii;
+                is_found = true;
+            }
+        }
+        if (!is_found) {
+            // If not pushed, add to pushed control
+            result = m_control_pushed.size();
+            m_control_pushed.push_back(control);
+        }
+
+        return result;
+    }
+
+    // Parse and update saved values for signals
+    void LevelZeroIOGroup::read_batch(void)
+    {
+        m_is_batch_read = true;
+        // TODO: if ENERGY and ENERGY_TIMESTAMP or ACTIVE_TIME and
+        //       ACTIVE_TIMESTAMP signals are called at the same domain
+        //       level, instead call the paired version to guarantee we get the
+        //       value with the correct timestamp
+    }
+
+    // Write all controls that have been pushed and adjusted
+    void LevelZeroIOGroup::write_batch(void)
+    {
+        for (auto &sv : m_control_available) {
+            for (unsigned int domain_idx = 0;
+                 domain_idx < sv.second.controls.size(); ++domain_idx) {
+                if (sv.second.controls.at(domain_idx)->m_is_adjusted) {
+                    write_control(sv.first, sv.second.domain_type, domain_idx,
+                                  sv.second.controls.at(domain_idx)->m_setting);
+                }
+            }
+        }
+    }
+
+    // Return the latest value read by read_batch()
+    double LevelZeroIOGroup::sample(int batch_idx)
+    {
+        if (batch_idx < 0 || batch_idx >= (int)m_signal_pushed.size()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": batch_idx " + std::to_string(batch_idx) +
+                            " out of range", GEOPM_ERROR_INVALID,
+                            __FILE__, __LINE__);
+
+        }
+        //Not strictly necessary, but keeping to enforce general
+        //flow of read_batch followed by sample.
+        if (!m_is_batch_read) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": signal has not been read.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_signal_pushed[batch_idx]->sample();
+    }
+
+    // Save a setting to be written by a future write_batch()
+    void LevelZeroIOGroup::adjust(int batch_idx, double setting)
+    {
+        if (batch_idx < 0 || (unsigned)batch_idx >= m_control_pushed.size()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            "(): batch_idx " + std::to_string(batch_idx) +
+                            " out of range", GEOPM_ERROR_INVALID,
+                            __FILE__, __LINE__);
+        }
+
+        m_control_pushed.at(batch_idx)->m_setting = setting;
+        m_control_pushed.at(batch_idx)->m_is_adjusted = true;
+    }
+
+    // Read the value of a signal immediately, bypassing read_batch().
+    // Should not modify m_signal_value
+    double LevelZeroIOGroup::read_signal(const std::string &signal_name,
+                                         int domain_type, int domain_idx)
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": " + signal_name + " not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != signal_domain_type(signal_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
+                            + signal_name + ": domain_type must be " +
+                            std::to_string(signal_domain_type(signal_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 ||
+            domain_idx >= m_platform_topo.num_domain(signal_domain_type(signal_name))) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": domain_idx out of range.", GEOPM_ERROR_INVALID,
+                            __FILE__, __LINE__);
+        }
+
+        double result = NAN;
+        auto it = m_signal_available.find(signal_name);
+        if (it != m_signal_available.end()) {
+            result = (it->second.m_signals.at(domain_idx))->read();
+        }
+        else {
+    #ifdef GEOPM_DEBUG
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": Handling not defined for " + signal_name,
+                            GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+    #endif
+        }
+        return result;
+    }
+
+    // Write to the control immediately, bypassing write_batch()
+    void LevelZeroIOGroup::write_control(const std::string &control_name,
+                                         int domain_type, int domain_idx,
+                                         double setting)
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
+                            + control_name + " not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != control_domain_type(control_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
+                            + control_name + ": domain_type must be " +
+                            std::to_string(control_domain_type(control_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 ||
+            domain_idx >= m_platform_topo.num_domain(
+                                          control_domain_type(control_name))) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": domain_idx out of range.", GEOPM_ERROR_INVALID,
+                            __FILE__, __LINE__);
+        }
+
+        if (control_name == "LEVELZERO::FREQUENCY_GPU_CONTROL" ||
+            control_name == "FREQUENCY_ACCELERATOR_CONTROL") {
+            m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
+                                                      geopm::LevelZero::M_DOMAIN_COMPUTE,
+                                                      setting / 1e6);
+        }
+        else {
+    #ifdef GEOPM_DEBUG
+                throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                                "Handling not defined for " + control_name,
+                                GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+    #endif
+        }
+    }
+
+    // Implemented to allow an IOGroup to save platform settings before starting
+    // to adjust them
+    void LevelZeroIOGroup::save_control(void)
+    {
+        for (int domain_idx = 0;
+             domain_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+             ++domain_idx) {
+            // TODO: Read ALL LEVELZERO Power Limits, frequency settings, etc
+        }
+    }
+
+    // Implemented to allow an IOGroup to restore previously saved
+    // platform settings
+    void LevelZeroIOGroup::restore_control(void)
+    {
+        /// @todo: Usage of the LEVELZERO API for setting frequency, power, etc
+        ///        requires root privileges.  As such several unit tests will
+        ///        fail when calling restore_control.  Once a non-privileged
+        ///        solution is available this may be used
+    }
+
+    // Hint to Agent about how to aggregate signals from this IOGroup
+    std::function<double(const std::vector<double> &)> LevelZeroIOGroup::agg_function(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
+                            + signal_name + "not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return it->second.m_agg_function;
+    }
+
+    // Specifies how to print signals from this IOGroup
+    std::function<std::string(double)> LevelZeroIOGroup::format_function(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
+                            + signal_name + "not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return it->second.m_format_function;
+    }
+
+    // A user-friendly description of each signal
+    std::string LevelZeroIOGroup::signal_description(const std::string &signal_name) const
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": signal_name " + signal_name +
+                            " not valid for LevelZeroIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return m_signal_available.at(signal_name).m_description;
+    }
+
+    // A user-friendly description of each control
+    std::string LevelZeroIOGroup::control_description(const std::string &control_name) const
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": " +
+                            control_name + "not valid for LevelZeroIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_control_available.at(control_name).m_description;
+    }
+
+    // Name used for registration with the IOGroup factory
+    std::string LevelZeroIOGroup::plugin_name(void)
+    {
+        return "levelzero";
+    }
+
+    int LevelZeroIOGroup::signal_behavior(const std::string &signal_name) const
+    {
+        return IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE;
+    }
+
+    // Function used by the factory to create objects of this type
+    std::unique_ptr<IOGroup> LevelZeroIOGroup::make_plugin(void)
+    {
+        return geopm::make_unique<LevelZeroIOGroup>();
+    }
+
+    void LevelZeroIOGroup::register_signal_alias(const std::string &alias_name,
+                                            const std::string &signal_name)
+    {
+        if (m_signal_available.find(alias_name) != m_signal_available.end()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": signal_name " + alias_name +
+                            " was previously registered.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            // skip adding an alias if underlying signal is not found
+            return;
+        }
+        // copy signal info but append to description
+        m_signal_available[alias_name] = it->second;
+        m_signal_available[alias_name].m_description =
+            m_signal_available[signal_name].m_description + '\n' +
+                                            "    alias_for: " + signal_name;
+    }
+
+    void LevelZeroIOGroup::register_control_alias(const std::string &alias_name,
+                                           const std::string &control_name)
+    {
+        if (m_control_available.find(alias_name) != m_control_available.end()) {
+            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                            ": contro1_name " + alias_name +
+                            " was previously registered.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto it = m_control_available.find(control_name);
+        if (it == m_control_available.end()) {
+            // skip adding an alias if underlying control is not found
+            return;
+        }
+        // copy control info but append to description
+        m_control_available[alias_name] = it->second;
+        m_control_available[alias_name].m_description =
+       m_control_available[control_name].m_description + '\n' +
+                                         "    alias_for: " + control_name;
+    }
+}

--- a/src/LevelZeroIOGroup.cpp
+++ b/src/LevelZeroIOGroup.cpp
@@ -604,6 +604,9 @@ namespace geopm
         //       ACTIVE_TIMESTAMP signals are called at the same domain
         //       level, instead call the paired version to guarantee we get the
         //       value with the correct timestamp
+        for (auto &sv : m_signal_pushed) {
+            std::dynamic_pointer_cast<LevelZeroSignal>(sv)->read_batch_element();
+        }
     }
 
     // Write all controls that have been pushed and adjusted

--- a/src/LevelZeroIOGroup.cpp
+++ b/src/LevelZeroIOGroup.cpp
@@ -354,7 +354,7 @@ namespace geopm
                 std::shared_ptr<Signal> signal =
                         std::make_shared<LevelZeroSignal>(sv.second.m_devpool_func,
                                                           domain_idx,
-                                                          sv.second.scalar);
+                                                          sv.second.m_scalar);
                 result.push_back(signal);
             }
             sv.second.m_signals = result;
@@ -376,7 +376,7 @@ namespace geopm
                 std::shared_ptr<control_s> ctrl = std::make_shared<control_s>(control_s{0, false});
                 result.push_back(ctrl);
             }
-            sv.second.controls = result;
+            sv.second.m_controls = result;
         }
     }
 
@@ -399,19 +399,19 @@ namespace geopm
                     "LEVELZERO::ENERGY_TIMESTAMP"},
             {"LEVELZERO::UTILIZATION",
                     "GPU utilization"
-                        "n  Level Zero logical engines may may to the same hardware"
+                        "n  Level Zero logical engines may map to the same hardware"
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
                     "LEVELZERO::ACTIVE_TIME",
                     "LEVELZERO::ACTIVE_TIME_TIMESTAMP"},
             {"LEVELZERO::UTILIZATION_COMPUTE",
                     "Compute engine utilization"
-                        "n  Level Zero logical engines may may to the same hardware"
+                        "n  Level Zero logical engines may map to the same hardware"
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
                     "LEVELZERO::ACTIVE_TIME_COMPUTE",
                     "LEVELZERO::ACTIVE_TIME_COMPUTE_TIMESTAMP"},
             {"LEVELZERO::UTILIZATION_COPY",
                     "Copy engine utilization"
-                        "n  Level Zero logical engines may may to the same hardware"
+                        "n  Level Zero logical engines may map to the same hardware"
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
                     "LEVELZERO::ACTIVE_TIME_COPY",
                     "LEVELZERO::ACTIVE_TIME_COPY_TIMESTAMP"},
@@ -422,14 +422,14 @@ namespace geopm
             if (read_it != m_signal_available.end()
                 && time_it != m_signal_available.end()) {
                 auto readings = read_it->second.m_signals;
-                int domain = read_it->second.domain_type;
+                int domain = read_it->second.m_domain_type;
                 int num_domain = m_platform_topo.num_domain(domain);
                 GEOPM_DEBUG_ASSERT(num_domain == (int)readings.size(),
                                    "size of domain for " + ds.base_name +
                                    " does not match number of signals available.");
 
                 auto time_sig = time_it->second.m_signals;
-                GEOPM_DEBUG_ASSERT(time_it->second.domain_type == domain,
+                GEOPM_DEBUG_ASSERT(time_it->second.m_domain_type == domain,
                                    "domain for " + ds.time_name +
                                    " does not match " + ds.base_name);
 
@@ -493,7 +493,7 @@ namespace geopm
         int result = GEOPM_DOMAIN_INVALID;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {
-            result = it->second.domain_type;
+            result = it->second.m_domain_type;
         }
         return result;
     }
@@ -504,7 +504,7 @@ namespace geopm
         int result = GEOPM_DOMAIN_INVALID;
         auto it = m_control_available.find(control_name);
         if (it != m_control_available.end()) {
-            result = it->second.domain_type;
+            result = it->second.m_domain_type;
         }
         return result;
     }
@@ -616,7 +616,7 @@ namespace geopm
         int result = -1;
         bool is_found = false;
         std::shared_ptr<control_s> control = m_control_available.at(
-                                             control_name).controls.at(domain_idx);
+                                             control_name).m_controls.at(domain_idx);
 
         // Check if control was already pushed
         for (size_t ii = 0; !is_found && ii < m_control_pushed.size(); ++ii) {
@@ -649,10 +649,10 @@ namespace geopm
     {
         for (auto &sv : m_control_available) {
             for (unsigned int domain_idx = 0;
-                 domain_idx < sv.second.controls.size(); ++domain_idx) {
-                if (sv.second.controls.at(domain_idx)->m_is_adjusted) {
-                    write_control(sv.first, sv.second.domain_type, domain_idx,
-                                  sv.second.controls.at(domain_idx)->m_setting);
+                 domain_idx < sv.second.m_controls.size(); ++domain_idx) {
+                if (sv.second.m_controls.at(domain_idx)->m_is_adjusted) {
+                    write_control(sv.first, sv.second.m_domain_type, domain_idx,
+                                  sv.second.m_controls.at(domain_idx)->m_setting);
                 }
             }
         }

--- a/src/LevelZeroIOGroup.hpp
+++ b/src/LevelZeroIOGroup.hpp
@@ -102,18 +102,18 @@ namespace geopm
 
             struct signal_info {
                 std::string m_description;
-                int domain_type;
+                int m_domain_type;
                 std::function<double(const std::vector<double> &)> m_agg_function;
                 std::function<std::string(double)> m_format_function;
                 std::vector<std::shared_ptr<Signal> > m_signals;
                 std::function<double (unsigned int)> m_devpool_func;
-                double scalar;
+                double m_scalar;
             };
 
             struct control_info {
                 std::string m_description;
-                std::vector<std::shared_ptr<control_s> > controls;
-                int domain_type;
+                std::vector<std::shared_ptr<control_s> > m_controls;
+                int m_domain_type;
                 std::function<double(const std::vector<double> &)> m_agg_function;
                 std::function<std::string(double)> m_format_function;
             };

--- a/src/LevelZeroIOGroup.hpp
+++ b/src/LevelZeroIOGroup.hpp
@@ -95,8 +95,7 @@ namespace geopm
             void register_control_alias(const std::string &alias_name,
                                         const std::string &control_name);
 
-            struct control_s
-            {
+            struct control_s {
                 double m_setting;
                 bool m_is_adjusted;
             };
@@ -128,6 +127,9 @@ namespace geopm
             std::vector<std::shared_ptr<Signal> > m_signal_pushed;
             std::vector<std::shared_ptr<control_s> > m_control_pushed;
             const std::set<std::string> m_special_signal_set;
+
+            //GEOPM Domain indexed
+            std::vector<std::pair<double,double> > m_frequency_range;
     };
 }
 #endif

--- a/src/LevelZeroIOGroup.hpp
+++ b/src/LevelZeroIOGroup.hpp
@@ -127,6 +127,7 @@ namespace geopm
             std::map<std::string, control_info> m_control_available;
             std::vector<std::shared_ptr<Signal> > m_signal_pushed;
             std::vector<std::shared_ptr<control_s> > m_control_pushed;
+            const std::set<std::string> m_special_signal_set;
     };
 }
 #endif

--- a/src/LevelZeroIOGroup.hpp
+++ b/src/LevelZeroIOGroup.hpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2015, 2016, 2017, 2018, 2019, 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LEVELZEROIOGROUP_HPP_INCLUDE
+#define LEVELZEROIOGROUP_HPP_INCLUDE
+
+#include <map>
+#include <vector>
+#include <string>
+#include <memory>
+#include <functional>
+
+#include "IOGroup.hpp"
+#include "LevelZeroSignal.hpp"
+
+namespace geopm
+{
+    class PlatformTopo;
+    class LevelZeroDevicePool;
+
+    /// @brief IOGroup that provides signals and controls for Accelerators
+    class LevelZeroIOGroup : public IOGroup
+    {
+        public:
+            LevelZeroIOGroup();
+            LevelZeroIOGroup(const PlatformTopo &platform_topo,
+                             const LevelZeroDevicePool &device_pool);
+            virtual ~LevelZeroIOGroup() = default;
+            std::set<std::string> signal_names(void) const override;
+            std::set<std::string> control_names(void) const override;
+            bool is_valid_signal(const std::string &signal_name) const override;
+            bool is_valid_control(const std::string &control_name) const override;
+            int signal_domain_type(const std::string &signal_name) const override;
+            int control_domain_type(const std::string &control_name) const override;
+            int push_signal(const std::string &signal_name, int domain_type,
+                            int domain_idx)  override;
+            int push_control(const std::string &control_name, int domain_type,
+                             int domain_idx) override;
+            void read_batch(void) override;
+            void write_batch(void) override;
+            double sample(int batch_idx) override;
+            void adjust(int batch_idx, double setting) override;
+            double read_signal(const std::string &signal_name, int domain_type,
+                               int domain_idx) override;
+            void write_control(const std::string &control_name, int domain_type,
+                               int domain_idx, double setting) override;
+            void save_control(void) override;
+            void restore_control(void) override;
+            std::function<double(const std::vector<double> &)> agg_function(
+                                 const std::string &signal_name) const override;
+            std::function<std::string(double)> format_function(
+                                 const std::string &signal_name) const override;
+            std::string signal_description(const std::string
+                                           &signal_name) const override;
+            std::string control_description(const std::string
+                                            &control_name) const override;
+            int signal_behavior(const std::string &signal_name) const override;
+            static std::string plugin_name(void);
+            static std::unique_ptr<IOGroup> make_plugin(void);
+        private:
+            void init(void);
+
+            void register_derivative_signals(void);
+            void register_signal_alias(const std::string &alias_name,
+                                       const std::string &signal_name);
+            void register_control_alias(const std::string &alias_name,
+                                        const std::string &control_name);
+
+            struct control_s
+            {
+                double m_setting;
+                bool m_is_adjusted;
+            };
+
+            struct signal_info {
+                std::string m_description;
+                int domain_type;
+                std::function<double(const std::vector<double> &)> m_agg_function;
+                std::function<std::string(double)> m_format_function;
+                std::vector<std::shared_ptr<Signal> > m_signals;
+                std::function<double (unsigned int)> m_devpool_func;
+                double scalar;
+            };
+
+            struct control_info {
+                std::string m_description;
+                std::vector<std::shared_ptr<control_s> > controls;
+                int domain_type;
+                std::function<double(const std::vector<double> &)> m_agg_function;
+                std::function<std::string(double)> m_format_function;
+            };
+
+            const PlatformTopo &m_platform_topo;
+            const LevelZeroDevicePool &m_levelzero_device_pool;
+            bool m_is_batch_read;
+
+            std::map<std::string, signal_info> m_signal_available;
+            std::map<std::string, control_info> m_control_available;
+            std::vector<std::shared_ptr<Signal> > m_signal_pushed;
+            std::vector<std::shared_ptr<control_s> > m_control_pushed;
+    };
+}
+#endif

--- a/src/LevelZeroImp.hpp
+++ b/src/LevelZeroImp.hpp
@@ -98,6 +98,7 @@ namespace geopm
                 // These are enum geopm_levelzero_domain_e indexed, then subdevice indexed
                 std::vector<std::vector<zes_freq_handle_t> > freq_domain;
                 std::vector<std::vector<zes_engine_handle_t> > engine_domain;
+                mutable std::vector<std::vector<uint64_t> > cached_timestamp;
             };
 
             struct m_device_info_s {
@@ -114,6 +115,7 @@ namespace geopm
 
                 // Device/Package domains
                 zes_pwr_handle_t power_domain;
+                mutable uint64_t cached_energy_timestamp;
             };
 
 

--- a/src/LevelZeroImp.hpp
+++ b/src/LevelZeroImp.hpp
@@ -60,6 +60,9 @@ namespace geopm
                                  int l0_domain_idx) const override;
             double frequency_max(unsigned int l0_device_idx, int l0_domain,
                                  int l0_domain_idx) const override;
+            std::pair<double, double> frequency_range(unsigned int l0_device_idx,
+                                                      int l0_domain,
+                                                      int l0_domain_idx) const override;
 
             int engine_domain_count(unsigned int l0_device_idx, int domain) const override;
             std::pair<uint64_t, uint64_t> active_time_pair(unsigned int l0_device_idx,
@@ -77,7 +80,8 @@ namespace geopm
             int32_t power_limit_max(unsigned int l0_device_idx) const override;
 
             void frequency_control(unsigned int l0_device_idx, int l0_domain,
-                                           int l0_domain_idx, double setting) const override;
+                                   int l0_domain_idx, double range_min,
+                                   double range_max) const override;
 
         private:
             struct m_frequency_s {

--- a/src/LevelZeroSignal.cpp
+++ b/src/LevelZeroSignal.cpp
@@ -58,9 +58,9 @@ namespace geopm
         }
     }
 
-    void LevelZeroSignal::read_batch_element(void)
+    void LevelZeroSignal::set_sample(double value)
     {
-        m_value = read();
+        m_value = value;
     }
 
     double LevelZeroSignal::sample(void)

--- a/src/LevelZeroSignal.cpp
+++ b/src/LevelZeroSignal.cpp
@@ -58,13 +58,18 @@ namespace geopm
         }
     }
 
+    void LevelZeroSignal::read_batch_element(void)
+    {
+        m_value = read();
+    }
+
     double LevelZeroSignal::sample(void)
     {
         if (!m_is_batch_ready) {
             throw Exception("setup_batch() must be called before sample().",
                             GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
         }
-        return read();
+        return m_value;
     }
 
     double LevelZeroSignal::read(void) const

--- a/src/LevelZeroSignal.cpp
+++ b/src/LevelZeroSignal.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "LevelZeroSignal.hpp"
+
+#include "geopm_hash.h"
+#include "geopm_debug.hpp"
+#include "MSRIO.hpp"
+#include "Exception.hpp"
+#include "Helper.hpp"
+
+namespace geopm
+{
+    LevelZeroSignal::LevelZeroSignal(std::function<double (unsigned int)> devpool_func,
+                                     unsigned int domain_idx, double scalar)
+        : m_devpool_func(devpool_func)
+        , m_domain_idx(domain_idx)
+        , m_scalar(scalar)
+        , m_is_batch_ready(false)
+    {
+    }
+
+    void LevelZeroSignal::setup_batch(void)
+    {
+        if (!m_is_batch_ready) {
+            m_is_batch_ready = true;
+        }
+    }
+
+    double LevelZeroSignal::sample(void)
+    {
+        if (!m_is_batch_ready) {
+            throw Exception("setup_batch() must be called before sample().",
+                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        return read();
+    }
+
+    double LevelZeroSignal::read(void) const
+    {
+        return m_devpool_func(m_domain_idx) * m_scalar;
+    }
+}

--- a/src/LevelZeroSignal.cpp
+++ b/src/LevelZeroSignal.cpp
@@ -33,12 +33,7 @@
 #include "config.h"
 
 #include "LevelZeroSignal.hpp"
-
-#include "geopm_hash.h"
-#include "geopm_debug.hpp"
-#include "MSRIO.hpp"
 #include "Exception.hpp"
-#include "Helper.hpp"
 
 namespace geopm
 {

--- a/src/LevelZeroSignal.hpp
+++ b/src/LevelZeroSignal.hpp
@@ -58,7 +58,7 @@ namespace geopm
             void setup_batch(void) override;
             double sample(void) override;
             double read(void) const override;
-            void set_sample(double value);
+            void set_sample(double value) override;
         private:
             std::function<double (unsigned int)> m_devpool_func;
             unsigned int m_domain_idx;

--- a/src/LevelZeroSignal.hpp
+++ b/src/LevelZeroSignal.hpp
@@ -58,7 +58,7 @@ namespace geopm
             void setup_batch(void) override;
             double sample(void) override;
             double read(void) const override;
-            void read_batch_element(void);
+            void set_sample(double value);
         private:
             std::function<double (unsigned int)> m_devpool_func;
             unsigned int m_domain_idx;

--- a/src/LevelZeroSignal.hpp
+++ b/src/LevelZeroSignal.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LEVELZEROSIGNAL_HPP_INCLUDE
+#define LEVELZEROSIGNAL_HPP_INCLUDE
+
+#include <cstdint>
+#include <cmath>
+
+#include <string>
+#include <memory>
+#include <functional>
+
+#include "Signal.hpp"
+#include "LevelZeroDevicePool.hpp"
+
+
+namespace geopm
+{
+    class LevelZeroDevicePool;
+
+    class LevelZeroSignal : public Signal
+    {
+        public:
+            virtual ~LevelZeroSignal() = default;
+            LevelZeroSignal(std::function<double (unsigned int)> devpool_func,
+                         unsigned int accelerator, double scalar);
+            LevelZeroSignal(const LevelZeroSignal &other) = delete;
+            void setup_batch(void) override;
+            double sample(void) override;
+            double read(void) const override;
+        private:
+            std::function<double (unsigned int)> m_devpool_func;
+            unsigned int m_domain_idx;
+            double m_scalar;
+            bool m_is_batch_ready;
+    };
+}
+
+#endif

--- a/src/LevelZeroSignal.hpp
+++ b/src/LevelZeroSignal.hpp
@@ -58,11 +58,13 @@ namespace geopm
             void setup_batch(void) override;
             double sample(void) override;
             double read(void) const override;
+            void read_batch_element(void);
         private:
             std::function<double (unsigned int)> m_devpool_func;
             unsigned int m_domain_idx;
             double m_scalar;
             bool m_is_batch_ready;
+            double m_value;
     };
 }
 

--- a/src/LevelZeroSignal.hpp
+++ b/src/LevelZeroSignal.hpp
@@ -33,11 +33,6 @@
 #ifndef LEVELZEROSIGNAL_HPP_INCLUDE
 #define LEVELZEROSIGNAL_HPP_INCLUDE
 
-#include <cstdint>
-#include <cmath>
-
-#include <string>
-#include <memory>
 #include <functional>
 
 #include "Signal.hpp"

--- a/src/Signal.hpp
+++ b/src/Signal.hpp
@@ -55,6 +55,8 @@ namespace geopm
             /// @brief Read directly the value of the signal without
             ///        affecting any pushed batch signals.
             virtual double read(void) const = 0;
+            /// @brief Set the value to be returned by sample()
+            virtual void set_sample(double) {};
     };
 }
 

--- a/test/LevelZeroDevicePoolTest.cpp
+++ b/test/LevelZeroDevicePoolTest.cpp
@@ -116,7 +116,7 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
         EXPECT_EQ((uint64_t)(value+sub_idx+num_accelerator_subdevice*30), m_device_pool.active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_EQ((uint64_t)(value+sub_idx+num_accelerator_subdevice*40), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
 
-        EXPECT_NO_THROW(m_device_pool.frequency_control(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, value));
+        EXPECT_NO_THROW(m_device_pool.frequency_control(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, value, value));
     }
 }
 

--- a/test/LevelZeroIOGroupTest.cpp
+++ b/test/LevelZeroIOGroupTest.cpp
@@ -277,6 +277,149 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     }
 }
 
+TEST_F(LevelZeroIOGroupTest, read_timestamp_batch_reverse)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+    const int num_accelerator_subdevice = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP);
+
+    std::vector<uint64_t> mock_energy = {630000000, 280000000, 470000000, 950000000};
+    std::vector<uint64_t> mock_energy_timestamp = {153, 70, 300, 50};
+
+    std::vector<uint64_t> mock_active_time = {123, 970, 550, 20, 52, 567, 888, 923};
+    std::vector<uint64_t> mock_active_time_compute = {1, 90, 50, 0, 123, 144, 521, 445};
+    std::vector<uint64_t> mock_active_time_copy = {12, 20, 30, 40, 44, 55, 66, 77};
+    std::vector<uint64_t> mock_active_time_timestamp = {182, 970, 650, 33, 283, 331, 675, 9000};
+    std::vector<uint64_t> mock_active_time_timestamp_compute = {12, 90, 150, 3, 772, 248, 932, 122};
+    std::vector<uint64_t> mock_active_time_timestamp_copy = {50, 60, 53, 55, 66, 77, 88, 99};
+
+    std::vector<int> energy_batch_idx;
+    std::vector<int> active_time_batch_idx;
+    std::vector<int> active_time_compute_batch_idx;
+    std::vector<int> active_time_copy_batch_idx;
+
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_active_time.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_compute.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_copy.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_active_time_timestamp.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_timestamp_compute.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_timestamp_copy.at(sub_idx)));
+
+        active_time_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        active_time_compute_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME_COMPUTE_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        active_time_copy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME_COPY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+    }
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, energy_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy_timestamp.at(accel_idx)));
+
+        energy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ENERGY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+    }
+
+    levelzero_io.read_batch();
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        double active_time = levelzero_io.sample(active_time_batch_idx.at(sub_idx)-1);
+        double active_time_timestamp = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
+
+        EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_timestamp, mock_active_time_timestamp.at(sub_idx)/1e6);
+
+        double active_time_gpu = levelzero_io.sample(active_time_batch_idx.at(sub_idx)-1);
+        double active_time_timestamp_gpu = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
+
+        EXPECT_DOUBLE_EQ(active_time_gpu, mock_active_time.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_timestamp_gpu, mock_active_time_timestamp.at(sub_idx)/1e6);
+
+        double active_time_copy = levelzero_io.sample(active_time_batch_idx.at(sub_idx)-1);
+        double active_time_timestamp_copy = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
+
+        EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_timestamp_copy, mock_active_time_timestamp.at(sub_idx)/1e6);
+    }
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double energy = levelzero_io.sample(energy_batch_idx.at(accel_idx)-1);
+        double energy_timestamp = levelzero_io.sample(energy_batch_idx.at(accel_idx));
+
+        EXPECT_DOUBLE_EQ(energy, mock_energy.at(accel_idx)/1e6);
+        EXPECT_DOUBLE_EQ(energy_timestamp, mock_energy_timestamp.at(accel_idx)/1e6);
+    }
+}
+
+
+TEST_F(LevelZeroIOGroupTest, read_timestamp_batch)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+    const int num_accelerator_subdevice = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP);
+
+    std::vector<uint64_t> mock_energy = {630000000, 280000000, 470000000, 950000000};
+    std::vector<uint64_t> mock_energy_timestamp = {153, 70, 300, 50};
+
+    std::vector<uint64_t> mock_active_time = {123, 970, 550, 20, 52, 567, 888, 923};
+    std::vector<uint64_t> mock_active_time_compute = {1, 90, 50, 0, 123, 144, 521, 445};
+    std::vector<uint64_t> mock_active_time_copy = {12, 20, 30, 40, 44, 55, 66, 77};
+    std::vector<uint64_t> mock_active_time_timestamp = {182, 970, 650, 33, 283, 331, 675, 9000};
+    std::vector<uint64_t> mock_active_time_timestamp_compute = {12, 90, 150, 3, 772, 248, 932, 122};
+    std::vector<uint64_t> mock_active_time_timestamp_copy = {50, 60, 53, 55, 66, 77, 88, 99};
+
+    std::vector<int> energy_batch_idx;
+    std::vector<int> active_time_batch_idx;
+    std::vector<int> active_time_compute_batch_idx;
+    std::vector<int> active_time_copy_batch_idx;
+
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_active_time.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_compute.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_copy.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_active_time_timestamp.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_timestamp_compute.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_timestamp_copy.at(sub_idx)));
+
+        active_time_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        active_time_compute_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        active_time_copy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+    }
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, energy_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy_timestamp.at(accel_idx)));
+
+        energy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+    }
+
+    levelzero_io.read_batch();
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        double active_time = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
+        double active_time_timestamp = levelzero_io.sample(active_time_batch_idx.at(sub_idx)+1);
+
+        EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_timestamp, mock_active_time_timestamp.at(sub_idx)/1e6);
+
+        double active_time_gpu = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
+        double active_time_timestamp_gpu = levelzero_io.sample(active_time_batch_idx.at(sub_idx)+1);
+
+        EXPECT_DOUBLE_EQ(active_time_gpu, mock_active_time.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_timestamp_gpu, mock_active_time_timestamp.at(sub_idx)/1e6);
+
+        double active_time_copy = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
+        double active_time_timestamp_copy = levelzero_io.sample(active_time_batch_idx.at(sub_idx)+1);
+
+        EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_timestamp_copy, mock_active_time_timestamp.at(sub_idx)/1e6);
+    }
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double energy = levelzero_io.sample(energy_batch_idx.at(accel_idx));
+        double energy_timestamp = levelzero_io.sample(energy_batch_idx.at(accel_idx)+1);
+
+        EXPECT_DOUBLE_EQ(energy, mock_energy.at(accel_idx)/1e6);
+        EXPECT_DOUBLE_EQ(energy_timestamp, mock_energy_timestamp.at(accel_idx)/1e6);
+    }
+}
+
 TEST_F(LevelZeroIOGroupTest, read_signal)
 {
     const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
@@ -291,17 +434,13 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
     std::vector<double> mock_freq_max_mem = {1000, 2200, 3200, 1450, 1313, 1414, 1515, 1616};
     //Active time
     std::vector<uint64_t> mock_active_time = {123, 970, 550, 20, 52, 567, 888, 923};
-    std::vector<uint64_t> mock_active_time_timestamp = {182, 970, 650, 33, 283, 331, 675, 9000};
     std::vector<uint64_t> mock_active_time_compute = {1, 90, 50, 0, 123, 144, 521, 445};
-    std::vector<uint64_t> mock_active_time_timestamp_compute = {12, 90, 150, 3, 772, 248, 932, 122};
     std::vector<uint64_t> mock_active_time_copy = {12, 20, 30, 40, 44, 55, 66, 77};
-    std::vector<uint64_t> mock_active_time_timestamp_copy = {50, 60, 53, 55, 66, 77, 88, 99};
     //Power & energy
     std::vector<int32_t> mock_power_limit_min = {30000, 80000, 20000, 70000};
     std::vector<int32_t> mock_power_limit_max = {310000, 280000, 320000, 270000};
     std::vector<int32_t> mock_power_limit_tdp = {320000, 290000, 330000, 280000};
     std::vector<uint64_t> mock_energy = {630000000, 280000000, 470000000, 950000000};
-    std::vector<uint64_t> mock_energy_timestamp = {153, 70, 300, 50};
 
     for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
         //Frequency
@@ -314,11 +453,8 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
 
         //Active time
         EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_active_time.at(sub_idx)));
-        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_active_time_timestamp.at(sub_idx)));
         EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_compute.at(sub_idx)));
-        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_timestamp_compute.at(sub_idx)));
         EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_copy.at(sub_idx)));
-        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_timestamp_copy.at(sub_idx)));
     }
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
@@ -327,7 +463,6 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
         EXPECT_CALL(*m_device_pool, power_limit_max(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_power_limit_max.at(accel_idx)));
         EXPECT_CALL(*m_device_pool, power_limit_tdp(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_power_limit_tdp.at(accel_idx)));
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
-        EXPECT_CALL(*m_device_pool, energy_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy_timestamp.at(accel_idx)));
     }
 
     LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
@@ -352,16 +487,10 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
         //Active time
         double active_time = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx)/1e6);
-        double active_time_timestamp = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
-        EXPECT_DOUBLE_EQ(active_time_timestamp, mock_active_time_timestamp.at(sub_idx)/1e6);
         double active_time_compute = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(active_time_compute, mock_active_time_compute.at(sub_idx)/1e6);
-        double active_time_timestamp_compute = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
-        EXPECT_DOUBLE_EQ(active_time_timestamp_compute, mock_active_time_timestamp_compute.at(sub_idx)/1e6);
         double active_time_copy = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time_copy.at(sub_idx)/1e6);
-        double active_time_timestamp_copy = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
-        EXPECT_DOUBLE_EQ(active_time_timestamp_copy, mock_active_time_timestamp_copy.at(sub_idx)/1e6);
     }
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
@@ -375,9 +504,6 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
 
         double energy = levelzero_io.read_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(accel_idx)/1e6);
-        double energy_timestamp = levelzero_io.read_signal("LEVELZERO::ENERGY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        EXPECT_DOUBLE_EQ(energy_timestamp, mock_energy_timestamp.at(accel_idx)/1e6);
-
     }
 
     // Assume DerivativeSignals class functions as expected
@@ -450,4 +576,9 @@ TEST_F(LevelZeroIOGroupTest, error_path)
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COPY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COMPUTE_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::ENERGY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
 }

--- a/test/LevelZeroIOGroupTest.cpp
+++ b/test/LevelZeroIOGroupTest.cpp
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <unistd.h>
+#include <limits.h>
+
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "config.h"
+#include "Helper.hpp"
+#include "Exception.hpp"
+#include "PlatformTopo.hpp"
+#include "PluginFactory.hpp"
+#include "LevelZeroIOGroup.hpp"
+#include "geopm_test.hpp"
+#include "MockLevelZeroDevicePool.hpp"
+#include "MockLevelZero.hpp"
+#include "MockPlatformTopo.hpp"
+
+using geopm::LevelZeroIOGroup;
+using geopm::PlatformTopo;
+using geopm::Exception;
+using testing::Return;
+
+class LevelZeroIOGroupTest : public :: testing :: Test
+{
+    protected:
+        void SetUp();
+        void TearDown();
+        void write_affinitization(const std::string &affinitization_str);
+
+        std::unique_ptr<MockPlatformTopo> m_platform_topo;
+        std::shared_ptr<MockLevelZeroDevicePool> m_device_pool;
+};
+
+void LevelZeroIOGroupTest::SetUp()
+{
+    const int num_board = 1;
+    const int num_package = 2;
+    const int num_board_accelerator = 4;
+    const int num_board_accelerator_subdevice = 8;
+    const int num_core = 20;
+    const int num_cpu = 40;
+
+    m_device_pool = std::make_shared<MockLevelZeroDevicePool>();
+    m_platform_topo = geopm::make_unique<MockPlatformTopo>();
+
+    //Platform Topo prep
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD))
+        .WillByDefault(Return(num_board));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .WillByDefault(Return(num_package));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR))
+        .WillByDefault(Return(num_board_accelerator));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP))
+        .WillByDefault(Return(num_board_accelerator_subdevice));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_CPU))
+        .WillByDefault(Return(num_cpu));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_CORE))
+        .WillByDefault(Return(num_core));
+
+    for (int cpu_idx = 0; cpu_idx < num_cpu; ++cpu_idx) {
+        if (cpu_idx < 10) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(0));
+        }
+        else if (cpu_idx < 20) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(1));
+        }
+        else if (cpu_idx < 30) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(2));
+        }
+        else {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(3));
+        }
+    }
+
+    for (int cpu_idx = 0; cpu_idx < num_cpu; ++cpu_idx) {
+        if (cpu_idx < 5) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(0));
+        }
+        else if (cpu_idx < 10) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(1));
+        }
+        else if (cpu_idx < 15) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(2));
+        }
+        else if (cpu_idx < 20) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(3));
+        }
+        else if (cpu_idx < 25) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(4));
+        }
+        else if (cpu_idx < 30) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(5));
+        }
+        else if (cpu_idx < 35) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(6));
+        }
+        else {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(7));
+        }
+    }
+
+
+    EXPECT_CALL(*m_device_pool, num_accelerator(GEOPM_DOMAIN_BOARD_ACCELERATOR)).WillRepeatedly(Return(num_board_accelerator));
+    EXPECT_CALL(*m_device_pool, num_accelerator(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP)).WillRepeatedly(Return(num_board_accelerator_subdevice));
+}
+
+void LevelZeroIOGroupTest::TearDown()
+{
+}
+
+TEST_F(LevelZeroIOGroupTest, valid_signals)
+{
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+    for (const auto &sig : levelzero_io.signal_names()) {
+        EXPECT_TRUE(levelzero_io.is_valid_signal(sig));
+        EXPECT_NE(GEOPM_DOMAIN_INVALID, levelzero_io.signal_domain_type(sig));
+        EXPECT_LT(-1, levelzero_io.signal_behavior(sig));
+    }
+}
+
+TEST_F(LevelZeroIOGroupTest, push_control_adjust_write_batch)
+{
+    const int num_accelerator_subdevice = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP);
+    std::map<int, double> batch_value;
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    std::vector<double> mock_freq = {1530, 1320, 420, 135, 1620, 812, 199, 1700};
+
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        batch_value[(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL",
+                                        GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx))] = mock_freq.at(sub_idx)*1e6;
+        batch_value[(levelzero_io.push_control("FREQUENCY_ACCELERATOR_CONTROL",
+                                        GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx))] = mock_freq.at(sub_idx)*1e6;
+        EXPECT_CALL(*m_device_pool,
+                    frequency_control(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, mock_freq.at(sub_idx))).Times(2);
+    }
+
+    for (auto& sv: batch_value) {
+        // Given that we are mocking LEVELZERODevicePool the actual setting here doesn't matter
+        EXPECT_NO_THROW(levelzero_io.adjust(sv.first, sv.second));
+    }
+    EXPECT_NO_THROW(levelzero_io.write_batch());
+}
+
+TEST_F(LevelZeroIOGroupTest, write_control)
+{
+    const int num_accelerator_subdevice = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP);
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    std::vector<double> mock_freq = {1530, 1320, 420, 135, 900, 9001, 8010, 4500};
+
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        EXPECT_CALL(*m_device_pool,
+                    frequency_control(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, mock_freq.at(sub_idx))).Times(2);
+
+        EXPECT_NO_THROW(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL",
+                                              GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx,
+                                              mock_freq.at(sub_idx)*1e6));
+
+        EXPECT_NO_THROW(levelzero_io.write_control("FREQUENCY_ACCELERATOR_CONTROL",
+                                              GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx,
+                                              mock_freq.at(sub_idx)*1e6));
+    }
+}
+
+TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+    const int num_accelerator_subdevice = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP);
+
+    std::vector<double> mock_freq = {1530, 1630, 1320, 1420, 420, 520, 135, 235};
+    std::vector<double> mock_energy = {9000000, 11000000, 2300000, 5341000000};
+    std::vector<int> batch_idx;
+
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq.at(sub_idx)));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+    }
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+    }
+
+
+    levelzero_io.read_batch();
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        double frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        double frequency_batch = levelzero_io.sample(batch_idx.at(sub_idx));
+
+        EXPECT_DOUBLE_EQ(frequency, mock_freq.at(sub_idx)*1e6);
+        EXPECT_DOUBLE_EQ(frequency, frequency_batch);
+    }
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double energy = levelzero_io.read_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double energy_batch = levelzero_io.sample(batch_idx.at(num_accelerator_subdevice+accel_idx));
+
+        EXPECT_DOUBLE_EQ(energy, mock_energy.at(accel_idx)/1e6);
+        EXPECT_DOUBLE_EQ(energy, energy_batch);
+    }
+
+    //second round of testing with a modified value
+    mock_freq = {1730, 1830, 1520, 1620, 620, 720, 335, 435};
+    mock_energy = {9320000, 12300000, 2360000, 3417000000};
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq.at(sub_idx)));
+    }
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
+    }
+
+    levelzero_io.read_batch();
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        double frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        double frequency_batch = levelzero_io.sample(batch_idx.at(sub_idx));
+
+        EXPECT_DOUBLE_EQ(frequency, mock_freq.at(sub_idx)*1e6);
+        EXPECT_DOUBLE_EQ(frequency, frequency_batch);
+    }
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double energy = levelzero_io.read_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double energy_batch = levelzero_io.sample(batch_idx.at(num_accelerator_subdevice+accel_idx));
+
+        EXPECT_DOUBLE_EQ(energy, mock_energy.at(accel_idx)/1e6);
+        EXPECT_DOUBLE_EQ(energy, energy_batch);
+    }
+}
+
+TEST_F(LevelZeroIOGroupTest, read_signal)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+    const int num_accelerator_subdevice = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP);
+
+    //Frequency
+    std::vector<double> mock_freq_gpu = {1530, 1320, 420, 135, 900, 927, 293, 400};
+    std::vector<double> mock_freq_mem = {130, 1020, 200, 150, 300, 442, 782, 1059};
+    std::vector<double> mock_freq_min_gpu = {200, 320, 400, 350, 111, 222, 333, 444};
+    std::vector<double> mock_freq_max_gpu = {2000, 3200, 4200, 1350, 555, 666, 777, 888};
+    std::vector<double> mock_freq_min_mem = {100, 220, 300, 450, 999, 1010, 1111, 1212};
+    std::vector<double> mock_freq_max_mem = {1000, 2200, 3200, 1450, 1313, 1414, 1515, 1616};
+    //Active time
+    std::vector<uint64_t> mock_active_time = {123, 970, 550, 20, 52, 567, 888, 923};
+    std::vector<uint64_t> mock_active_time_timestamp = {182, 970, 650, 33, 283, 331, 675, 9000};
+    std::vector<uint64_t> mock_active_time_compute = {1, 90, 50, 0, 123, 144, 521, 445};
+    std::vector<uint64_t> mock_active_time_timestamp_compute = {12, 90, 150, 3, 772, 248, 932, 122};
+    std::vector<uint64_t> mock_active_time_copy = {12, 20, 30, 40, 44, 55, 66, 77};
+    std::vector<uint64_t> mock_active_time_timestamp_copy = {50, 60, 53, 55, 66, 77, 88, 99};
+    //Power & energy
+    std::vector<int32_t> mock_power_limit_min = {30000, 80000, 20000, 70000};
+    std::vector<int32_t> mock_power_limit_max = {310000, 280000, 320000, 270000};
+    std::vector<int32_t> mock_power_limit_tdp = {320000, 290000, 330000, 280000};
+    std::vector<uint64_t> mock_energy = {630000000, 280000000, 470000000, 950000000};
+    std::vector<uint64_t> mock_energy_timestamp = {153, 70, 300, 50};
+
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        //Frequency
+        EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq_gpu.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_freq_mem.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_min(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq_min_gpu.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_max(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq_max_gpu.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_min(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_freq_min_mem.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_max(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_freq_max_mem.at(sub_idx)));
+
+        //Active time
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_active_time.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_active_time_timestamp.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_compute.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_timestamp_compute.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_copy.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_timestamp_copy.at(sub_idx)));
+    }
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        //Power & energy
+        EXPECT_CALL(*m_device_pool, power_limit_min(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_power_limit_min.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power_limit_max(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_power_limit_max.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, power_limit_tdp(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_power_limit_tdp.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, energy_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy_timestamp.at(accel_idx)));
+    }
+
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
+        //Frequency
+        double frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        double frequency_alias = levelzero_io.read_signal("FREQUENCY_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(frequency, frequency_alias);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_gpu.at(sub_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_mem.at(sub_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MIN_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_min_gpu.at(sub_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MAX_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_max_gpu.at(sub_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MIN_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_min_mem.at(sub_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MAX_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_max_mem.at(sub_idx)*1e6);
+
+        //Active time
+        double active_time = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx)/1e6);
+        double active_time_timestamp = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(active_time_timestamp, mock_active_time_timestamp.at(sub_idx)/1e6);
+        double active_time_compute = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(active_time_compute, mock_active_time_compute.at(sub_idx)/1e6);
+        double active_time_timestamp_compute = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(active_time_timestamp_compute, mock_active_time_timestamp_compute.at(sub_idx)/1e6);
+        double active_time_copy = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time_copy.at(sub_idx)/1e6);
+        double active_time_timestamp_copy = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(active_time_timestamp_copy, mock_active_time_timestamp_copy.at(sub_idx)/1e6);
+    }
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        //Power & energy
+        double power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_MIN", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_min.at(accel_idx)/1e3);
+        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_MAX", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_max.at(accel_idx)/1e3);
+        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_DEFAULT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_tdp.at(accel_idx)/1e3);
+
+        double energy = levelzero_io.read_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(energy, mock_energy.at(accel_idx)/1e6);
+        double energy_timestamp = levelzero_io.read_signal("LEVELZERO::ENERGY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(energy_timestamp, mock_energy_timestamp.at(accel_idx)/1e6);
+
+    }
+
+    // Assume DerivativeSignals class functions as expected
+    // Just check validity of derived signals
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::POWER"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::UTILIZATION"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::UTILIZATION_COMPUTE"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::UTILIZATION_COPY"));
+}
+
+//Test case: Error path testing including:
+//              - Attempt to push a signal at an invalid domain level
+//              - Attempt to push an invalid signal
+//              - Attempt to sample without a read_batch prior
+//              - Attempt to read a signal at an invalid domain level
+//              - Attempt to push a control at an invalid domain level
+//              - Attempt to adjust a non-existent batch index
+//              - Attempt to write a control at an invalid domain level
+TEST_F(LevelZeroIOGroupTest, error_path)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+    const int num_accelerator_subdevice = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP);
+
+    std::vector<int> batch_idx;
+
+    std::vector<double> mock_freq = {1530, 1320, 420, 135};
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, accel_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq.at(accel_idx)));
+    }
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.sample(0),
+                               GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "signal_name LEVELZERO::INVALID not valid for LevelZeroIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "LEVELZERO::INVALID not valid for LevelZeroIOGroup");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.adjust(0, 12345.6),
+                               GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD, 0, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "control_name LEVELZERO::INVALID not valid for LevelZeroIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0, 1530000000),
+                               GEOPM_ERROR_INVALID, "LEVELZERO::INVALID not valid for LevelZeroIOGroup");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+}

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -298,6 +298,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/LevelZeroIOGroupTest.write_control \
               test/gtest_links/LevelZeroIOGroupTest.push_control_adjust_write_batch \
               test/gtest_links/LevelZeroIOGroupTest.read_signal_and_batch \
+              test/gtest_links/LevelZeroIOGroupTest.read_timestamp_batch \
+              test/gtest_links/LevelZeroIOGroupTest.read_timestamp_batch_reverse \
               test/gtest_links/MSRIOGroupTest.adjust \
               test/gtest_links/MSRIOGroupTest.control_error \
               test/gtest_links/MSRIOGroupTest.cpuid \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -296,6 +296,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/LevelZeroIOGroupTest.read_signal \
               test/gtest_links/LevelZeroIOGroupTest.error_path \
               test/gtest_links/LevelZeroIOGroupTest.write_control \
+              test/gtest_links/LevelZeroIOGroupTest.save_restore \
               test/gtest_links/LevelZeroIOGroupTest.push_control_adjust_write_batch \
               test/gtest_links/LevelZeroIOGroupTest.read_signal_and_batch \
               test/gtest_links/LevelZeroIOGroupTest.read_timestamp_batch \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -292,6 +292,12 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/LevelZeroDevicePoolTest.subdevice_range_check \
               test/gtest_links/LevelZeroDevicePoolTest.device_range_check \
               test/gtest_links/LevelZeroDevicePoolTest.device_function_check \
+              test/gtest_links/LevelZeroIOGroupTest.valid_signals \
+              test/gtest_links/LevelZeroIOGroupTest.read_signal \
+              test/gtest_links/LevelZeroIOGroupTest.error_path \
+              test/gtest_links/LevelZeroIOGroupTest.write_control \
+              test/gtest_links/LevelZeroIOGroupTest.push_control_adjust_write_batch \
+              test/gtest_links/LevelZeroIOGroupTest.read_signal_and_batch \
               test/gtest_links/MSRIOGroupTest.adjust \
               test/gtest_links/MSRIOGroupTest.control_error \
               test/gtest_links/MSRIOGroupTest.cpuid \
@@ -636,6 +642,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/IOGroupTest.cpp \
                           test/LevelZeroAcceleratorTopoTest.cpp \
                           test/LevelZeroDevicePoolTest.cpp \
+                          test/LevelZeroIOGroupTest.cpp \
                           test/MSRIOGroupTest.cpp \
                           test/MSRIOTest.cpp \
                           test/MSRFieldControlTest.cpp \

--- a/test/MockLevelZero.hpp
+++ b/test/MockLevelZero.hpp
@@ -52,6 +52,8 @@ class MockLevelZero : public geopm::LevelZero
                     (const, override));
         MOCK_METHOD(double, frequency_max, (unsigned int, int, int),
                     (const, override));
+        MOCK_METHOD((std::pair<double, double>), frequency_range,
+                    (unsigned int, int, int), (const, override));
 
         MOCK_METHOD(int, engine_domain_count, (unsigned int, int),
                     (const, override));
@@ -77,7 +79,7 @@ class MockLevelZero : public geopm::LevelZero
                     (unsigned int), (const, override));
 
         MOCK_METHOD(void, frequency_control,
-                    (unsigned int, int, int, double), (const, override));
+                    (unsigned int, int, int, double, double), (const, override));
 };
 
 #endif

--- a/test/MockLevelZeroDevicePool.hpp
+++ b/test/MockLevelZeroDevicePool.hpp
@@ -40,36 +40,39 @@
 class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
 {
     public:
-        MOCK_METHOD(num_accelerator,
-                    int(int), (const, override));
+        MOCK_METHOD(int, num_accelerator,
+                    (int), (const, override));
 
-        MOCK_METHOD(frequency_status,
-                    double(int, unsigned int, int), (const, override));
-        MOCK_METHOD(frequency_min,
-                    double(int, unsigned int, int), (const, override));
-        MOCK_METHOD(frequency_max,
-                    double(int, unsigned int, int), (const, override));
+        MOCK_METHOD(double, frequency_status,
+                    (int, unsigned int, int), (const, override));
+        MOCK_METHOD(double, frequency_min,
+                    (int, unsigned int, int), (const, override));
+        MOCK_METHOD(double, frequency_max,
+                    (int, unsigned int, int), (const, override));
 
-        MOCK_METHOD(active_time,
-                    uint64_t(int, unsigned int, int), (const, override));
-        MOCK_METHOD(active_time_timestamp,
-                    uint64_t(int, unsigned int, int), (const, override));
+        MOCK_METHOD((std::pair<uint64_t, uint64_t>), active_time_pair,
+                    (int, unsigned int, int), (const, override));
+        MOCK_METHOD(uint64_t, active_time,
+                    (int, unsigned int, int), (const, override));
+        MOCK_METHOD(uint64_t, active_time_timestamp,
+                    (int, unsigned int, int), (const, override));
 
-        MOCK_METHOD(power_limit_tdp,
-                    int32_t(int, unsigned int, int), (const, override));
-        MOCK_METHOD(power_limit_min,
-                    int32_t(int, unsigned int, int), (const, override));
-        MOCK_METHOD(power_limit_max,
-                    int32_t(int, unsigned int, int), (const, override));
+        MOCK_METHOD(int32_t, power_limit_tdp,
+                    (int, unsigned int, int), (const, override));
+        MOCK_METHOD(int32_t, power_limit_min,
+                    (int, unsigned int, int), (const, override));
+        MOCK_METHOD(int32_t, power_limit_max,
+                    (int, unsigned int, int), (const, override));
 
-        MOCK_METHOD(energy,
-                    uint64_t(int, unsigned int, int), (const, override));
-        MOCK_METHOD(energy_timestamp,
-                    uint64_t(int, unsigned int, int), (const, override));
+        MOCK_METHOD((std::pair<uint64_t, uint64_t>), energy_pair,
+                    (int, unsigned int, int), (const, override));
+        MOCK_METHOD(uint64_t, energy,
+                    (int, unsigned int, int), (const, override));
+        MOCK_METHOD(uint64_t, energy_timestamp,
+                    (int, unsigned int, int), (const, override));
 
-        MOCK_METHOD(frequency_control,
-                    void(int, unsigned int, int, double),
-                    (const, override));
+        MOCK_METHOD(void, frequency_control,
+                    (int, unsigned int, int, double),(const, override));
 };
 
 #endif

--- a/test/MockLevelZeroDevicePool.hpp
+++ b/test/MockLevelZeroDevicePool.hpp
@@ -49,6 +49,8 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
                     (int, unsigned int, int), (const, override));
         MOCK_METHOD(double, frequency_max,
                     (int, unsigned int, int), (const, override));
+        MOCK_METHOD((std::pair<double, double>), frequency_range,
+                    (int, unsigned int, int), (const, override));
 
         MOCK_METHOD((std::pair<uint64_t, uint64_t>), active_time_pair,
                     (int, unsigned int, int), (const, override));
@@ -72,7 +74,7 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
                     (int, unsigned int, int), (const, override));
 
         MOCK_METHOD(void, frequency_control,
-                    (int, unsigned int, int, double),(const, override));
+                    (int, unsigned int, int, double, double),(const, override));
 };
 
 #endif


### PR DESCRIPTION
A follow on PR to #1781 based on a breakdown of #1683.  

This PR Provides:
- An IO Group that uses the above to provide users with the ability to monitor and control Level Zero devices via geopmread/write and agents.
- Testing of the above features

Summary of Change:
- Addition of LevelZeroIOGroup to provide interface to the LevelZeroDevicePool.
- Addition of LevelZeroSignal to allow leveraging existing the DerivativeSignal class.
- Modifications to IOGroup to include Level Zero code when needed.
- Addition of Unit tests and mock object to test basic IO Group Functions.
- Addition of Integration tests to test IOGroup and Device Pool functionality on supported systems.

Known Issues & Future Work:
- Currently signals required a timestamp (energy, active time and its variants) first call for the value, then the timestamp.  This may lead to inaccurate measurements over time.  New _pair function variants have been provided by the DevicePool to address this issue, but the Signal updates have not been completed.
- Addition of signals: frequency throttle reasons, frequency tdp, frequency efficient, etc