### PR TITLE
Add geopm-service to the GH actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,13 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ dev ]
+    branches:
+      - dev
+      - geopm-service
   pull_request:
-    branches: [ dev ]
+    branches:
+      - dev
+      - geopm-service
 
 jobs:
   build_and_test:


### PR DESCRIPTION
Required to enable CI for the service branch.