### PR TITLE
Fix tophash check

### DIFF
--- a/integration/apps/build_func.sh
+++ b/integration/apps/build_func.sh
@@ -67,13 +67,11 @@ clone_repo_git(){
     fi
 
     cd ${DIRNAME}
-    local HASH=$(git rev-parse --short HEAD)
-    cd -
-    if [ "${TOPHASH}" != "${HASH}" ]; then
-        echo "Error: Current source hash (${HASH}) is different than expected hash (${TOPHASH})."
+    if ! git reset --hard ${TOPHASH}; then
+        echo "Error: Could not reset to specified git hash: ${TOPHASH}." 1>&2
         return 1
     fi
-
+    cd -
     backup_archive ${ARCHIVE} ${DIRNAME}
 }
 


### PR DESCRIPTION
Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>

- Relates to #2002  [bug report/feature request/story] from github issues
- Fixes #2003  change request from github issues.

[Brief description of the change]
The implementation for the feature was modified because the existing code did not use the HASH input to reset the git checkout to a particular commit. It checked that the HASH matched the HEAD for a checkout. If the repository had advanced, it stopped the build process. We would like to checkout to a tested commit version and do not have control over branches/tags in a public repository not maintained by the geopm team.

_Note_:

Prior to creating a pull request, please see the documentation at
either of the following links:

https://github.com/geopm/geopm/blob/dev/CONTRIBUTING.rst#change-request

https://geopm.github.io/contrib.html#change-request

about the process to change the GEOPM repository.
