### PR TITLE
Remove unused contructors from `geopm::Exception`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@
 /tutorial/tutorial_[0-9]*_trace-*
 /tutorial/tutorial_4_imbalance.conf
 /VERSION
+compile_commands.json

--- a/configure.ac
+++ b/configure.ac
@@ -576,7 +576,9 @@ AC_SUBST([ENABLE_BETA])
 GEOPM_SOURCE_DIR=$(readlink -f $srcdir)
 AC_DEFINE_UNQUOTED([GEOPM_SOURCE_DIR], ["$GEOPM_SOURCE_DIR"], [Root of the GEOPM source directory])
 
-AC_CONFIG_FILES([Makefile specs/geopm.spec specs/geopm-dudley.spec specs/geopm-ohpc.spec specs/geopm-theta.spec scripts/geopmpy/version.py test/geopm_test.sh scripts/test/geopmpy_test.sh], [chmod a+x test/geopm_test.sh scripts/test/geopmpy_test.sh])
+AC_CONFIG_FILES([Makefile specs/geopm.spec specs/geopm-dudley.spec specs/geopm-ohpc.spec specs/geopm-theta.spec scripts/geopmpy/version.py])
+AC_CONFIG_FILES([test/geopm_test.sh], [chmod a+x test/geopm_test.sh])
+AC_CONFIG_FILES([scripts/test/geopmpy_test.sh], [chmod a+x scripts/test/geopmpy_test.sh])
 AC_OUTPUT
 
 CC_VERSION=$(${CC} --version | head -n1)

--- a/service/.gitignore
+++ b/service/.gitignore
@@ -33,3 +33,4 @@
 /install-sh
 /ltmain.sh
 /missing
+compile_commands.json

--- a/service/src/Exception.cpp
+++ b/service/src/Exception.cpp
@@ -113,16 +113,6 @@ namespace geopm
         return err;
     }
 
-    Exception::Exception(const std::string &what, int err, const char *file, int line)
-        : std::runtime_error(ErrorMessage::get().message_fixed(err) + (
-                                 what.size() != 0 ? (std::string(": ") + what) : std::string("")) + (
-                                 file != NULL ? (std::string(": at geopm/") + std::string(file) +
-                                 std::string(":") + std::to_string(line)) : std::string("")))
-        , m_err(err ? err : GEOPM_ERROR_RUNTIME)
-    {
-
-    }
-
     Exception::Exception()
         : Exception("", GEOPM_ERROR_RUNTIME, NULL, 0)
     {
@@ -136,20 +126,12 @@ namespace geopm
 
     }
 
-    Exception::Exception(int err)
-        : Exception("", err, NULL, 0)
-    {
-
-    }
-
-    Exception::Exception(const std::string &what, int err)
-        : Exception(what, err, NULL, 0)
-    {
-
-    }
-
-    Exception::Exception(int err, const char *file, int line)
-        : Exception("", err, file, line)
+    Exception::Exception(const std::string &what, int err, const char *file, int line)
+        : std::runtime_error(ErrorMessage::get().message_fixed(err) + (
+                                 what.size() != 0 ? (std::string(": ") + what) : std::string("")) + (
+                                 file != NULL ? (std::string(": at geopm/") + std::string(file) +
+                                 std::string(":") + std::to_string(line)) : std::string("")))
+        , m_err(err ? err : GEOPM_ERROR_RUNTIME)
     {
 
     }

--- a/service/src/geopm/Exception.hpp
+++ b/service/src/geopm/Exception.hpp
@@ -78,48 +78,6 @@ namespace geopm
             /// GEOPM_ERROR_RUNTIME (-1) is used for the error code.
             Exception();
             Exception(const Exception &other);
-            /// @brief Error number only constructor.
-            ///
-            /// User provides error code.  Enables an abbreviated
-            /// what() result.
-            ///
-            /// @param [in] err Error code, positive values are system
-            ///        errors (see errno(3)), negative values are
-            ///        GEOPM errors.  If zero is specified
-            ///        GEOPM_ERROR_RUNTIME (-1) is assumed.
-            Exception(int err);
-            /// @brief Message and error number constructor.
-            ///
-            /// User provides message and error code.  The error
-            /// message provided is appended to the abbreviated what()
-            /// result.
-            ///
-            /// @param [in] what Extension to error message returned
-            ///        by what() method.
-            ///
-            /// @param [in] err Error code, positive values are system
-            ///        errors (see errno(3)), negative values are
-            ///        GEOPM errors.  If zero is specified
-            ///        GEOPM_ERROR_RUNTIME (-1) is assumed.
-            Exception(const std::string &what, int err);
-            /// @brief Error number and line number constructor.
-            ///
-            /// User provides error code, file name, and line number.
-            /// The what() method produces the abbreviated message
-            /// with the file and line number information appended.
-            ///
-            /// @param [in] err Error code, positive values are system
-            ///        errors (see errno(3)), negative values are
-            ///        GEOPM errors.  If zero is specified
-            ///        GEOPM_ERROR_RUNTIME (-1) is assumed.
-            ///
-            /// @param [in] file Name of source file where exception
-            ///        was thrown, e.g. preprocessor `__FILE__`.
-            ///
-            /// @param [in] line Line number in source file where
-            ///        exception was thrown, e.g. preprocessor
-            ///        `__LINE__`.
-            Exception(int err, const char *file, int line);
             /// @brief Message, error number, file and line
             ///        constructor.
             ///

--- a/service/test/ExceptionTest.cpp
+++ b/service/test/ExceptionTest.cpp
@@ -46,62 +46,29 @@ TEST_F(ExceptionTest, hello)
     const std::string geopm_tag("<geopm> ");
     std::string what_str;
 
-    geopm::Exception ex0(GEOPM_ERROR_INVALID);
-    EXPECT_EQ(GEOPM_ERROR_INVALID, ex0.err_value());
+    geopm::Exception ex0("Hello world", GEOPM_ERROR_NO_AGENT, __FILE__, __LINE__);
+    EXPECT_EQ(GEOPM_ERROR_NO_AGENT, ex0.err_value());
     what_str = std::string(ex0.what());
-    EXPECT_TRUE(what_str.size() != 0);
-    EXPECT_TRUE(what_str.compare(0, geopm_tag.length(), geopm_tag) == 0);
-    EXPECT_TRUE(what_str.find("argument") != std::string::npos);
-    std::cerr << "Error: " << ex0.what() << std::endl;
-
-    geopm::Exception ex1("Hello world", GEOPM_ERROR_LOGIC);
-    EXPECT_EQ(GEOPM_ERROR_LOGIC, ex1.err_value());
-    what_str = std::string(ex1.what());
-    EXPECT_TRUE(what_str.size() != 0);
-    EXPECT_TRUE(what_str.compare(0, geopm_tag.length(), geopm_tag) == 0);
-    EXPECT_TRUE(what_str.find("Hello world") != std::string::npos);
-    std::cerr << "Error: " << ex1.what() << std::endl;
-
-    geopm::Exception ex2(GEOPM_ERROR_FILE_PARSE, __FILE__, __LINE__);
-    EXPECT_EQ(GEOPM_ERROR_FILE_PARSE, ex2.err_value());
-    what_str = std::string(ex2.what());
-    EXPECT_TRUE(what_str.size() != 0);
-    EXPECT_TRUE(what_str.compare(0, geopm_tag.length(), geopm_tag) == 0);
-    EXPECT_TRUE(what_str.find("parse") != std::string::npos);
-    EXPECT_TRUE(what_str.find("ExceptionTest.cpp") != std::string::npos);
-    std::cerr << "Error: " << ex2.what() << std::endl;
-
-    geopm::Exception ex3("Hello world", GEOPM_ERROR_NO_AGENT, __FILE__, __LINE__);
-    EXPECT_EQ(GEOPM_ERROR_NO_AGENT, ex3.err_value());
-    what_str = std::string(ex3.what());
     EXPECT_TRUE(what_str.size() != 0);
     EXPECT_TRUE(what_str.compare(0, geopm_tag.length(), geopm_tag) == 0);
     EXPECT_TRUE(what_str.find("agent") != std::string::npos);
     EXPECT_TRUE(what_str.find("ExceptionTest.cpp") != std::string::npos);
-    std::cerr << "Error value = " << ex3.err_value() << std::endl;
+    std::cerr << "Error value = " << ex0.err_value() << std::endl;
     try {
-        throw ex3;
+        throw ex0;
     }
     catch (...) {
         int err = geopm::exception_handler(std::current_exception());
         EXPECT_EQ(GEOPM_ERROR_NO_AGENT, err);
     }
 
-    geopm::Exception ex4(0);
-    EXPECT_EQ(GEOPM_ERROR_RUNTIME, ex4.err_value());
-    what_str = std::string(ex4.what());
+    geopm::Exception ex1;
+    EXPECT_EQ(GEOPM_ERROR_RUNTIME, ex1.err_value());
+    what_str = std::string(ex1.what());
     EXPECT_TRUE(what_str.size() != 0);
     EXPECT_TRUE(what_str.compare(0, geopm_tag.length(), geopm_tag) == 0);
     EXPECT_TRUE(what_str.find("untime") != std::string::npos);
-    std::cerr << "Error: " << ex4.what() << std::endl;
-
-    geopm::Exception ex5;
-    EXPECT_EQ(GEOPM_ERROR_RUNTIME, ex5.err_value());
-    what_str = std::string(ex5.what());
-    EXPECT_TRUE(what_str.size() != 0);
-    EXPECT_TRUE(what_str.compare(0, geopm_tag.length(), geopm_tag) == 0);
-    EXPECT_TRUE(what_str.find("untime") != std::string::npos);
-    std::cerr << "Error: " << ex5.what() << std::endl;
+    std::cerr << "Error: " << ex1.what() << std::endl;
 }
 
 TEST_F(ExceptionTest, last_message)

--- a/src/OptionParser.cpp
+++ b/src/OptionParser.cpp
@@ -184,7 +184,8 @@ namespace geopm
     {
         auto it = m_bool_opts.find(name);
         if (it == m_bool_opts.end()) {
-            throw geopm::Exception(std::string("Invalid option ") + name, GEOPM_ERROR_INVALID);
+            throw geopm::Exception(std::string("Invalid option ") + name,
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         return it->second.value;
     }
@@ -193,7 +194,8 @@ namespace geopm
     {
         auto it = m_str_opts.find(name);
         if (it == m_str_opts.end()) {
-            throw geopm::Exception(std::string("Invalid option ") + name, GEOPM_ERROR_INVALID);
+            throw geopm::Exception(std::string("Invalid option ") + name,
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         return it->second.value;
     }


### PR DESCRIPTION
 - Remove unused contructors from `geopm::Exception`
   - Fixes #1852 from github issues
 - Adding the `compile_commands.json` to `.gitignore`
   - `compile_commands.json` is generated by `bear`
 - Removed tests for deleted constructors of Exception class.
   - This fixes broken build #1853

Signed-off-by: Konstantin Rebrov <konstantin.rebrov@intel.com>