### PR TITLE
Nightly CI enabling enhancements for the build script

### DIFF
--- a/README
+++ b/README
@@ -458,10 +458,8 @@ the integration scripts in a work directory.
     # Set a place to locate the output of the tests
     export GEOPM_WORKDIR=${HOME}/geopm_test
     #####   ALL USERS   #####
-    # Script defines bash functions to build and install GEOPM
-    source $GEOPM_SOURCE/integration/apps/build_func.sh
-    # Execute out-of-place build and install using build function
-    install_geopm
+    # Execute out-of-place build and install using build script in base dir
+    ${GEOPM_SOURCE}/build.sh
     # Set up run environment to use installed GEOPM
     source $GEOPM_SOURCE/integration/config/run_env.sh
     # Create a directory for output
@@ -475,9 +473,9 @@ python package to validate the runtime.  Please report failures of
 these tests as issues.
 
 Note that if the `GEOPM_SKIP_COMPILER_CHECK` environment variable is
-set when `install_geopm` is called, then the check to verify that the
-Intel compilers are used will be bypassed.  This can be useful for
-performing builds with the GNU toolchain.
+set when `${GEOPM_SOURCE}/build.sh` is called, then the check to
+verify that the Intel compilers are used will be bypassed.  This can
+be useful for performing builds with the GNU toolchain.
 
 RESOURCE MANAGER INTEGRATION
 ----------------------------

--- a/build.sh
+++ b/build.sh
@@ -31,8 +31,10 @@
 #
 
 # Simple script that will build and test both the base and the service.
-# Example invocation:
-#   git clean -ffdx && GEOPM_RUN_TESTS=yes ./build.sh
+# Example invocations (proceeded by "git clean -ffdx"):
+#   GEOPM_GLOBAL_CONFIG_OPTIONS="--enable-debug" GEOPM_RUN_TESTS=yes ./build.sh
+#   GEOPM_BASE_CONFIG_OPTIONS="--enable-beta" ./build.sh
+#   GEOPM_SERVICE_CONFIG_OPTIONS="--enable-levelzero" ./build.sh
 
 set -e
 
@@ -90,7 +92,7 @@ build(){
 
 # Run the service build
 cd service
-CC=gcc CXX=g++ build ${GEOPM_SERVICE_CONFIG_OPTIONS}
+CC=gcc CXX=g++ build "${GEOPM_SERVICE_CONFIG_OPTIONS}"
 
 # Run the base build
 cd ../.. # PWD here is service/build

--- a/build.sh
+++ b/build.sh
@@ -47,14 +47,15 @@ usage(){
     echo "    GEOPM_GLOBAL_CONFIG_OPTIONS : Configure options applicable to all build types."
     echo "    GEOPM_BASE_CONFIG_OPTIONS : Configure options only applicable to the base build."
     echo "    GEOPM_SERVICE_CONFIG_OPTIONS : Configure options only applicable to the service build."
+    echo "        Ensure quotes are used when specifying multiple options.  See examples below."
     echo "    GEOPM_NUM_THREADS : The number of threads to use when running make (default: 9)."
     echo "    GEOPM_RUN_TESTS : Set to enable running of unit tests."
     echo "    GEOPM_SKIP_INSTALL : Set to skip \"make install\"."
     echo
     echo "Examples (proceeded by \"git clean -ffdx\" to ensure the build tree is clean):"
-    echo "    GEOPM_GLOBAL_CONFIG_OPTIONS="--enable-debug" GEOPM_RUN_TESTS=yes ./build.sh"
-    echo "    GEOPM_BASE_CONFIG_OPTIONS="--enable-beta" ./build.sh"
-    echo "    GEOPM_SERVICE_CONFIG_OPTIONS="--enable-levelzero" ./build.sh"
+    echo "    GEOPM_GLOBAL_CONFIG_OPTIONS=\"--enable-debug --enable-coverage\" GEOPM_RUN_TESTS=yes ./build.sh"
+    echo "    GEOPM_BASE_CONFIG_OPTIONS=\"--enable-beta\" ./build.sh"
+    echo "    GEOPM_SERVICE_CONFIG_OPTIONS=\"--enable-levelzero --enable-systemd\" ./build.sh"
 }
 
 if [[ ${1} == '--help' ]]; then

--- a/build.sh
+++ b/build.sh
@@ -31,18 +31,42 @@
 #
 
 # Simple script that will build and test both the base and the service.
-# Example invocations (proceeded by "git clean -ffdx"):
-#   GEOPM_GLOBAL_CONFIG_OPTIONS="--enable-debug" GEOPM_RUN_TESTS=yes ./build.sh
-#   GEOPM_BASE_CONFIG_OPTIONS="--enable-beta" ./build.sh
-#   GEOPM_SERVICE_CONFIG_OPTIONS="--enable-levelzero" ./build.sh
 
 set -e
+
+usage(){
+    echo "Usage:"
+    echo "    <ENVIRONMENT_OVERRIDES> ${0}"
+    echo
+    echo "Requirements:"
+    echo "    GEOPM_SOURCE and GEOPM_INSTALL are set in the calling environment."
+    echo "    Ideally this is done with ~/.geopmrc."
+    echo "    See integration/README.md for more information."
+    echo
+    echo "ENVIRONMENT_OVERRIDES allows for the following variables to be specified:"
+    echo "    GEOPM_GLOBAL_CONFIG_OPTIONS : Configure options applicable to all build types."
+    echo "    GEOPM_BASE_CONFIG_OPTIONS : Configure options only applicable to the base build."
+    echo "    GEOPM_SERVICE_CONFIG_OPTIONS : Configure options only applicable to the service build."
+    echo "    GEOPM_NUM_THREADS : The number of threads to use when running make (default: 9)."
+    echo "    GEOPM_RUN_TESTS : Set to enable running of unit tests."
+    echo "    GEOPM_SKIP_INSTALL : Set to skip \"make install\"."
+    echo
+    echo "Examples (proceeded by \"git clean -ffdx\" to ensure the build tree is clean):"
+    echo "    GEOPM_GLOBAL_CONFIG_OPTIONS="--enable-debug" GEOPM_RUN_TESTS=yes ./build.sh"
+    echo "    GEOPM_BASE_CONFIG_OPTIONS="--enable-beta" ./build.sh"
+    echo "    GEOPM_SERVICE_CONFIG_OPTIONS="--enable-levelzero" ./build.sh"
+}
+
+if [[ ${1} == '--help' ]]; then
+    usage
+    exit 1
+fi
 
 GEOPM_SOURCE=${GEOPM_SOURCE:-${PWD}}
 cd ${GEOPM_SOURCE}
 BUILD_ENV="integration/config/build_env.sh"
 if [ ! -f "${BUILD_ENV}" ]; then
-    echo "Error: Please set GEOPM_SOURCE in your environment."
+    usage
     exit 1
 fi
 source ${BUILD_ENV}

--- a/configure.ac
+++ b/configure.ac
@@ -106,17 +106,6 @@ fi
 AC_SUBST([enable_beta])
 AM_CONDITIONAL([ENABLE_BETA], [test "x$enable_beta" = "x1"])
 
-AC_ARG_ENABLE([cnl-iogroup],
-  [AS_HELP_STRING([--enable-cnl-iogroup], [Enable the CNL IOGroup])],
-[if test "x$enable_cnl_iogroup" = "xno" ; then
-  enable_cnl_iogroup="0"
-else
-  enable_cnl_iogroup="1"
-fi
-],
-[enable_cnl_iogroup="0"]
-)
-
 if test "x$enable_debug" = "x1" ; then
   AC_DEFINE([GEOPM_DEBUG], [ ], [Enables code for debugging])
   CFLAGS="$CFLAGS -O0 -g"

--- a/configure.ac
+++ b/configure.ac
@@ -127,11 +127,6 @@ if test "x$enable_overhead" = "x1" ; then
 fi
 AC_SUBST([enable_overhead])
 
-if test "x$enable_msrsafe_ioctl_write" = "x1" ; then
-  AC_DEFINE([GEOPM_MSRSAFE_IOCTL_WRITE], [ ], [Enables use of msr-safe ioctl feature for writing (broken as of msr-safe version 1.2.0)])
-fi
-AC_SUBST([enable_msrsafe_ioctl_write])
-
 AC_ARG_WITH([sqlite3], [AS_HELP_STRING([--with-sqlite3=PATH],
             [specify directory for installed sqlite3 package.])])
 if test "x$with_sqlite3" != x; then
@@ -150,11 +145,6 @@ if test "x$with_sqlite3_lib" != x; then
   LD_LIBRARY_PATH="$with_sqlite3_lib:$LD_LIBRARY_PATH"
   EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L$with_sqlite3_lib"
 fi
-
-if test "x$enable_cnl_iogroup" = "x1" ; then
-  AC_DEFINE([GEOPM_CNL_IOGROUP], [ ], [Enables the CNL IOGroup])
-fi
-AC_SUBST([enable_cnl_iogroup])
 
 AC_ARG_WITH([mpi-bin], [AS_HELP_STRING([--with-mpi-bin=PATH],
             [specify directory for mpi compiler wrapper binaries])])
@@ -627,5 +617,4 @@ AC_MSG_RESULT([openmp             : ${enable_openmp}])
 AC_MSG_RESULT([fortran            : ${enable_fortran}])
 AC_MSG_RESULT([ompt               : ${enable_ompt}])
 AC_MSG_RESULT([beta               : ${enable_beta}])
-AC_MSG_RESULT([bloat              : ${enable_bloat}])
 AC_MSG_RESULT([===============================================================================])

--- a/integration/apps/build_func.sh
+++ b/integration/apps/build_func.sh
@@ -175,22 +175,3 @@ clean_geopm() {
         fi
     fi
 }
-
-# Build geopm in a subdirectory and install into GEOPM build
-# All arguments are forwarded to the configure command
-install_geopm() {
-    local CONFIG_EXT="$@"
-    local BASE_DIR=${PWD}
-    local BUILD_DIR=${GEOPM_SOURCE}/integration/build
-    clean_geopm ${BUILD_DIR} && \
-    cd ${GEOPM_SOURCE} && \
-    ./autogen.sh && \
-    mkdir -p ${BUILD_DIR} && \
-    cd ${BUILD_DIR} && \
-    ${GEOPM_SOURCE}/configure --prefix=${GEOPM_INSTALL} ${CONFIG_EXT} && \
-    make -j10 && \
-    make install
-    local ERR=$?
-    cd ${BASE_DIR}
-    return ${ERR}
-}


### PR DESCRIPTION
- Make the script aware of integration/config/build_env.sh
- Use env vars from ~/.geopmrc where appropriate
- Enable incremental builds as much as possible
  + There's still a weird issue where performing  an initial build and install, then without making any changes running ```make && make install``` from the service dir, then running ```make``` in the basedir causes the basedir to be completely rebuilt.  Not sure why this happens.
- Allow for configure time options to be passed into the script.
- Refactor the script.
- Remove old build function.
- Related to #1832.