### PR TITLE
Added DCGMIOGroup for NVIDIA Profiling Metrics

### DIFF
--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -154,6 +154,8 @@ libgeopmd_la_SOURCES = $(include_HEADERS) \
                        src/DifferenceSignal.cpp \
                        src/DifferenceSignal.hpp \
                        src/DCGMDevicePool.hpp \
+                       src/DCGMIOGroup.hpp \
+                       src/DCGMIOGroup.cpp \
                        src/DomainControl.cpp \
                        src/DomainControl.hpp \
                        src/Exception.cpp \

--- a/service/src/DCGMDevicePool.hpp
+++ b/service/src/DCGMDevicePool.hpp
@@ -101,6 +101,14 @@ namespace geopm
             ///       0 indicates no limit
             /// @param [in] max_samples maximun number of samples to store
             virtual void max_samples(int max_samples) = 0;
+
+            /// @brief Enable DCGM data polling through setting the watch fields
+            //         This function may be called repeatedly with updated polling
+            //         rate or storage settings.
+            virtual void polling_enable(void) = 0;
+
+            /// @brief Disable DCGM data polling through calling unwatchfields
+            virtual void polling_disable(void) = 0;
     };
 
     DCGMDevicePool &dcgm_device_pool();

--- a/service/src/DCGMDevicePoolImp.hpp
+++ b/service/src/DCGMDevicePoolImp.hpp
@@ -54,6 +54,8 @@ namespace geopm
             virtual void update_rate(int field_update_rate) override;
             virtual void max_storage_time(int max_storage_time) override;
             virtual void max_samples(int max_samples) override;
+            virtual void polling_enable(void) override;
+            virtual void polling_disable(void) override;
 
         private:
             virtual void check_result(const dcgmReturn_t result, const std::string error, const int line);
@@ -62,6 +64,7 @@ namespace geopm
             double m_max_keep_age;
             int m_max_keep_sample;
             int m_dcgm_dev_count;
+            bool m_dcgm_polling;
 
             dcgmHandle_t m_dcgm_handle;
             dcgmFieldGrp_t m_field_group_id;

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -62,7 +62,7 @@ namespace geopm
         , m_dcgm_device_pool(device_pool)
         , m_is_batch_read(false)
         , m_signal_available({{"DCGM::SM_ACTIVE", {
-                                  "SM activity expressed as a ratio of cycles",
+                                  "Streaming Multiprocessor activity expressed as a ratio of cycles",
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
@@ -73,7 +73,7 @@ namespace geopm
                                   string_format_double
                                   }},
                               {"DCGM::SM_OCCUPANCY", {
-                                  "Warp residency expressed as a ratio of maximum warps per cycles",
+                                  "Warp residency expressed as a ratio of maximum warps",
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
@@ -84,7 +84,7 @@ namespace geopm
                                   string_format_double
                                   }},
                               {"DCGM::DRAM_ACTIVE", {
-                                  "DRAM Send & Receive expresed as a ratio of cycles",
+                                  "DRAM send & receive expressed as a ratio of cycles",
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
@@ -420,17 +420,7 @@ namespace geopm
     // platform settings
     void DCGMIOGroup::restore_control(void)
     {
-        // The 1 second update rate used here is the default sample rate discussed
-        // in the DCGM user guide.
-        m_dcgm_device_pool.update_rate(1e6); //1 second
-
-        // The max samples restore value is based upon the defaults used in DCGM
-        // sdk example code for field value access provided as part of the DCGM install
-        m_dcgm_device_pool.max_samples(3600); //3600 samples
-
-        // The max storage time restore value is based upon the defaults used in DCGM
-        // sdk example code for field value access provided as part of the DCGM install
-        m_dcgm_device_pool.max_storage_time(3600); //3600 seconds
+        m_dcgm_device_pool.polling_disable();
     }
 
     void DCGMIOGroup::save_control(const std::string &save_path)

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -1,0 +1,544 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <cmath>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <cstring>
+#include <sched.h>
+#include <errno.h>
+
+#include "DCGMIOGroup.hpp"
+#include "DCGMDevicePool.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm/Exception.hpp"
+#include "geopm/Agg.hpp"
+#include "geopm/Helper.hpp"
+
+namespace geopm
+{
+    DCGMIOGroup::DCGMIOGroup()
+        : DCGMIOGroup(platform_topo(), dcgm_device_pool())
+    {
+    }
+
+    // Set up mapping between signal and control names and corresponding indices
+    DCGMIOGroup::DCGMIOGroup(const PlatformTopo &platform_topo, DCGMDevicePool &device_pool)
+        : m_platform_topo(platform_topo)
+        , m_dcgm_device_pool(device_pool)
+        , m_is_batch_read(false)
+        , m_signal_available({{"DCGM::SM_ACTIVE", {
+                                  "SM activity expressed as a ratio of cycles",
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_dcgm_device_pool.field_value(
+                                                   domain_idx, geopm::DCGMDevicePool::M_SM_ACTIVE);
+                                  },
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"DCGM::SM_OCCUPANCY", {
+                                  "Warp residency expressed as a ratio of maximum warps per cycles",
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_dcgm_device_pool.field_value(
+                                                   domain_idx, geopm::DCGMDevicePool::M_SM_OCCUPANCY);
+                                  },
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                              {"DCGM::DRAM_ACTIVE", {
+                                  "DRAM Send & Receive expresed as a ratio of cycles",
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_dcgm_device_pool.field_value(
+                                                   domain_idx, geopm::DCGMDevicePool::M_DRAM_ACTIVE);
+                                  },
+                                  Agg::average,
+                                  string_format_double
+                                  }},
+                             })
+        , m_control_available({{"DCGM::FIELD_UPDATE_RATE", {
+                                    "Rate at which field data is polled in seconds",
+                                    {},
+                                    Agg::expect_same,
+                                    string_format_double
+                                    }},
+                               {"DCGM::MAX_STORAGE_TIME", {
+                                    "Maximum time field data is stored in seconds",
+                                    {},
+                                    Agg::expect_same,
+                                    string_format_double
+                                    }},
+                               {"DCGM::MAX_SAMPLES", {
+                                    "Maximum number of samples.  0=no limit",
+                                    {},
+                                    Agg::expect_same,
+                                    string_format_integer
+                                    }}
+                              })
+    {
+        // confirm all DCGM devices correspond to a board_accelerator
+        if (m_dcgm_device_pool.dcgm_device() != m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": "
+                            "DCGM enabled device count does not match BOARD_ACCELERATOR count",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        // populate signals for each domain
+        for (auto &sv : m_signal_available) {
+            std::vector<std::shared_ptr<signal_s> > result;
+            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(signal_domain_type(sv.first)); ++domain_idx) {
+                std::shared_ptr<signal_s> sgnl = std::make_shared<signal_s>(signal_s{0, false});
+                result.push_back(sgnl);
+            }
+            sv.second.signals = result;
+        }
+
+        // populate controls for each domain
+        for (auto &sv : m_control_available) {
+            std::vector<std::shared_ptr<control_s> > result;
+            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(control_domain_type(sv.first)); ++domain_idx) {
+                std::shared_ptr<control_s> ctrl = std::make_shared<control_s>(control_s{0, false});
+                result.push_back(ctrl);
+            }
+            sv.second.controls = result;
+        }
+    }
+
+    DCGMIOGroup::~DCGMIOGroup(void)
+    {
+    }
+
+    // Extract the set of all signal names from the index map
+    std::set<std::string> DCGMIOGroup::signal_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &sv : m_signal_available) {
+            result.insert(sv.first);
+        }
+        return result;
+    }
+
+    // Extract the set of all control names from the index map
+    std::set<std::string> DCGMIOGroup::control_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &sv : m_control_available) {
+            result.insert(sv.first);
+        }
+        return result;
+    }
+
+    // Check signal name using index map
+    bool DCGMIOGroup::is_valid_signal(const std::string &signal_name) const
+    {
+        return m_signal_available.find(signal_name) != m_signal_available.end();
+    }
+
+    // Check control name using index map
+    bool DCGMIOGroup::is_valid_control(const std::string &control_name) const
+    {
+        return m_control_available.find(control_name) != m_control_available.end();
+    }
+
+    // Return domain for all valid signals
+    int DCGMIOGroup::signal_domain_type(const std::string &signal_name) const
+    {
+        return is_valid_signal(signal_name) ? GEOPM_DOMAIN_BOARD_ACCELERATOR : GEOPM_DOMAIN_INVALID;
+    }
+
+    // Return domain for all valid controls
+    int DCGMIOGroup::control_domain_type(const std::string &control_name) const
+    {
+        return is_valid_control(control_name) ? GEOPM_DOMAIN_BOARD : GEOPM_DOMAIN_INVALID;
+    }
+
+    // Mark the given signal to be read by read_batch()
+    int DCGMIOGroup::push_signal(const std::string &signal_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": signal_name " + signal_name +
+                            " not valid for DCGMIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != signal_domain_type(signal_name)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": " + signal_name + ": domain_type must be " +
+                            std::to_string(signal_domain_type(signal_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(signal_domain_type(signal_name))) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (m_is_batch_read) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": cannot push signal after call to read_batch().",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        int result = -1;
+        bool is_found = false;
+        std::shared_ptr<signal_s> signal = m_signal_available.at(signal_name).signals.at(domain_idx);
+
+        // Check if signal was already pushed
+        for (size_t ii = 0; !is_found && ii < m_signal_pushed.size(); ++ii) {
+            // same location means this signal or its alias was already pushed
+            if (m_signal_pushed[ii].get() == signal.get()) {
+                result = ii;
+                is_found = true;
+            }
+        }
+        if (!is_found) {
+            // If not pushed, add to pushed signals and configure for batch reads
+            result = m_signal_pushed.size();
+            signal->m_do_read = true;
+            m_signal_pushed.push_back(signal);
+        }
+
+        return result;
+    }
+
+    // Mark the given control to be written by write_batch()
+    int DCGMIOGroup::push_control(const std::string &control_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": control_name " + control_name +
+                            " not valid for DCGMIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != control_domain_type(control_name)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": " + control_name + ": domain_type must be " +
+                            std::to_string(control_domain_type(control_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(domain_type)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        int result = -1;
+        bool is_found = false;
+        std::shared_ptr<control_s> control = m_control_available.at(control_name).controls.at(domain_idx);
+
+        // Check if control was already pushed
+        for (size_t ii = 0; !is_found && ii < m_control_pushed.size(); ++ii) {
+            // same location means this control or its alias was already pushed
+            if (m_control_pushed[ii] == control) {
+                result = ii;
+                is_found = true;
+            }
+        }
+        if (!is_found) {
+            // If not pushed, add to pushed control
+            result = m_control_pushed.size();
+            m_control_pushed.push_back(control);
+        }
+
+        return result;
+    }
+
+    // Parse and update saved values for signals
+    void DCGMIOGroup::read_batch(void)
+    {
+        m_is_batch_read = true;
+        if(!m_signal_pushed.empty()) {
+            // NOTE: Doing this requires all signals to operate at the
+            //       GEOPM_BOARD_ACCELERATOR domain, but it means
+            //       dcgmGetLatestValuesForFields only has to be called
+            //       once per GEOPM_BOARD_ACCELERATOR domain.
+            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(
+                 GEOPM_DOMAIN_BOARD_ACCELERATOR); ++domain_idx) {
+
+                m_dcgm_device_pool.update_field_value(domain_idx);
+
+                for (auto &sv : m_signal_available) {
+                    if (sv.second.signals.at(domain_idx)->m_do_read) {
+                        sv.second.signals.at(domain_idx)->m_value =
+                            sv.second.m_devpool_func(domain_idx);
+                    }
+                }
+            }
+        }
+    }
+
+    // Write all controls that have been pushed and adjusted
+    void DCGMIOGroup::write_batch(void)
+    {
+        for (auto &sv : m_control_available) {
+            for (unsigned int domain_idx = 0; domain_idx < sv.second.controls.size(); ++domain_idx) {
+                if (sv.second.controls.at(domain_idx)->m_is_adjusted) {
+                    write_control(sv.first, control_domain_type(sv.first), domain_idx,
+                                  sv.second.controls.at(domain_idx)->m_setting);
+                }
+            }
+        }
+    }
+
+    // Return the latest value read by read_batch()
+    double DCGMIOGroup::sample(int batch_idx)
+    {
+        // Do conversion of signal values stored in read batch
+        if (batch_idx < 0 || batch_idx >= (int)m_signal_pushed.size()) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": batch_idx " +std::to_string(batch_idx)+ " out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (!m_is_batch_read) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": signal has not been read.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_signal_pushed[batch_idx]->m_value;
+    }
+
+    // Save a setting to be written by a future write_batch()
+    void DCGMIOGroup::adjust(int batch_idx, double setting)
+    {
+        if (batch_idx < 0 || (unsigned)batch_idx >= m_control_pushed.size()) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + "(): batch_idx " +std::to_string(batch_idx)+ " out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        m_control_pushed.at(batch_idx)->m_setting = setting;
+        m_control_pushed.at(batch_idx)->m_is_adjusted = true;
+    }
+
+    // Read the value of a signal immediately, bypassing read_batch().  Should not modify m_signal_value
+    double DCGMIOGroup::read_signal(const std::string &signal_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            " not valid for DCGMIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != signal_domain_type(signal_name)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": " + signal_name + ": domain_type must be " +
+                            std::to_string(signal_domain_type(signal_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(signal_domain_type(signal_name))) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        double result = NAN;
+        m_dcgm_device_pool.update_field_value(domain_idx);
+
+        auto it = m_signal_available.find(signal_name);
+        if (it != m_signal_available.end()) {
+            result = it->second.m_devpool_func(domain_idx);
+        }
+        else {
+    #ifdef GEOPM_DEBUG
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": Handling not defined for " +
+                            signal_name, GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+    #endif
+        }
+        return result;
+    }
+
+    // Write to the control immediately, bypassing write_batch()
+    void DCGMIOGroup::write_control(const std::string &control_name, int domain_type, int domain_idx, double setting)
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": " + control_name +
+                            " not valid for DCGMIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != control_domain_type(control_name)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": " + control_name + ": domain_type must be " +
+                            std::to_string(control_domain_type(control_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (control_name == "DCGM::FIELD_UPDATE_RATE") {
+            m_dcgm_device_pool.field_update_rate(domain_idx, setting*1e6);
+        }
+        else if (control_name == "DCGM::MAX_STORAGE_TIME") {
+            m_dcgm_device_pool.max_storage_time(domain_idx, setting);
+        }
+        else if (control_name == "DCGM::MAX_SAMPLES") {
+            m_dcgm_device_pool.max_samples(domain_idx, setting);
+        }
+        else {
+    #ifdef GEOPM_DEBUG
+                throw Exception("DCGMIOGroup::" + std::string(__func__) + "Handling not defined for "
+                                + control_name, GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+    #endif
+        }
+    }
+
+    // Implemented to allow an IOGroup to save platform settings before starting
+    // to adjust them
+    void DCGMIOGroup::save_control(void)
+    {
+        for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(
+             GEOPM_DOMAIN_BOARD); ++domain_idx) {
+            //TODO: Implement
+        }
+    }
+
+    // Implemented to allow an IOGroup to restore previously saved
+    // platform settings
+    void DCGMIOGroup::restore_control(void)
+    {
+        for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(
+             GEOPM_DOMAIN_BOARD); ++domain_idx) {
+            //TODO: Implement
+        }
+    }
+
+    void DCGMIOGroup::save_control(const std::string &save_path)
+    {
+        throw Exception("DCGMIOGroup::save_control()",
+                        GEOPM_ERROR_NOT_IMPLEMENTED, __FILE__, __LINE__);
+    }
+
+    void DCGMIOGroup::restore_control(const std::string &save_path)
+    {
+        throw Exception("DCGMIOGroup::restore_control()",
+                        GEOPM_ERROR_NOT_IMPLEMENTED, __FILE__, __LINE__);
+    }
+
+    // Hint to Agent about how to aggregate signals from this IOGroup
+    std::function<double(const std::vector<double> &)> DCGMIOGroup::agg_function(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            "not valid for DCGMIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return it->second.m_agg_function;
+    }
+
+    // Specifies how to print signals from this IOGroup
+    std::function<std::string(double)> DCGMIOGroup::format_function(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            "not valid for DCGMIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return it->second.m_format_function;
+    }
+
+    // A user-friendly description of each signal
+    std::string DCGMIOGroup::signal_description(const std::string &signal_name) const
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": signal_name " + signal_name +
+                            " not valid for DCGMIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return m_signal_available.at(signal_name).m_description;
+    }
+
+    // A user-friendly description of each control
+    std::string DCGMIOGroup::control_description(const std::string &control_name) const
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": " + control_name +
+                            "not valid for DCGMIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_control_available.at(control_name).m_description;
+    }
+
+    int DCGMIOGroup::signal_behavior(const std::string &signal_name) const
+    {
+        return IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE;
+    }
+
+    // Name used for registration with the IOGroup factory
+    std::string DCGMIOGroup::plugin_name(void)
+    {
+        return "dcgm";
+    }
+
+    // Function used by the factory to create objects of this type
+    std::unique_ptr<IOGroup> DCGMIOGroup::make_plugin(void)
+    {
+        return geopm::make_unique<DCGMIOGroup>();
+    }
+
+    void DCGMIOGroup::register_signal_alias(const std::string &alias_name,
+                                            const std::string &signal_name)
+    {
+        if (m_signal_available.find(alias_name) != m_signal_available.end()) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": signal_name " + alias_name +
+                            " was previously registered.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            // skip adding an alias if underlying signal is not found
+            return;
+        }
+        // copy signal info but append to description
+        m_signal_available[alias_name] = it->second;
+        m_signal_available[alias_name].m_description =
+            m_signal_available[signal_name].m_description + '\n' + "    alias_for: " + signal_name;
+    }
+
+    void DCGMIOGroup::register_control_alias(const std::string &alias_name,
+                                           const std::string &control_name)
+    {
+        if (m_control_available.find(alias_name) != m_control_available.end()) {
+            throw Exception("DCGMIOGroup::" + std::string(__func__) + ": contro1_name " + alias_name +
+                            " was previously registered.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto it = m_control_available.find(control_name);
+        if (it == m_control_available.end()) {
+            // skip adding an alias if underlying control is not found
+            return;
+        }
+        // copy control info but append to description
+        m_control_available[alias_name] = it->second;
+        m_control_available[alias_name].m_description =
+        m_control_available[control_name].m_description + '\n' + "    alias_for: " + control_name;
+    }
+}

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -129,7 +129,7 @@ namespace geopm
                 std::shared_ptr<signal_s> sgnl = std::make_shared<signal_s>(signal_s{0, false});
                 result.push_back(sgnl);
             }
-            sv.second.signals = result;
+            sv.second.m_signals = result;
         }
         register_signal_alias("ACCELERATOR_COMPUTE_ACTIVITY", "DCGM::SM_ACTIVE");
         register_signal_alias("ACCELERATOR_MEMORY_ACTIVITY", "DCGM::DRAM_ACTIVE");
@@ -141,7 +141,7 @@ namespace geopm
                 std::shared_ptr<control_s> ctrl = std::make_shared<control_s>(control_s{0, false});
                 result.push_back(ctrl);
             }
-            sv.second.controls = result;
+            sv.second.m_controls = result;
         }
     }
 
@@ -217,7 +217,7 @@ namespace geopm
 
         int result = -1;
         bool is_found = false;
-        std::shared_ptr<signal_s> signal = m_signal_available.at(signal_name).signals.at(domain_idx);
+        std::shared_ptr<signal_s> signal = m_signal_available.at(signal_name).m_signals.at(domain_idx);
 
         // Check if signal was already pushed
         for (size_t ii = 0; !is_found && ii < m_signal_pushed.size(); ++ii) {
@@ -257,7 +257,7 @@ namespace geopm
 
         int result = -1;
         bool is_found = false;
-        std::shared_ptr<control_s> control = m_control_available.at(control_name).controls.at(domain_idx);
+        std::shared_ptr<control_s> control = m_control_available.at(control_name).m_controls.at(domain_idx);
 
         // Check if control was already pushed
         for (size_t ii = 0; !is_found && ii < m_control_pushed.size(); ++ii) {
@@ -291,8 +291,8 @@ namespace geopm
                 m_dcgm_device_pool.update_field_value(domain_idx);
 
                 for (auto &sv : m_signal_available) {
-                    if (sv.second.signals.at(domain_idx)->m_do_read) {
-                        sv.second.signals.at(domain_idx)->m_value =
+                    if (sv.second.m_signals.at(domain_idx)->m_do_read) {
+                        sv.second.m_signals.at(domain_idx)->m_value =
                             sv.second.m_devpool_func(domain_idx);
                     }
                 }
@@ -304,10 +304,10 @@ namespace geopm
     void DCGMIOGroup::write_batch(void)
     {
         for (auto &sv : m_control_available) {
-            for (unsigned int domain_idx = 0; domain_idx < sv.second.controls.size(); ++domain_idx) {
-                if (sv.second.controls.at(domain_idx)->m_is_adjusted) {
+            for (unsigned int domain_idx = 0; domain_idx < sv.second.m_controls.size(); ++domain_idx) {
+                if (sv.second.m_controls.at(domain_idx)->m_is_adjusted) {
                     write_control(sv.first, control_domain_type(sv.first), domain_idx,
-                                  sv.second.controls.at(domain_idx)->m_setting);
+                                  sv.second.m_controls.at(domain_idx)->m_setting);
                 }
             }
         }
@@ -414,20 +414,12 @@ namespace geopm
     // to adjust them
     void DCGMIOGroup::save_control(void)
     {
-        for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(
-             GEOPM_DOMAIN_BOARD); ++domain_idx) {
-            //TODO: Implement
-        }
     }
 
     // Implemented to allow an IOGroup to restore previously saved
     // platform settings
     void DCGMIOGroup::restore_control(void)
     {
-        for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(
-             GEOPM_DOMAIN_BOARD); ++domain_idx) {
-            //TODO: Implement
-        }
     }
 
     void DCGMIOGroup::save_control(const std::string &save_path)

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -394,7 +394,7 @@ namespace geopm
         }
 
         if (control_name == "DCGM::FIELD_UPDATE_RATE") {
-            m_dcgm_device_pool.field_update_rate(setting*1e3);
+            m_dcgm_device_pool.field_update_rate(setting*1e6);
         }
         else if (control_name == "DCGM::MAX_STORAGE_TIME") {
             m_dcgm_device_pool.max_storage_time(setting);

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -414,12 +414,17 @@ namespace geopm
     // to adjust them
     void DCGMIOGroup::save_control(void)
     {
+        // There is no explicit saved stated for this IOGroup.
+        // Prior to its usage no GEOPM specific DCGM field group
+        // should be in use/watched by DCGM.
     }
 
     // Implemented to allow an IOGroup to restore previously saved
     // platform settings
     void DCGMIOGroup::restore_control(void)
     {
+        // Restore the to 'saved' initial state of no
+        // GEOPM specific DCGM field group being watched
         m_dcgm_device_pool.polling_disable();
     }
 

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -131,6 +131,8 @@ namespace geopm
             }
             sv.second.signals = result;
         }
+        register_signal_alias("ACCELERATOR_COMPUTE_ACTIVITY", "DCGM::SM_ACTIVE");
+        register_signal_alias("ACCELERATOR_MEMORY_ACTIVITY", "DCGM::DRAM_ACTIVE");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {
@@ -386,19 +388,19 @@ namespace geopm
                             std::to_string(control_domain_type(control_name)),
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR)) {
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD)) {
             throw Exception("DCGMIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         if (control_name == "DCGM::FIELD_UPDATE_RATE") {
-            m_dcgm_device_pool.field_update_rate(domain_idx, setting*1e6);
+            m_dcgm_device_pool.field_update_rate(setting*1e3);
         }
         else if (control_name == "DCGM::MAX_STORAGE_TIME") {
-            m_dcgm_device_pool.max_storage_time(domain_idx, setting);
+            m_dcgm_device_pool.max_storage_time(setting);
         }
         else if (control_name == "DCGM::MAX_SAMPLES") {
-            m_dcgm_device_pool.max_samples(domain_idx, setting);
+            m_dcgm_device_pool.max_samples(setting);
         }
         else {
     #ifdef GEOPM_DEBUG

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -66,7 +66,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_dcgm_device_pool.field_value(
+                                      return this->m_dcgm_device_pool.sample_field_value(
                                                    domain_idx, geopm::DCGMDevicePool::M_SM_ACTIVE);
                                   },
                                   Agg::average,
@@ -77,7 +77,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_dcgm_device_pool.field_value(
+                                      return this->m_dcgm_device_pool.sample_field_value(
                                                    domain_idx, geopm::DCGMDevicePool::M_SM_OCCUPANCY);
                                   },
                                   Agg::average,
@@ -88,7 +88,7 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_dcgm_device_pool.field_value(
+                                      return this->m_dcgm_device_pool.sample_field_value(
                                                    domain_idx, geopm::DCGMDevicePool::M_DRAM_ACTIVE);
                                   },
                                   Agg::average,

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -427,14 +427,11 @@ namespace geopm
 
     void DCGMIOGroup::save_control(const std::string &save_path)
     {
-        throw Exception("DCGMIOGroup::save_control()",
-                        GEOPM_ERROR_NOT_IMPLEMENTED, __FILE__, __LINE__);
     }
 
     void DCGMIOGroup::restore_control(const std::string &save_path)
     {
-        throw Exception("DCGMIOGroup::restore_control()",
-                        GEOPM_ERROR_NOT_IMPLEMENTED, __FILE__, __LINE__);
+        restore_control();
     }
 
     // Hint to Agent about how to aggregate signals from this IOGroup
@@ -492,7 +489,7 @@ namespace geopm
     // Name used for registration with the IOGroup factory
     std::string DCGMIOGroup::plugin_name(void)
     {
-        return "dcgm";
+        return "DCGM";
     }
 
     // Function used by the factory to create objects of this type

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -420,9 +420,17 @@ namespace geopm
     // platform settings
     void DCGMIOGroup::restore_control(void)
     {
-        m_dcgm_device_pool.update_rate(1*1e6); //1 second
-        m_dcgm_device_pool.max_samples(0); //0 = no limit
-        m_dcgm_device_pool.max_storage_time(10); //10 seconds.
+        // The 1 second update rate used here is the default sample rate discussed
+        // in the DCGM user guide.
+        m_dcgm_device_pool.update_rate(1e6); //1 second
+
+        // The max samples restore value is based upon the defaults used in DCGM
+        // sdk example code for field value access provided as part of the DCGM install
+        m_dcgm_device_pool.max_samples(3600); //3600 samples
+
+        // The max storage time restore value is based upon the defaults used in DCGM
+        // sdk example code for field value access provided as part of the DCGM install
+        m_dcgm_device_pool.max_storage_time(3600); //3600 seconds
     }
 
     void DCGMIOGroup::save_control(const std::string &save_path)

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -66,8 +66,8 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_dcgm_device_pool.sample_field_value(
-                                                   domain_idx, geopm::DCGMDevicePool::M_SM_ACTIVE);
+                                      return this->m_dcgm_device_pool.sample(
+                                                   domain_idx, geopm::DCGMDevicePool::M_FIELD_ID_SM_ACTIVE);
                                   },
                                   Agg::average,
                                   string_format_double
@@ -77,8 +77,8 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_dcgm_device_pool.sample_field_value(
-                                                   domain_idx, geopm::DCGMDevicePool::M_SM_OCCUPANCY);
+                                      return this->m_dcgm_device_pool.sample(
+                                                   domain_idx, geopm::DCGMDevicePool::M_FIELD_ID_SM_OCCUPANCY);
                                   },
                                   Agg::average,
                                   string_format_double
@@ -88,8 +88,8 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return this->m_dcgm_device_pool.sample_field_value(
-                                                   domain_idx, geopm::DCGMDevicePool::M_DRAM_ACTIVE);
+                                      return this->m_dcgm_device_pool.sample(
+                                                   domain_idx, geopm::DCGMDevicePool::M_FIELD_ID_DRAM_ACTIVE);
                                   },
                                   Agg::average,
                                   string_format_double
@@ -116,7 +116,7 @@ namespace geopm
                               })
     {
         // confirm all DCGM devices correspond to a board_accelerator
-        if (m_dcgm_device_pool.dcgm_device() != m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR)) {
+        if (m_dcgm_device_pool.num_device() != m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR)) {
             throw Exception("DCGMIOGroup::" + std::string(__func__) + ": "
                             "DCGM enabled device count does not match BOARD_ACCELERATOR count",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -288,7 +288,7 @@ namespace geopm
             for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(
                  GEOPM_DOMAIN_BOARD_ACCELERATOR); ++domain_idx) {
 
-                m_dcgm_device_pool.update_field_value(domain_idx);
+                m_dcgm_device_pool.update(domain_idx);
 
                 for (auto &sv : m_signal_available) {
                     if (sv.second.m_signals.at(domain_idx)->m_do_read) {
@@ -360,7 +360,7 @@ namespace geopm
         }
 
         double result = NAN;
-        m_dcgm_device_pool.update_field_value(domain_idx);
+        m_dcgm_device_pool.update(domain_idx);
 
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {
@@ -394,7 +394,7 @@ namespace geopm
         }
 
         if (control_name == "DCGM::FIELD_UPDATE_RATE") {
-            m_dcgm_device_pool.field_update_rate(setting*1e6);
+            m_dcgm_device_pool.update_rate(setting*1e6);
         }
         else if (control_name == "DCGM::MAX_STORAGE_TIME") {
             m_dcgm_device_pool.max_storage_time(setting);
@@ -420,9 +420,8 @@ namespace geopm
     // platform settings
     void DCGMIOGroup::restore_control(void)
     {
-        m_dcgm_device_pool.field_update_rate(1*1e6); //1 second
+        m_dcgm_device_pool.update_rate(1*1e6); //1 second
         m_dcgm_device_pool.max_samples(0); //0 = no limit
-        // TODO: determine better default
         m_dcgm_device_pool.max_storage_time(10); //10 seconds.
     }
 

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -420,6 +420,10 @@ namespace geopm
     // platform settings
     void DCGMIOGroup::restore_control(void)
     {
+        m_dcgm_device_pool.field_update_rate(1*1e6); //1 second
+        m_dcgm_device_pool.max_samples(0); //0 = no limit
+        // TODO: determine better default
+        m_dcgm_device_pool.max_storage_time(10); //10 seconds.
     }
 
     void DCGMIOGroup::save_control(const std::string &save_path)

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -131,8 +131,8 @@ namespace geopm
             }
             sv.second.m_signals = result;
         }
-        register_signal_alias("ACCELERATOR_COMPUTE_ACTIVITY", "DCGM::SM_ACTIVE");
-        register_signal_alias("ACCELERATOR_MEMORY_ACTIVITY", "DCGM::DRAM_ACTIVE");
+        register_signal_alias("GPU_COMPUTE_ACTIVITY", "DCGM::SM_ACTIVE");
+        register_signal_alias("GPU_MEMORY_ACTIVITY", "DCGM::DRAM_ACTIVE");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {

--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -494,6 +494,11 @@ namespace geopm
         return IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE;
     }
 
+    std::string DCGMIOGroup::name(void) const
+    {
+        return plugin_name();
+    }
+
     // Name used for registration with the IOGroup factory
     std::string DCGMIOGroup::plugin_name(void)
     {

--- a/service/src/DCGMIOGroup.hpp
+++ b/service/src/DCGMIOGroup.hpp
@@ -75,6 +75,7 @@ namespace geopm
             int signal_behavior(const std::string &signal_name) const override;
             void save_control(const std::string &save_path) override;
             void restore_control(const std::string &save_path) override;
+            std::string name(void) const override;
             static std::string plugin_name(void);
             static std::unique_ptr<geopm::IOGroup> make_plugin(void);
         private:

--- a/service/src/DCGMIOGroup.hpp
+++ b/service/src/DCGMIOGroup.hpp
@@ -99,7 +99,7 @@ namespace geopm
 
             struct signal_info {
                 std::string m_description;
-                std::vector<std::shared_ptr<signal_s> > signals;
+                std::vector<std::shared_ptr<signal_s> > m_signals;
                 std::function<double (unsigned int)> m_devpool_func;
                 std::function<double(const std::vector<double> &)> m_agg_function;
                 std::function<std::string(double)> m_format_function;
@@ -107,7 +107,7 @@ namespace geopm
 
             struct control_info {
                 std::string m_description;
-                std::vector<std::shared_ptr<control_s> > controls;
+                std::vector<std::shared_ptr<control_s> > m_controls;
                 std::function<double(const std::vector<double> &)> m_agg_function;
                 std::function<std::string(double)> m_format_function;
             };

--- a/service/src/DCGMIOGroup.hpp
+++ b/service/src/DCGMIOGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2021, Intel Corporation
+ * Copyright (c) 2015 - 2022, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,7 +58,7 @@ namespace geopm
             bool is_valid_control(const std::string &control_name) const override;
             int signal_domain_type(const std::string &signal_name) const override;
             int control_domain_type(const std::string &control_name) const override;
-            int push_signal(const std::string &signal_name, int domain_type, int domain_idx)  override;
+            int push_signal(const std::string &signal_name, int domain_type, int domain_idx) override;
             int push_control(const std::string &control_name, int domain_type, int domain_idx) override;
             void read_batch(void) override;
             void write_batch(void) override;

--- a/service/src/DCGMIOGroup.hpp
+++ b/service/src/DCGMIOGroup.hpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DCGMIOGROUP_HPP_INCLUDE
+#define DCGMIOGROUP_HPP_INCLUDE
+
+#include <map>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "geopm/IOGroup.hpp"
+
+namespace geopm
+{
+    class PlatformTopo;
+    class DCGMDevicePool;
+
+    /// @brief IOGroup that provides signals and controls for DCGM Accelerators
+    class DCGMIOGroup : public IOGroup
+    {
+        public:
+            DCGMIOGroup();
+            DCGMIOGroup(const PlatformTopo &platform_topo, DCGMDevicePool &device_pool);
+            ~DCGMIOGroup();
+            std::set<std::string> signal_names(void) const override;
+            std::set<std::string> control_names(void) const override;
+            bool is_valid_signal(const std::string &signal_name) const override;
+            bool is_valid_control(const std::string &control_name) const override;
+            int signal_domain_type(const std::string &signal_name) const override;
+            int control_domain_type(const std::string &control_name) const override;
+            int push_signal(const std::string &signal_name, int domain_type, int domain_idx)  override;
+            int push_control(const std::string &control_name, int domain_type, int domain_idx) override;
+            void read_batch(void) override;
+            void write_batch(void) override;
+            double sample(int batch_idx) override;
+            void adjust(int batch_idx, double setting) override;
+            double read_signal(const std::string &signal_name, int domain_type, int domain_idx) override;
+            void write_control(const std::string &control_name, int domain_type, int domain_idx, double setting) override;
+            void save_control(void) override;
+            void restore_control(void) override;
+            std::function<double(const std::vector<double> &)> agg_function(const std::string &signal_name) const override;
+            std::function<std::string(double)> format_function(const std::string &signal_name) const override;
+            std::string signal_description(const std::string &signal_name) const override;
+            std::string control_description(const std::string &control_name) const override;
+            int signal_behavior(const std::string &signal_name) const override;
+            void save_control(const std::string &save_path) override;
+            void restore_control(const std::string &save_path) override;
+            static std::string plugin_name(void);
+            static std::unique_ptr<geopm::IOGroup> make_plugin(void);
+        private:
+            void register_signal_alias(const std::string &alias_name, const std::string &signal_name);
+            void register_control_alias(const std::string &alias_name, const std::string &control_name);
+
+            const PlatformTopo &m_platform_topo;
+            DCGMDevicePool &m_dcgm_device_pool;
+            bool m_is_batch_read;
+
+            struct signal_s
+            {
+                double m_value;
+                bool m_do_read;
+            };
+
+            struct control_s
+            {
+                double m_setting;
+                bool m_is_adjusted;
+            };
+
+            struct signal_info {
+                std::string m_description;
+                std::vector<std::shared_ptr<signal_s> > signals;
+                std::function<double (unsigned int)> m_devpool_func;
+                std::function<double(const std::vector<double> &)> m_agg_function;
+                std::function<std::string(double)> m_format_function;
+            };
+
+            struct control_info {
+                std::string m_description;
+                std::vector<std::shared_ptr<control_s> > controls;
+                std::function<double(const std::vector<double> &)> m_agg_function;
+                std::function<std::string(double)> m_format_function;
+            };
+
+            std::map<std::string, signal_info> m_signal_available;
+            std::map<std::string, control_info> m_control_available;
+            std::vector<std::shared_ptr<signal_s> > m_signal_pushed;
+            std::vector<std::shared_ptr<control_s> > m_control_pushed;
+    };
+}
+#endif

--- a/service/src/IOGroup.cpp
+++ b/service/src/IOGroup.cpp
@@ -51,6 +51,9 @@
 #ifdef GEOPM_CNL_IOGROUP
 #include "CNLIOGroup.hpp"
 #endif
+#ifdef GEOPM_ENABLE_DCGM
+#include "DCGMIOGroup.hpp"
+#endif
 #ifdef GEOPM_ENABLE_NVML
 #include "NVMLIOGroup.hpp"
 #endif
@@ -128,6 +131,10 @@ namespace geopm
 #ifdef GEOPM_CNL_IOGROUP
         register_plugin(CNLIOGroup::plugin_name(),
                         CNLIOGroup::make_plugin);
+#endif
+#ifdef GEOPM_ENABLE_DCGM
+        register_plugin(DCGMIOGroup::plugin_name(),
+                        DCGMIOGroup::make_plugin);
 #endif
 #ifdef GEOPM_ENABLE_NVML
         register_plugin(NVMLIOGroup::plugin_name(),

--- a/service/test/DCGMIOGroupTest.cpp
+++ b/service/test/DCGMIOGroupTest.cpp
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <unistd.h>
+#include <limits.h>
+
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "config.h"
+#include "geopm/Helper.hpp"
+#include "geopm/Exception.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm/PluginFactory.hpp"
+#include "DCGMIOGroup.hpp"
+#include "geopm_test.hpp"
+#include "MockDCGMDevicePool.hpp"
+#include "MockPlatformTopo.hpp"
+
+using geopm::DCGMIOGroup;
+using geopm::PlatformTopo;
+using geopm::Exception;
+using testing::Return;
+
+class DCGMIOGroupTest : public :: testing :: Test
+{
+    protected:
+        void SetUp();
+        void TearDown();
+        void write_affinitization(const std::string &affinitization_str);
+
+        std::shared_ptr<MockDCGMDevicePool> m_device_pool;
+        std::unique_ptr<MockPlatformTopo> m_platform_topo;
+};
+
+void DCGMIOGroupTest::SetUp()
+{
+    const int num_board = 1;
+    const int num_package = 2;
+    const int num_board_accelerator = 4;
+    const int num_core = 20;
+    const int num_cpu = 40;
+
+    m_device_pool = std::make_shared<MockDCGMDevicePool>();
+    m_platform_topo = geopm::make_unique<MockPlatformTopo>();
+
+    //Platform Topo prep
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD))
+        .WillByDefault(Return(num_board));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .WillByDefault(Return(num_package));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR))
+        .WillByDefault(Return(num_board_accelerator));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_CPU))
+        .WillByDefault(Return(num_cpu));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_CORE))
+        .WillByDefault(Return(num_core));
+
+    for (int cpu_idx = 0; cpu_idx < num_cpu; ++cpu_idx) {
+        if (cpu_idx < 10) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(0));
+        }
+        else if (cpu_idx < 20) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(1));
+        }
+        else if (cpu_idx < 30) {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(2));
+        }
+        else {
+            ON_CALL(*m_platform_topo, domain_idx(GEOPM_DOMAIN_BOARD_ACCELERATOR, cpu_idx))
+                .WillByDefault(Return(3));
+        }
+    }
+
+    EXPECT_CALL(*m_device_pool, dcgm_device()).WillRepeatedly(Return(num_board_accelerator));
+}
+
+void DCGMIOGroupTest::TearDown()
+{
+}
+
+TEST_F(DCGMIOGroupTest, valid_signals)
+{
+    DCGMIOGroup dcgm_io(*m_platform_topo, *m_device_pool);
+    for (const auto &sig : dcgm_io.signal_names()) {
+        EXPECT_TRUE(dcgm_io.is_valid_signal(sig));
+        EXPECT_NE(GEOPM_DOMAIN_INVALID, dcgm_io.signal_domain_type(sig));
+        EXPECT_LT(-1, dcgm_io.signal_behavior(sig));
+    }
+}
+
+TEST_F(DCGMIOGroupTest, push_control_adjust_write_batch)
+{
+    std::map<int, double> batch_value;
+    DCGMIOGroup dcgm_io(*m_platform_topo, *m_device_pool);
+
+    double mock_rate = 100;
+    double mock_time = 6000;
+    double mock_samples = 60000;
+
+    batch_value[(dcgm_io.push_control("DCGM::FIELD_UPDATE_RATE",
+                                    GEOPM_DOMAIN_BOARD, 0))] = mock_rate;
+    EXPECT_CALL(*m_device_pool,
+                field_update_rate(mock_rate*1e3)).Times(1);
+
+    batch_value[(dcgm_io.push_control("DCGM::MAX_STORAGE_TIME",
+                                    GEOPM_DOMAIN_BOARD, 0))] = mock_time;
+    EXPECT_CALL(*m_device_pool,
+                max_storage_time(mock_time)).Times(1);
+
+    batch_value[(dcgm_io.push_control("DCGM::MAX_SAMPLES",
+                                    GEOPM_DOMAIN_BOARD, 0))] = mock_samples;
+    EXPECT_CALL(*m_device_pool,
+                max_samples(mock_samples)).Times(1);
+
+    for (auto& sv: batch_value) {
+        // Given that we are mocking dcgmDevicePool the actual setting here doesn't matter
+        EXPECT_NO_THROW(dcgm_io.adjust(sv.first, sv.second));
+    }
+    EXPECT_NO_THROW(dcgm_io.write_batch());
+}
+
+TEST_F(DCGMIOGroupTest, write_control)
+{
+    DCGMIOGroup dcgm_io(*m_platform_topo, *m_device_pool);
+
+    double mock_rate = 100;
+    double mock_time = 6000;
+    double mock_samples = 60000;
+
+    EXPECT_CALL(*m_device_pool,
+                field_update_rate(mock_rate*1e3)).Times(1);
+    EXPECT_NO_THROW(dcgm_io.write_control("DCGM::FIELD_UPDATE_RATE",
+                                          GEOPM_DOMAIN_BOARD, 0,
+                                          mock_rate));
+
+    EXPECT_CALL(*m_device_pool,
+                max_storage_time(mock_time)).Times(1);
+    EXPECT_NO_THROW(dcgm_io.write_control("DCGM::MAX_STORAGE_TIME",
+                                          GEOPM_DOMAIN_BOARD, 0,
+                                          mock_time));
+
+    EXPECT_CALL(*m_device_pool,
+                max_samples(mock_samples)).Times(1);
+    EXPECT_NO_THROW(dcgm_io.write_control("DCGM::MAX_SAMPLES",
+                                          GEOPM_DOMAIN_BOARD, 0,
+                                          mock_samples));
+}
+
+TEST_F(DCGMIOGroupTest, read_signal_and_batch)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+
+    std::vector<double> mock_sm_active = {1, 0.75, 0.5, 0.25};
+    std::vector<double> mock_sm_occupancy = {0.8, 0.64, 0.35, 0.27};
+    std::vector<double> mock_dram_active = {0, 0.78, 0.11, 0.33};
+    std::vector<int> batch_idx;
+
+    DCGMIOGroup dcgm_io(*m_platform_topo, *m_device_pool);
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
+    }
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        batch_idx.push_back(dcgm_io.push_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+    }
+    dcgm_io.read_batch();
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double sm = dcgm_io.read_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double sm_batch = dcgm_io.sample(batch_idx.at(accel_idx));
+
+        EXPECT_DOUBLE_EQ(sm, mock_sm_active.at(accel_idx));
+        EXPECT_DOUBLE_EQ(sm, sm_batch);
+    }
+
+    mock_sm_active = {0.9, 0.45, 0.3, 0.29};
+    //second round of testing with a modified value
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
+    }
+    dcgm_io.read_batch();
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double sm = dcgm_io.read_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double sm_batch = dcgm_io.sample(batch_idx.at(accel_idx));
+
+        EXPECT_DOUBLE_EQ(sm, (mock_sm_active.at(accel_idx)));
+        EXPECT_DOUBLE_EQ(sm, sm_batch);
+    }
+}
+
+TEST_F(DCGMIOGroupTest, read_signal)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+
+    std::vector<double> mock_sm_active = {1, 0.75, 0.5, 0.25};
+    std::vector<double> mock_sm_occupancy = {0.8, 0.64, 0.35, 0.27};
+    std::vector<double> mock_dram_active = {0, 0.78, 0.11, 0.33};
+
+    std::vector<int> active_process_list = {40961, 40962, 40963};
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_SM_OCCUPANCY)).WillRepeatedly(Return(mock_sm_occupancy.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_DRAM_ACTIVE)).WillRepeatedly(Return(mock_dram_active.at(accel_idx)));;
+    }
+
+    DCGMIOGroup dcgm_io(*m_platform_topo, *m_device_pool);
+
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        double sm_active = dcgm_io.read_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double sm_active_alias = dcgm_io.read_signal("ACCELERATOR_COMPUTE_ACTIVITY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(sm_active, sm_active_alias);
+        EXPECT_DOUBLE_EQ(sm_active, mock_sm_active.at(accel_idx));
+
+        double sm_occupancy = dcgm_io.read_signal("DCGM::SM_OCCUPANCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(sm_occupancy, mock_sm_occupancy.at(accel_idx));
+
+        double dram_active = dcgm_io.read_signal("DCGM::DRAM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double dram_active_alias = dcgm_io.read_signal("ACCELERATOR_MEMORY_ACTIVITY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        EXPECT_DOUBLE_EQ(dram_active, dram_active_alias);
+        EXPECT_DOUBLE_EQ(dram_active, mock_dram_active.at(accel_idx));
+    }
+}
+
+//Test case: Error path testing including:
+//              - Attempt to push a signal at an invalid domain level
+//              - Attempt to push an invalid signal
+//              - Attempt to sample without a read_batch prior
+//              - Attempt to read a signal at an invalid domain level
+//              - Attempt to push a control at an invalid domain level
+//              - Attempt to adjust a non-existent batch index
+//              - Attempt to write a control at an invalid domain level
+TEST_F(DCGMIOGroupTest, error_path)
+{
+    const int num_accelerator = m_platform_topo->num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR);
+
+    std::vector<int> batch_idx;
+
+    std::vector<double> mock_sm_active = {0.22, 0.79, 0.65, 0.37};
+    for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
+        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
+    }
+
+    EXPECT_CALL(*m_device_pool, dcgm_device()).WillOnce(Return(num_accelerator-1));
+    GEOPM_EXPECT_THROW_MESSAGE(DCGMIOGroup dcgm_io_fail(*m_platform_topo, *m_device_pool), GEOPM_ERROR_INVALID, "DCGM enabled device count does not match BOARD_ACCELERATOR count");
+    EXPECT_CALL(*m_device_pool, dcgm_device()).WillRepeatedly(Return(num_accelerator));
+
+    DCGMIOGroup dcgm_io(*m_platform_topo, *m_device_pool);
+
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.push_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.sample(0),
+                               GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.read_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.push_signal("DCGM::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "signal_name DCGM::INVALID not valid for DCGMIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.read_signal("DCGM::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "DCGM::INVALID not valid for DCGMIOGroup");
+
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.push_control("DCGM::FIELD_UPDATE_RATE", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.adjust(0, 12345.6),
+                               GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.write_control("DCGM::FIELD_UPDATE_RATE", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_type must be");
+
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.push_control("DCGM::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, "control_name DCGM::INVALID not valid for DCGMIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.write_control("DCGM::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0, 1530000000),
+                               GEOPM_ERROR_INVALID, "DCGM::INVALID not valid for DCGMIOGroup");
+
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.push_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.push_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.read_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.read_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.push_control("DCGM::MAX_SAMPLES", GEOPM_DOMAIN_BOARD, num_accelerator),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.push_control("DCGM::MAX_SAMPLES", GEOPM_DOMAIN_BOARD, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.write_control("DCGM::MAX_SAMPLES", GEOPM_DOMAIN_BOARD, num_accelerator, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(dcgm_io.write_control("DCGM::MAX_SAMPLES", GEOPM_DOMAIN_BOARD, -1, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+}

--- a/service/test/DCGMIOGroupTest.cpp
+++ b/service/test/DCGMIOGroupTest.cpp
@@ -137,7 +137,7 @@ TEST_F(DCGMIOGroupTest, push_control_adjust_write_batch)
     batch_value[(dcgm_io.push_control("DCGM::FIELD_UPDATE_RATE",
                                     GEOPM_DOMAIN_BOARD, 0))] = mock_rate;
     EXPECT_CALL(*m_device_pool,
-                field_update_rate(mock_rate*1e3)).Times(1);
+                field_update_rate(mock_rate*1e6)).Times(1);
 
     batch_value[(dcgm_io.push_control("DCGM::MAX_STORAGE_TIME",
                                     GEOPM_DOMAIN_BOARD, 0))] = mock_time;
@@ -165,7 +165,7 @@ TEST_F(DCGMIOGroupTest, write_control)
     double mock_samples = 60000;
 
     EXPECT_CALL(*m_device_pool,
-                field_update_rate(mock_rate*1e3)).Times(1);
+                field_update_rate(mock_rate*1e6)).Times(1);
     EXPECT_NO_THROW(dcgm_io.write_control("DCGM::FIELD_UPDATE_RATE",
                                           GEOPM_DOMAIN_BOARD, 0,
                                           mock_rate));

--- a/service/test/DCGMIOGroupTest.cpp
+++ b/service/test/DCGMIOGroupTest.cpp
@@ -244,7 +244,7 @@ TEST_F(DCGMIOGroupTest, read_signal)
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         double sm_active = dcgm_io.read_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        double sm_active_alias = dcgm_io.read_signal("ACCELERATOR_COMPUTE_ACTIVITY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double sm_active_alias = dcgm_io.read_signal("GPU_COMPUTE_ACTIVITY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(sm_active, sm_active_alias);
         EXPECT_DOUBLE_EQ(sm_active, mock_sm_active.at(accel_idx));
 
@@ -252,7 +252,7 @@ TEST_F(DCGMIOGroupTest, read_signal)
         EXPECT_DOUBLE_EQ(sm_occupancy, mock_sm_occupancy.at(accel_idx));
 
         double dram_active = dcgm_io.read_signal("DCGM::DRAM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        double dram_active_alias = dcgm_io.read_signal("ACCELERATOR_MEMORY_ACTIVITY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double dram_active_alias = dcgm_io.read_signal("GPU_MEMORY_ACTIVITY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(dram_active, dram_active_alias);
         EXPECT_DOUBLE_EQ(dram_active, mock_dram_active.at(accel_idx));
     }

--- a/service/test/DCGMIOGroupTest.cpp
+++ b/service/test/DCGMIOGroupTest.cpp
@@ -137,7 +137,7 @@ TEST_F(DCGMIOGroupTest, push_control_adjust_write_batch)
     batch_value[(dcgm_io.push_control("DCGM::FIELD_UPDATE_RATE",
                                     GEOPM_DOMAIN_BOARD, 0))] = mock_rate;
     EXPECT_CALL(*m_device_pool,
-                update_rate(mock_rate*1e6)).Times(1);
+                update_rate(mock_rate * 1e6)).Times(1);
 
     batch_value[(dcgm_io.push_control("DCGM::MAX_STORAGE_TIME",
                                     GEOPM_DOMAIN_BOARD, 0))] = mock_time;
@@ -145,7 +145,7 @@ TEST_F(DCGMIOGroupTest, push_control_adjust_write_batch)
                 max_storage_time(mock_time)).Times(1);
 
     batch_value[(dcgm_io.push_control("DCGM::MAX_SAMPLES",
-                                    GEOPM_DOMAIN_BOARD, 0))] = mock_samples;
+                 GEOPM_DOMAIN_BOARD, 0))] = mock_samples;
     EXPECT_CALL(*m_device_pool,
                 max_samples(mock_samples)).Times(1);
 
@@ -165,7 +165,7 @@ TEST_F(DCGMIOGroupTest, write_control)
     double mock_samples = 60000;
 
     EXPECT_CALL(*m_device_pool,
-                update_rate(mock_rate*1e6)).Times(1);
+                update_rate(mock_rate * 1e6)).Times(1);
     EXPECT_NO_THROW(dcgm_io.write_control("DCGM::FIELD_UPDATE_RATE",
                                           GEOPM_DOMAIN_BOARD, 0,
                                           mock_rate));

--- a/service/test/DCGMIOGroupTest.cpp
+++ b/service/test/DCGMIOGroupTest.cpp
@@ -195,7 +195,7 @@ TEST_F(DCGMIOGroupTest, read_signal_and_batch)
     DCGMIOGroup dcgm_io(*m_platform_topo, *m_device_pool);
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, sample_field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
     }
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         batch_idx.push_back(dcgm_io.push_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
@@ -212,7 +212,7 @@ TEST_F(DCGMIOGroupTest, read_signal_and_batch)
     mock_sm_active = {0.9, 0.45, 0.3, 0.29};
     //second round of testing with a modified value
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, sample_field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
     }
     dcgm_io.read_batch();
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
@@ -235,9 +235,9 @@ TEST_F(DCGMIOGroupTest, read_signal)
     std::vector<int> active_process_list = {40961, 40962, 40963};
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
-        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_SM_OCCUPANCY)).WillRepeatedly(Return(mock_sm_occupancy.at(accel_idx)));
-        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_DRAM_ACTIVE)).WillRepeatedly(Return(mock_dram_active.at(accel_idx)));;
+        EXPECT_CALL(*m_device_pool, sample_field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, sample_field_value(accel_idx, geopm::DCGMDevicePool::M_SM_OCCUPANCY)).WillRepeatedly(Return(mock_sm_occupancy.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, sample_field_value(accel_idx, geopm::DCGMDevicePool::M_DRAM_ACTIVE)).WillRepeatedly(Return(mock_dram_active.at(accel_idx)));;
     }
 
     DCGMIOGroup dcgm_io(*m_platform_topo, *m_device_pool);
@@ -274,7 +274,7 @@ TEST_F(DCGMIOGroupTest, error_path)
 
     std::vector<double> mock_sm_active = {0.22, 0.79, 0.65, 0.37};
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        EXPECT_CALL(*m_device_pool, field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
+        EXPECT_CALL(*m_device_pool, sample_field_value(accel_idx, geopm::DCGMDevicePool::M_SM_ACTIVE)).WillRepeatedly(Return(mock_sm_active.at(accel_idx)));
     }
 
     EXPECT_CALL(*m_device_pool, dcgm_device()).WillOnce(Return(num_accelerator-1));

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -97,6 +97,12 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/CpuinfoIOGroupTest.push_signal \
               test/gtest_links/CpuinfoIOGroupTest.read_signal \
               test/gtest_links/CpuinfoIOGroupTest.valid_signals \
+              test/gtest_links/DCGMIOGroupTest.read_signal \
+              test/gtest_links/DCGMIOGroupTest.read_signal_and_batch \
+              test/gtest_links/DCGMIOGroupTest.write_control \
+              test/gtest_links/DCGMIOGroupTest.push_control_adjust_write_batch \
+              test/gtest_links/DCGMIOGroupTest.error_path \
+              test/gtest_links/DCGMIOGroupTest.valid_signals \
               test/gtest_links/DerivativeSignalTest.errors \
               test/gtest_links/DerivativeSignalTest.read_batch_flat \
               test/gtest_links/DerivativeSignalTest.read_batch_first \
@@ -366,6 +372,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/CNLIOGroupTest.cpp \
                           test/CombinedSignalTest.cpp \
                           test/CpuinfoIOGroupTest.cpp \
+                          test/DCGMIOGroupTest.cpp \
                           test/DerivativeSignalTest.cpp \
                           test/DifferenceSignalTest.cpp \
                           test/DomainControlTest.cpp \
@@ -386,6 +393,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/MockBatchClient.hpp \
                           test/MockBatchStatus.hpp \
                           test/MockControl.hpp \
+                          test/MockDCGMDevicePool.hpp \
                           test/MockIOGroup.hpp \
                           test/MockMSRIO.hpp \
                           test/MockNVMLDevicePool.hpp \

--- a/service/test/MockDCGMDevicePool.hpp
+++ b/service/test/MockDCGMDevicePool.hpp
@@ -41,7 +41,7 @@ class MockDCGMDevicePool : public geopm::DCGMDevicePool
 {
     public:
         MOCK_METHOD(int, dcgm_device, (), (const, override));
-        MOCK_METHOD(double, field_value, (int, int), (const, override));
+        MOCK_METHOD(double, sample_field_value, (int, int), (const, override));
         MOCK_METHOD(void, update_field_value, (int), (override));
         MOCK_METHOD(void, field_update_rate, (int), (override));
         MOCK_METHOD(void, max_storage_time, (int), (override));

--- a/service/test/MockDCGMDevicePool.hpp
+++ b/service/test/MockDCGMDevicePool.hpp
@@ -46,6 +46,8 @@ class MockDCGMDevicePool : public geopm::DCGMDevicePool
         MOCK_METHOD(void, update_rate, (int), (override));
         MOCK_METHOD(void, max_storage_time, (int), (override));
         MOCK_METHOD(void, max_samples, (int), (override));
+        MOCK_METHOD(void, polling_enable, (), (override));
+        MOCK_METHOD(void, polling_disable, (), (override));
 };
 
 #endif

--- a/service/test/MockDCGMDevicePool.hpp
+++ b/service/test/MockDCGMDevicePool.hpp
@@ -40,10 +40,10 @@
 class MockDCGMDevicePool : public geopm::DCGMDevicePool
 {
     public:
-        MOCK_METHOD(int, dcgm_device, (), (const, override));
-        MOCK_METHOD(double, sample_field_value, (int, int), (const, override));
-        MOCK_METHOD(void, update_field_value, (int), (override));
-        MOCK_METHOD(void, field_update_rate, (int), (override));
+        MOCK_METHOD(int, num_device, (), (const, override));
+        MOCK_METHOD(double, sample, (int, int), (const, override));
+        MOCK_METHOD(void, update, (int), (override));
+        MOCK_METHOD(void, update_rate, (int), (override));
         MOCK_METHOD(void, max_storage_time, (int), (override));
         MOCK_METHOD(void, max_samples, (int), (override));
 };

--- a/service/test/MockDCGMDevicePool.hpp
+++ b/service/test/MockDCGMDevicePool.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MOCKDCGMDEVICEPOOL_HPP_INCLUDE
+#define MOCKDCGMDEVICEPOOL_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "DCGMDevicePool.hpp"
+
+class MockDCGMDevicePool : public geopm::DCGMDevicePool
+{
+    public:
+        MOCK_METHOD(int, dcgm_device, (), (const, override));
+        MOCK_METHOD(double, field_value, (int, int), (const, override));
+        MOCK_METHOD(void, update_field_value, (int), (override));
+        MOCK_METHOD(void, field_update_rate, (int), (override));
+        MOCK_METHOD(void, max_storage_time, (int), (override));
+        MOCK_METHOD(void, max_samples, (int), (override));
+};
+
+#endif


### PR DESCRIPTION
Signed-off-by: lowren.h.lawson@intel.com <lowren.h.lawson@intel.com>

Addition of a DCGM IOGroup that connects to a local standalone nv-hostengine in order to provide NVIDIA Profiling metrics.
Requires PR #1917 

Details of change
- Fulfills Feature #1902 from github issues.
- Fixes Issue #1903 from github issues.

Remaining opens:
- [ ] Save/Restore of sample rate.  This is complicated by not having a clear way to query these values - we can reset to default values (1s, etc) or the agent preferred values (100ms, etc)