### PR TITLE
Add helper methods for batch server startup

### DIFF
--- a/service/src/Helper.cpp
+++ b/service/src/Helper.cpp
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 
 #include <cmath>
 #include <climits>
@@ -289,4 +290,26 @@ namespace geopm
         }
         return env_string;
     }
+
+    unsigned int pid_to_uid(const int pid) {
+        int err = 0;
+        std::string proc_path = "/proc/" + std::to_string(pid);
+        struct stat stat_struct;
+        err = stat(proc_path.c_str(), &stat_struct);
+        if (err) {
+            throw Exception("pid_to_uid(): ", errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        return stat_struct.st_uid;
+    };
+
+    unsigned int pid_to_gid(const int pid) {
+        int err = 0;
+        std::string proc_path = "/proc/" + std::to_string(pid);
+        struct stat stat_struct;
+        err = stat(proc_path.c_str(), &stat_struct);
+        if (err) {
+            throw Exception("pid_to_gid(): ", errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+        return stat_struct.st_gid;
+    };
 }

--- a/service/src/SharedMemory.cpp
+++ b/service/src/SharedMemory.cpp
@@ -113,7 +113,7 @@ namespace geopm
 
     }
 
-    void SharedMemoryImp::create_memory_region(const std::string &shm_key, size_t size, bool world_perms)
+    void SharedMemoryImp::create_memory_region(const std::string &shm_key, size_t size, bool is_secure)
     {
         if (!size) {
             throw Exception("SharedMemoryImp: Cannot create shared memory region of zero size", GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
@@ -123,8 +123,8 @@ namespace geopm
 
         mode_t old_mask = umask(0);
         int shm_id = 0;
-        if (world_perms) {
-            shm_id = shm_open(m_shm_key.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+        if (is_secure) {
+            shm_id = shm_open(m_shm_key.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
         }
         else {
             shm_id = shm_open(m_shm_key.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);

--- a/service/src/SharedMemoryImp.hpp
+++ b/service/src/SharedMemoryImp.hpp
@@ -58,7 +58,8 @@ namespace geopm
             ///        an inter-process shared memory region.
             /// @param [in] shm_key Shared memory key to create the region.
             /// @param [in] size Size of the region to create.
-            void create_memory_region(const std::string &shm_key, size_t size);
+            /// @param [in] world_perms Allow world r/w.
+            void create_memory_region(const std::string &shm_key, size_t size, bool world_perms);
             /// @brief Takes a key and attempts to attach to a
             ///        inter-process shared memory region. This version of the
             ///        constructor tries to attach multiple times until a timeout

--- a/service/src/SharedMemoryImp.hpp
+++ b/service/src/SharedMemoryImp.hpp
@@ -58,8 +58,8 @@ namespace geopm
             ///        an inter-process shared memory region.
             /// @param [in] shm_key Shared memory key to create the region.
             /// @param [in] size Size of the region to create.
-            /// @param [in] world_perms Allow world r/w.
-            void create_memory_region(const std::string &shm_key, size_t size, bool world_perms);
+            /// @param [in] is_secure Disallow group and world r/w if true.
+            void create_memory_region(const std::string &shm_key, size_t size, bool is_secure);
             /// @brief Takes a key and attempts to attach to a
             ///        inter-process shared memory region. This version of the
             ///        constructor tries to attach multiple times until a timeout

--- a/service/src/SharedMemoryImp.hpp
+++ b/service/src/SharedMemoryImp.hpp
@@ -67,6 +67,11 @@ namespace geopm
             /// @param [in] timeout Length in seconds to keep retrying the
             ///             attachment process to a shared memory region.
             void attach_memory_region(const std::string &shm_key, unsigned int timeout);
+            /// @brief Modifies the shared memory to be owned by the specified gid
+            //         and uid if current permissions allow for the change.
+            /// @param [in] gid Group ID to become owner.
+            /// @param [in] uid User ID to become owner.
+            void chown(const unsigned int gid, const unsigned int uid) override;
         private:
             /// @brief Shared memory key for the region.
             std::string m_shm_key;

--- a/service/src/geopm/Helper.hpp
+++ b/service/src/geopm/Helper.hpp
@@ -159,6 +159,16 @@ namespace geopm
     /// @param [in] The name of the environment variable to read.
     /// @return The contents of the variable if present, otherwise an empty string.
     std::string get_env(const std::string &name);
+
+    /// @brief Query for the user id assoiciated with the process id.
+    /// @param [in] pid The process id to query.
+    /// @return The user id.
+    unsigned int pid_to_uid(const int pid);
+
+    /// @brief Query for the group id assoiciated with the process id.
+    /// @param [in] pid The process id to query.
+    /// @return The group id.
+    unsigned int pid_to_gid(const int pid);
 }
 
 #endif

--- a/service/src/geopm/SharedMemory.hpp
+++ b/service/src/geopm/SharedMemory.hpp
@@ -69,6 +69,9 @@ namespace geopm
             /// @brief Attaches to the shared memory region with the given key.  If
             ///        it cannot attach within the timeout, throws an exception.
             static std::unique_ptr<SharedMemory> make_unique_user(const std::string &shm_key, unsigned int timeout);
+            /// @brief Modifies the shared memory to be owned by the specified gid
+            //         and uid if current permissions allow for the change.
+            virtual void chown(const unsigned int gid, const unsigned int uid) = 0;
     };
 }
 

--- a/service/src/geopm/SharedMemory.hpp
+++ b/service/src/geopm/SharedMemory.hpp
@@ -66,6 +66,8 @@ namespace geopm
             virtual std::unique_ptr<SharedMemoryScopedLock> get_scoped_lock(void) = 0;
             /// @brief Creates a shared memory region with the given key and size.
             static std::unique_ptr<SharedMemory> make_unique_owner(const std::string &shm_key, size_t size);
+            /// @brief Creates a shared memory region with the given key and size without world permissions.
+            static std::unique_ptr<SharedMemory> make_unique_owner_secure(const std::string &shm_key, size_t size);
             /// @brief Attaches to the shared memory region with the given key.  If
             ///        it cannot attach within the timeout, throws an exception.
             static std::unique_ptr<SharedMemory> make_unique_user(const std::string &shm_key, unsigned int timeout);

--- a/service/src/geopm/SharedMemory.hpp
+++ b/service/src/geopm/SharedMemory.hpp
@@ -66,7 +66,7 @@ namespace geopm
             virtual std::unique_ptr<SharedMemoryScopedLock> get_scoped_lock(void) = 0;
             /// @brief Creates a shared memory region with the given key and size.
             static std::unique_ptr<SharedMemory> make_unique_owner(const std::string &shm_key, size_t size);
-            /// @brief Creates a shared memory region with the given key and size without world permissions.
+            /// @brief Creates a shared memory region with the given key and size without group or world permissions.
             static std::unique_ptr<SharedMemory> make_unique_owner_secure(const std::string &shm_key, size_t size);
             /// @brief Attaches to the shared memory region with the given key.  If
             ///        it cannot attach within the timeout, throws an exception.

--- a/service/test/HelperTest.cpp
+++ b/service/test/HelperTest.cpp
@@ -34,6 +34,7 @@
 
 #include <string>
 #include <vector>
+#include <unistd.h>
 
 #include "geopm/Helper.hpp"
 #include "geopm.h"
@@ -116,4 +117,13 @@ TEST(HelperTest, check_hint)
     GEOPM_EXPECT_THROW_MESSAGE(geopm::check_hint(hint),
                                GEOPM_ERROR_INVALID,
                                "invalid hint");
+}
+
+TEST(HelperTest, pid_to)
+{
+    unsigned int uid = getuid();
+    unsigned int gid = getgid();
+    unsigned int pid = getpid();
+    EXPECT_EQ(uid, geopm::pid_to_uid(pid));
+    EXPECT_EQ(gid, geopm::pid_to_gid(pid));
 }

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -85,6 +85,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/HelperTest.string_ends_with \
               test/gtest_links/HelperTest.string_join \
               test/gtest_links/HelperTest.string_split \
+              test/gtest_links/HelperTest.pid_to \
               test/gtest_links/IOGroupTest.control_names_are_valid \
               test/gtest_links/IOGroupTest.controls_have_descriptions \
               test/gtest_links/IOGroupTest.signal_names_are_valid \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -244,6 +244,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/SharedMemoryTest.lock_shmem_u \
               test/gtest_links/SharedMemoryTest.share_data \
               test/gtest_links/SharedMemoryTest.share_data_ipc \
+              test/gtest_links/SharedMemoryTest.default_world_permissions \
+              test/gtest_links/SharedMemoryTest.secure_no_world_permissions \
               test/gtest_links/SSTControlTest.mailbox_adjust_batch \
               test/gtest_links/SSTControlTest.mmio_adjust_batch \
               test/gtest_links/SSTControlTest.save_restore_mmio \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -245,8 +245,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/SharedMemoryTest.lock_shmem_u \
               test/gtest_links/SharedMemoryTest.share_data \
               test/gtest_links/SharedMemoryTest.share_data_ipc \
-              test/gtest_links/SharedMemoryTest.default_world_permissions \
-              test/gtest_links/SharedMemoryTest.secure_no_world_permissions \
+              test/gtest_links/SharedMemoryTest.default_permissions \
+              test/gtest_links/SharedMemoryTest.secure_permissions \
               test/gtest_links/SSTControlTest.mailbox_adjust_batch \
               test/gtest_links/SSTControlTest.mmio_adjust_batch \
               test/gtest_links/SSTControlTest.save_restore_mmio \

--- a/service/test/SharedMemoryTest.cpp
+++ b/service/test/SharedMemoryTest.cpp
@@ -230,7 +230,7 @@ TEST_F(SharedMemoryTest, chown)
                                GEOPM_ERROR_RUNTIME, "unlinked");
 }
 
-TEST_F(SharedMemoryTest, default_world_permissions)
+TEST_F(SharedMemoryTest, default_permissions)
 {
     int shm_id = -1;
     uint32_t permissions_bits = 0;
@@ -245,11 +245,11 @@ TEST_F(SharedMemoryTest, default_world_permissions)
     m_shmem->unlink(); // Manually unlink unless config_shmem_u() is called
 }
 
-TEST_F(SharedMemoryTest, secure_no_world_permissions)
+TEST_F(SharedMemoryTest, secure_permissions)
 {
     int shm_id = -1;
     uint32_t permissions_bits = 0;
-    uint32_t expected_permissions = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
+    uint32_t expected_permissions = S_IRUSR | S_IWUSR;
     struct stat stat_struct;
 
     config_shmem_s();

--- a/test/MockSharedMemory.hpp
+++ b/test/MockSharedMemory.hpp
@@ -61,6 +61,8 @@ class MockSharedMemory : public geopm::SharedMemory
         MOCK_METHOD(std::unique_ptr<geopm::SharedMemoryScopedLock>,
                     get_scoped_lock, (), (override));
         MOCK_METHOD(void, unlink, (), (override));
+        MOCK_METHOD(void, chown, (const unsigned int gid, const unsigned int uid),
+                    (override));
 
     protected:
         std::vector<char> m_buffer;


### PR DESCRIPTION
- Relates to #1860.
- Fixes #1960.

- Adds SharedMemory:chown, geopm::pid_to_uid, and geopm::pid_to_gid.
- Adds new SharedMemory API to create segments without world permissions: SharedMemory::make_unique_owner_secure.
