### PR TITLE
Remove unused contructors from `geopm::Exception`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@
 /tutorial/tutorial_[0-9]*_trace-*
 /tutorial/tutorial_4_imbalance.conf
 /VERSION
+compile_commands.json

--- a/service/.gitignore
+++ b/service/.gitignore
@@ -33,3 +33,4 @@
 /install-sh
 /ltmain.sh
 /missing
+compile_commands.json

--- a/service/src/Exception.cpp
+++ b/service/src/Exception.cpp
@@ -113,16 +113,6 @@ namespace geopm
         return err;
     }
 
-    Exception::Exception(const std::string &what, int err, const char *file, int line)
-        : std::runtime_error(ErrorMessage::get().message_fixed(err) + (
-                                 what.size() != 0 ? (std::string(": ") + what) : std::string("")) + (
-                                 file != NULL ? (std::string(": at geopm/") + std::string(file) +
-                                 std::string(":") + std::to_string(line)) : std::string("")))
-        , m_err(err ? err : GEOPM_ERROR_RUNTIME)
-    {
-
-    }
-
     Exception::Exception()
         : Exception("", GEOPM_ERROR_RUNTIME, NULL, 0)
     {
@@ -136,20 +126,12 @@ namespace geopm
 
     }
 
-    Exception::Exception(int err)
-        : Exception("", err, NULL, 0)
-    {
-
-    }
-
-    Exception::Exception(const std::string &what, int err)
-        : Exception(what, err, NULL, 0)
-    {
-
-    }
-
-    Exception::Exception(int err, const char *file, int line)
-        : Exception("", err, file, line)
+    Exception::Exception(const std::string &what, int err, const char *file, int line)
+        : std::runtime_error(ErrorMessage::get().message_fixed(err) + (
+                                 what.size() != 0 ? (std::string(": ") + what) : std::string("")) + (
+                                 file != NULL ? (std::string(": at geopm/") + std::string(file) +
+                                 std::string(":") + std::to_string(line)) : std::string("")))
+        , m_err(err ? err : GEOPM_ERROR_RUNTIME)
     {
 
     }

--- a/service/src/geopm/Exception.hpp
+++ b/service/src/geopm/Exception.hpp
@@ -78,48 +78,6 @@ namespace geopm
             /// GEOPM_ERROR_RUNTIME (-1) is used for the error code.
             Exception();
             Exception(const Exception &other);
-            /// @brief Error number only constructor.
-            ///
-            /// User provides error code.  Enables an abbreviated
-            /// what() result.
-            ///
-            /// @param [in] err Error code, positive values are system
-            ///        errors (see errno(3)), negative values are
-            ///        GEOPM errors.  If zero is specified
-            ///        GEOPM_ERROR_RUNTIME (-1) is assumed.
-            Exception(int err);
-            /// @brief Message and error number constructor.
-            ///
-            /// User provides message and error code.  The error
-            /// message provided is appended to the abbreviated what()
-            /// result.
-            ///
-            /// @param [in] what Extension to error message returned
-            ///        by what() method.
-            ///
-            /// @param [in] err Error code, positive values are system
-            ///        errors (see errno(3)), negative values are
-            ///        GEOPM errors.  If zero is specified
-            ///        GEOPM_ERROR_RUNTIME (-1) is assumed.
-            Exception(const std::string &what, int err);
-            /// @brief Error number and line number constructor.
-            ///
-            /// User provides error code, file name, and line number.
-            /// The what() method produces the abbreviated message
-            /// with the file and line number information appended.
-            ///
-            /// @param [in] err Error code, positive values are system
-            ///        errors (see errno(3)), negative values are
-            ///        GEOPM errors.  If zero is specified
-            ///        GEOPM_ERROR_RUNTIME (-1) is assumed.
-            ///
-            /// @param [in] file Name of source file where exception
-            ///        was thrown, e.g. preprocessor `__FILE__`.
-            ///
-            /// @param [in] line Line number in source file where
-            ///        exception was thrown, e.g. preprocessor
-            ///        `__LINE__`.
-            Exception(int err, const char *file, int line);
             /// @brief Message, error number, file and line
             ///        constructor.
             ///


### PR DESCRIPTION
- Adding the `compile_commands.json` to `.gitignore`
  - `compile_commands.json` is generated by `bear`
- Fixes #1852 from github issues