### PR TITLE
Fix all of the dead GEOPM web links in the documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -27,6 +27,6 @@ either of the following links:
 
 https://github.com/geopm/geopm/blob/dev/CONTRIBUTING.rst#feature-request
 
-https://geopm.github.io/geopmdpy/contrib.html#feature-request
+https://geopm.github.io/contrib.html#feature-request
 
 about the process of developing a GEOPM feature.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -152,7 +152,7 @@ Developers Guide
 
 The guide for developers is maintained here:
 
-https://geopm.github.io/geopmdpy/devel.html
+https://geopm.github.io/devel.html
 
 Refer to this guide to learn how to make changes to the GEOPM source
 code.

--- a/README
+++ b/README
@@ -11,7 +11,7 @@ GEOPM - Global Extensible Open Power Manager
 Web Pages
 ---------
 https://geopm.github.io <br>
-https://geopm.github.io/geopmdpy/ <br>
+https://geopm.github.io/ <br>
 https://geopm.github.io/man/geopm.7.html <br>
 https://geopm.slack.com
 
@@ -67,7 +67,7 @@ repository.  Please refer to the `service/README.rst` file for further
 documentation about the GEOPM Service.  Additionally a comprehensive
 overview of the GEOPM service is posted here:
 
-https://geopm.github.io/geopmdpy/
+https://geopm.github.io/
 
 
 GEOPM HPC Runtime
@@ -91,7 +91,7 @@ resource manager.
 More documentation on the GEOPM HPC Runtime is posted with our web
 documentation here:
 
-https://geopm.github.io/geopmdpy/runtime.html
+https://geopm.github.io/runtime.html
 
 
 Guide for Contributors
@@ -102,7 +102,7 @@ contributing guide for how some guidelines on how to participate.
 This guide is located in the root of the GEOPM repository in a file
 called `CONTRIBUTING.rst`.  This guide can also be viewed here:
 
-https://geopm.github.io/geopmdpy/contrib.html
+https://geopm.github.io/contrib.html
 
 
 Guide for GEOPM Developers
@@ -111,7 +111,7 @@ Guide for GEOPM Developers
 GEOPM is an open development project and we use Github to plan, review
 and test our work.  The proccess we follow is documented here:
 
-https://geopm.github.io/geopmdpy/devel.html
+https://geopm.github.io/devel.html
 
 this web page provides a guide for developers wishing to modify source
 code anywhere in the GEOPM repository for both the `geopm-service` and

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -11,6 +11,6 @@ either of the following links:
 
 https://github.com/geopm/geopm/blob/dev/CONTRIBUTING.rst#change-request
 
-https://geopm.github.io/geopmdpy/contrib.html#change-request
+https://geopm.github.io/contrib.html#change-request
 
 about the process to change the GEOPM repository.

--- a/service/README.rst
+++ b/service/README.rst
@@ -1,6 +1,6 @@
 
-GEOPM Systemd Service and Daemon
-================================
+GEOPM Systemd Service
+=====================
 
 
 *

--- a/service/docs/source/conf.py
+++ b/service/docs/source/conf.py
@@ -44,7 +44,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'GEOPM Service'
+project = 'GEOPM'
 copyright = '2021, Intel (R) Corporation'
 author = 'Intel (R) Corporation'
 

--- a/service/docs/source/requires.rst
+++ b/service/docs/source/requires.rst
@@ -8,7 +8,7 @@ all provided by commonly used Linux distributions.  A user that is
 only interested in using the GEOPM Service will find all of the
 dependencies in this page.  A user of the GEOPM HPC Runtime should
 refer to the documentation for that feature
-`here <https://geopm.github.io/geopmdpy/runtime.html>`__ to learn
+`here <https://geopm.github.io/runtime.html>`__ to learn
 about the external dependencies that the runtime requires.
 
 Build Requirements

--- a/service/dox/blurb.md
+++ b/service/dox/blurb.md
@@ -1,7 +1,7 @@
 GEOPM Systemd Service and Daemon
 ================================
 
-* [Primary documentation](https://geopm.github.io/geopmdpy/)
+* [Primary documentation](https://geopm.github.io)
 
 * Fine grained access management system for hardware features: read
   hardware "signals" and write hardware "controls".


### PR DESCRIPTION
- The sphinx documentation has become our primary web page.
- There is a redirect for geopm.github.io/geopmdpy, but there
  is no redirect for files other than index.html.

Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>

- Fixes to #1948 bug report from github issues
- Fixes #1949 change request from github issues.
