### PR TITLE
Reorder the SharedMemory::chown() arguments to reflect wrapped function

### DIFF
--- a/service/src/SharedMemory.cpp
+++ b/service/src/SharedMemory.cpp
@@ -278,7 +278,7 @@ namespace geopm
         m_do_unlink_check = true;
     }
 
-    void SharedMemoryImp::chown(const unsigned int gid, const unsigned int uid) {
+    void SharedMemoryImp::chown(const unsigned int uid, const unsigned int gid) {
         int err = 0;
         int shm_id = -1;
         if (m_is_linked) {

--- a/service/src/SharedMemoryImp.hpp
+++ b/service/src/SharedMemoryImp.hpp
@@ -70,9 +70,9 @@ namespace geopm
             void attach_memory_region(const std::string &shm_key, unsigned int timeout);
             /// @brief Modifies the shared memory to be owned by the specified gid
             //         and uid if current permissions allow for the change.
-            /// @param [in] gid Group ID to become owner.
             /// @param [in] uid User ID to become owner.
-            void chown(const unsigned int gid, const unsigned int uid) override;
+            /// @param [in] gid Group ID to become owner.
+            void chown(const unsigned int uid, const unsigned int gid) override;
         private:
             /// @brief Shared memory key for the region.
             std::string m_shm_key;

--- a/service/src/geopm/SharedMemory.hpp
+++ b/service/src/geopm/SharedMemory.hpp
@@ -73,7 +73,7 @@ namespace geopm
             static std::unique_ptr<SharedMemory> make_unique_user(const std::string &shm_key, unsigned int timeout);
             /// @brief Modifies the shared memory to be owned by the specified gid
             //         and uid if current permissions allow for the change.
-            virtual void chown(const unsigned int gid, const unsigned int uid) = 0;
+            virtual void chown(const unsigned int uid, const unsigned int gid) = 0;
     };
 }
 

--- a/service/test/SharedMemoryTest.cpp
+++ b/service/test/SharedMemoryTest.cpp
@@ -214,11 +214,11 @@ TEST_F(SharedMemoryTest, lock_shmem_u)
 TEST_F(SharedMemoryTest, chown)
 {
     config_shmem();
-    gid_t gid = getgid();
     uid_t uid = getuid();
+    gid_t gid = getgid();
 
     // Sanity check: set to my own gid/uid
-    EXPECT_NO_THROW(m_shmem->chown(gid, uid));
+    EXPECT_NO_THROW(m_shmem->chown(uid, gid));
 
     // Try to set root gid/uid
     GEOPM_EXPECT_THROW_MESSAGE(m_shmem->chown(0, 0),
@@ -226,7 +226,7 @@ TEST_F(SharedMemoryTest, chown)
 
     m_shmem->unlink(); // Manually unlink unless config_shmem_u() is called
 
-    GEOPM_EXPECT_THROW_MESSAGE(m_shmem->chown(gid, uid),
+    GEOPM_EXPECT_THROW_MESSAGE(m_shmem->chown(uid, gid),
                                GEOPM_ERROR_RUNTIME, "unlinked");
 }
 


### PR DESCRIPTION
Fixes #1989