### PR TITLE
Fix the path for test logs printed in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,4 +118,4 @@ jobs:
            cat scripts/test/pytest_links/*.log || true
            cat service/geopmdpy_test/pytest_links/*.log || true
            cat test/gtest_links/*.log || true
-           cat test/service/gtest_links/*.log || true
+           cat service/test/gtest_links/*.log || true


### PR DESCRIPTION
- Fixes #1938
- The GitHub build workflow attempts to cat some log files after a failure is encountered. One of the file paths has its directories reversed. This change puts the reversed directories back in order.