### PR TITLE
Address code coverage issues

### DIFF
--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -361,9 +361,13 @@ $(GTEST_TESTS): test/gtest_links/%:
 	rm -f $@
 	ln -s $(abs_srcdir)/test/geopm_test.sh $@
 
-coverage: check
+init-coverage:
+	lcov --no-external --capture --initial --directory src --output-file coverage-service-initial.info
+
+coverage: | init-coverage check
 	lcov --no-external --capture --directory src --output-file coverage-service.info
-	genhtml coverage-service.info --output-directory coverage-service
+	lcov -a coverage-service-initial.info -a coverage-service.info --output-file coverage-service-combined.info
+	genhtml coverage-service-combined.info --output-directory coverage-service --legend -t $$(git describe) -f
 
 clean-local-gtest-script-links:
 	rm -f test/gtest_links/*

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -367,7 +367,7 @@ init-coverage:
 coverage: | init-coverage check
 	lcov --no-external --capture --directory src --output-file coverage-service.info
 	lcov -a coverage-service-initial.info -a coverage-service.info --output-file coverage-service-combined.info
-	genhtml coverage-service-combined.info --output-directory coverage-service --legend -t $$(git describe) -f
+	genhtml coverage-service-combined.info --output-directory coverage-service --legend -t $(VERSION) -f
 
 clean-local-gtest-script-links:
 	rm -f test/gtest_links/*

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -527,7 +527,7 @@ coverage: | init-coverage check
 	lcov --no-external --capture --directory src --output-file coverage-base.info
 	lcov -a coverage-base-initial.info -a coverage-base.info --output-file coverage-base-combined.info
 	lcov --remove coverage-base-combined.info "$$(realpath $$(pwd))/src/geopm_pmpi_fortran.c" --output-file coverage-base-combined-filtered.info
-	genhtml coverage-base-combined-filtered.info --output-directory coverage-base --legend -t $$(git describe) -f
+	genhtml coverage-base-combined-filtered.info --output-directory coverage-base --legend -t $(VERSION) -f
 
 clean-local-gtest-script-links:
 	rm -f test/gtest_links/*

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -520,9 +520,14 @@ $(GTEST_TESTS): test/gtest_links/%:
 	rm -f $@
 	ln -s $(abs_builddir)/test/geopm_test.sh $@
 
-coverage: check
+init-coverage:
+	lcov --no-external --capture --initial --directory src --output-file coverage-base-initial.info
+
+coverage: | init-coverage check
 	lcov --no-external --capture --directory src --output-file coverage-base.info
-	genhtml coverage-base.info --output-directory coverage-base
+	lcov -a coverage-base-initial.info -a coverage-base.info --output-file coverage-base-combined.info
+	lcov --remove coverage-base-combined.info "$$(realpath $$(pwd))/src/geopm_pmpi_fortran.c" --output-file coverage-base-combined-filtered.info
+	genhtml coverage-base-combined-filtered.info --output-directory coverage-base --legend -t $$(git describe) -f
 
 clean-local-gtest-script-links:
 	rm -f test/gtest_links/*


### PR DESCRIPTION
- Fixes #1894.
- Adds service integration tests to looper.
- Enhance ```make coverage``` to properly capture the initial state of all source files.
- Fix a bug in the build script where ```make coverage``` was failing if you use the full path to the configure script.
