### PR TITLE
Reporter update for accelerator alias signals

### DIFF
--- a/service/docs/source/geopm_report.7.rst
+++ b/service/docs/source/geopm_report.7.rst
@@ -226,12 +226,11 @@ The fields in each of these sections are described below:
                          unnested region (i.e. when a CPU is in the
                          unmarked region).
 
-  ``gpu-energy (J)``\: Total energy in joules consumed by all gpus.
+  ``gpu-energy (J)``\: Total energy in joules consumed by all GPUs.
 
+  ``gpu-power (W)``\: Average power for the GPUs in watts.
 
-  ``gpu-power (W)``\: Average power for the gpus in watts.
-
-  ``gpu-frequency (Hz)``\: Achieved frequency for the gpus in hertz.
+  ``gpu-frequency (Hz)``\: Achieved frequency for the GPUs in hertz.
 
 * ``Report Extensions``\ :
 

--- a/service/docs/source/geopm_report.7.rst
+++ b/service/docs/source/geopm_report.7.rst
@@ -112,16 +112,16 @@ each region.
 
 The fields in each of these sections are described below:
 
-  ``name``\ : Name of the region.  For user-defined regions, this is the
+  ``name``\: Name of the region.  For user-defined regions, this is the
           string passed to ``geopm_region()``\ ; for automatically
           detected OpenMP and MPI regions this is the function name.
           See `geopm_prof_c(3) <geopm_prof_c.3.html>`_ for more information.
 
-  ``hash``\ : The CRC32 hash of the region name.  This value is used by
+  ``hash``\: The CRC32 hash of the region name.  This value is used by
           agents to distinguish regions using the REGION_HASH signal
           and also appears in the trace.
 
-  ``runtime (s)``\ : The average across all processes of the total runtime
+  ``runtime (s)``\: The average across all processes of the total runtime
                  spent in the region.  For epoch totals, this is the
                  time from the first detected epoch to the end of the
                  application.  For application totals, this is the
@@ -134,7 +134,7 @@ The fields in each of these sections are described below:
                  values below; use ``sync-runtime`` for comparisons
                  instead.
 
-  ``count``\ : The total number of times this region was entered and
+  ``count``\: The total number of times this region was entered and
            exited, averaged accross all processes.  Fractional counts
            are possible if some processes entered a region a different
            number of times.  For epoch totals, this is the total
@@ -142,7 +142,7 @@ The fields in each of these sections are described below:
            The count has no meaning for the unmarked region and
            application totals.
 
-  ``sync-runtime (s)``\ : Total time for which the sampled region hash
+  ``sync-runtime (s)``\: Total time for which the sampled region hash
                       matched this region on all CPUs on the compute
                       node.  For epoch and application totals, this
                       value is the same as ``runtime (s)``.  The
@@ -153,74 +153,74 @@ The fields in each of these sections are described below:
                       sampled in the same way as the sync-runtime and
                       can be compared with it.
 
-  ``package-energy (J)``\ : Total energy in joules consumed by all
+  ``package-energy (J)``\: Total energy in joules consumed by all
                         processor packages (sockets).
 
-  ``dram-energy (J)``\ : Total energy in joules consumed by all DRAM on
+  ``dram-energy (J)``\: Total energy in joules consumed by all DRAM on
                      the board.
 
-  ``power (W)``\ : Average power for the processor package, calculated as
+  ``power (W)``\: Average power for the processor package, calculated as
                package-energy divided by sync-runtime.
 
-  ``frequency (%)``\ : Achieved core frequency as a percentage of the
+  ``frequency (%)``\: Achieved core frequency as a percentage of the
                    sticker (base) frequency for the processor.  This
                    frequency is calculated using the ratio of
                    CYCLES_THREAD to CYCLES_REFERENCE.
 
-  ``frequency (Hz)``\ : Achieved core frequency for the processor in
+  ``frequency (Hz)``\: Achieved core frequency for the processor in
                     hertz.  This frequency is calculated using the
                     ratio of CYCLES_THREAD to CYCLES_REFERENCE times
                     the sticker (base) frequency.
 
-  ``time-hint-network (s)``\ : The portion of sync-runtime where the
+  ``time-hint-network (s)``\: The portion of sync-runtime where the
                            region hint was GEOPM_REGION_HINT_NETWORK.
                            The region hint is determined by the hint
                            passed to ``geopm_region()`` for the most
                            nested region.
 
-  ``time-hint-ignore (s)``\ : The portion of sync-runtime where the region
+  ``time-hint-ignore (s)``\: The portion of sync-runtime where the region
                           hint was GEOPM_REGION_HINT_IGNORE.  The
                           region hint is determined by the hint passed
                           to ``geopm_region()`` for the most nested
                           region.
 
-  ``time-hint-compute (s)``\ : The portion of sync-runtime where the
+  ``time-hint-compute (s)``\: The portion of sync-runtime where the
                            region hint was GEOPM_REGION_HINT_COMPUTE.
                            The region hint is determined by the hint
                            passed to ``geopm_region()`` for the most
                            nested region.
 
-  ``time-hint-memory (s)``\ : The portion of sync-runtime where the region
+  ``time-hint-memory (s)``\: The portion of sync-runtime where the region
                           hint was GEOPM_REGION_HINT_MEMORY.  The
                           region hint is determined by the hint passed
                           to ``geopm_region()`` for the most nested
                           region.
 
-  ``time-hint-io (s)``\ : The portion of sync-runtime where the region
+  ``time-hint-io (s)``\: The portion of sync-runtime where the region
                       hint was GEOPM_REGION_HINT_IO.  The region hint
                       is determined by the hint passed to
                       ``geopm_region()`` for the most nested region.
 
-  ``time-hint-serial (s)``\ : The portion of sync-runtime where the region
+  ``time-hint-serial (s)``\: The portion of sync-runtime where the region
                           hint was GEOPM_REGION_HINT_SERIAL.  The
                           region hint is determined by the hint passed
                           to ``geopm_region()`` for the most nested
                           region.
 
-  ``time-hint-parallel (s)``\ : The portion of sync-runtime where the
+  ``time-hint-parallel (s)``\: The portion of sync-runtime where the
                             region hint was
                             GEOPM_REGION_HINT_PARALLEL.  The region
                             hint is determined by the hint passed to
                             ``geopm_region()`` for the most nested
                             region.
 
-  ``time-hint-unknown (s)``\ : The portion of sync-runtime where the
+  ``time-hint-unknown (s)``\: The portion of sync-runtime where the
                            region hint was GEOPM_REGION_HINT_UNKNOWN.
                            The region hint is determined by the hint
                            passed to ``geopm_region()`` for the most
                            nested region.
 
-  ``time-hint-unset (s)``\ : The portion of sync-runtime where the region
+  ``time-hint-unset (s)``\: The portion of sync-runtime where the region
                          hint was GEOPM_REGION_HINT_UNSET.  The region
                          hint also becomes unset when exiting an
                          unnested region (i.e. when a CPU is in the

--- a/service/docs/source/geopm_report.7.rst
+++ b/service/docs/source/geopm_report.7.rst
@@ -60,7 +60,7 @@ REPORT FORMAT
 -------------
 
 
-* 
+*
   ``Header Fields``\ :
 
   ``GEOPM Version``\ : The version of the GEOPM library and tools used
@@ -226,6 +226,13 @@ The fields in each of these sections are described below:
                          unnested region (i.e. when a CPU is in the
                          unmarked region).
 
+  ``accelerator-energy (J)``\: Total energy in joules consumed by all
+                            accelerators.
+
+  ``accelerator-power (W)``\: Average power for the accelerators.
+
+  ``accelerator-frequency (Hz)``\: Achieved frequency for the accelerators in
+                                hertz.
 
 * ``Report Extensions``\ :
 

--- a/service/docs/source/geopm_report.7.rst
+++ b/service/docs/source/geopm_report.7.rst
@@ -226,13 +226,12 @@ The fields in each of these sections are described below:
                          unnested region (i.e. when a CPU is in the
                          unmarked region).
 
-  ``gpu-energy (J)``\: Total energy in joules consumed by all
-                    accelerators.
+  ``gpu-energy (J)``\: Total energy in joules consumed by all gpus.
 
-  ``gpu-power (W)``\: Average power for the accelerators in watts.
 
-  ``gpu-frequency (Hz)``\: Achieved frequency for the accelerators in
-                        hertz.
+  ``gpu-power (W)``\: Average power for the gpus in watts.
+
+  ``gpu-frequency (Hz)``\: Achieved frequency for the gpus in hertz.
 
 * ``Report Extensions``\ :
 

--- a/service/docs/source/geopm_report.7.rst
+++ b/service/docs/source/geopm_report.7.rst
@@ -226,13 +226,13 @@ The fields in each of these sections are described below:
                          unnested region (i.e. when a CPU is in the
                          unmarked region).
 
-  ``accelerator-energy (J)``\: Total energy in joules consumed by all
-                            accelerators.
+  ``gpu-energy (J)``\: Total energy in joules consumed by all
+                    accelerators.
 
-  ``accelerator-power (W)``\: Average power for the accelerators.
+  ``gpu-power (W)``\: Average power for the accelerators in watts.
 
-  ``accelerator-frequency (Hz)``\: Achieved frequency for the accelerators in
-                                hertz.
+  ``gpu-frequency (Hz)``\: Achieved frequency for the accelerators in
+                        hertz.
 
 * ``Report Extensions``\ :
 

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -239,7 +239,10 @@ namespace geopm
         }
         register_signal_alias("GPU_POWER", M_NAME_PREFIX + "GPU_POWER");
         register_signal_alias("GPU_FREQUENCY_STATUS", M_NAME_PREFIX + "GPU_FREQUENCY_STATUS");
+        register_signal_alias("FREQUENCY_MIN_ACCELERATOR", "NVML::FREQUENCY_MIN");
+        register_signal_alias("FREQUENCY_MAX_ACCELERATOR", "NVML::FREQUENCY_MAX");
         register_signal_alias("ENERGY_ACCELERATOR", "NVML::TOTAL_ENERGY_CONSUMPTION");
+        register_signal_alias("UTILIZATION_ACCELERATOR", "NVML::UTILIZATION_ACCELERATOR");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {
@@ -265,6 +268,8 @@ namespace geopm
                                 ": No supported frequencies found for accelerator " + std::to_string(domain_idx),
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
+
+            // sort guarantees the ordering for min & max calls
             std::sort(supported_frequency.begin(), supported_frequency.end());
             m_supported_freq.push_back(supported_frequency);
         }

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -683,7 +683,7 @@ namespace geopm
                             "not valid for NVMLIOGroup",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        return it->second.m_agg_function;
+        return it->second.agg_function;
     }
 
     // Specifies how to print signals from this IOGroup
@@ -695,7 +695,7 @@ namespace geopm
                             "not valid for NVMLIOGroup",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        return it->second.m_format_function;
+        return it->second.format_function;
     }
 
     // A user-friendly description of each signal
@@ -728,7 +728,7 @@ namespace geopm
                             " not valid for NVMLIOGroup.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        return m_signal_available.at(signal_name).m_behavior;
+        return m_signal_available.at(signal_name).behavior;
     }
 
     void NVMLIOGroup::save_control(const std::string &save_path)

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -200,6 +200,7 @@ namespace geopm
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::expect_same,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_CONSTANT,
                                   string_format_double
                                   }}
                              })
@@ -239,10 +240,11 @@ namespace geopm
         }
         register_signal_alias("GPU_POWER", M_NAME_PREFIX + "GPU_POWER");
         register_signal_alias("GPU_FREQUENCY_STATUS", M_NAME_PREFIX + "GPU_FREQUENCY_STATUS");
-        register_signal_alias("FREQUENCY_MIN_ACCELERATOR", "NVML::FREQUENCY_MIN");
-        register_signal_alias("FREQUENCY_MAX_ACCELERATOR", "NVML::FREQUENCY_MAX");
-        register_signal_alias("ENERGY_ACCELERATOR", "NVML::TOTAL_ENERGY_CONSUMPTION");
-        register_signal_alias("UTILIZATION_ACCELERATOR", "NVML::UTILIZATION_ACCELERATOR");
+        register_signal_alias("GPU_FREQUENCY_MIN_AVAIL", M_NAME_PREFIX + "GPU_FREQUENCY_MIN_AVAIL");
+        register_signal_alias("GPU_FREQUENCY_MAX_AVAIL", M_NAME_PREFIX + "GPU_FREQUENCY_MAX_AVAIL");
+        register_signal_alias("GPU_ENERGY", M_NAME_PREFIX + "GPU_ENERGY_CONSUMPTION_TOTAL");
+        register_signal_alias("GPU_TEMPERATURE", M_NAME_PREFIX + "GPU_TEMPERATURE");
+        register_signal_alias("GPU_UTILIZATION", M_NAME_PREFIX + "GPU_UTILIZATION");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {
@@ -554,17 +556,17 @@ namespace geopm
         if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_STATUS" || signal_name == "GPU_FREQUENCY_STATUS") {
             result = (double) m_nvml_device_pool.frequency_status_sm(domain_idx) * 1e6;
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_MIN_AVAIL") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_MIN_AVAIL" || signal_name == "GPU_FREQUENCY_MIN_AVAIL") {
             if (m_supported_freq.at(domain_idx).size() != 0) {
                 result = 1e6 * m_supported_freq.at(domain_idx).front();
             }
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_MAX_AVAIL") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_MAX_AVAIL" || signal_name == "GPU_FREQUENCY_MAX_AVAIL") {
             if (m_supported_freq.at(domain_idx).size() != 0) {
                 result = 1e6 * m_supported_freq.at(domain_idx).back();
             }
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_UTILIZATION") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_UTILIZATION" || signal_name == "GPU_UTILIZATION") {
             result = (double) m_nvml_device_pool.utilization(domain_idx) / 100;
         }
         else if (signal_name == M_NAME_PREFIX + "GPU_THROTTLE_REASONS") {
@@ -580,10 +582,10 @@ namespace geopm
         else if (signal_name == M_NAME_PREFIX + "GPU_MEMORY_FREQUENCY_STATUS") {
             result = (double) m_nvml_device_pool.frequency_status_mem(domain_idx) * 1e6;
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_TEMPERATURE") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_TEMPERATURE" || signal_name == "GPU_TEMPERATURE") {
             result = (double) m_nvml_device_pool.temperature(domain_idx);
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_ENERGY_CONSUMPTION_TOTAL" || signal_name == "ENERGY_ACCELERATOR") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_ENERGY_CONSUMPTION_TOTAL" || signal_name == "GPU_ENERGY") {
             result = (double) m_nvml_device_pool.energy(domain_idx) / 1e3;
         }
         else if (signal_name == M_NAME_PREFIX + "GPU_PERFORMANCE_STATE") {
@@ -602,7 +604,7 @@ namespace geopm
             std::map<pid_t, double> process_map = accelerator_process_map();
             result = cpu_accelerator_affinity(domain_idx, process_map);
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL" || signal_name == "GPU_FREQUENCY_CONTROL") {
             result = m_frequency_control_request.at(domain_idx);
         }
         else {

--- a/service/src/NVMLIOGroup.hpp
+++ b/service/src/NVMLIOGroup.hpp
@@ -114,6 +114,7 @@ namespace geopm
                 std::vector<std::shared_ptr<signal_s> > signals;
                 int domain;
                 std::function<double(const std::vector<double> &)> m_agg_function;
+                int m_behavior;
                 std::function<std::string(double)> m_format_function;
             };
 

--- a/service/src/NVMLIOGroup.hpp
+++ b/service/src/NVMLIOGroup.hpp
@@ -113,17 +113,17 @@ namespace geopm
                 std::string m_description;
                 std::vector<std::shared_ptr<signal_s> > signals;
                 int domain;
-                std::function<double(const std::vector<double> &)> m_agg_function;
-                int m_behavior;
-                std::function<std::string(double)> m_format_function;
+                std::function<double(const std::vector<double> &)> agg_function;
+                int behavior;
+                std::function<std::string(double)> format_function;
             };
 
             struct control_info {
                 std::string m_description;
                 std::vector<std::shared_ptr<control_s> > controls;
                 int domain;
-                std::function<double(const std::vector<double> &)> m_agg_function;
-                std::function<std::string(double)> m_format_function;
+                std::function<double(const std::vector<double> &)> agg_function;
+                std::function<std::string(double)> format_function;
             };
 
             std::map<std::string, signal_info> m_signal_available;

--- a/service/test/NVMLIOGroupTest.cpp
+++ b/service/test/NVMLIOGroupTest.cpp
@@ -68,6 +68,9 @@ class NVMLIOGroupTest : public :: testing :: Test
         std::shared_ptr<MockNVMLDevicePool> m_device_pool;
         std::unique_ptr<MockPlatformTopo> m_platform_topo;
         std::shared_ptr<MockSaveControl> m_mock_save_ctl;
+
+        const std::string M_PLUGIN_NAME = "NVML";
+        const std::string M_NAME_PREFIX = M_PLUGIN_NAME + "::";
 };
 
 void NVMLIOGroupTest::SetUp()
@@ -146,7 +149,7 @@ TEST_F(NVMLIOGroupTest, push_control_adjust_write_batch)
     std::vector<double> mock_freq = {1530, 1320, 420, 135};
     std::vector<double> mock_power = {153600, 70000, 300000, 50000};
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        batch_value[(nvml_io.push_control("NVML::GPU_FREQUENCY_CONTROL",
+        batch_value[(nvml_io.push_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL",
                                         GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_freq.at(accel_idx) * 1e6;
         batch_value[(nvml_io.push_control("GPU_FREQUENCY_CONTROL",
                                         GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_freq.at(accel_idx) * 1e6;
@@ -154,11 +157,11 @@ TEST_F(NVMLIOGroupTest, push_control_adjust_write_batch)
                     frequency_control_sm(accel_idx, mock_freq.at(accel_idx),
                                          mock_freq.at(accel_idx))).Times(2);
 
-        batch_value[(nvml_io.push_control("NVML::GPU_FREQUENCY_RESET_CONTROL",
+        batch_value[(nvml_io.push_control(M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL",
                                         GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_freq.at(accel_idx);
         EXPECT_CALL(*m_device_pool, frequency_reset_control(accel_idx)).Times(1);
 
-        batch_value[(nvml_io.push_control("NVML::GPU_POWER_LIMIT_CONTROL",
+        batch_value[(nvml_io.push_control(M_NAME_PREFIX + "GPU_POWER_LIMIT_CONTROL",
                                         GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_power.at(accel_idx) / 1e3;
         batch_value[(nvml_io.push_control("GPU_POWER_LIMIT_CONTROL",
                                         GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx))] = mock_power.at(accel_idx) / 1e3;
@@ -184,11 +187,11 @@ TEST_F(NVMLIOGroupTest, write_control)
         EXPECT_CALL(*m_device_pool,
                     frequency_control_sm(accel_idx, mock_freq.at(accel_idx),
                                          mock_freq.at(accel_idx))).Times(2);
-        EXPECT_NO_THROW(nvml_io.write_control("NVML::GPU_FREQUENCY_CONTROL",
+        EXPECT_NO_THROW(nvml_io.write_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL",
                                               GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx,
                                               mock_freq.at(accel_idx) * 1e6));
         // Verify the write was cached properly
-        double frequency = nvml_io.read_signal("NVML::GPU_FREQUENCY_CONTROL",
+        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL",
                                                GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx) * 1e6);
 
@@ -197,11 +200,11 @@ TEST_F(NVMLIOGroupTest, write_control)
                                               mock_freq.at(accel_idx) * 1e6));
 
         EXPECT_CALL(*m_device_pool, frequency_reset_control(accel_idx)).Times(1);
-        EXPECT_NO_THROW(nvml_io.write_control("NVML::GPU_FREQUENCY_RESET_CONTROL",
+        EXPECT_NO_THROW(nvml_io.write_control(M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL",
                                               GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, 12345));
 
         EXPECT_CALL(*m_device_pool, power_control(accel_idx, mock_power.at(accel_idx))).Times(2);
-        EXPECT_NO_THROW(nvml_io.write_control("NVML::GPU_POWER_LIMIT_CONTROL",
+        EXPECT_NO_THROW(nvml_io.write_control(M_NAME_PREFIX + "GPU_POWER_LIMIT_CONTROL",
                                               GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx,
                                               mock_power.at(accel_idx) / 1e3));
         EXPECT_NO_THROW(nvml_io.write_control("GPU_POWER_LIMIT_CONTROL",
@@ -223,11 +226,11 @@ TEST_F(NVMLIOGroupTest, read_signal_and_batch)
         EXPECT_CALL(*m_device_pool, frequency_status_sm(accel_idx)).WillRepeatedly(Return(mock_freq.at(accel_idx)));
     }
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        batch_idx.push_back(nvml_io.push_signal("NVML::GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+        batch_idx.push_back(nvml_io.push_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
     }
     nvml_io.read_batch();
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        double frequency = nvml_io.read_signal("NVML::GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         double frequency_batch = nvml_io.sample(batch_idx.at(accel_idx));
 
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx) * 1e6);
@@ -241,7 +244,7 @@ TEST_F(NVMLIOGroupTest, read_signal_and_batch)
     }
     nvml_io.read_batch();
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        double frequency = nvml_io.read_signal("NVML::GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         double frequency_batch = nvml_io.sample(batch_idx.at(accel_idx));
 
         EXPECT_DOUBLE_EQ(frequency, (mock_freq.at(accel_idx)) * 1e6);
@@ -294,58 +297,60 @@ TEST_F(NVMLIOGroupTest, read_signal)
     std::sort(mock_supported_freq.begin(), mock_supported_freq.end());
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        double frequency = nvml_io.read_signal("NVML::GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         double frequency_alias = nvml_io.read_signal("GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(frequency, frequency_alias);
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx) * 1e6);
 
-        double frequency_min = nvml_io.read_signal("NVML::GPU_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        double frequency_min_alias = nvml_io.read_signal("FREQUENCY_MIN_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_min = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_min_alias = nvml_io.read_signal("GPU_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(frequency_min, mock_supported_freq.front() * 1e6);
         EXPECT_DOUBLE_EQ(frequency_min, frequency_min_alias);
 
-        double frequency_max = nvml_io.read_signal("NVML::GPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        double frequency_max_alias = nvml_io.read_signal("FREQUENCY_MAX_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_max = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_max_alias = nvml_io.read_signal("GPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(frequency_max, mock_supported_freq.back() * 1e6);
         EXPECT_DOUBLE_EQ(frequency_max, frequency_max_alias);
 
-        double utilization_accelerator = nvml_io.read_signal("NVML::GPU_UTILIZATION", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        double utilization_accelerator_alias = nvml_io.read_signal("UTILIZATION_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double utilization_accelerator = nvml_io.read_signal(M_NAME_PREFIX + "GPU_UTILIZATION", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double utilization_accelerator_alias = nvml_io.read_signal("GPU_UTILIZATION", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(utilization_accelerator, mock_utilization_accelerator.at(accel_idx) / 100);
         EXPECT_DOUBLE_EQ(utilization_accelerator, utilization_accelerator_alias);
 
-        double throttle_reasons = nvml_io.read_signal("NVML::GPU_THROTTLE_REASONS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double throttle_reasons = nvml_io.read_signal(M_NAME_PREFIX + "GPU_THROTTLE_REASONS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(throttle_reasons, mock_throttle_reasons.at(accel_idx));
 
-        double power = nvml_io.read_signal("NVML::GPU_POWER", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double power = nvml_io.read_signal(M_NAME_PREFIX + "GPU_POWER", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         double power_alias = nvml_io.read_signal("GPU_POWER", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(power, power_alias);
         EXPECT_DOUBLE_EQ(power, mock_power.at(accel_idx) / 1e3);
 
-        double frequency_mem = nvml_io.read_signal("NVML::GPU_MEMORY_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_mem = nvml_io.read_signal(M_NAME_PREFIX + "GPU_MEMORY_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(frequency_mem, mock_freq_mem.at(accel_idx) * 1e6);
 
-        double temperature = nvml_io.read_signal("NVML::GPU_TEMPERATURE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double temperature = nvml_io.read_signal(M_NAME_PREFIX + "GPU_TEMPERATURE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double temperature_alias = nvml_io.read_signal("GPU_TEMPERATURE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(temperature, mock_temperature.at(accel_idx));
+        EXPECT_DOUBLE_EQ(temperature, temperature_alias);
 
-        double total_energy_consumption = nvml_io.read_signal("NVML::GPU_ENERGY_CONSUMPTION_TOTAL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
-        double total_energy_consumption_alias = nvml_io.read_signal("ENERGY_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double total_energy_consumption = nvml_io.read_signal(M_NAME_PREFIX + "GPU_ENERGY_CONSUMPTION_TOTAL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double total_energy_consumption_alias = nvml_io.read_signal("GPU_ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(total_energy_consumption, mock_energy.at(accel_idx) / 1e3);
         EXPECT_DOUBLE_EQ(total_energy_consumption, total_energy_consumption_alias);
 
-        double performance_state = nvml_io.read_signal("NVML::GPU_PERFORMANCE_STATE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double performance_state = nvml_io.read_signal(M_NAME_PREFIX + "GPU_PERFORMANCE_STATE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(performance_state, mock_performance_state.at(accel_idx));
 
-        double pcie_rx_throughput = nvml_io.read_signal("NVML::GPU_PCIE_RX_THROUGHPUT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double pcie_rx_throughput = nvml_io.read_signal(M_NAME_PREFIX + "GPU_PCIE_RX_THROUGHPUT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(pcie_rx_throughput, mock_pcie_rx_throughput.at(accel_idx) * 1024);
 
-        double pcie_tx_throughput = nvml_io.read_signal("NVML::GPU_PCIE_TX_THROUGHPUT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double pcie_tx_throughput = nvml_io.read_signal(M_NAME_PREFIX + "GPU_PCIE_TX_THROUGHPUT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(pcie_tx_throughput, mock_pcie_tx_throughput.at(accel_idx) * 1024);
 
-        double utilization_mem = nvml_io.read_signal("NVML::GPU_MEMORY_UTILIZATION", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double utilization_mem = nvml_io.read_signal(M_NAME_PREFIX + "GPU_MEMORY_UTILIZATION", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(utilization_mem, mock_utilization_mem.at(accel_idx) / 100);
 
-        frequency = nvml_io.read_signal("NVML::GPU_FREQUENCY_CONTROL",
+        frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL",
                                         GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(frequency, 0); // 0 until first write
     }
@@ -354,7 +359,7 @@ TEST_F(NVMLIOGroupTest, read_signal)
         // FIXME: The most complex signal is the cpu accelerator active afifinitzation signal, which is currently
         //        not fully testable due to needing a running process for get affinity.  For now using a no throw check
         double affin = NAN;
-        EXPECT_NO_THROW(affin = nvml_io.read_signal("NVML::GPU_CPU_ACTIVE_AFFINITIZATION", GEOPM_DOMAIN_CPU, cpu_idx));
+        EXPECT_NO_THROW(affin = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CPU_ACTIVE_AFFINITIZATION", GEOPM_DOMAIN_CPU, cpu_idx));
         EXPECT_DOUBLE_EQ(affin, -1);
     }
 }
@@ -393,46 +398,46 @@ TEST_F(NVMLIOGroupTest, error_path)
 
     NVMLIOGroup nvml_io(*m_platform_topo, *m_device_pool, nullptr);
 
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal("NVML::GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
     GEOPM_EXPECT_THROW_MESSAGE(nvml_io.sample(0),
                                GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal("NVML::GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
 
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal("NVML::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
                                GEOPM_ERROR_INVALID, "signal_name NVML::INVALID not valid for NVMLIOGroup");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal("NVML::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
-                               GEOPM_ERROR_INVALID, "NVML::INVALID not valid for NVMLIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+                               GEOPM_ERROR_INVALID, M_NAME_PREFIX + "INVALID not valid for NVMLIOGroup");
 
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control("NVML::GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
     GEOPM_EXPECT_THROW_MESSAGE(nvml_io.adjust(0, 12345.6),
                                GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control("NVML::GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0, 1530000000),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_type must be");
 
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control("NVML::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
                                GEOPM_ERROR_INVALID, "control_name NVML::INVALID not valid for NVMLIOGroup");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control("NVML::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0, 1530000000),
-                               GEOPM_ERROR_INVALID, "NVML::INVALID not valid for NVMLIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0, 1530000000),
+                               GEOPM_ERROR_INVALID, M_NAME_PREFIX + "INVALID not valid for NVMLIOGroup");
 
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal("NVML::GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal("NVML::GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal("NVML::GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal("NVML::GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control("NVML::GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control("NVML::GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control("NVML::GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator, 1530000000),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, num_accelerator, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control("NVML::GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1, 1530000000),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR, -1, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 }
 

--- a/service/test/NVMLIOGroupTest.cpp
+++ b/service/test/NVMLIOGroupTest.cpp
@@ -300,13 +300,19 @@ TEST_F(NVMLIOGroupTest, read_signal)
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(accel_idx) * 1e6);
 
         double frequency_min = nvml_io.read_signal("NVML::GPU_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_min_alias = nvml_io.read_signal("FREQUENCY_MIN_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(frequency_min, mock_supported_freq.front() * 1e6);
+        EXPECT_DOUBLE_EQ(frequency_min, frequency_min_alias);
 
         double frequency_max = nvml_io.read_signal("NVML::GPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double frequency_max_alias = nvml_io.read_signal("FREQUENCY_MAX_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(frequency_max, mock_supported_freq.back() * 1e6);
+        EXPECT_DOUBLE_EQ(frequency_max, frequency_max_alias);
 
         double utilization_accelerator = nvml_io.read_signal("NVML::GPU_UTILIZATION", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double utilization_accelerator_alias = nvml_io.read_signal("UTILIZATION_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(utilization_accelerator, mock_utilization_accelerator.at(accel_idx) / 100);
+        EXPECT_DOUBLE_EQ(utilization_accelerator, utilization_accelerator_alias);
 
         double throttle_reasons = nvml_io.read_signal("NVML::GPU_THROTTLE_REASONS", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(throttle_reasons, mock_throttle_reasons.at(accel_idx));
@@ -323,7 +329,9 @@ TEST_F(NVMLIOGroupTest, read_signal)
         EXPECT_DOUBLE_EQ(temperature, mock_temperature.at(accel_idx));
 
         double total_energy_consumption = nvml_io.read_signal("NVML::GPU_ENERGY_CONSUMPTION_TOTAL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double total_energy_consumption_alias = nvml_io.read_signal("ENERGY_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(total_energy_consumption, mock_energy.at(accel_idx) / 1e3);
+        EXPECT_DOUBLE_EQ(total_energy_consumption, total_energy_consumption_alias);
 
         double performance_state = nvml_io.read_signal("NVML::GPU_PERFORMANCE_STATE", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(performance_state, mock_performance_state.at(accel_idx));

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -423,13 +423,13 @@ namespace geopm
         };
 
         auto all_names = m_platform_io.signal_names();
-        if (all_names.find("ENERGY_ACCELERATOR") != all_names.end()) {
+        if (all_names.count("ENERGY_ACCELERATOR") != 0) {
             m_sync_fields.push_back({"accelerator-energy (J)", {"ENERGY_ACCELERATOR"}, sample_only});
         }
-        if (all_names.find("POWER_ACCELERATOR") != all_names.end()) {
+        if (all_names.count("POWER_ACCELERATOR") != 0) {
             m_sync_fields.push_back({"accelerator-power (W)", {"POWER_ACCELERATOR"}, sample_only});
         }
-        if (all_names.find("FREQUENCY_ACCELERATOR") != all_names.end()) {
+        if (all_names.count("FREQUENCY_ACCELERATOR") != 0) {
             m_sync_fields.push_back({"accelerator-frequency (HZ)", {"FREQUENCY_ACCELERATOR"}, sample_only});
         }
 

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -426,7 +426,7 @@ namespace geopm
         std::vector<m_sync_field_s> gpu_sync_fields = {
             {"gpu-energy (J)", {"GPU_ENERGY"}, sample_only},
             {"gpu-power (W)", {"GPU_POWER"}, sample_only},
-            {"gpu-frequency (Hz)", {"GPU_FREQUENCY"}, sample_only}
+            {"gpu-frequency (Hz)", {"GPU_FREQUENCY_STATUS"}, sample_only}
         };
 
         for (const auto &field : gpu_sync_fields) {

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -425,6 +425,8 @@ namespace geopm
         auto all_names = platform_io().signal_names();
         if (all_names.find("ENERGY_ACCELERATOR") != all_names.end()) {
             m_sync_fields.push_back({"accelerator-energy (J)", {"ENERGY_ACCELERATOR"}, sample_only});
+            m_sync_fields.push_back({"accelerator-power (W)", {"POWER_ACCELERATOR"}, sample_only});
+            m_sync_fields.push_back({"accelerator-frequency (HZ)", {"FREQUENCY_ACCELERATOR"}, sample_only});
         }
 
         for (const auto &field : m_sync_fields) {

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -422,10 +422,14 @@ namespace geopm
             {"time-hint-unset (s)", {"TIME_HINT_UNSET"}, sample_only},
         };
 
-        auto all_names = platform_io().signal_names();
+        auto all_names = m_platform_io.signal_names();
         if (all_names.find("ENERGY_ACCELERATOR") != all_names.end()) {
             m_sync_fields.push_back({"accelerator-energy (J)", {"ENERGY_ACCELERATOR"}, sample_only});
+        }
+        if (all_names.find("POWER_ACCELERATOR") != all_names.end()) {
             m_sync_fields.push_back({"accelerator-power (W)", {"POWER_ACCELERATOR"}, sample_only});
+        }
+        if (all_names.find("FREQUENCY_ACCELERATOR") != all_names.end()) {
             m_sync_fields.push_back({"accelerator-frequency (HZ)", {"FREQUENCY_ACCELERATOR"}, sample_only});
         }
 

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -426,7 +426,7 @@ namespace geopm
         std::vector<m_sync_field_s> gpu_sync_fields = {
             {"gpu-energy (J)", {"GPU_ENERGY"}, sample_only},
             {"gpu-power (W)", {"GPU_POWER"}, sample_only},
-            {"gpu-frequency (HZ)", {"GPU_FREQUENCY"}, sample_only}
+            {"gpu-frequency (Hz)", {"GPU_FREQUENCY"}, sample_only}
         };
 
         for (const auto &field : gpu_sync_fields) {

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -422,6 +422,11 @@ namespace geopm
             {"time-hint-unset (s)", {"TIME_HINT_UNSET"}, sample_only},
         };
 
+        auto all_names = platform_io().signal_names();
+        if (all_names.find("ENERGY_ACCELERATOR") != all_names.end()) {
+            m_sync_fields.push_back({"accelerator-energy (J)", {"ENERGY_ACCELERATOR"}, sample_only});
+        }
+
         for (const auto &field : m_sync_fields) {
             for (const auto &signal : field.supporting_signals) {
                 m_sync_signal_idx[signal] = m_sample_agg->push_signal(signal, GEOPM_DOMAIN_BOARD, 0);

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -423,14 +423,18 @@ namespace geopm
         };
 
         auto all_names = m_platform_io.signal_names();
-        if (all_names.count("ENERGY_ACCELERATOR") != 0) {
-            m_sync_fields.push_back({"accelerator-energy (J)", {"ENERGY_ACCELERATOR"}, sample_only});
-        }
-        if (all_names.count("POWER_ACCELERATOR") != 0) {
-            m_sync_fields.push_back({"accelerator-power (W)", {"POWER_ACCELERATOR"}, sample_only});
-        }
-        if (all_names.count("FREQUENCY_ACCELERATOR") != 0) {
-            m_sync_fields.push_back({"accelerator-frequency (HZ)", {"FREQUENCY_ACCELERATOR"}, sample_only});
+        std::vector<m_sync_field_s> gpu_sync_fields = {
+            {"gpu-energy (J)", {"GPU_ENERGY"}, sample_only},
+            {"gpu-power (W)", {"GPU_POWER"}, sample_only},
+            {"gpu-frequency (HZ)", {"GPU_FREQUENCY"}, sample_only}
+        };
+
+        for (const auto &field : gpu_sync_fields) {
+            for (const auto &signal : field.supporting_signals) {
+                if (all_names.count(signal) != 0) {
+                    m_sync_fields.push_back(field);
+                }
+            }
         }
 
         for (const auto &field : m_sync_fields) {

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -294,7 +294,7 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/RecordFilterTest.make_proxy_epoch \
               test/gtest_links/RecordFilterTest.make_edit_distance \
               test/gtest_links/ReporterTest.generate \
-              test/gtest_links/ReporterTest.generate_accelerator \
+              test/gtest_links/ReporterTest.generate_gpu \
               test/gtest_links/SampleAggregatorTest.epoch_application_total \
               test/gtest_links/SampleAggregatorTest.sample_application \
               test/gtest_links/SchedTest.test_proc_cpuset_0 \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -294,6 +294,7 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/RecordFilterTest.make_proxy_epoch \
               test/gtest_links/RecordFilterTest.make_edit_distance \
               test/gtest_links/ReporterTest.generate \
+              test/gtest_links/ReporterTest.generate_accelerator \
               test/gtest_links/SampleAggregatorTest.epoch_application_total \
               test/gtest_links/SampleAggregatorTest.sample_application \
               test/gtest_links/SchedTest.test_proc_cpuset_0 \

--- a/test/ReporterTest.cpp
+++ b/test/ReporterTest.cpp
@@ -101,6 +101,9 @@ class ReporterTest : public testing::Test
             M_ENERGY_PKG_ENV_IDX_0,
             M_ENERGY_PKG_ENV_IDX_1,
             M_EPOCH_COUNT_IDX,
+            M_ENERGY_ACCELERATOR_IDX,
+            M_POWER_ACCELERATOR_IDX,
+            M_FREQUENCY_ACCELERATOR_IDX,
         };
         ReporterTest();
         void TearDown(void);
@@ -153,6 +156,20 @@ class ReporterTest : public testing::Test
             {GEOPM_REGION_HASH_UNMARKED, 222},
             {GEOPM_REGION_HASH_EPOCH, 334},
             {GEOPM_REGION_HASH_APP, 4444}
+        };
+        std::map<uint64_t, double> m_region_frequency_accelerator = {
+            {geopm_crc32_str("all2all"), 567},
+            {geopm_crc32_str("model-init"), 890},
+            {GEOPM_REGION_HASH_UNMARKED, 123},
+            {GEOPM_REGION_HASH_EPOCH, 456},
+            {GEOPM_REGION_HASH_APP, 74489}
+        };
+        std::map<uint64_t, double> m_region_power_accelerator = {
+            {geopm_crc32_str("all2all"), 764},
+            {geopm_crc32_str("model-init"), 653},
+            {GEOPM_REGION_HASH_UNMARKED, 211},
+            {GEOPM_REGION_HASH_EPOCH, 432},
+            {GEOPM_REGION_HASH_APP, 8992}
         };
         std::map<uint64_t, double> m_region_clk_core = {
             {geopm_crc32_str("all2all"), 4545},
@@ -228,17 +245,6 @@ ReporterTest::ReporterTest()
         .WillOnce(Return(1.0));
 
     m_comm = std::make_shared<ReporterTestMockComm>();
-    m_reporter = geopm::make_unique<ReporterImp>(m_start_time,
-                                                 m_report_name,
-                                                 m_platform_io,
-                                                 m_platform_topo,
-                                                 0,
-                                                 m_sample_agg,
-                                                 m_region_agg,
-                                                 "ENERGY_PACKAGE@package",
-                                                 "",
-                                                 true);
-    m_reporter->init();
 }
 
 void ReporterTest::TearDown(void)
@@ -250,6 +256,21 @@ void check_report(std::istream &expected, std::istream &result);
 
 TEST_F(ReporterTest, generate)
 {
+    std::set<std::string> signal_names = {};
+    EXPECT_CALL(m_platform_io, signal_names()).WillOnce(Return(signal_names));
+
+    m_reporter = geopm::make_unique<ReporterImp>(m_start_time,
+                                                 m_report_name,
+                                                 m_platform_io,
+                                                 m_platform_topo,
+                                                 0,
+                                                 m_sample_agg,
+                                                 m_region_agg,
+                                                 "ENERGY_PACKAGE@package",
+                                                 "",
+                                                 true);
+    m_reporter->init();
+
     // ApplicationIO calls: to be removed
     EXPECT_CALL(m_application_io, report_name()).WillOnce(Return(m_report_name));
     EXPECT_CALL(m_application_io, profile_name());
@@ -301,6 +322,7 @@ TEST_F(ReporterTest, generate)
         EXPECT_CALL(*m_sample_agg, sample_region(M_ENERGY_PKG_ENV_IDX_1, rid.first))
             .WillRepeatedly(Return(rid.second/4.0));
     }
+
     for (auto rid : m_region_clk_core) {
         EXPECT_CALL(*m_sample_agg, sample_region(M_CLK_CORE_IDX, rid.first))
             .WillRepeatedly(Return(rid.second));
@@ -309,6 +331,22 @@ TEST_F(ReporterTest, generate)
         EXPECT_CALL(*m_sample_agg, sample_region(M_CLK_REF_IDX, rid.first))
             .WillRepeatedly(Return(rid.second));
     }
+
+    for (auto rid : m_region_energy) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_ENERGY_ACCELERATOR_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second/1.0));
+    }
+
+    for (auto rid : m_region_frequency_accelerator) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_FREQUENCY_ACCELERATOR_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second/1.0));
+    }
+
+    for (auto rid : m_region_power_accelerator) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_POWER_ACCELERATOR_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second/1.0));
+    }
+
 
     // same hint values for all regions
     EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_COMPUTE_IDX, _))
@@ -328,7 +366,7 @@ TEST_F(ReporterTest, generate)
 
     // Other calls
     EXPECT_CALL(m_tree_comm, overhead_send()).WillOnce(Return(678 * 56));
-    EXPECT_CALL(*m_comm, rank()).WillRepeatedly(Return(0));
+    EXPECT_CALL(*m_comm, rank()).WillOnce(Return(0));
     EXPECT_CALL(*m_comm, num_rank()).WillOnce(Return(1));
 
     std::vector<std::pair<std::string, std::string> > agent_header {
@@ -457,6 +495,282 @@ TEST_F(ReporterTest, generate)
         "      time-hint-parallel (s): 0.6\n"
         "      time-hint-unknown (s): 0.7\n"
         "      time-hint-unset (s): 0.8\n"
+        "      ENERGY_PACKAGE@package-0: 1111\n"
+        "      ENERGY_PACKAGE@package-1: 1111\n"
+        "      geopmctl memory HWM (B): @ANY_STRING@\n"
+        "      geopmctl network BW (B/s): 678\n\n";
+
+    std::istringstream exp_stream(expected);
+
+    m_reporter->update();
+    m_reporter->generate("my_agent", agent_header, agent_node_report, m_region_agent_detail,
+                         m_application_io,
+                         m_comm, m_tree_comm);
+    std::ifstream report(m_report_name);
+    check_report(exp_stream, report);
+}
+
+TEST_F(ReporterTest, generate_accelerator)
+{
+
+    // accelerator signals
+    EXPECT_CALL(*m_sample_agg, push_signal("ENERGY_ACCELERATOR", GEOPM_DOMAIN_BOARD, 0))
+        .WillOnce(Return(M_ENERGY_ACCELERATOR_IDX));
+    EXPECT_CALL(*m_sample_agg, push_signal("POWER_ACCELERATOR", GEOPM_DOMAIN_BOARD, 0))
+        .WillOnce(Return(M_POWER_ACCELERATOR_IDX));
+    EXPECT_CALL(*m_sample_agg, push_signal("FREQUENCY_ACCELERATOR", GEOPM_DOMAIN_BOARD, 0))
+        .WillOnce(Return(M_FREQUENCY_ACCELERATOR_IDX));
+
+    std::set<std::string> signal_names = {"ENERGY_ACCELERATOR","POWER_ACCELERATOR","FREQUENCY_ACCELERATOR"};
+    EXPECT_CALL(m_platform_io, signal_names()).WillOnce(Return(signal_names));
+
+    m_reporter = geopm::make_unique<ReporterImp>(m_start_time,
+                                                 m_report_name,
+                                                 m_platform_io,
+                                                 m_platform_topo,
+                                                 0,
+                                                 m_sample_agg,
+                                                 m_region_agg,
+                                                 "ENERGY_PACKAGE@package",
+                                                 "",
+                                                 true);
+    m_reporter->init();
+
+    // ApplicationIO calls: to be removed
+    EXPECT_CALL(m_application_io, report_name()).WillOnce(Return(m_report_name));
+    EXPECT_CALL(m_application_io, profile_name());
+    EXPECT_CALL(m_application_io, region_name_set());
+
+    // ProcessRegionAgregator
+    EXPECT_CALL(*m_region_agg, update);
+    for (auto rid : m_region_runtime) {
+        EXPECT_CALL(*m_region_agg, get_runtime_average(rid.first))
+            .WillOnce(Return(rid.second));
+    }
+    for (auto rid : m_region_count) {
+        if (GEOPM_REGION_HASH_EPOCH == rid.first) {
+            EXPECT_CALL(m_platform_io, sample(M_EPOCH_COUNT_IDX))
+                .WillOnce(Return(rid.second));
+        }
+        else {
+            EXPECT_CALL(*m_region_agg, get_count_average(rid.first))
+                .WillOnce(Return(rid.second));
+        }
+    }
+
+    // SampleAggregator
+    EXPECT_CALL(*m_sample_agg, update);
+    for (auto rid : m_region_network_time) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_NETWORK_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second));
+    }
+    for (auto rid : m_region_ignore_time) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_IGNORE_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second));
+    }
+    for (auto rid : m_region_sync_rt) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second));
+    }
+    EXPECT_CALL(*m_sample_agg, sample_application(M_TIME_IDX))
+        .WillRepeatedly(Return(56));
+    EXPECT_CALL(*m_sample_agg, sample_epoch(M_TIME_IDX))
+        .WillRepeatedly(Return(70));
+
+    for (auto rid : m_region_energy) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_ENERGY_PKG_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second/2.0));
+        EXPECT_CALL(*m_sample_agg, sample_region(M_ENERGY_DRAM_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second/2.0));
+        EXPECT_CALL(*m_sample_agg, sample_region(M_ENERGY_PKG_ENV_IDX_0, rid.first))
+            .WillRepeatedly(Return(rid.second/4.0));
+        EXPECT_CALL(*m_sample_agg, sample_region(M_ENERGY_PKG_ENV_IDX_1, rid.first))
+            .WillRepeatedly(Return(rid.second/4.0));
+        EXPECT_CALL(*m_sample_agg, sample_region(M_ENERGY_ACCELERATOR_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second/1.0));
+    }
+
+    for (auto rid : m_region_frequency_accelerator) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_FREQUENCY_ACCELERATOR_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second/1.0));
+    }
+
+    for (auto rid : m_region_power_accelerator) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_POWER_ACCELERATOR_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second/1.0));
+    }
+
+    for (auto rid : m_region_clk_core) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_CLK_CORE_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second));
+    }
+    for (auto rid : m_region_clk_ref) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_CLK_REF_IDX, rid.first))
+            .WillRepeatedly(Return(rid.second));
+    }
+
+    // same hint values for all regions
+    EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_COMPUTE_IDX, _))
+        .WillRepeatedly(Return(0.2));
+    EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_MEMORY_IDX, _))
+        .WillRepeatedly(Return(0.3));
+    EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_IO_IDX, _))
+        .WillRepeatedly(Return(0.4));
+    EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_SERIAL_IDX, _))
+        .WillRepeatedly(Return(0.5));
+    EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_PARALLEL_IDX, _))
+        .WillRepeatedly(Return(0.6));
+    EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_UNKNOWN_IDX, _))
+        .WillRepeatedly(Return(0.7));
+    EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_UNSET_IDX, _))
+        .WillRepeatedly(Return(0.8));
+
+    // Other calls
+    EXPECT_CALL(m_tree_comm, overhead_send()).WillOnce(Return(678 * 56));
+    EXPECT_CALL(*m_comm, rank()).WillRepeatedly(Return(0));
+    EXPECT_CALL(*m_comm, num_rank()).WillOnce(Return(1));
+
+    std::vector<std::pair<std::string, std::string> > agent_header {
+        {"one", "1"},
+        {"two", "2"} };
+    std::vector<std::pair<std::string, std::string> > agent_node_report {
+        {"three", "3"},
+        {"four", "4"} };
+
+    std::string expected = "GEOPM Version: " + std::string(geopm_version()) + "\n"
+        "Start Time: " + m_start_time + "\n"
+        "Profile: " + m_profile_name + "\n"
+        "Agent: my_agent\n"
+        "Policy: DYNAMIC\n"
+        "one: 1\n"
+        "two: 2\n"
+        "\n"
+        "Hosts:\n"
+        "  " + geopm::hostname() + ":\n"
+        "    three: 3\n"
+        "    four: 4\n"
+        "    Regions:\n"
+        "    -\n"
+        "      region: \"all2all\"\n"
+        "      hash: 0x3ddc81bf\n"
+        "      runtime (s): 33.33\n"
+        "      count: 20\n"
+        "      sync-runtime (s): 555\n"
+        "      package-energy (J): 388.5\n"
+        "      dram-energy (J): 388.5\n"
+        "      power (W): 0.7\n"
+        "      frequency (%): 81.8182\n"
+        "      frequency (Hz): 0.818182\n"
+        "      time-hint-network (s): 3.4\n"
+        "      time-hint-ignore (s): 3.5\n"
+        "      time-hint-compute (s): 0.2\n"
+        "      time-hint-memory (s): 0.3\n"
+        "      time-hint-io (s): 0.4\n"
+        "      time-hint-serial (s): 0.5\n"
+        "      time-hint-parallel (s): 0.6\n"
+        "      time-hint-unknown (s): 0.7\n"
+        "      time-hint-unset (s): 0.8\n"
+        "      accelerator-energy (J): 777\n"
+        "      accelerator-power (W): 764\n"
+        "      accelerator-frequency (HZ): 567\n"
+        "      ENERGY_PACKAGE@package-0: 194.25\n"
+        "      ENERGY_PACKAGE@package-1: 194.25\n"
+        "      agent stat: 1\n"
+        "      agent other stat: 2\n"
+        "    -\n"
+        "      region: \"model-init\"\n"
+        "      hash: 0x644f9787\n"
+        "      runtime (s): 22.11\n"
+        "      count: 1\n"
+        "      sync-runtime (s): 333\n"
+        "      package-energy (J): 444\n"
+        "      dram-energy (J): 444\n"
+        "      power (W): 1.33333\n"
+        "      frequency (%): 84.8485\n"
+        "      frequency (Hz): 0.848485\n"
+        "      time-hint-network (s): 5.6\n"
+        "      time-hint-ignore (s): 5.7\n"
+        "      time-hint-compute (s): 0.2\n"
+        "      time-hint-memory (s): 0.3\n"
+        "      time-hint-io (s): 0.4\n"
+        "      time-hint-serial (s): 0.5\n"
+        "      time-hint-parallel (s): 0.6\n"
+        "      time-hint-unknown (s): 0.7\n"
+        "      time-hint-unset (s): 0.8\n"
+        "      accelerator-energy (J): 888\n"
+        "      accelerator-power (W): 653\n"
+        "      accelerator-frequency (HZ): 890\n"
+        "      ENERGY_PACKAGE@package-0: 222\n"
+        "      ENERGY_PACKAGE@package-1: 222\n"
+        "      agent stat: 2\n"
+        "    Unmarked Totals:\n"
+        "      runtime (s): 0.56\n"
+        "      count: 0\n"
+        "      sync-runtime (s): 444\n"
+        "      package-energy (J): 111\n"
+        "      dram-energy (J): 111\n"
+        "      power (W): 0.25\n"
+        "      frequency (%): 77.2727\n"
+        "      frequency (Hz): 0.772727\n"
+        "      time-hint-network (s): 1.2\n"
+        "      time-hint-ignore (s): 1.3\n"
+        "      time-hint-compute (s): 0.2\n"
+        "      time-hint-memory (s): 0.3\n"
+        "      time-hint-io (s): 0.4\n"
+        "      time-hint-serial (s): 0.5\n"
+        "      time-hint-parallel (s): 0.6\n"
+        "      time-hint-unknown (s): 0.7\n"
+        "      time-hint-unset (s): 0.8\n"
+        "      accelerator-energy (J): 222\n"
+        "      accelerator-power (W): 211\n"
+        "      accelerator-frequency (HZ): 123\n"
+        "      ENERGY_PACKAGE@package-0: 55.5\n"
+        "      ENERGY_PACKAGE@package-1: 55.5\n"
+        "      agent stat: 3\n"
+        "    Epoch Totals:\n"
+        "      runtime (s): 70\n"
+        "      count: 66\n"
+        "      sync-runtime (s): 70\n"
+        "      package-energy (J): 167\n"
+        "      dram-energy (J): 167\n"
+        "      power (W): 2.38571\n"
+        "      frequency (%): 88.6364\n"
+        "      frequency (Hz): 0.886364\n"
+        "      time-hint-network (s): 4.2\n"
+        "      time-hint-ignore (s): 4.3\n"
+        "      time-hint-compute (s): 0.2\n"
+        "      time-hint-memory (s): 0.3\n"
+        "      time-hint-io (s): 0.4\n"
+        "      time-hint-serial (s): 0.5\n"
+        "      time-hint-parallel (s): 0.6\n"
+        "      time-hint-unknown (s): 0.7\n"
+        "      time-hint-unset (s): 0.8\n"
+        "      accelerator-energy (J): 334\n"
+        "      accelerator-power (W): 432\n"
+        "      accelerator-frequency (HZ): 456\n"
+        "      ENERGY_PACKAGE@package-0: 83.5\n"
+        "      ENERGY_PACKAGE@package-1: 83.5\n"
+        "    Application Totals:\n"
+        "      runtime (s): 56\n"
+        "      count: 0\n"
+        "      sync-runtime (s): 56\n"
+        "      package-energy (J): 2222\n"
+        "      dram-energy (J): 2222\n"
+        "      power (W): 39.6786\n"
+        "      frequency (%): 66.6447\n"
+        "      frequency (Hz): 0.666447\n"
+        "      time-hint-network (s): 45\n"
+        "      time-hint-ignore (s): 46\n"
+        "      time-hint-compute (s): 0.2\n"
+        "      time-hint-memory (s): 0.3\n"
+        "      time-hint-io (s): 0.4\n"
+        "      time-hint-serial (s): 0.5\n"
+        "      time-hint-parallel (s): 0.6\n"
+        "      time-hint-unknown (s): 0.7\n"
+        "      time-hint-unset (s): 0.8\n"
+        "      accelerator-energy (J): 4444\n"
+        "      accelerator-power (W): 8992\n"
+        "      accelerator-frequency (HZ): 74489\n"
         "      ENERGY_PACKAGE@package-0: 1111\n"
         "      ENERGY_PACKAGE@package-1: 1111\n"
         "      geopmctl memory HWM (B): @ANY_STRING@\n"

--- a/test/ReporterTest.cpp
+++ b/test/ReporterTest.cpp
@@ -101,9 +101,9 @@ class ReporterTest : public testing::Test
             M_ENERGY_PKG_ENV_IDX_0,
             M_ENERGY_PKG_ENV_IDX_1,
             M_EPOCH_COUNT_IDX,
-            M_ENERGY_ACCELERATOR_IDX,
-            M_POWER_ACCELERATOR_IDX,
-            M_FREQUENCY_ACCELERATOR_IDX,
+            M_ENERGY_GPU_IDX,
+            M_POWER_GPU_IDX,
+            M_FREQUENCY_GPU_IDX,
         };
         ReporterTest();
         void TearDown(void);
@@ -158,14 +158,14 @@ class ReporterTest : public testing::Test
             {GEOPM_REGION_HASH_EPOCH, 334},
             {GEOPM_REGION_HASH_APP, 4444}
         };
-        std::map<uint64_t, double> m_region_frequency_accelerator = {
+        std::map<uint64_t, double> m_region_frequency_gpu = {
             {geopm_crc32_str("all2all"), 567},
             {geopm_crc32_str("model-init"), 890},
             {GEOPM_REGION_HASH_UNMARKED, 123},
             {GEOPM_REGION_HASH_EPOCH, 456},
             {GEOPM_REGION_HASH_APP, 74489}
         };
-        std::map<uint64_t, double> m_region_power_accelerator = {
+        std::map<uint64_t, double> m_region_power_gpu = {
             {geopm_crc32_str("all2all"), 764},
             {geopm_crc32_str("model-init"), 653},
             {GEOPM_REGION_HASH_UNMARKED, 211},
@@ -502,18 +502,18 @@ TEST_F(ReporterTest, generate)
     check_report(exp_stream, report);
 }
 
-TEST_F(ReporterTest, generate_accelerator)
+TEST_F(ReporterTest, generate_gpu)
 {
 
-    // accelerator signals
-    EXPECT_CALL(*m_sample_agg, push_signal("ENERGY_ACCELERATOR", GEOPM_DOMAIN_BOARD, 0))
-        .WillOnce(Return(M_ENERGY_ACCELERATOR_IDX));
-    EXPECT_CALL(*m_sample_agg, push_signal("POWER_ACCELERATOR", GEOPM_DOMAIN_BOARD, 0))
-        .WillOnce(Return(M_POWER_ACCELERATOR_IDX));
-    EXPECT_CALL(*m_sample_agg, push_signal("FREQUENCY_ACCELERATOR", GEOPM_DOMAIN_BOARD, 0))
-        .WillOnce(Return(M_FREQUENCY_ACCELERATOR_IDX));
+    // gpu signals
+    EXPECT_CALL(*m_sample_agg, push_signal("GPU_ENERGY", GEOPM_DOMAIN_BOARD, 0))
+        .WillOnce(Return(M_ENERGY_GPU_IDX));
+    EXPECT_CALL(*m_sample_agg, push_signal("GPU_POWER", GEOPM_DOMAIN_BOARD, 0))
+        .WillOnce(Return(M_POWER_GPU_IDX));
+    EXPECT_CALL(*m_sample_agg, push_signal("GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0))
+        .WillOnce(Return(M_FREQUENCY_GPU_IDX));
 
-    std::set<std::string> signal_names = {"ENERGY_ACCELERATOR","POWER_ACCELERATOR","FREQUENCY_ACCELERATOR"};
+    std::set<std::string> signal_names = {"GPU_ENERGY","GPU_POWER","GPU_FREQUENCY_STATUS"};
     EXPECT_CALL(m_platform_io, signal_names()).WillOnce(Return(signal_names));
 
     //setup default values for 'generate' tests
@@ -532,17 +532,17 @@ TEST_F(ReporterTest, generate_accelerator)
     m_reporter->init();
 
     for (auto rid : m_region_energy) {
-        EXPECT_CALL(*m_sample_agg, sample_region(M_ENERGY_ACCELERATOR_IDX, rid.first))
+        EXPECT_CALL(*m_sample_agg, sample_region(M_ENERGY_GPU_IDX, rid.first))
             .WillRepeatedly(Return(rid.second/1.0));
     }
 
-    for (auto rid : m_region_frequency_accelerator) {
-        EXPECT_CALL(*m_sample_agg, sample_region(M_FREQUENCY_ACCELERATOR_IDX, rid.first))
+    for (auto rid : m_region_frequency_gpu) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_FREQUENCY_GPU_IDX, rid.first))
             .WillRepeatedly(Return(rid.second/1.0));
     }
 
-    for (auto rid : m_region_power_accelerator) {
-        EXPECT_CALL(*m_sample_agg, sample_region(M_POWER_ACCELERATOR_IDX, rid.first))
+    for (auto rid : m_region_power_gpu) {
+        EXPECT_CALL(*m_sample_agg, sample_region(M_POWER_GPU_IDX, rid.first))
             .WillRepeatedly(Return(rid.second/1.0));
     }
 
@@ -586,9 +586,9 @@ TEST_F(ReporterTest, generate_accelerator)
         "      time-hint-parallel (s): 0.6\n"
         "      time-hint-unknown (s): 0.7\n"
         "      time-hint-unset (s): 0.8\n"
-        "      accelerator-energy (J): 777\n"
-        "      accelerator-power (W): 764\n"
-        "      accelerator-frequency (HZ): 567\n"
+        "      gpu-energy (J): 777\n"
+        "      gpu-power (W): 764\n"
+        "      gpu-frequency (Hz): 567\n"
         "      ENERGY_PACKAGE@package-0: 194.25\n"
         "      ENERGY_PACKAGE@package-1: 194.25\n"
         "      agent stat: 1\n"
@@ -613,9 +613,9 @@ TEST_F(ReporterTest, generate_accelerator)
         "      time-hint-parallel (s): 0.6\n"
         "      time-hint-unknown (s): 0.7\n"
         "      time-hint-unset (s): 0.8\n"
-        "      accelerator-energy (J): 888\n"
-        "      accelerator-power (W): 653\n"
-        "      accelerator-frequency (HZ): 890\n"
+        "      gpu-energy (J): 888\n"
+        "      gpu-power (W): 653\n"
+        "      gpu-frequency (Hz): 890\n"
         "      ENERGY_PACKAGE@package-0: 222\n"
         "      ENERGY_PACKAGE@package-1: 222\n"
         "      agent stat: 2\n"
@@ -637,9 +637,9 @@ TEST_F(ReporterTest, generate_accelerator)
         "      time-hint-parallel (s): 0.6\n"
         "      time-hint-unknown (s): 0.7\n"
         "      time-hint-unset (s): 0.8\n"
-        "      accelerator-energy (J): 222\n"
-        "      accelerator-power (W): 211\n"
-        "      accelerator-frequency (HZ): 123\n"
+        "      gpu-energy (J): 222\n"
+        "      gpu-power (W): 211\n"
+        "      gpu-frequency (Hz): 123\n"
         "      ENERGY_PACKAGE@package-0: 55.5\n"
         "      ENERGY_PACKAGE@package-1: 55.5\n"
         "      agent stat: 3\n"
@@ -661,9 +661,9 @@ TEST_F(ReporterTest, generate_accelerator)
         "      time-hint-parallel (s): 0.6\n"
         "      time-hint-unknown (s): 0.7\n"
         "      time-hint-unset (s): 0.8\n"
-        "      accelerator-energy (J): 334\n"
-        "      accelerator-power (W): 432\n"
-        "      accelerator-frequency (HZ): 456\n"
+        "      gpu-energy (J): 334\n"
+        "      gpu-power (W): 432\n"
+        "      gpu-frequency (Hz): 456\n"
         "      ENERGY_PACKAGE@package-0: 83.5\n"
         "      ENERGY_PACKAGE@package-1: 83.5\n"
         "    Application Totals:\n"
@@ -684,9 +684,9 @@ TEST_F(ReporterTest, generate_accelerator)
         "      time-hint-parallel (s): 0.6\n"
         "      time-hint-unknown (s): 0.7\n"
         "      time-hint-unset (s): 0.8\n"
-        "      accelerator-energy (J): 4444\n"
-        "      accelerator-power (W): 8992\n"
-        "      accelerator-frequency (HZ): 74489\n"
+        "      gpu-energy (J): 4444\n"
+        "      gpu-power (W): 8992\n"
+        "      gpu-frequency (Hz): 74489\n"
         "      ENERGY_PACKAGE@package-0: 1111\n"
         "      ENERGY_PACKAGE@package-1: 1111\n"
         "      geopmctl memory HWM (B): @ANY_STRING@\n"

--- a/test/ReporterTest.cpp
+++ b/test/ReporterTest.cpp
@@ -332,22 +332,6 @@ TEST_F(ReporterTest, generate)
             .WillRepeatedly(Return(rid.second));
     }
 
-    for (auto rid : m_region_energy) {
-        EXPECT_CALL(*m_sample_agg, sample_region(M_ENERGY_ACCELERATOR_IDX, rid.first))
-            .WillRepeatedly(Return(rid.second/1.0));
-    }
-
-    for (auto rid : m_region_frequency_accelerator) {
-        EXPECT_CALL(*m_sample_agg, sample_region(M_FREQUENCY_ACCELERATOR_IDX, rid.first))
-            .WillRepeatedly(Return(rid.second/1.0));
-    }
-
-    for (auto rid : m_region_power_accelerator) {
-        EXPECT_CALL(*m_sample_agg, sample_region(M_POWER_ACCELERATOR_IDX, rid.first))
-            .WillRepeatedly(Return(rid.second/1.0));
-    }
-
-
     // same hint values for all regions
     EXPECT_CALL(*m_sample_agg, sample_region(M_TIME_COMPUTE_IDX, _))
         .WillRepeatedly(Return(0.2));
@@ -366,7 +350,7 @@ TEST_F(ReporterTest, generate)
 
     // Other calls
     EXPECT_CALL(m_tree_comm, overhead_send()).WillOnce(Return(678 * 56));
-    EXPECT_CALL(*m_comm, rank()).WillOnce(Return(0));
+    EXPECT_CALL(*m_comm, rank()).WillRepeatedly(Return(0));
     EXPECT_CALL(*m_comm, num_rank()).WillOnce(Return(1));
 
     std::vector<std::pair<std::string, std::string> > agent_header {


### PR DESCRIPTION
- Relates to #1940.  This PR will not close this feature on its own.  
- Related to #1943 
- Addresses #1946 
- Addresses #1653
- Follow on to PR #1944 

This PR adds per signal NVML behavior required for proper reporting, aliases that may be used in either NVML or LevelZero (but have not yet been propagated to the LevelZeroIOGroup), and finally adds support for accelerator power, frequency, and energy in the report (Reporter.cpp). 

Tasks keeping this in draft:
- [x] Unit testing of aliases
- [x] Unit or integration testing of report capability