### PR TITLE
Implement POSIXSignal and tests for it

### DIFF
--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -194,6 +194,8 @@ libgeopmd_la_SOURCES = $(include_HEADERS) \
                        src/PlatformIOImp.hpp \
                        src/PlatformTopo.cpp \
                        src/PlatformTopoImp.hpp \
+                       src/POSIXSignal.cpp \
+                       src/POSIXSignal.hpp \
                        src/RawMSRSignal.cpp \
                        src/RawMSRSignal.hpp \
                        src/SDBus.hpp \

--- a/service/src/POSIXSignal.cpp
+++ b/service/src/POSIXSignal.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "POSIXSignal.hpp"
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+#include <cerrno>
+
+namespace geopm
+{
+
+    std::unique_ptr<POSIXSignal> POSIXSignal::make_unique(void)
+    {
+        return geopm::make_unique<POSIXSignalImp>();
+    }
+
+    sigset_t POSIXSignalImp::make_sigset(const std::set<int> &signal_set) const
+    {
+        sigset_t result;
+        int err = sigemptyset(&result);
+        check_return(err, "sigemptyset()");
+        for (const auto &it : signal_set) {
+            int err = sigaddset(&result, it);
+            check_return(err, "sigaddset()");
+        }
+        return result;
+    }
+
+    POSIXSignal::m_info_s POSIXSignalImp::reduce_info(siginfo_t const &info) const
+    {
+        return {};
+    }
+
+    int POSIXSignalImp::sig_wait_info(sigset_t const *sigset, siginfo_t *info) const
+    {
+        return 0;
+    }
+
+    int POSIXSignalImp::sig_timed_wait(sigset_t const *sigset, siginfo_t *info,
+                                       const timespec *timout) const
+    {
+        return 0;
+    }
+
+    void POSIXSignalImp::sig_queue(pid_t pid, int sig, int value) const
+    {
+
+    }
+
+    void POSIXSignalImp::sig_action(int signum, const struct sigaction *act,
+                                    struct sigaction *oldact) const
+    {
+
+    }
+
+#if 0 // This method is not defined any more.  Leaving the code here
+      // as an example
+    int POSIXSignalImp::signal_wait(const sigset_t &sigset) const
+    {
+        int result;
+        int err = sigwait(&sigset, &result);
+        check_return(err, "sigwait");
+        return result;
+    }
+#endif
+
+
+    void POSIXSignalImp::check_return(int err, const std::string &func_name) const
+    {
+        if (err == -1) {
+            throw Exception("POSIXSignal(): POSIX signal function call " + func_name +
+                            " returned an error", errno, __FILE__, __LINE__);
+        }
+    }
+}

--- a/service/src/POSIXSignal.hpp
+++ b/service/src/POSIXSignal.hpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef POSIXSIGNAL_HPP_INCLUDE
+#define POSIXSIGNAL_HPP_INCLUDE
+
+#include <signal.h>
+#include <memory>
+#include <set>
+
+namespace geopm
+{
+    class POSIXSignal
+    {
+        public:
+            /// @brief Reduced information set from siginfo_t struct
+            /// defined in signal.h.
+            struct m_info_s {
+                int signo;
+                int value;
+                int pid;
+            };
+
+            POSIXSignal() = default;
+            virtual ~POSIXSignal() = default;
+            /// @brief Factory method for POSIXSignal interface
+            ///
+            /// @return Unique pointer to an implementation of the
+            ///         POSIXSignal interface.
+            static std::unique_ptr<POSIXSignal> make_unique(void);
+
+            /// @brief Create a sigset_t from a set of signal numbers
+            ///
+            /// @param signal_set [in]: Set of all signal numbers to
+            ///                         add to the sigset.
+            ///
+            /// @return A sigset_t that is zeroed execept for
+            ///         specified signals
+            virtual sigset_t make_sigset(const std::set<int> &signal_set) const = 0;
+
+            /// @brief Extract the signal number, signal value integer
+            ///        and sending PID from a siginfo_t struct to
+            ///        simplify mock data.
+            virtual m_info_s reduce_info(const siginfo_t &info) const = 0;
+
+            //------------------------------------------------------------------
+            // Functions below here are wrappers around signal(7)
+            // functions.  They differ only in the conversion of error
+            // return values into raised geopm::Exceptions based on
+            // errno value.
+            // ------------------------------------------------------------------
+
+            /// @brief Wrapper for sigwaitinfo(3) that converts errors
+            ///        into Exceptions.
+            ///
+            /// See documentation for sigwaitinfo(3) about parameters
+            /// and return value.
+            virtual int sig_wait_info(const sigset_t *sigset,
+                                      siginfo_t *info) const = 0;
+
+            /// @brief Wrapper for sigtimedwait(3) that converts errors
+            ///        into Exceptions.
+            ///
+            /// See documentation for sigtimedwait(3) about parameters
+            /// and return value.
+            virtual int sig_timed_wait(const sigset_t *sigset, siginfo_t *info,
+                                       const struct timespec *timeout) const = 0;
+
+            /// @brief Wrapper for sigqueue(3) that converts errors
+            ///        into Exceptions.
+            ///
+            /// See documentation for sigqueue(3) about parameters.
+            virtual void sig_queue(pid_t pid, int sig,
+                                   int value) const= 0;
+
+            /// @brief Wrapper for sigaction(3) that converts errors
+            ///        into Exceptions.
+            ///
+            /// See documentation for sigaction(3) about parameters.
+            virtual void sig_action(int signum, const struct sigaction *act,
+                                    struct sigaction *oldact) const = 0;
+    };
+
+    class POSIXSignalImp : public POSIXSignal
+    {
+        public:
+            POSIXSignalImp() = default;
+            virtual ~POSIXSignalImp() = default;
+            sigset_t make_sigset(const std::set<int> &signal_set) const override;
+            m_info_s reduce_info(const siginfo_t &info) const override;
+            int sig_wait_info(const sigset_t *sigset,
+                              siginfo_t *info) const override;
+            int sig_timed_wait(const sigset_t *sigset, siginfo_t *info,
+                               const struct timespec *timeout) const override;
+            void sig_queue(pid_t pid, int sig, int value) const override;
+            void sig_action(int signum, const struct sigaction *act,
+                            struct sigaction *oldact) const override;
+        private:
+            void check_return(int err, const std::string &func_name) const;
+    };
+}
+
+#endif

--- a/service/src/POSIXSignal.hpp
+++ b/service/src/POSIXSignal.hpp
@@ -45,9 +45,9 @@ namespace geopm
             /// @brief Reduced information set from siginfo_t struct
             /// defined in signal.h.
             struct m_info_s {
-                int signo;
-                int value;
-                int pid;
+                int signo;  // siginfo_t::si_signo;  /* Signal number */
+                int value;  // siginfo_t::si_value;  /* Signal value */
+                int pid;    // siginfo_t::si_pid;    /* Sending process ID */
             };
 
             POSIXSignal() = default;
@@ -60,6 +60,8 @@ namespace geopm
 
             /// @brief Create a sigset_t from a set of signal numbers
             ///
+            /// @throw geopm::Exception upon EINVAL
+            ///
             /// @param signal_set [in]: Set of all signal numbers to
             ///                         add to the sigset.
             ///
@@ -70,6 +72,10 @@ namespace geopm
             /// @brief Extract the signal number, signal value integer
             ///        and sending PID from a siginfo_t struct to
             ///        simplify mock data.
+            ///
+            /// @param info [in]: see sigaction(2) man page
+            ///
+            /// @return m_info_s reduced information set from siginfo_t struct
             virtual m_info_s reduce_info(const siginfo_t &info) const = 0;
 
             //------------------------------------------------------------------
@@ -79,35 +85,64 @@ namespace geopm
             // errno value.
             // ------------------------------------------------------------------
 
-            /// @brief Wrapper for sigwaitinfo(3) that converts errors
+            /// @brief Wrapper for sigwaitinfo(2) that converts errors
             ///        into Exceptions.
             ///
-            /// See documentation for sigwaitinfo(3) about parameters
-            /// and return value.
+            /// @throw geopm::Exception upon EAGAIN, EINTR, EINVAL
+            ///
+            /// @remark See documentation for sigwaitinfo(2) about parameters
+            ///         and return value.
             virtual int sig_wait_info(const sigset_t *sigset,
                                       siginfo_t *info) const = 0;
 
-            /// @brief Wrapper for sigtimedwait(3) that converts errors
+            /// @brief Wrapper for sigtimedwait(2) that converts errors
             ///        into Exceptions.
             ///
-            /// See documentation for sigtimedwait(3) about parameters
-            /// and return value.
+            /// @throw geopm::Exception upon EAGAIN, EINTR, EINVAL
+            ///
+            /// @remark See documentation for sigtimedwait(2) about parameters
+            ///         and return value.
             virtual int sig_timed_wait(const sigset_t *sigset, siginfo_t *info,
                                        const struct timespec *timeout) const = 0;
 
             /// @brief Wrapper for sigqueue(3) that converts errors
             ///        into Exceptions.
             ///
-            /// See documentation for sigqueue(3) about parameters.
+            /// @throw geopm::Exception upon EINVAL, ESRCH
+            ///
+            /// @remark See documentation for sigqueue(3) about parameters.
             virtual void sig_queue(pid_t pid, int sig,
                                    int value) const= 0;
 
-            /// @brief Wrapper for sigaction(3) that converts errors
+            /// @brief Wrapper for sigaction(2) that converts errors
             ///        into Exceptions.
             ///
-            /// See documentation for sigaction(3) about parameters.
+            /// @throw geopm::Exception upon EFAULT, EINVAL
+            ///
+            /// @warning The Linux API sigaction(2) does not properly implement error checking,
+            ///          so this function checks for EFAULT if `act` or `oldact` are `nullptr`
+            ///
+            /// @remark See documentation for sigaction(2) about parameters.
             virtual void sig_action(int signum, const struct sigaction *act,
                                     struct sigaction *oldact) const = 0;
+
+            /// @brief Wrapper for sigprocmask(2) that converts errors
+            ///        into Exceptions.
+            ///
+            /// @throw geopm::Exception upon EFAULT, EINVAL
+            ///
+            /// @remark See documentation for sigprocmask(2) about parameters
+            ///         and return value.
+            virtual void sig_proc_mask(int how, const sigset_t *set, sigset_t *oldset) const = 0;
+
+            /// @brief Wrapper for sigsuspend(2) that converts errors
+            ///        into Exceptions.
+            ///
+            /// @throw geopm::Exception upon EFAULT
+            ///
+            /// @remark See documentation for sigprocmask(2) about parameters
+            ///         and return value. Except that it doesn't return an error by defualt.
+            virtual void sig_suspend(const sigset_t *mask) const = 0;
     };
 
     class POSIXSignalImp : public POSIXSignal
@@ -124,6 +159,8 @@ namespace geopm
             void sig_queue(pid_t pid, int sig, int value) const override;
             void sig_action(int signum, const struct sigaction *act,
                             struct sigaction *oldact) const override;
+            void sig_proc_mask(int how, const sigset_t *set, sigset_t *oldset) const override;
+            void sig_suspend(const sigset_t *mask) const override;
         private:
             void check_return(int err, const std::string &func_name) const;
     };

--- a/service/src/POSIXSignal.hpp
+++ b/service/src/POSIXSignal.hpp
@@ -140,7 +140,7 @@ namespace geopm
             ///
             /// @throw geopm::Exception upon EFAULT
             ///
-            /// @remark See documentation for sigprocmask(2) about parameters
+            /// @remark See documentation for sigsuspend(2) about parameters
             ///         and return value. Except that it doesn't return an error by defualt.
             virtual void sig_suspend(const sigset_t *mask) const = 0;
     };

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -213,6 +213,11 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/PlatformTopoTest.ppc_num_domain \
               test/gtest_links/PlatformTopoTest.singleton_construction \
               test/gtest_links/PlatformTopoTest.call_c_wrappers \
+              test/gtest_links/POSIXSignalTest.make_sigset \
+              test/gtest_links/POSIXSignalTest.reduce_info \
+              test/gtest_links/POSIXSignalTest.sig_timed_wait \
+              test/gtest_links/POSIXSignalTest.sig_queue \
+              test/gtest_links/POSIXSignalTest.sig_action \
               test/gtest_links/RawMSRSignalTest.errors \
               test/gtest_links/RawMSRSignalTest.read \
               test/gtest_links/RawMSRSignalTest.read_batch \
@@ -329,6 +334,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/MockSSTIoctl.hpp \
                           test/NVMLAcceleratorTopoTest.cpp \
                           test/NVMLIOGroupTest.cpp \
+                          test/POSIXSignalTest.cpp \
                           test/PlatformIOTest.cpp \
                           test/PlatformTopoTest.cpp \
                           test/RawMSRSignalTest.cpp \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -213,11 +213,21 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/PlatformTopoTest.ppc_num_domain \
               test/gtest_links/PlatformTopoTest.singleton_construction \
               test/gtest_links/PlatformTopoTest.call_c_wrappers \
-              test/gtest_links/POSIXSignalTest.make_sigset \
+              test/gtest_links/POSIXSignalTest.make_sigset_correct \
+              test/gtest_links/POSIXSignalTest.make_sigset_EINVAL \
+              test/gtest_links/POSIXSignalTest.make_sigset_zeroed \
               test/gtest_links/POSIXSignalTest.reduce_info \
-              test/gtest_links/POSIXSignalTest.sig_timed_wait \
-              test/gtest_links/POSIXSignalTest.sig_queue \
-              test/gtest_links/POSIXSignalTest.sig_action \
+              test/gtest_links/POSIXSignalTest.sig_timed_wait_EAGAIN \
+              test/gtest_links/POSIXSignalTest.sig_timed_wait_EINVAL \
+              test/gtest_links/POSIXSignalTest.sig_queue_EINVAL \
+              test/gtest_links/POSIXSignalTest.sig_queue_ESRCH \
+              test/gtest_links/POSIXSignalTest.sig_queue_EPERM \
+              test/gtest_links/POSIXSignalTest.sig_action_EINVAL \
+              test/gtest_links/POSIXSignalTest.sig_proc_mask_SIG_SETMASK \
+              test/gtest_links/POSIXSignalTest.sig_proc_mask_SIG_BLOCK \
+              test/gtest_links/POSIXSignalTest.sig_proc_mask_SIG_UNBLOCK \
+              test/gtest_links/POSIXSignalTest.sig_proc_mask_EINVAL \
+              test/gtest_links/POSIXSignalTest.sig_suspend_EFAULT \
               test/gtest_links/RawMSRSignalTest.errors \
               test/gtest_links/RawMSRSignalTest.read \
               test/gtest_links/RawMSRSignalTest.read_batch \

--- a/service/test/POSIXSignalTest.cpp
+++ b/service/test/POSIXSignalTest.cpp
@@ -30,11 +30,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "config.h"
-#include "POSIXSignal.hpp"
 
 #include <memory>
 #include <unistd.h>
+#include <signal.h>   // for sigprocmask() from Linux API
+#include <cstring>    // for memset(), memcmp()
+#include <vector>     // for std::vector
+#include <set>        // for std::set
+#include <algorithm>  // for std::set_union(), std::set_difference(), std::remove()
 
+#include "POSIXSignal.hpp"
 #include "gtest/gtest.h"
 #include "geopm_test.hpp"
 
@@ -45,87 +50,333 @@ class POSIXSignalTest : public :: testing :: Test
 {
     public:
         void SetUp(void);
+        void TearDown(void);
     protected:
         std::shared_ptr<POSIXSignalImp> m_posix_sig;
+
+        std::set<int> convert_sigset(const sigset_t &the_sigset);
+    private:
+        sigset_t m_backup_sigset;
 };
 
+/**
+ * @brief save the process's sigset before running the test fixture
+ *
+ * @details For testing the sigprocmask(), which modifies the process's sigset.
+ * This proces is running multiple tests, and we do not want the tests to leave any residue.
+ * Usually variable scope would be sufficient to enforce, but we are modifying the state of the process
+ * because we are testing the system calls API.
+ */
 void POSIXSignalTest::SetUp(void)
 {
     m_posix_sig = std::make_shared<POSIXSignalImp>();
+
+    //  `if (set == nullptr)` the current value of the signal mask is saved
+    sigprocmask(SIG_SETMASK, nullptr, &m_backup_sigset);
 }
 
-TEST_F(POSIXSignalTest, make_sigset)
+/**
+ * @brief restore the process's sigset after finished running the test fixture
+ *
+ * @see POSIXSignalTest::SetUp()
+ */
+void POSIXSignalTest::TearDown(void)
 {
-    sigset_t sigset = m_posix_sig->make_sigset({SIGCONT, SIGSTOP});
+    // explicitly delete managed object
+    m_posix_sig.reset();
+
+    sigprocmask(SIG_SETMASK, &m_backup_sigset, nullptr);
+}
+
+/**
+ * @param the_sigset [in]: see sigaction(2) for information
+ *
+ * @return std::set<int> equivalent to the passed in sigset_t
+ */
+std::set<int> POSIXSignalTest::convert_sigset(const sigset_t &the_sigset)
+{
+    std::set<int> result;
+    /// 1  ... 31 are POSIX defined signals
+    /// 32 and 33 are reserved for something
+    /// 34 ... 63 are user defined signals in Linux convention
+    for (int signo = 1; signo < 64; ++signo)
+    {
+        int is_in_set = sigismember(&the_sigset, signo);
+        EXPECT_NE(-1, is_in_set);
+        if (is_in_set) {
+            result.insert(signo);
+        }
+    }
+    return result;
+}
+
+/**
+ * @test A correct usage of make_sigset()
+ */
+TEST_F(POSIXSignalTest, make_sigset_correct)
+{
+    std::set<int> signal_set = {SIGCONT, SIGTSTP};
+    sigset_t sigset = m_posix_sig->make_sigset(signal_set);
     EXPECT_EQ(1, sigismember(&sigset, SIGCONT));
-    EXPECT_EQ(1, sigismember(&sigset, SIGSTOP));
+    EXPECT_EQ(1, sigismember(&sigset, SIGTSTP));
     EXPECT_EQ(0, sigismember(&sigset, SIGIO));
     EXPECT_EQ(0, sigismember(&sigset, SIGCHLD));
-    std::string errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigaddset() returned an error";
-    GEOPM_EXPECT_THROW_MESSAGE(m_posix_sig->make_sigset({-1}),
-                               EINVAL, errmsg_expect);
 }
 
+/**
+ * @test A usage of make_sigset() with invalid parameter
+ */
+TEST_F(POSIXSignalTest, make_sigset_EINVAL)
+{
+    std::set<int> signal_set = {-1};
+    std::string errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigaddset() returned an error";
+    GEOPM_EXPECT_THROW_MESSAGE(m_posix_sig->make_sigset(signal_set), EINVAL, errmsg_expect);
+}
+
+/**
+ * @test check that the returned sigset_t is indeed zeroed
+ */
+TEST_F(POSIXSignalTest, make_sigset_zeroed)
+{
+    std::set<int> signal_set;  // an empty set
+    // convert from std::set<int> to sigset_t
+    sigset_t sigset = m_posix_sig->make_sigset(signal_set);
+    // convert from sigset_t to std::set<int>
+    std::set<int> empty_set = convert_sigset(sigset);
+    // the resulting std::set<int> should be empty
+    EXPECT_EQ(0U, empty_set.size());
+}
+
+/**
+ * @test check that reduce_info works as expected
+ */
 TEST_F(POSIXSignalTest, reduce_info)
 {
-    siginfo_t siginfo {};
-    int expect_signal = SIGCHLD;
-    int expect_pid = 1234;
-    int expect_value = 4321;
+    siginfo_t siginfo;
+    const int expect_signal = SIGCHLD;
+    const int expect_value  = 4321;
+    const int expect_pid    = 1234;
 
-    siginfo.si_signo = expect_signal;
-    siginfo.si_pid = expect_pid;
+    siginfo.si_signo           = expect_signal;
     siginfo.si_value.sival_int = expect_value;
+    siginfo.si_pid             = expect_pid;
 
     POSIXSignal::m_info_s info = m_posix_sig->reduce_info(siginfo);
 
     EXPECT_EQ(expect_signal, info.signo);
-    EXPECT_EQ(expect_pid, info.pid);
-    EXPECT_EQ(expect_value, info.value);
+    EXPECT_EQ(expect_value,  info.value);
+    EXPECT_EQ(expect_pid,    info.pid);
 }
 
-TEST_F(POSIXSignalTest, sig_timed_wait)
+/**
+ * @test A usage of sig_timed_wait() with simulated signal timeout
+ */
+TEST_F(POSIXSignalTest, sig_timed_wait_EAGAIN)
 {
     siginfo_t info;
     timespec timeout {0,1000};
-    sigset_t sigset = m_posix_sig->make_sigset({SIGSTOP});
+    std::set<int> signal_set = {SIGTSTP};
+    sigset_t sigset = m_posix_sig->make_sigset(signal_set);
     std::string errmsg_expect = "Resource temporarily unavailable: POSIXSignal(): POSIX signal function call sigtimedwait() returned an error";
     GEOPM_EXPECT_THROW_MESSAGE(
         m_posix_sig->sig_timed_wait(&sigset, &info, &timeout),
         EAGAIN, errmsg_expect);
+}
 
-    timeout = {-1, -1};
-    errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigtimedwait() returned an error";
+/**
+ * @test A usage of sig_timed_wait() with invalid timeout value
+ */
+TEST_F(POSIXSignalTest, sig_timed_wait_EINVAL)
+{
+    siginfo_t info;
+    timespec timeout = {-1, -1};
+    std::set<int> signal_set = {SIGTSTP};
+    sigset_t sigset = m_posix_sig->make_sigset(signal_set);
+    std::string errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigtimedwait() returned an error";
     GEOPM_EXPECT_THROW_MESSAGE(
         m_posix_sig->sig_timed_wait(&sigset, &info, &timeout),
         EINVAL, errmsg_expect);
 }
 
-TEST_F(POSIXSignalTest, sig_queue)
+/**
+ * @test trying to send an invalid signal
+ */
+TEST_F(POSIXSignalTest, sig_queue_EINVAL)
 {
     std::string errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigqueue() returned an error";
     int pid = getpid();
     GEOPM_EXPECT_THROW_MESSAGE(
         m_posix_sig->sig_queue(pid, -1, 2),
         EINVAL, errmsg_expect);
+}
 
-    errmsg_expect = "No such process: POSIXSignal(): POSIX signal function call sigqueue() returned an error";
+/**
+ * @test trying to send a signal to a non existing process
+ */
+TEST_F(POSIXSignalTest, sig_queue_ESRCH)
+{
+    std::string errmsg_expect = "No such process: POSIXSignal(): POSIX signal function call sigqueue() returned an error";
     GEOPM_EXPECT_THROW_MESSAGE(
         m_posix_sig->sig_queue(999999999, SIGCONT, 2),
         ESRCH, errmsg_expect);
 }
 
-TEST_F(POSIXSignalTest, sig_action)
+/**
+ * @test trying to send a signal to the init process
+ *
+ * @remark https://unix.stackexchange.com/a/145581
+ */
+TEST_F(POSIXSignalTest, sig_queue_EPERM)
 {
-    std::string errmsg_expect = "Bad address: POSIXSignal(): POSIX signal function call sigaction() returned an error";
+    std::string errmsg_expect = "Operation not permitted: POSIXSignal(): POSIX signal function call sigqueue() returned an error";
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_posix_sig->sig_queue(1, SIGCONT, 2),
+        EPERM, errmsg_expect);
+}
+
+/**
+ * @test attempt is made to chenge the action for SIGKILL, which cannot be caught or ignored.
+ */
+TEST_F(POSIXSignalTest, sig_action_EINVAL)
+{
+    std::string errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigaction() returned an error";
     struct sigaction oldact;
     struct sigaction newact;
     GEOPM_EXPECT_THROW_MESSAGE(
-        m_posix_sig->sig_action(SIGCONT, nullptr, &oldact),
-        EFAULT, errmsg_expect);
-
-    errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigaction() returned an error";
-    GEOPM_EXPECT_THROW_MESSAGE(
         m_posix_sig->sig_action(SIGKILL, &newact, &oldact),
         EINVAL, errmsg_expect);
+}
+
+/**
+ * @test check if we can overwrite the current signal set
+ */
+TEST_F(POSIXSignalTest, sig_proc_mask_SIG_SETMASK)
+{
+    std::set<int> signal_set = {SIGTSTP};
+    sigset_t sigset = m_posix_sig->make_sigset(signal_set);
+    sigset_t saved_sigset;
+
+    // Set current signal set to argument
+    m_posix_sig->sig_proc_mask(SIG_SETMASK, &sigset, nullptr);
+    // Retrieve current signal set
+    m_posix_sig->sig_proc_mask(SIG_SETMASK, nullptr, &saved_sigset);
+
+    std::set<int> saved_signal_set = convert_sigset(saved_sigset);
+
+    // Compare the two signal sets for equality to see if the signal set was changed
+    EXPECT_EQ(signal_set, saved_signal_set);
+}
+
+/**
+ * @test check the union of the current set and the set argument
+ */
+TEST_F(POSIXSignalTest, sig_proc_mask_SIG_BLOCK)
+{
+    std::set<int> original_signal_set   = {SIGTSTP, SIGCHLD};
+    std::set<int> additional_signal_set = {SIGCHLD, SIGCONT};
+    // Pre allocate enough memory to store the maximum size of the set union, as 0 values
+    std::vector<int> union_signal_vector(original_signal_set.size() + additional_signal_set.size(), 0);
+    std::set_union(
+        original_signal_set.cbegin(), original_signal_set.cend(),
+        additional_signal_set.cbegin(), additional_signal_set.cend(),
+        union_signal_vector.begin()
+    );
+    // Erase all the 0 values from the vector
+    union_signal_vector.erase(
+        std::remove(union_signal_vector.begin(), union_signal_vector.end(), 0),
+        union_signal_vector.end()
+    );
+    // Convert the std::vector into std::set
+    std::set<int> union_signal_set(
+        std::make_move_iterator(union_signal_vector.cbegin()),
+        std::make_move_iterator(union_signal_vector.cend())
+    );
+
+    // Convert our std::set<int> into sigset_t
+    sigset_t original_sigset   = m_posix_sig->make_sigset(original_signal_set);
+    sigset_t additional_sigset = m_posix_sig->make_sigset(additional_signal_set);
+
+    // Set the original sigset
+    m_posix_sig->sig_proc_mask(SIG_SETMASK, &original_sigset, nullptr);
+    // The set of blocked signals is the union of the original sigset and the additional sigset
+    m_posix_sig->sig_proc_mask(SIG_BLOCK, &additional_sigset, nullptr);
+    // Recored the resulting value of the sigset
+    sigset_t resulting_sigset;
+    m_posix_sig->sig_proc_mask(SIG_SETMASK, nullptr, &resulting_sigset);
+    // Convert resulting_sigset into std::set<int>
+    std::set<int> resulting_set = convert_sigset(resulting_sigset);
+
+    // Compare the two sigset_t for equality to see if the union operation succeeded
+    EXPECT_EQ(union_signal_set, resulting_set);
+}
+
+/**
+ * @test check unblocking signals from the current set
+ */
+TEST_F(POSIXSignalTest, sig_proc_mask_SIG_UNBLOCK)
+{
+    std::set<int> original_signal_set = {SIGTSTP, SIGCHLD};
+    std::set<int> deleted_signal_set  = {SIGCHLD, SIGCONT};
+    // The unblocked_signal_vector can be at most the size of the original_signal_set
+    // (if deleted_signal_set didn't take out any items from the original_signal_set)
+    std::vector<int> unblocked_signal_vector(original_signal_set.size(), 0);
+    std::set_difference(
+        original_signal_set.cbegin(), original_signal_set.cend(),
+        deleted_signal_set.cbegin(), deleted_signal_set.cend(),
+        unblocked_signal_vector.begin()
+    );
+    // Erase all the 0 values from the vector
+    unblocked_signal_vector.erase(
+        std::remove(unblocked_signal_vector.begin(), unblocked_signal_vector.end(), 0),
+        unblocked_signal_vector.end()
+    );
+    // Convert the std::vector into std::set
+    std::set<int> unblocked_signal_set(
+        std::make_move_iterator(unblocked_signal_vector.cbegin()),
+        std::make_move_iterator(unblocked_signal_vector.cend())
+    );
+
+    // Convert our std::set<int> into sigset_t
+    sigset_t original_sigset  = m_posix_sig->make_sigset(original_signal_set);
+    sigset_t deleted_sigset   = m_posix_sig->make_sigset(deleted_signal_set);
+
+    // Set the original sigset
+    m_posix_sig->sig_proc_mask(SIG_SETMASK, &original_sigset, nullptr);
+    // The signals in deleted_sigset are removed from the current set of blocked signals.
+    // It is permissible to attempt to unblock a signal which is not blocked.
+    m_posix_sig->sig_proc_mask(SIG_UNBLOCK, &deleted_sigset, nullptr);
+    // Recored the resulting value of the sigset
+    sigset_t resulting_sigset;
+    m_posix_sig->sig_proc_mask(SIG_SETMASK, nullptr, &resulting_sigset);
+    // Convert resulting_sigset into std::set<int>
+    std::set<int> resulting_set = convert_sigset(resulting_sigset);
+
+    // Compare the two sigset_t for equality to see if the difference operation succeeded
+    EXPECT_EQ(unblocked_signal_set, resulting_set);
+}
+
+/**
+ * @test the value specified as the first parameter was invalid
+ */
+TEST_F(POSIXSignalTest, sig_proc_mask_EINVAL)
+{
+    std::set<int> signal_set = {SIGUSR1};
+    sigset_t sigset = m_posix_sig->make_sigset(signal_set);
+    sigset_t old_sigset;
+
+    std::string errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigprocmask() returned an error";
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_posix_sig->sig_proc_mask(-1, &sigset, &old_sigset),
+        EINVAL, errmsg_expect);
+}
+
+/**
+ * @test the mask argument points to memory which is not a valid part of the process address space
+ */
+TEST_F(POSIXSignalTest, sig_suspend_EFAULT)
+{
+    std::string errmsg_expect = "Bad address: POSIXSignal(): POSIX signal function call sigsuspend() returned an error";
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_posix_sig->sig_suspend((const sigset_t*) 10),
+        EFAULT, errmsg_expect);
 }

--- a/service/test/POSIXSignalTest.cpp
+++ b/service/test/POSIXSignalTest.cpp
@@ -119,13 +119,13 @@ TEST_F(POSIXSignalTest, sig_action)
 {
     std::string errmsg_expect = "Bad address: POSIXSignal(): POSIX signal function call sigaction() returned an error";
     struct sigaction oldact;
-    struct sigaction newact {};
+    struct sigaction newact;
     GEOPM_EXPECT_THROW_MESSAGE(
         m_posix_sig->sig_action(SIGCONT, nullptr, &oldact),
         EFAULT, errmsg_expect);
 
     errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigaction() returned an error";
     GEOPM_EXPECT_THROW_MESSAGE(
-        m_posix_sig->sig_action(-1, &newact, &oldact),
+        m_posix_sig->sig_action(SIGKILL, &newact, &oldact),
         EINVAL, errmsg_expect);
 }

--- a/service/test/POSIXSignalTest.cpp
+++ b/service/test/POSIXSignalTest.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+#include "POSIXSignal.hpp"
+
+#include <memory>
+#include <unistd.h>
+
+#include "gtest/gtest.h"
+#include "geopm_test.hpp"
+
+using geopm::POSIXSignal;
+using geopm::POSIXSignalImp;
+
+class POSIXSignalTest : public :: testing :: Test
+{
+    public:
+        void SetUp(void);
+    protected:
+        std::shared_ptr<POSIXSignalImp> m_posix_sig;
+};
+
+void POSIXSignalTest::SetUp(void)
+{
+    m_posix_sig = std::make_shared<POSIXSignalImp>();
+}
+
+TEST_F(POSIXSignalTest, make_sigset)
+{
+    sigset_t sigset = m_posix_sig->make_sigset({SIGCONT, SIGSTOP});
+    EXPECT_EQ(1, sigismember(&sigset, SIGCONT));
+    EXPECT_EQ(1, sigismember(&sigset, SIGSTOP));
+    EXPECT_EQ(0, sigismember(&sigset, SIGIO));
+    EXPECT_EQ(0, sigismember(&sigset, SIGCHLD));
+    std::string errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigaddset() returned an error";
+    GEOPM_EXPECT_THROW_MESSAGE(m_posix_sig->make_sigset({-1}),
+                               EINVAL, errmsg_expect);
+}
+
+TEST_F(POSIXSignalTest, reduce_info)
+{
+    siginfo_t siginfo {};
+    int expect_signal = SIGCHLD;
+    int expect_pid = 1234;
+    int expect_value = 4321;
+
+    siginfo.si_signo = expect_signal;
+    siginfo.si_pid = expect_pid;
+    siginfo.si_value.sival_int = expect_value;
+
+    POSIXSignal::m_info_s info = m_posix_sig->reduce_info(siginfo);
+
+    EXPECT_EQ(expect_signal, info.signo);
+    EXPECT_EQ(expect_pid, info.pid);
+    EXPECT_EQ(expect_value, info.value);
+}
+
+TEST_F(POSIXSignalTest, sig_timed_wait)
+{
+    siginfo_t info;
+    timespec timeout {0,1000};
+    sigset_t sigset = m_posix_sig->make_sigset({SIGSTOP});
+    std::string errmsg_expect = "Resource temporarily unavailable: POSIXSignal(): POSIX signal function call sigtimedwait() returned an error";
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_posix_sig->sig_timed_wait(&sigset, &info, &timeout),
+        EAGAIN, errmsg_expect);
+
+    timeout = {-1, -1};
+    errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigtimedwait() returned an error";
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_posix_sig->sig_timed_wait(&sigset, &info, &timeout),
+        EINVAL, errmsg_expect);
+}
+
+TEST_F(POSIXSignalTest, sig_queue)
+{
+    std::string errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigqueue() returned an error";
+    int pid = getpid();
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_posix_sig->sig_queue(pid, -1, 2),
+        EINVAL, errmsg_expect);
+
+    errmsg_expect = "No such process: POSIXSignal(): POSIX signal function call sigqueue() returned an error";
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_posix_sig->sig_queue(999999999, SIGCONT, 2),
+        ESRCH, errmsg_expect);
+}
+
+TEST_F(POSIXSignalTest, sig_action)
+{
+    std::string errmsg_expect = "Bad address: POSIXSignal(): POSIX signal function call sigaction() returned an error";
+    struct sigaction oldact;
+    struct sigaction newact {};
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_posix_sig->sig_action(SIGCONT, nullptr, &oldact),
+        EFAULT, errmsg_expect);
+
+    errmsg_expect = "Invalid argument: POSIXSignal(): POSIX signal function call sigaction() returned an error";
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_posix_sig->sig_action(-1, &newact, &oldact),
+        EINVAL, errmsg_expect);
+}


### PR DESCRIPTION
- Relates to #1856 from github issues
- Fixes #1856 change request from github issues.

This pull request fleshes out the class POSIXSignal, which is a wrapper around the POSIX signal classes that are used by the GEOPM, and also adds comprlehensive units for this class.