### PR TITLE
Addition of DCGMDevicePool for NVIDIA Profiling Metrics

### DIFF
--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -161,6 +161,7 @@ libgeopmd_la_SOURCES = $(include_HEADERS) \
                        src/DerivativeSignal.hpp \
                        src/DifferenceSignal.cpp \
                        src/DifferenceSignal.hpp \
+                       src/DCGMDevicePool.hpp \
                        src/DomainControl.cpp \
                        src/DomainControl.hpp \
                        src/Exception.cpp \
@@ -262,10 +263,13 @@ levelzero_source_files = src/LevelZero.cpp \
                          src/LevelZero.hpp \
                          #end
 
+dcgm_source_files = src/DCGMDevicePool.cpp \
+                    src/DCGMDevicePoolImp.hpp \
+                    #end
+
 if ENABLE_LEVELZERO
     libgeopmd_la_SOURCES += $(levelzero_source_files)
     EXTRA_DIST += src/LevelZeroThrow.cpp
-
 else
     libgeopmd_la_SOURCES += src/LevelZeroThrow.cpp
     EXTRA_DIST += $(levelzero_source_files)
@@ -277,6 +281,14 @@ if ENABLE_NVML
 else
     libgeopmd_la_SOURCES += src/NVMLDevicePoolThrow.cpp
     EXTRA_DIST += $(nvml_source_files)
+endif
+
+if ENABLE_DCGM
+    libgeopmd_la_SOURCES += $(dcgm_source_files)
+    EXTRA_DIST += src/DCGMDevicePoolThrow.cpp
+else
+    libgeopmd_la_SOURCES += src/DCGMDevicePoolThrow.cpp
+    EXTRA_DIST += $(dcgm_source_files)
 endif
 
 io.github.geopm.xml:

--- a/service/configure.ac
+++ b/service/configure.ac
@@ -122,6 +122,19 @@ fi
 AC_SUBST([enable_nvml])
 AM_CONDITIONAL([ENABLE_NVML], [test "x$enable_nvml" = "x1"])
 
+AC_ARG_ENABLE([dcgm],
+  [AS_HELP_STRING([--enable-dcgm], [Enables use of the DCGM library to support NVIDIA board accelerators])],
+[if test "x$enable_dcgm" = "xno" ; then
+  enable_dcgm="0"
+else
+  enable_dcgm="1"
+fi
+],
+[enable_dcgm="0"]
+)
+AC_SUBST([enable_dcgm])
+AM_CONDITIONAL([ENABLE_DCGM], [test "x$enable_dcgm" = "x1"])
+
 AC_ARG_ENABLE([cnl-iogroup],
   [AS_HELP_STRING([--enable-cnl-iogroup], [Enable the CNL IOGroup])],
 [if test "x$enable_cnl_iogroup" = "xno" ; then
@@ -148,6 +161,11 @@ if test "x$enable_coverage" = "x1" ; then
 fi
 AC_SUBST([enable_coverage])
 
+if test "x$enable_dcgm" = "x1" ; then
+  ENABLE_DCGM=True
+  AC_DEFINE([GEOPM_ENABLE_DCGM], [ ], [Enables use of the DCGM library to support NVIDA board accelerators])
+fi
+
 if test "x$enable_nvml" = "x1" ; then
   ENABLE_NVML=True
   AC_DEFINE([GEOPM_ENABLE_NVML], [ ], [Enables use of the NVML library to support NVML board accelerators])
@@ -172,6 +190,14 @@ if test "x$with_nvml" != x; then
   EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -I$with_nvml/include"
   LD_LIBRARY_PATH="$with_nvml/lib:$LD_LIBRARY_PATH"
   EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L$with_nvml/lib"
+fi
+
+AC_ARG_WITH([dcgm], [AS_HELP_STRING([--with-dcgm=PATH],
+            [specify directory for installed dcgm package.])])
+if test "x$with_dcgm" != x; then
+  EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -I$with_dcgm/include"
+  LD_LIBRARY_PATH="$with_dcgm/lib64:$LD_LIBRARY_PATH"
+  EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L$with_dcgm/lib64"
 fi
 
 AC_ARG_WITH([levelzero], [AS_HELP_STRING([--with-levelzero=PATH],
@@ -239,6 +265,16 @@ if test "x$enable_systemd" = "x1" ; then
         exit -1])
     AC_CHECK_HEADER([systemd/sd-bus.h], [], [
         echo "missing systemd/sd-bus.h: sd_bus interface is required"
+        exit -1])
+fi
+
+if test "x$enable_dcgm" = "x1" ; then
+    AC_SEARCH_LIBS([dcgmInit], [dcgm])
+    AC_CHECK_LIB([dcgm], [dcgmInit], [], [
+        echo "missing dcgm: DCGM library is required, use --with-dcgm to specify location"
+        exit -1])
+    AC_CHECK_HEADER([dcgm_structs.h], [], [
+        echo "missing dcgm_structs.h: DCGM headers are required, use --with-dcgm to specify location"
         exit -1])
 fi
 
@@ -350,6 +386,7 @@ AC_MSG_RESULT([GEOPM_CONFIG_PATH  : ${GEOPM_CONFIG_PATH}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([debug              : ${enable_debug}])
 AC_MSG_RESULT([coverage           : ${enable_coverage}])
+AC_MSG_RESULT([dcgm               : ${enable_dcgm}])
 AC_MSG_RESULT([nvml               : ${enable_nvml}])
 AC_MSG_RESULT([levelzero          : ${enable_levelzero}])
 AC_MSG_RESULT([===============================================================================])

--- a/service/src/DCGMDevicePool.cpp
+++ b/service/src/DCGMDevicePool.cpp
@@ -56,7 +56,7 @@ namespace geopm
     {
         m_dcgm_field_ids[M_FIELD_ID_SM_ACTIVE] = DCGM_FI_PROF_SM_ACTIVE;
         m_dcgm_field_ids[M_FIELD_ID_SM_OCCUPANCY] = DCGM_FI_PROF_SM_OCCUPANCY;
-        m_dcgm_field_ids[M_FIELD_ID_SM_DRAM_ACTIVE] = DCGM_FI_PROF_DRAM_ACTIVE;
+        m_dcgm_field_ids[M_FIELD_ID_DRAM_ACTIVE] = DCGM_FI_PROF_DRAM_ACTIVE;
 
         dcgmReturn_t result;
 
@@ -66,8 +66,7 @@ namespace geopm
 
         // We are assuming a local version of DCGM.  This could transition to a
         // dcgmStartEmbedded at a later date.
-        const char *host_ip = "127.0.0.1";
-        result = dcgmConnect(host_ip, &m_dcgm_handle);
+        result = dcgmConnect((char*)"127.0.0.1", &m_dcgm_handle);
         check_result(result, "Error connecting to standalone DCGM instance", __LINE__);
 
         //Check all devices are DCGM enabled
@@ -76,14 +75,14 @@ namespace geopm
         check_result(result, "Error fetching DCGM supported devices.", __LINE__);
 
         dcgmFieldValue_v1 init_val = {};
-        init_val.dbl = NAN;
+        init_val.value.dbl = NAN;
         init_val.status = DCGM_ST_UNINITIALIZED;
         std::vector<dcgmFieldValue_v1> field_values(M_NUM_FIELD_ID, init_val);
-        m_dgcm_field_values.resize(m_dcgm_dev_count, field_values)
+        m_dcgm_field_values.resize(m_dcgm_dev_count, field_values);
 
         //Setup Field Group
 
-        const char *geopm_group = "geopm_field_group";
+        char geopm_group[] = "geopm_field_group";
         result = dcgmFieldGroupCreate(m_dcgm_handle, M_NUM_FIELD_ID, m_dcgm_field_ids,
                                       geopm_group, &m_field_group_id);
 

--- a/service/src/DCGMDevicePool.cpp
+++ b/service/src/DCGMDevicePool.cpp
@@ -157,7 +157,7 @@ namespace geopm
         check_dcgm_result(result, "Error getting latest values for fields in read_batch", __LINE__);
     }
 
-    void DCGMDevicePoolImp::field_update_rate(int accel_idx, int field_update_rate)
+    void DCGMDevicePoolImp::field_update_rate(int field_update_rate)
     {
         dcgmReturn_t result;
         m_update_freq = field_update_rate;
@@ -166,7 +166,7 @@ namespace geopm
         check_dcgm_result(result, "Error setting Field Update Rate", __LINE__);
     }
 
-    void DCGMDevicePoolImp::max_storage_time(int accel_idx, int max_storage_time)
+    void DCGMDevicePoolImp::max_storage_time(int max_storage_time)
     {
         dcgmReturn_t result;
         m_max_keep_age = max_storage_time;
@@ -175,7 +175,7 @@ namespace geopm
         check_dcgm_result(result, "Error setting Max Storage Time", __LINE__);
     }
 
-    void DCGMDevicePoolImp::max_samples(int accel_idx, int max_samples)
+    void DCGMDevicePoolImp::max_samples(int max_samples)
     {
         dcgmReturn_t result;
         m_max_keep_sample = max_samples;

--- a/service/src/DCGMDevicePool.cpp
+++ b/service/src/DCGMDevicePool.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <cmath>
+
+#include <iostream>
+#include <string>
+
+#include "geopm/Exception.hpp"
+#include "DCGMDevicePoolImp.hpp"
+
+namespace geopm
+{
+
+    DCGMDevicePool &dcgm_device_pool()
+    {
+        static DCGMDevicePoolImp instance;
+        return instance;
+    }
+
+    DCGMDevicePoolImp::DCGMDevicePoolImp()
+        : m_update_freq(1000)    // 1 millisecond
+        , m_max_keep_age(1.0)    // 1 second
+        , m_max_keep_sample(100) // 100 samples
+    {
+        // Guarantee geopm_dcgm_field_ids_e order is used
+        m_dcgm_field_ids[M_SM_ACTIVE] = DCGM_FI_PROF_SM_ACTIVE;
+        m_dcgm_field_ids[M_SM_OCCUPANCY] = DCGM_FI_PROF_SM_OCCUPANCY;
+        m_dcgm_field_ids[M_DRAM_ACTIVE] = DCGM_FI_PROF_DRAM_ACTIVE;
+        m_dcgm_field_ids[M_PCIE_TX_BYTES] = DCGM_FI_PROF_PCIE_TX_BYTES;
+        m_dcgm_field_ids[M_PCIE_RX_BYTES] = DCGM_FI_PROF_PCIE_RX_BYTES;
+
+        dcgmReturn_t result;
+
+        //Initialize DCGM
+        result = dcgmInit();
+        check_dcgm_result(result, "Error Initializing DCGM.");
+
+        // We are assuming a local version of DCGM.  This could transition to a
+        // dcgmStartEmbedded at a later date.
+        char *host_ip = "127.0.0.1";
+        result = dcgmConnect(host_ip, &m_dcgm_handle);
+        check_dcgm_result(result, "Error connecting to standalone DCGM instance");
+
+        //Check all devices are DCGM enabled
+        unsigned int dcgm_dev_id_list[DCGM_MAX_NUM_DEVICES];
+        result = dcgmGetAllSupportedDevices(m_dcgm_handle, dcgm_dev_id_list, &m_dcgm_dev_count);
+        check_dcgm_result(result, "Error fetching DCGM supported devices.");
+
+        for(int i = 0; i < m_dcgm_dev_count; ++i) {
+            std::vector<dcgmFieldValue_v1> field_values(sizeof(m_dcgm_field_ids)/sizeof(m_dcgm_field_ids[0]));
+            m_dcgm_field_values.push_back(field_values);;
+        }
+
+        //Setup Field Group
+        result = dcgmFieldGroupCreate(m_dcgm_handle, sizeof(m_dcgm_field_ids)/sizeof(m_dcgm_field_ids[0]), &m_dcgm_field_ids[0],
+                                      (char *)"geopm_fields", &m_field_group_id);
+        check_dcgm_result(result, "Error creating DCGM geopm_fields group.");
+
+        // Note: Currently we are using dcgmWatchFields, but may transition to using
+        //       dcgmProfWatchFields at a later date
+        result = dcgmWatchFields(m_dcgm_handle, DCGM_GROUP_ALL_GPUS, m_field_group_id, m_update_freq,
+                                 m_max_keep_age, m_max_keep_sample);
+
+        check_dcgm_result(result, "Error setting default watch field configuration.");
+    }
+
+    DCGMDevicePoolImp::~DCGMDevicePoolImp()
+    {
+        //Shutdown DCGM
+        dcgmStatusDestroy(NULL);
+        dcgmGroupDestroy(m_dcgm_handle, DCGM_GROUP_ALL_GPUS);
+    }
+
+    void DCGMDevicePoolImp::check_dcgm_result(const dcgmReturn_t result, const std::string error)
+    {
+        if (result != DCGM_ST_OK) {
+            throw Exception("DCGMDevicePool::" + std::string(__func__) + ": "
+                            + error + ": " + errorString(result),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+
+    int DCGMDevicePoolImp::dcgm_device() const {
+        return m_dcgm_dev_count;
+    }
+
+    double DCGMDevicePoolImp::field_value(int accel_idx, int geopm_field_id) const {
+        double result;
+        result = m_dcgm_field_values.at(accel_idx).at(geopm_field_id).value.dbl;
+        return result;
+    }
+
+    void DCGMDevicePoolImp::update_field_value(int accel_idx)
+    {
+        dcgmReturn_t result;
+        result = dcgmGetLatestValuesForFields(m_dcgm_handle, accel_idx,
+                        &m_dcgm_field_ids[0], sizeof(m_dcgm_field_ids)/sizeof(m_dcgm_field_ids[0]),
+                        &(m_dcgm_field_values.at(accel_idx))[0]);
+        check_dcgm_result(result, "Error getting latest values for fields in read_batch");
+    }
+
+    void DCGMDevicePoolImp::field_update_rate(int accel_idx, int field_update_rate)
+    {
+        dcgmReturn_t result;
+        m_update_freq = field_update_rate;
+        result = dcgmWatchFields(m_dcgm_handle, DCGM_GROUP_ALL_GPUS, m_field_group_id, m_update_freq,
+                                 m_max_keep_age, m_max_keep_sample);
+        check_dcgm_result(result, "Error setting Field Update Rate");
+    }
+
+    void DCGMDevicePoolImp::max_storage_time(int accel_idx, int max_storage_time)
+    {
+        dcgmReturn_t result;
+        m_max_keep_age = max_storage_time;
+        result = dcgmWatchFields(m_dcgm_handle, DCGM_GROUP_ALL_GPUS, m_field_group_id, m_update_freq,
+                                 m_max_keep_age, m_max_keep_sample);
+        check_dcgm_result(result, "Error setting Max Storage Time");
+    }
+
+    void DCGMDevicePoolImp::max_samples(int accel_idx, int max_samples)
+    {
+        dcgmReturn_t result;
+        m_max_keep_sample = max_samples;
+        result = dcgmWatchFields(m_dcgm_handle, DCGM_GROUP_ALL_GPUS, m_field_group_id, m_update_freq,
+                                 m_max_keep_age, m_max_keep_sample);
+        check_dcgm_result(result, "Error setting Max Samples");
+    }
+}

--- a/service/src/DCGMDevicePool.cpp
+++ b/service/src/DCGMDevicePool.cpp
@@ -67,7 +67,7 @@ namespace geopm
 
         // We are assuming a local version of DCGM.  This could transition to a
         // dcgmStartEmbedded at a later date.
-        char *host_ip = "127.0.0.1";
+        char host_ip[] = "127.0.0.1";
         result = dcgmConnect(host_ip, &m_dcgm_handle);
         check_dcgm_result(result, "Error connecting to standalone DCGM instance", __LINE__);
 
@@ -144,7 +144,7 @@ namespace geopm
     double DCGMDevicePoolImp::sample_field_value(int accel_idx, int geopm_field_id) const {
         double result = NAN;
 
-        if (m_dcgm_field_values.at(accel_idx).at(geopm_field_id).status == DCGM_ST_OK); {
+        if (m_dcgm_field_values.at(accel_idx).at(geopm_field_id).status == DCGM_ST_OK) {
             result = m_dcgm_field_values.at(accel_idx).at(geopm_field_id).value.dbl;
         }
         return result;

--- a/service/src/DCGMDevicePool.cpp
+++ b/service/src/DCGMDevicePool.cpp
@@ -50,9 +50,9 @@ namespace geopm
     }
 
     DCGMDevicePoolImp::DCGMDevicePoolImp()
-        : m_update_freq(1000)    // 1 millisecond
-        , m_max_keep_age(1.0)    // 1 second
-        , m_max_keep_sample(100) // 100 samples
+        : m_update_freq(100000)    // 100 millisecond
+        , m_max_keep_age(1.0)      // 1 second
+        , m_max_keep_sample(100)   // 100 samples
     {
         // Guarantee geopm_dcgm_field_ids_e order is used
         m_dcgm_field_ids[M_SM_ACTIVE] = DCGM_FI_PROF_SM_ACTIVE;
@@ -124,7 +124,6 @@ namespace geopm
     DCGMDevicePoolImp::~DCGMDevicePoolImp()
     {
         //Shutdown DCGM
-        dcgmStatusDestroy(NULL);
         dcgmFieldGroupDestroy(m_dcgm_handle, m_field_group_id);
         dcgmGroupDestroy(m_dcgm_handle, DCGM_GROUP_ALL_GPUS);
     }
@@ -142,9 +141,12 @@ namespace geopm
         return m_dcgm_dev_count;
     }
 
-    double DCGMDevicePoolImp::field_value(int accel_idx, int geopm_field_id) const {
-        double result;
-        result = m_dcgm_field_values.at(accel_idx).at(geopm_field_id).value.dbl;
+    double DCGMDevicePoolImp::sample_field_value(int accel_idx, int geopm_field_id) const {
+        double result = NAN;
+
+        if (m_dcgm_field_values.at(accel_idx).at(geopm_field_id).status == DCGM_ST_OK); {
+            result = m_dcgm_field_values.at(accel_idx).at(geopm_field_id).value.dbl;
+        }
         return result;
     }
 

--- a/service/src/DCGMDevicePool.hpp
+++ b/service/src/DCGMDevicePool.hpp
@@ -66,7 +66,7 @@ namespace geopm
             virtual ~DCGMDevicePool() = default;
 
             /// @brief Number of accelerators that support DCGM on the platform.
-            /// @return Number of accelerators.
+            /// @return Number of accelerators supported by DCGM.
             virtual int num_device() const = 0;
             /// @brief Get the value for the provided geopm_field_id.
             ///
@@ -82,19 +82,23 @@ namespace geopm
             virtual double sample(int accel_idx, int field_id) const = 0;
 
             /// @brief Query DCGM for the latest value for an accelerator.
-            ///        Note that this is the last value DCGM cahced.  This
-            //         updates the DCGM device pool stored value that is provided
-            //         via the sample_field_value function
+            ///        Note that this is the last value DCGM cached.  This
+            ///        updates the DCGM device pool stored value that is provided
+            ///        via the sample_field_value function
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             virtual void update(int accel_idx) = 0;
-            /// @brief Set field update rate for DCGM devices.
+            /// @brief Set field update rate for DCGM devices.  This is the rate
+            //         at which the DCGM engine will poll for metrics
             /// @param [in] field_update_rate DCGM update rate in microseconds.
             virtual void update_rate(int field_update_rate) = 0;
-            /// @brief Set maximum storage time for for DCGM devices.
+            /// @brief Set maximum storage time for for DCGM devices.  This is
+            ///        the maximum time a DCGM sample will be kept.
             /// @param [in] max_storage_time maximum storage time in seconds
             virtual void max_storage_time(int max_storage_time) = 0;
-            /// @brief Set maximum samples to store for for DCGM devices.
+            /// @brief Set maximum samples to store for for DCGM devices. This is
+            ///       the maximum number of DCGM samples that will be kept.
+            ///       0 indicates no limit
             /// @param [in] max_samples maximun number of samples to store
             virtual void max_samples(int max_samples) = 0;
     };

--- a/service/src/DCGMDevicePool.hpp
+++ b/service/src/DCGMDevicePool.hpp
@@ -42,8 +42,6 @@ namespace geopm
                 M_SM_ACTIVE,
                 M_SM_OCCUPANCY,
                 M_DRAM_ACTIVE,
-                M_PCIE_TX_BYTES,
-                M_PCIE_RX_BYTES,
                 M_FIELD_IDS
             };
 

--- a/service/src/DCGMDevicePool.hpp
+++ b/service/src/DCGMDevicePool.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DCGMDEVICEPOOL_HPP_INCLUDE
+#define DCGMDEVICEPOOL_HPP_INCLUDE
+
+namespace geopm
+{
+    class DCGMDevicePool
+    {
+        public:
+            enum geopm_dcgm_field_ids_e {
+                M_SM_ACTIVE,
+                M_SM_OCCUPANCY,
+                M_DRAM_ACTIVE,
+                M_PCIE_TX_BYTES,
+                M_PCIE_RX_BYTES,
+                M_FIELD_IDS
+            };
+
+            DCGMDevicePool() = default;
+            virtual ~DCGMDevicePool() = default;
+
+            virtual int dcgm_device() const = 0;
+            virtual double field_value(int accel_idx, int geopm_field_id) const = 0;
+            virtual void update_field_value(int accel_idx) = 0;
+            virtual void field_update_rate(int accel_idx, int field_update_rate) = 0;
+            virtual void max_storage_time(int accel_idx, int max_storage_time) = 0;
+            virtual void max_samples(int accel_idx, int max_samples) = 0;
+    };
+
+    DCGMDevicePool &dcgm_device_pool();
+}
+#endif

--- a/service/src/DCGMDevicePool.hpp
+++ b/service/src/DCGMDevicePool.hpp
@@ -35,6 +35,11 @@
 
 namespace geopm
 {
+    /// An interface for the NVIDIA Data Center GPU Manager (DCGM).
+    /// This class is a wrapper around all calls to the DCGM library
+    /// and is intented to be called via the DCGMIOGroup.  Its primary
+    /// function is provided an abstracted interface to DCGM metrics
+    /// of interest.
     class DCGMDevicePool
     {
         public:
@@ -69,10 +74,12 @@ namespace geopm
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return The value for the specified field
-            virtual double field_value(int accel_idx, int geopm_field_id) const = 0;
+            virtual double sample_field_value(int accel_idx, int geopm_field_id) const = 0;
 
             /// @brief Query DCGM for the latest value for an accelerator.
-            ///        Note that this is the last value DCGM cached
+            ///        Note that this is the last value DCGM cahced.  This
+            //         updates the DCGM device pool stored value that is provided
+            //         via the sample_field_value function
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             virtual void update_field_value(int accel_idx) = 0;

--- a/service/src/DCGMDevicePool.hpp
+++ b/service/src/DCGMDevicePool.hpp
@@ -43,23 +43,23 @@ namespace geopm
     class DCGMDevicePool
     {
         public:
-            enum geopm_dcgm_field_ids_e {
+            enum m_field_id_e {
                 /*!
                  * @brief Field ID associated with DCGM SM Active metrics
                  */
-                M_SM_ACTIVE,
+                M_FIELD_ID_SM_ACTIVE,
                 /*!
                  * @brief Field ID associated with SM Occupancy metrics
                  */
-                M_SM_OCCUPANCY,
+                M_FIELD_ID_SM_OCCUPANCY,
                 /*!
                  * @brief Field ID associated with DCGM DRAM Active metrics
                  */
-                M_DRAM_ACTIVE,
+                M_FIELD_ID_DRAM_ACTIVE,
                 /*!
                  * @brief Number of valid field ids
                  */
-                M_FIELD_IDS
+                M_NUM_FIELD_ID
             };
 
             DCGMDevicePool() = default;
@@ -67,14 +67,19 @@ namespace geopm
 
             /// @brief Number of accelerators that support DCGM on the platform.
             /// @return Number of accelerators.
-            virtual int dcgm_device() const = 0;
+            virtual int num_device() const = 0;
             /// @brief Get the value for the provided geopm_field_id.
-            ///        This value should not change unless update_field_value
-            //         has been called
+            ///
+            /// This value should not change unless update_field_value
+            /// has been called
+            ///
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
+            ///
+            /// @param [in] field_id One of the m_field_id_e values
+            ///
             /// @return The value for the specified field
-            virtual double sample_field_value(int accel_idx, int geopm_field_id) const = 0;
+            virtual double sample(int accel_idx, int field_id) const = 0;
 
             /// @brief Query DCGM for the latest value for an accelerator.
             ///        Note that this is the last value DCGM cahced.  This
@@ -82,10 +87,10 @@ namespace geopm
             //         via the sample_field_value function
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
-            virtual void update_field_value(int accel_idx) = 0;
+            virtual void update(int accel_idx) = 0;
             /// @brief Set field update rate for DCGM devices.
             /// @param [in] field_update_rate DCGM update rate in microseconds.
-            virtual void field_update_rate(int field_update_rate) = 0;
+            virtual void update_rate(int field_update_rate) = 0;
             /// @brief Set maximum storage time for for DCGM devices.
             /// @param [in] max_storage_time maximum storage time in seconds
             virtual void max_storage_time(int max_storage_time) = 0;

--- a/service/src/DCGMDevicePool.hpp
+++ b/service/src/DCGMDevicePool.hpp
@@ -39,21 +39,52 @@ namespace geopm
     {
         public:
             enum geopm_dcgm_field_ids_e {
+                /*!
+                 * @brief Field ID associated with DCGM SM Active metrics
+                 */
                 M_SM_ACTIVE,
+                /*!
+                 * @brief Field ID associated with SM Occupancy metrics
+                 */
                 M_SM_OCCUPANCY,
+                /*!
+                 * @brief Field ID associated with DCGM DRAM Active metrics
+                 */
                 M_DRAM_ACTIVE,
+                /*!
+                 * @brief Number of valid field ids
+                 */
                 M_FIELD_IDS
             };
 
             DCGMDevicePool() = default;
             virtual ~DCGMDevicePool() = default;
 
+            /// @brief Number of accelerators that support DCGM on the platform.
+            /// @return Number of accelerators.
             virtual int dcgm_device() const = 0;
+            /// @brief Get the value for the provided geopm_field_id.
+            ///        This value should not change unless update_field_value
+            //         has been called
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator.
+            /// @return The value for the specified field
             virtual double field_value(int accel_idx, int geopm_field_id) const = 0;
+
+            /// @brief Query DCGM for the latest value for an accelerator.
+            ///        Note that this is the last value DCGM cached
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator.
             virtual void update_field_value(int accel_idx) = 0;
-            virtual void field_update_rate(int accel_idx, int field_update_rate) = 0;
-            virtual void max_storage_time(int accel_idx, int max_storage_time) = 0;
-            virtual void max_samples(int accel_idx, int max_samples) = 0;
+            /// @brief Set field update rate for DCGM devices.
+            /// @param [in] field_update_rate DCGM update rate in microseconds.
+            virtual void field_update_rate(int field_update_rate) = 0;
+            /// @brief Set maximum storage time for for DCGM devices.
+            /// @param [in] max_storage_time maximum storage time in seconds
+            virtual void max_storage_time(int max_storage_time) = 0;
+            /// @brief Set maximum samples to store for for DCGM devices.
+            /// @param [in] max_samples maximun number of samples to store
+            virtual void max_samples(int max_samples) = 0;
     };
 
     DCGMDevicePool &dcgm_device_pool();

--- a/service/src/DCGMDevicePoolImp.hpp
+++ b/service/src/DCGMDevicePoolImp.hpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DCGMDEVICEPOOLIMP_HPP_INCLUDE
+#define DCGMDEVICEPOOLIMP_HPP_INCLUDE
+
+#include <vector>
+
+#include "dcgm_agent.h"
+#include "dcgm_structs.h"
+
+#include "DCGMDevicePool.hpp"
+
+namespace geopm
+{
+
+    class DCGMDevicePoolImp : public DCGMDevicePool
+    {
+        public:
+            DCGMDevicePoolImp();
+            virtual ~DCGMDevicePoolImp();
+
+            virtual int dcgm_device() const override;
+            virtual double field_value(int accel_idx, int geopm_field_id) const override;
+            virtual void update_field_value(int accel_idx) override;
+            virtual void field_update_rate(int accel_idx, int field_update_rate) override;
+            virtual void max_storage_time(int accel_idx, int max_storage_time) override;
+            virtual void max_samples(int accel_idx, int max_samples) override;
+
+        private:
+            virtual void check_dcgm_result(const dcgmReturn_t result, const std::string error);
+
+            long long m_update_freq;
+            double m_max_keep_age;
+            int m_max_keep_sample;
+            int m_dcgm_dev_count;
+
+            dcgmHandle_t m_dcgm_handle;
+            dcgmFieldGrp_t m_field_group_id;
+
+            unsigned short m_dcgm_field_ids[M_FIELD_IDS];
+
+            std::vector<std::vector<dcgmFieldValue_v1>> m_dcgm_field_values;
+    };
+}
+#endif

--- a/service/src/DCGMDevicePoolImp.hpp
+++ b/service/src/DCGMDevicePoolImp.hpp
@@ -42,7 +42,6 @@
 
 namespace geopm
 {
-
     class DCGMDevicePoolImp : public DCGMDevicePool
     {
         public:
@@ -57,7 +56,7 @@ namespace geopm
             virtual void max_samples(int accel_idx, int max_samples) override;
 
         private:
-            virtual void check_dcgm_result(const dcgmReturn_t result, const std::string error);
+            virtual void check_dcgm_result(const dcgmReturn_t result, const std::string error, const int line);
 
             long long m_update_freq;
             double m_max_keep_age;
@@ -69,6 +68,7 @@ namespace geopm
 
             unsigned short m_dcgm_field_ids[M_FIELD_IDS];
 
+            // Accelerator indexed vector of vector of field values
             std::vector<std::vector<dcgmFieldValue_v1>> m_dcgm_field_values;
     };
 }

--- a/service/src/DCGMDevicePoolImp.hpp
+++ b/service/src/DCGMDevicePoolImp.hpp
@@ -56,7 +56,7 @@ namespace geopm
             virtual void max_samples(int max_samples) override;
 
         private:
-            virtual void check_result(const dcgmReturn_t result, const std::string &error, int line);
+            virtual void check_result(const dcgmReturn_t result, const std::string error, const int line);
 
             long long m_update_freq;
             double m_max_keep_age;

--- a/service/src/DCGMDevicePoolImp.hpp
+++ b/service/src/DCGMDevicePoolImp.hpp
@@ -48,15 +48,15 @@ namespace geopm
             DCGMDevicePoolImp();
             virtual ~DCGMDevicePoolImp();
 
-            virtual int dcgm_device() const override;
-            virtual double sample_field_value(int accel_idx, int geopm_field_id) const override;
-            virtual void update_field_value(int accel_idx) override;
-            virtual void field_update_rate(int field_update_rate) override;
+            virtual int num_device() const override;
+            virtual double sample(int accel_idx, int field_id) const override;
+            virtual void update(int accel_idx) override;
+            virtual void update_rate(int field_update_rate) override;
             virtual void max_storage_time(int max_storage_time) override;
             virtual void max_samples(int max_samples) override;
 
         private:
-            virtual void check_dcgm_result(const dcgmReturn_t result, const std::string error, const int line);
+            virtual void check_result(const dcgmReturn_t result, const std::string &error, int line);
 
             long long m_update_freq;
             double m_max_keep_age;
@@ -66,7 +66,7 @@ namespace geopm
             dcgmHandle_t m_dcgm_handle;
             dcgmFieldGrp_t m_field_group_id;
 
-            unsigned short m_dcgm_field_ids[M_FIELD_IDS];
+            unsigned short m_dcgm_field_ids[M_NUM_FIELD_ID];
 
             // Accelerator indexed vector of vector of field values
             std::vector<std::vector<dcgmFieldValue_v1>> m_dcgm_field_values;

--- a/service/src/DCGMDevicePoolImp.hpp
+++ b/service/src/DCGMDevicePoolImp.hpp
@@ -49,7 +49,7 @@ namespace geopm
             virtual ~DCGMDevicePoolImp();
 
             virtual int dcgm_device() const override;
-            virtual double field_value(int accel_idx, int geopm_field_id) const override;
+            virtual double sample_field_value(int accel_idx, int geopm_field_id) const override;
             virtual void update_field_value(int accel_idx) override;
             virtual void field_update_rate(int field_update_rate) override;
             virtual void max_storage_time(int max_storage_time) override;

--- a/service/src/DCGMDevicePoolImp.hpp
+++ b/service/src/DCGMDevicePoolImp.hpp
@@ -51,9 +51,9 @@ namespace geopm
             virtual int dcgm_device() const override;
             virtual double field_value(int accel_idx, int geopm_field_id) const override;
             virtual void update_field_value(int accel_idx) override;
-            virtual void field_update_rate(int accel_idx, int field_update_rate) override;
-            virtual void max_storage_time(int accel_idx, int max_storage_time) override;
-            virtual void max_samples(int accel_idx, int max_samples) override;
+            virtual void field_update_rate(int field_update_rate) override;
+            virtual void max_storage_time(int max_storage_time) override;
+            virtual void max_samples(int max_samples) override;
 
         private:
             virtual void check_dcgm_result(const dcgmReturn_t result, const std::string error, const int line);

--- a/service/src/DCGMDevicePoolThrow.cpp
+++ b/service/src/DCGMDevicePoolThrow.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <string>
+
+#include "geopm/Exception.hpp"
+
+namespace geopm
+{
+    class DCGMDevicePool;
+
+    const DCGMDevicePool &dcgm_device_pool()
+    {
+        throw Exception("DCGMDevicePoolThrow::" + std::string(__func__) +
+                        ": GEOPM configured without dcgm library support.  Please configure with --enable-dcgm",
+                        GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: lowren.h.lawson@intel.com <lowren.h.lawson@intel.com>

Addition of a DCGM Device pool that connects to a local standalone nv-hostengine in order to query NVIDIA Profiling metrics.  This PR is just the device pool and is not currently used by any classes in the code base.  This is a prerequisite for PR #1914.

Details of change:
- Added DCGMDevicePool class and throw.
- The user is expected to have setup a local instance of nv-hostengine for the device pool to connect to.  

Related Features:
- Relates to #1902
- Fixes #1915
- Fixes #1904

Long term it may be worth considering adding a way for the user to specify an IP address for the nv-hostengine.