### PR TITLE
Fix bug when the MSRIOGroup is not used in a batch read or write.

### DIFF
--- a/service/src/MSRIO.cpp
+++ b/service/src/MSRIO.cpp
@@ -286,6 +286,9 @@ namespace geopm
 
    void MSRIOImp::msr_ioctl_read(void)
     {
+        if (m_read_batch.numops == 0) {
+            return;
+        }
         GEOPM_DEBUG_ASSERT(m_read_batch.numops == m_read_batch_op.size() &&
                            m_read_batch.ops == m_read_batch_op.data(),
                            "Batch operations not updated prior to calling MSRIOImp::msr_ioctl_read()");
@@ -294,6 +297,9 @@ namespace geopm
 
     void MSRIOImp::msr_ioctl_write(void)
     {
+        if (m_write_batch.numops == 0) {
+            return;
+        }
         GEOPM_DEBUG_ASSERT(m_write_batch.numops == m_write_batch_op.size() &&
                            m_write_batch.ops == m_write_batch_op.data(),
                            "Batch operations not updated prior to calling MSRIOImp::msr_ioctl_write()");

--- a/service/src/MSRIOGroup.cpp
+++ b/service/src/MSRIOGroup.cpp
@@ -518,8 +518,9 @@ namespace geopm
 
     void MSRIOGroup::read_batch(void)
     {
-        m_msrio->read_batch();
-
+        if (m_signal_pushed.size() != 0) {
+            m_msrio->read_batch();
+        }
         // update timesignal value
         *m_time_batch = geopm_time_since(m_time_zero.get());
 
@@ -529,7 +530,7 @@ namespace geopm
 
     void MSRIOGroup::write_batch(void)
     {
-        if (m_control_pushed.size()) {
+        if (m_control_pushed.size() != 0) {
             if (std::any_of(m_is_adjusted.begin(), m_is_adjusted.end(), [](bool it) {return !it;})) {
                 throw Exception("MSRIOGroup::write_batch() called before all controls were adjusted",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);

--- a/service/test/MSRIOGroupTest.cpp
+++ b/service/test/MSRIOGroupTest.cpp
@@ -1285,3 +1285,13 @@ TEST_F(MSRIOGroupTest, parse_json_msrs)
               "    iogroup: MSRIOGroup",
               m_msrio_group->signal_description("MSR::MSR_ONE:FIELD_RO"));
 }
+
+TEST_F(MSRIOGroupTest, batch_calls_no_push)
+{
+    // Make sure calling read_batch and write batch with nothing
+    // pushed does not call into ioctl.
+    EXPECT_CALL(*m_msrio, read_batch()).Times(0);
+    EXPECT_CALL(*m_msrio, write_batch()).Times(0);
+    m_msrio_group->read_batch();
+    m_msrio_group->write_batch();
+}

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -139,6 +139,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/MSRIOGroupTest.valid_signal_names \
               test/gtest_links/MSRIOGroupTest.allowlist \
               test/gtest_links/MSRIOGroupTest.write_control \
+              test/gtest_links/MSRIOGroupTest.batch_calls_no_push \
               test/gtest_links/MSRIOTest.read_aligned \
               test/gtest_links/MSRIOTest.read_batch \
               test/gtest_links/MSRIOTest.read_unaligned \


### PR DESCRIPTION
- Fixes #1756
- Fixes #1981 