### PR TITLE
Improve test coverage for `ServiceIOGroupTest` and `BatchServerTest`:

### DIFF
--- a/service/src/BatchServer.cpp
+++ b/service/src/BatchServer.cpp
@@ -69,6 +69,9 @@ static void action_sigchld(int signo, siginfo_t *siginfo, void *context)
             g_sigchld_status = child_status;
         }
     }
+    if (child_pid == -1) {
+        g_sigchld_status = errno ? errno : GEOPM_ERROR_RUNTIME;
+    }
     ++g_sigchld_count;
 }
 

--- a/service/src/BatchServer.cpp
+++ b/service/src/BatchServer.cpp
@@ -250,6 +250,7 @@ namespace geopm
                     out_message = BatchStatus::M_MESSAGE_QUIT;
                     break;
                 case BatchStatus::M_MESSAGE_TERMINATE:
+                    out_message = BatchStatus::M_MESSAGE_TERMINATE;
                     break;
                 default:
                     throw Exception("BatchServerImp::run_batch(): Received unknown response from client: " +

--- a/service/src/BatchServer.hpp
+++ b/service/src/BatchServer.hpp
@@ -140,12 +140,13 @@ namespace geopm
             ///        block until the first function completes.
             int fork_with_setup(std::function<void(void)> setup,
                                 std::function<void(void)> run);
+            void child_register_handler(void);
+            void parent_register_handler(void);
+
         private:
             void push_requests(void);
             void read_and_update(void);
             void update_and_write(void);
-            void parent_register_handler(void);
-            void child_register_handler(void);
             void check_invalid_signal(void);
             void check_return(int ret, const std::string &func_name) const;
             char read_message(void);

--- a/service/src/BatchServer.hpp
+++ b/service/src/BatchServer.hpp
@@ -138,7 +138,7 @@ namespace geopm
             void create_shmem(void);
             /// @brief Fork a process that runs two functions and
             ///        block until the first function completes.
-            int fork_with_setup(std::function<void(void)> setup,
+            int fork_with_setup(std::function<char(void)> setup,
                                 std::function<void(void)> run);
             void child_register_handler(void);
             void parent_register_handler(void);

--- a/service/src/Exception.cpp
+++ b/service/src/Exception.cpp
@@ -80,6 +80,10 @@ extern "C"
 
 namespace geopm
 {
+    std::string error_message(int error_value)
+    {
+        return geopm::ErrorMessage::get().message_fixed(error_value);
+    }
 
     int exception_handler(std::exception_ptr eptr, bool do_print)
     {

--- a/service/src/geopm/Exception.hpp
+++ b/service/src/geopm/Exception.hpp
@@ -119,6 +119,13 @@ namespace geopm
             /// The error code associated with the exception.
             int m_err;
     };
+
+    /// @brief Function that converts an error code into an error message.
+    ///
+    /// @param error_value The error code associated with the exception.
+    ///
+    /// @return string The error message associated with the error code.
+    std::string error_message(int error_value);
 }
 
 #endif

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -57,6 +57,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/BatchServerTest.read_batch_exception \
               test/gtest_links/BatchServerTest.create_shmem \
               test/gtest_links/BatchServerTest.fork_with_setup \
+              test/gtest_links/BatchServerTest.fork_with_setup_exception \
               test/gtest_links/BatchServerTest.destructor_exceptions \
               test/gtest_links/BatchServerTest.fork_and_terminate_child \
               test/gtest_links/BatchServerTest.fork_and_terminate_parent \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -50,6 +50,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/BatchServerTest.run_batch_read_empty \
               test/gtest_links/BatchServerTest.run_batch_write \
               test/gtest_links/BatchServerTest.run_batch_write_empty \
+              test/gtest_links/BatchServerTest.receive_message_terminate \
+              test/gtest_links/BatchServerTest.receive_message_default \
               test/gtest_links/BatchServerTest.receive_message_exception \
               test/gtest_links/BatchServerTest.write_message_exception \
               test/gtest_links/BatchServerTest.read_batch_exception \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -61,6 +61,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/BatchServerTest.destructor_exceptions \
               test/gtest_links/BatchServerTest.fork_and_terminate_child \
               test/gtest_links/BatchServerTest.fork_and_terminate_parent \
+              test/gtest_links/BatchServerTest.action_sigchld \
+              test/gtest_links/BatchServerTest.action_sigchld_error \
               test/gtest_links/BatchStatusTest.client_send_to_server_fifo_expect \
               test/gtest_links/BatchStatusTest.server_send_to_client_fifo_expect \
               test/gtest_links/BatchStatusTest.server_send_to_client_fifo \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -58,6 +58,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/BatchServerTest.create_shmem \
               test/gtest_links/BatchServerTest.fork_with_setup \
               test/gtest_links/BatchServerTest.destructor_exceptions \
+              test/gtest_links/BatchServerTest.fork_and_terminate_child \
+              test/gtest_links/BatchServerTest.fork_and_terminate_parent \
               test/gtest_links/BatchStatusTest.client_send_to_server_fifo_expect \
               test/gtest_links/BatchStatusTest.server_send_to_client_fifo_expect \
               test/gtest_links/BatchStatusTest.server_send_to_client_fifo \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -261,7 +261,9 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/ServiceIOGroupTest.signal_control_info \
               test/gtest_links/ServiceIOGroupTest.domain_type \
               test/gtest_links/ServiceIOGroupTest.read_signal_behavior \
+              test/gtest_links/ServiceIOGroupTest.read_signal_exception \
               test/gtest_links/ServiceIOGroupTest.write_control \
+              test/gtest_links/ServiceIOGroupTest.write_control_exception \
               test/gtest_links/ServiceIOGroupTest.valid_signal_aggregation \
               test/gtest_links/ServiceIOGroupTest.valid_format_function \
               test/gtest_links/ServiceIOGroupTest.push_signal \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -45,6 +45,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/BatchServerTest.get_server_pid \
               test/gtest_links/BatchServerTest.get_server_key \
               test/gtest_links/BatchServerTest.stop_batch \
+              test/gtest_links/BatchServerTest.stop_batch_exception \
               test/gtest_links/BatchServerTest.run_batch_read \
               test/gtest_links/BatchServerTest.run_batch_read_empty \
               test/gtest_links/BatchServerTest.run_batch_write \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -50,6 +50,9 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/BatchServerTest.run_batch_read_empty \
               test/gtest_links/BatchServerTest.run_batch_write \
               test/gtest_links/BatchServerTest.run_batch_write_empty \
+              test/gtest_links/BatchServerTest.receive_message_exception \
+              test/gtest_links/BatchServerTest.write_message_exception \
+              test/gtest_links/BatchServerTest.read_batch_exception \
               test/gtest_links/BatchServerTest.create_shmem \
               test/gtest_links/BatchServerTest.fork_with_setup \
               test/gtest_links/BatchStatusTest.client_send_to_server_fifo_expect \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -55,6 +55,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/BatchServerTest.read_batch_exception \
               test/gtest_links/BatchServerTest.create_shmem \
               test/gtest_links/BatchServerTest.fork_with_setup \
+              test/gtest_links/BatchServerTest.destructor_exceptions \
               test/gtest_links/BatchStatusTest.client_send_to_server_fifo_expect \
               test/gtest_links/BatchStatusTest.server_send_to_client_fifo_expect \
               test/gtest_links/BatchStatusTest.server_send_to_client_fifo \

--- a/service/test/ServiceIOGroupTest.cpp
+++ b/service/test/ServiceIOGroupTest.cpp
@@ -181,6 +181,37 @@ TEST_F(ServiceIOGroupTest, read_signal_behavior)
                                "BAD SIGNAL not valid for ServiceIOGroup");
 }
 
+TEST_F(ServiceIOGroupTest, read_signal_exception)
+{
+    // !is_valid_signal(signal_name)
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_serviceio_group->read_signal("NUM_VACCUM_TUBES", 4, 0),
+        GEOPM_ERROR_INVALID,
+        "ServiceIOGroup::read_signal(): signal name \""
+    );
+
+    // domain_type != signal_domain_type(signal_name)
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_serviceio_group->read_signal(m_expected_signals[0], 80, 0),
+        GEOPM_ERROR_INVALID,
+        "ServiceIOGroup::read_signal(): domain_type requested does not match the domain of the signal ("
+    );
+
+    // domain_idx < 0
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_serviceio_group->read_signal(m_expected_signals[0], 0, -8),
+        GEOPM_ERROR_INVALID,
+        "ServiceIOGroup::read_signal(): domain_idx out of range"
+    );
+
+    // domain_idx >= m_platform_topo.num_domain(domain_type)
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_serviceio_group->read_signal(m_expected_signals[0], 0, 80),
+        GEOPM_ERROR_INVALID,
+        "ServiceIOGroup::read_signal(): domain_idx out of range"
+    );
+}
+
 TEST_F(ServiceIOGroupTest, write_control)
 {
     for (unsigned ii = 0; ii < m_expected_controls.size(); ++ii) {
@@ -190,6 +221,39 @@ TEST_F(ServiceIOGroupTest, write_control)
         EXPECT_NO_THROW(m_serviceio_group->write_control("SERVICE::" + m_expected_controls.at(ii),
                                                          ii, ii, 7));
     }
+}
+
+TEST_F(ServiceIOGroupTest, write_control_exception)
+{
+    // !is_valid_control(control_name)
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_serviceio_group->write_control("NUM_VACCUM_TUBES", 4, 0, 7.0),
+        GEOPM_ERROR_INVALID,
+        "ServiceIOGroup::write_control(): control name \""
+        "NUM_VACCUM_TUBES"
+        "\" not found"
+    );
+
+    // domain_type != control_domain_type(control_name)
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_serviceio_group->write_control(m_expected_controls[0], 80, 0, 7.0),
+        GEOPM_ERROR_INVALID,
+        "ServiceIOGroup::write_control(): domain_type does not match the domain of the control."
+    );
+
+    // domain_idx < 0
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_serviceio_group->write_control(m_expected_controls[0], 0, -8, 7.0),
+        GEOPM_ERROR_INVALID,
+        "ServiceIOGroup::write_control(): domain_idx out of range"
+    );
+
+    // domain_idx >= m_platform_topo.num_domain(domain_type)
+    GEOPM_EXPECT_THROW_MESSAGE(
+        m_serviceio_group->write_control(m_expected_controls[0], 0, 80, 7.0),
+        GEOPM_ERROR_INVALID,
+        "ServiceIOGroup::write_control(): domain_idx out of range"
+    );
 }
 
 TEST_F(ServiceIOGroupTest, valid_signal_aggregation)
@@ -264,6 +328,7 @@ TEST_F(ServiceIOGroupTest, write_batch)
 TEST_F(ServiceIOGroupTest, save_control)
 {
     /// These are noops, make sure mock objects are not called into
+    /// We want it to fail if it tries to open the non-existent file path.
     m_serviceio_group->save_control();
     m_serviceio_group->save_control("/bad/file/path");
 }
@@ -271,6 +336,7 @@ TEST_F(ServiceIOGroupTest, save_control)
 TEST_F(ServiceIOGroupTest, restore_control)
 {
     /// These are noops, make sure mock objects are not called into
+    /// We want it to fail if it tries to open the non-existent file path.
     m_serviceio_group->restore_control();
     m_serviceio_group->restore_control("/bad/file/path");
 }

--- a/service/test/ServiceIOGroupTest.cpp
+++ b/service/test/ServiceIOGroupTest.cpp
@@ -184,32 +184,24 @@ TEST_F(ServiceIOGroupTest, read_signal_behavior)
 TEST_F(ServiceIOGroupTest, read_signal_exception)
 {
     // !is_valid_signal(signal_name)
-    GEOPM_EXPECT_THROW_MESSAGE(
-        m_serviceio_group->read_signal("NUM_VACCUM_TUBES", 4, 0),
-        GEOPM_ERROR_INVALID,
-        "ServiceIOGroup::read_signal(): signal name \""
-    );
+    GEOPM_EXPECT_THROW_MESSAGE(m_serviceio_group->read_signal("NUM_VACUUM_TUBES", 4, 0),
+                               GEOPM_ERROR_INVALID,
+                               "ServiceIOGroup::read_signal(): signal name \"NUM_VACUUM_TUBES\" not found");
 
     // domain_type != signal_domain_type(signal_name)
-    GEOPM_EXPECT_THROW_MESSAGE(
-        m_serviceio_group->read_signal(m_expected_signals[0], 80, 0),
-        GEOPM_ERROR_INVALID,
-        "ServiceIOGroup::read_signal(): domain_type requested does not match the domain of the signal ("
-    );
+    GEOPM_EXPECT_THROW_MESSAGE(m_serviceio_group->read_signal(m_expected_signals[0], 80, 0),
+                               GEOPM_ERROR_INVALID,
+                               "ServiceIOGroup::read_signal(): domain_type requested does not match the domain of the signal (");
 
     // domain_idx < 0
-    GEOPM_EXPECT_THROW_MESSAGE(
-        m_serviceio_group->read_signal(m_expected_signals[0], 0, -8),
-        GEOPM_ERROR_INVALID,
-        "ServiceIOGroup::read_signal(): domain_idx out of range"
-    );
+    GEOPM_EXPECT_THROW_MESSAGE(m_serviceio_group->read_signal(m_expected_signals[0], 0, -8),
+                               GEOPM_ERROR_INVALID,
+                               "ServiceIOGroup::read_signal(): domain_idx out of range");
 
     // domain_idx >= m_platform_topo.num_domain(domain_type)
-    GEOPM_EXPECT_THROW_MESSAGE(
-        m_serviceio_group->read_signal(m_expected_signals[0], 0, 80),
-        GEOPM_ERROR_INVALID,
-        "ServiceIOGroup::read_signal(): domain_idx out of range"
-    );
+    GEOPM_EXPECT_THROW_MESSAGE(m_serviceio_group->read_signal(m_expected_signals[0], 0, 80),
+                               GEOPM_ERROR_INVALID,
+                               "ServiceIOGroup::read_signal(): domain_idx out of range");
 }
 
 TEST_F(ServiceIOGroupTest, write_control)
@@ -226,34 +218,24 @@ TEST_F(ServiceIOGroupTest, write_control)
 TEST_F(ServiceIOGroupTest, write_control_exception)
 {
     // !is_valid_control(control_name)
-    GEOPM_EXPECT_THROW_MESSAGE(
-        m_serviceio_group->write_control("NUM_VACCUM_TUBES", 4, 0, 7.0),
-        GEOPM_ERROR_INVALID,
-        "ServiceIOGroup::write_control(): control name \""
-        "NUM_VACCUM_TUBES"
-        "\" not found"
-    );
+    GEOPM_EXPECT_THROW_MESSAGE(m_serviceio_group->write_control("NUM_VACUUM_TUBES", 4, 0, 7.0),
+                               GEOPM_ERROR_INVALID,
+                               "ServiceIOGroup::write_control(): control name \"NUM_VACUUM_TUBES\" not found");
 
     // domain_type != control_domain_type(control_name)
-    GEOPM_EXPECT_THROW_MESSAGE(
-        m_serviceio_group->write_control(m_expected_controls[0], 80, 0, 7.0),
-        GEOPM_ERROR_INVALID,
-        "ServiceIOGroup::write_control(): domain_type does not match the domain of the control."
-    );
+    GEOPM_EXPECT_THROW_MESSAGE(m_serviceio_group->write_control(m_expected_controls[0], 80, 0, 7.0),
+                               GEOPM_ERROR_INVALID,
+                               "ServiceIOGroup::write_control(): domain_type does not match the domain of the control.");
 
     // domain_idx < 0
-    GEOPM_EXPECT_THROW_MESSAGE(
-        m_serviceio_group->write_control(m_expected_controls[0], 0, -8, 7.0),
-        GEOPM_ERROR_INVALID,
-        "ServiceIOGroup::write_control(): domain_idx out of range"
-    );
+    GEOPM_EXPECT_THROW_MESSAGE(m_serviceio_group->write_control(m_expected_controls[0], 0, -8, 7.0),
+                               GEOPM_ERROR_INVALID,
+                               "ServiceIOGroup::write_control(): domain_idx out of range");
 
     // domain_idx >= m_platform_topo.num_domain(domain_type)
-    GEOPM_EXPECT_THROW_MESSAGE(
-        m_serviceio_group->write_control(m_expected_controls[0], 0, 80, 7.0),
-        GEOPM_ERROR_INVALID,
-        "ServiceIOGroup::write_control(): domain_idx out of range"
-    );
+    GEOPM_EXPECT_THROW_MESSAGE(m_serviceio_group->write_control(m_expected_controls[0], 0, 80, 7.0),
+                               GEOPM_ERROR_INVALID,
+                               "ServiceIOGroup::write_control(): domain_idx out of range");
 }
 
 TEST_F(ServiceIOGroupTest, valid_signal_aggregation)


### PR DESCRIPTION
Improve test coverage for `ServiceIOGroupTest`:
 - `ServiceIOGroupTest.read_signal_exception`
 - `ServiceIOGroupTest.write_control_exception`
 - `ServiceIOGroupTest.save_control`
 - `ServiceIOGroupTest.restore_control`

   - Relates to #2016  [bug report/feature request/story] from github issues
