### PR TITLE
Change sphinx html_logo to a URL

### DIFF
--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -260,11 +260,12 @@ io.github.geopm.xml:
 	PYTHONPATH=$(abs_srcdir):$(PYTHONPATH) \
 	$(PYTHON) -m geopmdpy.dbus_xml > $@
 
-install-python: setup.py
+
+$(abs_srcdir)/geopmdpy/version.py:
 # Move version.py into source for out of place builds
-	if [ ! -f $(abs_srcdir)/geopmdpy/version.py ]; then \
-	    cp geopmdpy/version.py $(abs_srcdir)/geopmdpy/version.py; \
-	fi
+	cp geopmdpy/version.py $@
+
+install-python: setup.py $(abs_srcdir)/geopmdpy/version.py
 	cd $(abs_srcdir) && $(PYTHON) ./setup.py install -O1 --root $(DESTDIR)/ --prefix $(prefix)
 
 clean-local-python: setup.py

--- a/service/docs/Makefile.mk
+++ b/service/docs/Makefile.mk
@@ -45,12 +45,7 @@ EXTRA_DIST += docs/geninfo.sh \
               docs/source/_static/.dirfile \
               # end
 
-docs/source/images/geopm-logo-clear.png:
-	echo "Warning: Create a symbolic link to geopm.github.io/images in docs/source/images, will use empty logo file" 1>&2
-	mkdir -p docs/source/images
-	touch docs/source/images/geopm-logo-clear.png
-
-docs: .libs/libgeopmd.so docs/source/images
+docs: .libs/libgeopmd.so
 	LD_LIBRARY_PATH=.libs:$(LD_LIBRARY_PATH) sphinx-build -M html docs/source docs/build
 
 clean-local-docs:

--- a/service/docs/Makefile.mk
+++ b/service/docs/Makefile.mk
@@ -45,8 +45,10 @@ EXTRA_DIST += docs/geninfo.sh \
               docs/source/_static/.dirfile \
               # end
 
-docs: .libs/libgeopmd.so
-	LD_LIBRARY_PATH=.libs:$(LD_LIBRARY_PATH) sphinx-build -M html docs/source docs/build
+docs: .libs/libgeopmd.so $(abs_srcdir)/geopmdpy/version.py
+	LD_LIBRARY_PATH=.libs:$(LD_LIBRARY_PATH) \
+	PYTHONPATH=$(abs_srcdir):$(PYTHONPATH) \
+	sphinx-build -M html $(abs_srcdir)/docs/source docs/build
 
 clean-local-docs:
 	rm -rf docs/build

--- a/service/docs/source/conf.py
+++ b/service/docs/source/conf.py
@@ -81,6 +81,5 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-html_logo = 'images/geopm-logo-clear.png'
+html_logo = 'https://geopm.github.io/images/geopm-logo-clear.png'
 logo_only = True


### PR DESCRIPTION
- This enables us to cleanly avoid putting binary files into our source tree.
- Avoids build requirement to create symbolic link to web page repo.


