### PR TITLE
Enable exception handling when acclerator support fails

### DIFF
--- a/service/src/AcceleratorTopo.cpp
+++ b/service/src/AcceleratorTopo.cpp
@@ -47,7 +47,7 @@ namespace geopm
         std::unique_ptr<AcceleratorTopo> result;
         try {
 #ifdef GEOPM_ENABLE_NVML
-            result = geopm::make_unique<NVMLAcceratorTopo>();
+            result = geopm::make_unique<NVMLAcceleratorTopo>();
 #elif defined(GEOPM_ENABLE_LEVELZERO)
             result = geopm::make_unique<LevelZeroAcceleratorTopo>();
 #else


### PR DESCRIPTION
- If LevelZero or NVML are enabled at configure time, but not
  at run time, PlatformIO will fail to load.
- Fixes #1952

Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>