### PR TITLE
Address build issues with newer GCC versions

### DIFF
--- a/examples/fft/Makefile.mk
+++ b/examples/fft/Makefile.mk
@@ -49,11 +49,11 @@ if ENABLE_OPENMP
 
     examples_fft_nas_ft_LDADD = libgeopm.la libgeopmfort.la $(MPI_FCLIBS) $(MPI_CXXLIBS)
     examples_fft_nas_ft_LDFLAGS = $(AM_LDFLAGS) $(MPI_LDFLAGS) $(OPENMP_CFLAGS)
-    examples_fft_nas_ft_FCFLAGS = -fopenmp -msse4.2 $(MPI_FCFLAGS) $(OPENMP_CFLAGS) -O3
-    examples_fft_nas_ft_FFLAGS =  -fopenmp -msse4.2 $(MPI_FFLAGS) $(OPENMP_CFLAGS) -O3
+    examples_fft_nas_ft_FCFLAGS = -std=legacy -fopenmp -msse4.2 $(MPI_FCFLAGS) $(OPENMP_CFLAGS) -O3
+    examples_fft_nas_ft_FFLAGS = -std=legacy -fopenmp -msse4.2 $(MPI_FFLAGS) $(OPENMP_CFLAGS) -O3
 if HAVE_IFORT
-    examples_fft_nas_ft_FCFLAGS += -xAVX -shared-intel -mcmodel=medium -fpic
-    examples_fft_nas_ft_FFLAGS += -xAVX -shared-intel -mcmodel=medium -fpic
+    examples_fft_nas_ft_FCFLAGS += -std=legacy -xAVX -shared-intel -mcmodel=medium -fpic
+    examples_fft_nas_ft_FFLAGS += -std=legacy -xAVX -shared-intel -mcmodel=medium -fpic
 endif
 endif
 endif

--- a/examples/fft/randi8.f
+++ b/examples/fft/randi8.f
@@ -59,7 +59,7 @@ c   arguments will generate a continuous sequence.
       parameter(d2m46=0.5d0**46)
 
       save i246m1
-      data i246m1/X'00003FFFFFFFFFFF'/
+      data i246m1/Z'00003FFFFFFFFFFF'/
 
       Lx = X
       La = A
@@ -90,7 +90,7 @@ c      parameter(i246m1=2**46-1)
       parameter(d2m46=0.5d0**46)
 
       save i246m1
-      data i246m1/X'00003FFFFFFFFFFF'/
+      data i246m1/Z'00003FFFFFFFFFFF'/
 
 c Note that the v6 compiler on an R8000 does something stupid with
 c the above. Using the following instead (or various other things)

--- a/geopm-theta.spec.in
+++ b/geopm-theta.spec.in
@@ -1,13 +1,13 @@
 %define pname geopm
 %define PNAME GEOPM
-%define install_prefix  /soft/perftools/%{pname}/%{pname}-%{version}
+%define install_prefix  /soft/perftools/%{pname}/%{pname}-%{version}-%{release}
 %define module_prefix   /soft/environment/modules/modulefiles/%{pname}
-%define module_name     %{version}
+%define module_name     %{version}-%{release}
 
 Name:          %{pname}
 Summary:       Global Extensible Open Power Manager
 Version:       @VERSION@
-Release:       1
+Release:       2
 License:       BSD-3-Clause
 Group:         System Environment/Libraries
 URL:           https://geopm.github.io
@@ -43,13 +43,16 @@ FCFLAGS='-dynamic -xCORE-AVX2' \
 FFLAGS='-dynamic -xCORE-AVX2' \
 ./configure --prefix=%{install_prefix} \
             --with-python=%{__python2} \
+            --disable-doc \
             || ( cat config.log && false )
-%{__make}
+%{__make} -j16
 
 
 %install
-pip install --ignore-installed --target=%{buildroot}/%{install_prefix}/lib/python%{python_version}/site-packages \
+module swap PrgEnv-intel PrgEnv-gnu
+%{__python2} -m pip install --ignore-installed --target=%{buildroot}/%{install_prefix}/lib/python%{python_version}/site-packages \
             -r ./scripts/requirements.txt
+module swap PrgEnv-gnu PrgEnv-intel
 %{__make} DESTDIR=%{buildroot} install
 rm -f $(find %{buildroot}/%{install_prefix} -name '*.a'; \
         find %{buildroot}/%{install_prefix} -name '*.la'; \
@@ -58,7 +61,7 @@ rm -f $(find %{buildroot}/%{install_prefix} -name '*.a'; \
 # Module file
 # OpenHPC module file
 %{__mkdir_p} %{buildroot}%{module_prefix}
-%{__cat} << EOF > %{buildroot}/%{module_prefix}/%{version}
+%{__cat} << EOF > %{buildroot}/%{module_prefix}/%{version}-%{release}
 #%Module1.0#####################################################################
 
 proc ModulesHelp { } {
@@ -66,11 +69,11 @@ proc ModulesHelp { } {
 puts stderr " "
 puts stderr "This module loads the %{pname} package built with the intel compiler"
 puts stderr "toolchain and the cray mpich MPI stack."
-puts stderr "\nVersion %{version}\n"
+puts stderr "\nVersion %{version}-%{release}\n"
 
 }
 module-whatis "Name: %{pname}"
-module-whatis "Version: %{version}"
+module-whatis "Version: %{version}-%{release}"
 module-whatis "Category: perftools"
 module-whatis "Description: %{summary}"
 module-whatis "URL: %{url}"
@@ -79,18 +82,19 @@ module-whatis "ALCF Theta guide: https://github.com/geopm/theta-tutorial/blob/ma
 
 conflict "darshan"
 
-set     version             %{version}
+prepend-path    PATH                    %{install_prefix}/bin
+prepend-path    PYTHONPATH              %{install_prefix}/lib/python%{python_version}/site-packages
+prepend-path    INCLUDE                 %{install_prefix}/include
+prepend-path    LD_LIBRARY_PATH         %{install_prefix}/lib
+prepend-path    MANPATH                 %{install_prefix}/share/man
 
-prepend-path    PATH                %{install_prefix}/bin
-prepend-path    PYTHONPATH          %{install_prefix}/lib/python%{python_version}/site-packages
-prepend-path    INCLUDE             %{install_prefix}/include
-prepend-path    LD_LIBRARY_PATH     %{install_prefix}/lib
-prepend-path    MANPATH             %{install_prefix}/share/man
+setenv          %{PNAME}_DIR            %{install_prefix}
+setenv          %{PNAME}_BIN            %{install_prefix}/bin
+setenv          %{PNAME}_LIB            %{install_prefix}/lib
+setenv          %{PNAME}_INC            %{install_prefix}/include
 
-setenv          %{PNAME}_DIR        %{install_prefix}
-setenv          %{PNAME}_BIN        %{install_prefix}/bin
-setenv          %{PNAME}_LIB        %{install_prefix}/lib
-setenv          %{PNAME}_INC        %{install_prefix}/include
+setenv          PMI_NO_FORK             1
+setenv          PMI_NO_PREINITIALIZE    1
 
 EOF
 

--- a/src/ProfileTable.hpp
+++ b/src/ProfileTable.hpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <map>
 #include <set>
+#include <string>
 
 #include "geopm_internal.h"
 


### PR DESCRIPTION
- Fixes build with gcc v10.3.1
- Use -std=legacy with FFLAGS and FCFLAGS.
- Update Fortran code to avoid GCC > 10.2 specific build option: -fallow-invalid-boz