### PR TITLE
Addition of NVML Minimum and Maximum Frequency Querying

### DIFF
--- a/service/src/NVMLDevicePool.cpp
+++ b/service/src/NVMLDevicePool.cpp
@@ -58,6 +58,7 @@ namespace geopm
 
     NVMLDevicePoolImp::NVMLDevicePoolImp(const int num_cpu)
         : M_MAX_CONTEXTS(64)
+        , M_MAX_FREQUENCIES(200)
         , M_NUM_CPU(num_cpu)
     {
         nvmlReturn_t nvml_result;
@@ -153,15 +154,15 @@ namespace geopm
     std::vector<unsigned int> NVMLDevicePoolImp::frequency_supported_sm(int accel_idx) const
     {
         check_accel_range(accel_idx);
-        unsigned int count = 100;
+        unsigned int count = M_MAX_FREQUENCIES;
         std::vector<unsigned int> supported_freqs(count);
 
         nvmlReturn_t nvml_result = nvmlDeviceGetSupportedGraphicsClocks(m_nvml_device.at(accel_idx),
                                                                         frequency_status_mem(accel_idx),
                                                                         &count, supported_freqs.data());
+        supported_freqs.resize(count);
 
         if (nvml_result == NVML_ERROR_INSUFFICIENT_SIZE) {
-            supported_freqs.resize(count);
             nvml_result = nvmlDeviceGetSupportedGraphicsClocks(m_nvml_device.at(accel_idx),
                                                                frequency_status_mem(accel_idx),
                                                                &count, supported_freqs.data());

--- a/service/src/NVMLDevicePool.cpp
+++ b/service/src/NVMLDevicePool.cpp
@@ -150,35 +150,27 @@ namespace geopm
         return (uint64_t)result;
     }
 
-    std::vector<double> NVMLDevicePoolImp::frequency_supported_sm(int accel_idx) const
+    std::vector<unsigned int> NVMLDevicePoolImp::frequency_supported_sm(int accel_idx) const
     {
         check_accel_range(accel_idx);
         unsigned int count = 100;
-        unsigned int *supported_freqs;
-        supported_freqs = new unsigned int[count];
-        std::vector<double> result;
+        std::vector<unsigned int> supported_freqs(count);
 
         nvmlReturn_t nvml_result = nvmlDeviceGetSupportedGraphicsClocks(m_nvml_device.at(accel_idx),
                                                                         frequency_status_mem(accel_idx),
-                                                                        &count, supported_freqs);
-        if (nvml_result == NVML_SUCCESS) {
-            for (unsigned int i = 0; i<count; i++) {
-                result.push_back(supported_freqs[i]);
-            }
-        }
-        else if (nvml_result == NVML_ERROR_INSUFFICIENT_SIZE) {
-            supported_freqs = new unsigned int[count];
+                                                                        &count, supported_freqs.data());
+
+        if (nvml_result == NVML_ERROR_INSUFFICIENT_SIZE) {
+            supported_freqs.resize(count);
             nvml_result = nvmlDeviceGetSupportedGraphicsClocks(m_nvml_device.at(accel_idx),
                                                                frequency_status_mem(accel_idx),
-                                                               &count, supported_freqs);
-            for (unsigned int i = 0; i<count; i++) {
-                result.push_back(supported_freqs[i]);
-            }
+                                                               &count, supported_freqs.data());
         }
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get SM Frequency for accelerator " +
                           std::to_string(accel_idx) + ".", __LINE__);
-        return result;
+
+        return supported_freqs;
     }
 
 

--- a/service/src/NVMLDevicePool.hpp
+++ b/service/src/NVMLDevicePool.hpp
@@ -56,16 +56,22 @@ namespace geopm
             /// @return CPU to Accelerator idea affinitization bitmask.
             virtual cpu_set_t *cpu_affinity_ideal_mask(int accel_idx) const = 0;
             /// @brief Get the NVML device streaming multiprocessor frequency
-            //         in MHz.
+            ///        in MHz.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator streaming multiproccesor frequency in MHz.
             virtual uint64_t frequency_status_sm(int accel_idx) const = 0;
+            /// @brief Get the supported NVML device streaming multiprocessor frequencies
+            ///        in MHz.
+            /// @param [in] accel_idx The index indicating a particular
+            ///        accelerator.
+            /// @return Accelerator supported streaming multiproccesor frequencies in MHz.
+            virtual std::vector<double> frequency_supported_sm(int accel_idx) const = 0;
             /// @brief Get the NVML device utilization metric.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator streaming multiprocessor utilization
-            //          percentage as a whole number from 0 to 100.
+            ///         percentage as a whole number from 0 to 100.
             virtual uint64_t utilization(int accel_idx) const = 0;
             /// @brief Get the NVML device power in milliwatts.
             /// @param [in] accel_idx The index indicating a particular
@@ -86,7 +92,7 @@ namespace geopm
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator clock throttle reasons as defined
-            //          in nvml.h.
+            ///         in nvml.h.
             virtual uint64_t throttle_reasons(int accel_idx) const = 0;
             /// @brief Get the current NVML device temperature.
             /// @param [in] accel_idx The index indicating a particular
@@ -94,27 +100,27 @@ namespace geopm
             /// @return Accelerator temperature in Celsius.
             virtual uint64_t temperature(int accel_idx) const = 0;
             /// @brief Get the total energy consumed counter value for
-            //         an NVML device in millijoules.
+            ///        an NVML device in millijoules.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator energy consumption in millijoules.
             virtual uint64_t energy(int accel_idx) const = 0;
             /// @brief Get the current performance state of an NVML
-            //         device.
+            ///        device.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator performance state, defined by the
-            //          NVML API as 0 to 15, with 0 being maximum performance,
-            //          15 being minimum performance, and 32 being unknown.
+            ///         NVML API as 0 to 15, with 0 being maximum performance,
+            ///         15 being minimum performance, and 32 being unknown.
             virtual uint64_t performance_state(int accel_idx) const = 0;
             /// @brief Get the pcie receive throughput over a 20ms period for
-            //         an NVML device.
+            ///        an NVML device.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator pcie receive throughput in kilobytes per second.
             virtual uint64_t throughput_rx_pcie(int accel_idx) const = 0;
             /// @brief Get the pcie transmit throughput over a 20ms period for
-            //         an NVML device.
+            ///        an NVML device.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator pcie transmit throughput in kilobytes per second.
@@ -123,14 +129,14 @@ namespace geopm
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator memory utilization percentage
-            //          as a whole number from 0 to 100.
+            ///         as a whole number from 0 to 100.
             virtual uint64_t utilization_mem(int accel_idx) const = 0;
             /// @brief Get the list of PIDs with an active context on an NVML
-            //         device.
+            ///        device.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return List of PIDs that are associated with a context on the
-            //          specified NVML device.
+            ///         specified NVML device.
             virtual std::vector<int> active_process_list(int accel_idx) const = 0;
 
             /// @brief Set min and max frequency for NVML device.

--- a/service/src/NVMLDevicePool.hpp
+++ b/service/src/NVMLDevicePool.hpp
@@ -66,7 +66,7 @@ namespace geopm
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.
             /// @return Accelerator supported streaming multiproccesor frequencies in MHz.
-            virtual std::vector<double> frequency_supported_sm(int accel_idx) const = 0;
+            virtual std::vector<unsigned int> frequency_supported_sm(int accel_idx) const = 0;
             /// @brief Get the NVML device utilization metric.
             /// @param [in] accel_idx The index indicating a particular
             ///        accelerator.

--- a/service/src/NVMLDevicePoolImp.hpp
+++ b/service/src/NVMLDevicePoolImp.hpp
@@ -66,6 +66,7 @@ namespace geopm
 
         private:
             const unsigned int M_MAX_CONTEXTS;
+            const unsigned int M_MAX_FREQUENCIES;
             const unsigned int M_NUM_CPU;
             virtual void check_accel_range(int accel_idx) const;
             virtual void check_nvml_result(nvmlReturn_t nvml_result, int error, const std::string &message, int line) const;

--- a/service/src/NVMLDevicePoolImp.hpp
+++ b/service/src/NVMLDevicePoolImp.hpp
@@ -46,6 +46,7 @@ namespace geopm
             virtual int num_accelerator(void) const override;
             virtual cpu_set_t *cpu_affinity_ideal_mask(int accel_idx) const override;
             virtual uint64_t frequency_status_sm(int accel_idx) const override;
+            virtual std::vector<double> frequency_supported_sm(int accel_idx) const override;
             virtual uint64_t utilization(int accel_idx) const override;
             virtual uint64_t power(int accel_idx) const override;
             virtual uint64_t power_limit(int accel_idx) const override;

--- a/service/src/NVMLDevicePoolImp.hpp
+++ b/service/src/NVMLDevicePoolImp.hpp
@@ -46,7 +46,7 @@ namespace geopm
             virtual int num_accelerator(void) const override;
             virtual cpu_set_t *cpu_affinity_ideal_mask(int accel_idx) const override;
             virtual uint64_t frequency_status_sm(int accel_idx) const override;
-            virtual std::vector<double> frequency_supported_sm(int accel_idx) const override;
+            virtual std::vector<unsigned int> frequency_supported_sm(int accel_idx) const override;
             virtual uint64_t utilization(int accel_idx) const override;
             virtual uint64_t power(int accel_idx) const override;
             virtual uint64_t power_limit(int accel_idx) const override;

--- a/service/src/NVMLIOGroup.hpp
+++ b/service/src/NVMLIOGroup.hpp
@@ -88,7 +88,7 @@ namespace geopm
             const NVMLDevicePool &m_nvml_device_pool;
             bool m_is_batch_read;
             std::vector<uint64_t> m_initial_power_limit;
-            std::vector<std::vector<unsigned int>> m_supported_freq;
+            std::vector<std::vector<unsigned int> > m_supported_freq;
 
             struct signal_s
             {

--- a/service/src/NVMLIOGroup.hpp
+++ b/service/src/NVMLIOGroup.hpp
@@ -88,7 +88,7 @@ namespace geopm
             const NVMLDevicePool &m_nvml_device_pool;
             bool m_is_batch_read;
             std::vector<uint64_t> m_initial_power_limit;
-            std::vector<std::vector<double>> m_supported_freq;
+            std::vector<std::vector<unsigned int>> m_supported_freq;
 
             struct signal_s
             {

--- a/service/src/NVMLIOGroup.hpp
+++ b/service/src/NVMLIOGroup.hpp
@@ -88,6 +88,7 @@ namespace geopm
             const NVMLDevicePool &m_nvml_device_pool;
             bool m_is_batch_read;
             std::vector<uint64_t> m_initial_power_limit;
+            std::vector<std::vector<double>> m_supported_freq;
 
             struct signal_s
             {

--- a/service/test/MockNVMLDevicePool.hpp
+++ b/service/test/MockNVMLDevicePool.hpp
@@ -43,7 +43,7 @@ class MockNVMLDevicePool : public geopm::NVMLDevicePool
         MOCK_METHOD(int, num_accelerator, (), (const, override));
         MOCK_METHOD(cpu_set_t *, cpu_affinity_ideal_mask, (int), (const, override));
         MOCK_METHOD(uint64_t, frequency_status_sm, (int), (const, override));
-        MOCK_METHOD(std::vector<double>, frequency_supported_sm, (int), (const, override));
+        MOCK_METHOD(std::vector<unsigned int>, frequency_supported_sm, (int), (const, override));
         MOCK_METHOD(uint64_t, utilization, (int), (const, override));
         MOCK_METHOD(uint64_t, power, (int), (const, override));
         MOCK_METHOD(uint64_t, power_limit, (int), (const, override));

--- a/service/test/MockNVMLDevicePool.hpp
+++ b/service/test/MockNVMLDevicePool.hpp
@@ -43,6 +43,7 @@ class MockNVMLDevicePool : public geopm::NVMLDevicePool
         MOCK_METHOD(int, num_accelerator, (), (const, override));
         MOCK_METHOD(cpu_set_t *, cpu_affinity_ideal_mask, (int), (const, override));
         MOCK_METHOD(uint64_t, frequency_status_sm, (int), (const, override));
+        MOCK_METHOD(std::vector<double>, frequency_supported_sm, (int), (const, override));
         MOCK_METHOD(uint64_t, utilization, (int), (const, override));
         MOCK_METHOD(uint64_t, power, (int), (const, override));
         MOCK_METHOD(uint64_t, power_limit, (int), (const, override));

--- a/service/test/NVMLIOGroupTest.cpp
+++ b/service/test/NVMLIOGroupTest.cpp
@@ -140,9 +140,9 @@ TEST_F(NVMLIOGroupTest, push_control_adjust_write_batch)
     std::vector<double> mock_power = {153600, 70000, 300000, 50000};
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         batch_value[(nvml_io.push_control("NVML::FREQUENCY_CONTROL",
-                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_freq.at(accel_idx)*1e6;
+                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_freq.at(accel_idx) * 1e6;
         batch_value[(nvml_io.push_control("FREQUENCY_ACCELERATOR_CONTROL",
-                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_freq.at(accel_idx)*1e6;
+                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_freq.at(accel_idx) * 1e6;
         EXPECT_CALL(*m_device_pool,
                     frequency_control_sm(accel_idx, mock_freq.at(accel_idx),
                                          mock_freq.at(accel_idx))).Times(2);
@@ -152,9 +152,9 @@ TEST_F(NVMLIOGroupTest, push_control_adjust_write_batch)
         EXPECT_CALL(*m_device_pool, frequency_reset_control(accel_idx)).Times(1);
 
         batch_value[(nvml_io.push_control("NVML::POWER_LIMIT_CONTROL",
-                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_power.at(accel_idx)/1e3;
+                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_power.at(accel_idx) / 1e3;
         batch_value[(nvml_io.push_control("POWER_ACCELERATOR_LIMIT_CONTROL",
-                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_power.at(accel_idx)/1e3;
+                                        GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_power.at(accel_idx) / 1e3;
         EXPECT_CALL(*m_device_pool, power_control(accel_idx, mock_power.at(accel_idx))).Times(2);
     }
 
@@ -179,10 +179,10 @@ TEST_F(NVMLIOGroupTest, write_control)
                                          mock_freq.at(accel_idx))).Times(2);
         EXPECT_NO_THROW(nvml_io.write_control("NVML::FREQUENCY_CONTROL",
                                               GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx,
-                                              mock_freq.at(accel_idx)*1e6));
+                                              mock_freq.at(accel_idx) * 1e6));
         EXPECT_NO_THROW(nvml_io.write_control("FREQUENCY_ACCELERATOR_CONTROL",
                                               GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx,
-                                              mock_freq.at(accel_idx)*1e6));
+                                              mock_freq.at(accel_idx) * 1e6));
 
         EXPECT_CALL(*m_device_pool, frequency_reset_control(accel_idx)).Times(1);
         EXPECT_NO_THROW(nvml_io.write_control("NVML::FREQUENCY_RESET_CONTROL",
@@ -191,10 +191,10 @@ TEST_F(NVMLIOGroupTest, write_control)
         EXPECT_CALL(*m_device_pool, power_control(accel_idx, mock_power.at(accel_idx))).Times(2);
         EXPECT_NO_THROW(nvml_io.write_control("NVML::POWER_LIMIT_CONTROL",
                                               GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx,
-                                              mock_power.at(accel_idx)/1e3));
+                                              mock_power.at(accel_idx) / 1e3));
         EXPECT_NO_THROW(nvml_io.write_control("POWER_ACCELERATOR_LIMIT_CONTROL",
                                               GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx,
-                                              mock_power.at(accel_idx)/1e3));
+                                              mock_power.at(accel_idx) / 1e3));
     }
 }
 
@@ -218,7 +218,7 @@ TEST_F(NVMLIOGroupTest, read_signal_and_batch)
         double frequency = nvml_io.read_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         double frequency_batch = nvml_io.sample(batch_idx.at(accel_idx));
 
-        EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx)*1e6);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx) * 1e6);
         EXPECT_DOUBLE_EQ(frequency, frequency_batch);
     }
 
@@ -232,7 +232,7 @@ TEST_F(NVMLIOGroupTest, read_signal_and_batch)
         double frequency = nvml_io.read_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         double frequency_batch = nvml_io.sample(batch_idx.at(accel_idx));
 
-        EXPECT_DOUBLE_EQ(frequency, (mock_freq.at(accel_idx))*1e6);
+        EXPECT_DOUBLE_EQ(frequency, (mock_freq.at(accel_idx)) * 1e6);
         EXPECT_DOUBLE_EQ(frequency, frequency_batch);
     }
 }
@@ -285,16 +285,16 @@ TEST_F(NVMLIOGroupTest, read_signal)
         double frequency = nvml_io.read_signal("NVML::FREQUENCY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         double frequency_alias = nvml_io.read_signal("FREQUENCY_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(frequency, frequency_alias);
-        EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx)*1e6);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx) * 1e6);
 
         double frequency_min = nvml_io.read_signal("NVML::FREQUENCY_MIN", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        EXPECT_DOUBLE_EQ(frequency_min, mock_supported_freq.front()*1e6);
+        EXPECT_DOUBLE_EQ(frequency_min, mock_supported_freq.front() * 1e6);
 
         double frequency_max = nvml_io.read_signal("NVML::FREQUENCY_MAX", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        EXPECT_DOUBLE_EQ(frequency_max, mock_supported_freq.back()*1e6);
+        EXPECT_DOUBLE_EQ(frequency_max, mock_supported_freq.back() * 1e6);
 
         double utilization_accelerator = nvml_io.read_signal("NVML::UTILIZATION_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        EXPECT_DOUBLE_EQ(utilization_accelerator, mock_utilization_accelerator.at(accel_idx)/100);
+        EXPECT_DOUBLE_EQ(utilization_accelerator, mock_utilization_accelerator.at(accel_idx) / 100);
 
         double throttle_reasons = nvml_io.read_signal("NVML::THROTTLE_REASONS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(throttle_reasons, mock_throttle_reasons.at(accel_idx));
@@ -302,28 +302,28 @@ TEST_F(NVMLIOGroupTest, read_signal)
         double power = nvml_io.read_signal("NVML::POWER", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         double power_alias = nvml_io.read_signal("POWER_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(power, power_alias);
-        EXPECT_DOUBLE_EQ(power, mock_power.at(accel_idx)/1e3);
+        EXPECT_DOUBLE_EQ(power, mock_power.at(accel_idx) / 1e3);
 
         double frequency_mem = nvml_io.read_signal("NVML::FREQUENCY_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        EXPECT_DOUBLE_EQ(frequency_mem, mock_freq_mem.at(accel_idx)*1e6);
+        EXPECT_DOUBLE_EQ(frequency_mem, mock_freq_mem.at(accel_idx) * 1e6);
 
         double temperature = nvml_io.read_signal("NVML::TEMPERATURE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(temperature, mock_temperature.at(accel_idx));
 
         double total_energy_consumption = nvml_io.read_signal("NVML::TOTAL_ENERGY_CONSUMPTION", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        EXPECT_DOUBLE_EQ(total_energy_consumption, mock_energy.at(accel_idx)/1e3);
+        EXPECT_DOUBLE_EQ(total_energy_consumption, mock_energy.at(accel_idx) / 1e3);
 
         double performance_state = nvml_io.read_signal("NVML::PERFORMANCE_STATE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(performance_state, mock_performance_state.at(accel_idx));
 
         double pcie_rx_throughput = nvml_io.read_signal("NVML::PCIE_RX_THROUGHPUT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        EXPECT_DOUBLE_EQ(pcie_rx_throughput, mock_pcie_rx_throughput.at(accel_idx)*1024);
+        EXPECT_DOUBLE_EQ(pcie_rx_throughput, mock_pcie_rx_throughput.at(accel_idx) * 1024);
 
         double pcie_tx_throughput = nvml_io.read_signal("NVML::PCIE_TX_THROUGHPUT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        EXPECT_DOUBLE_EQ(pcie_tx_throughput, mock_pcie_tx_throughput.at(accel_idx)*1024);
+        EXPECT_DOUBLE_EQ(pcie_tx_throughput, mock_pcie_tx_throughput.at(accel_idx) * 1024);
 
         double utilization_mem = nvml_io.read_signal("NVML::UTILIZATION_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        EXPECT_DOUBLE_EQ(utilization_mem, mock_utilization_mem.at(accel_idx)/100);
+        EXPECT_DOUBLE_EQ(utilization_mem, mock_utilization_mem.at(accel_idx) / 100);
     }
 
     for (int cpu_idx = 0; cpu_idx < num_cpu; ++cpu_idx) {


### PR DESCRIPTION
- Relates to #1941 
- Fixes #1942 

Adds a devicepool call for supported SM frequencies at the current Memory frequency (queried automatically).  
Adds IO Group usage of the above to provide a minimum and maximum frequency value.  

This approach may not function as expected if multiple memory frequencies are supported.  
Remaining Opens: 
- [x] Testing of the new IO Group signals
- [ ] Handling of multiple memory frequencies, possibly through adding a new signal that re-polls for min and maximum at the current memory frequency.  