### PR TITLE
Unlink shared memory keys after BatchClient attaches

### DIFF
--- a/service/src/BatchClient.cpp
+++ b/service/src/BatchClient.cpp
@@ -82,7 +82,12 @@ namespace geopm
         , m_signal_shmem(signal_shmem)
         , m_control_shmem(control_shmem)
     {
-
+        if (m_signal_shmem != nullptr) {
+            m_signal_shmem->unlink();
+        }
+        if (m_control_shmem != nullptr) {
+            m_control_shmem->unlink();
+        }
     }
 
     std::vector<double> BatchClientImp::read_batch(void)

--- a/service/src/BatchServer.cpp
+++ b/service/src/BatchServer.cpp
@@ -142,6 +142,13 @@ namespace geopm
                 std::cerr << "Warning: <geopm> BatchServerImp::~BatchServerImp(): Non-GEOPM exception thrown in destructor\n";
             }
         }
+        if (m_signal_shmem != nullptr) {
+            m_signal_shmem->unlink();
+        }
+
+        if (m_control_shmem != nullptr) {
+            m_control_shmem->unlink();
+        }
     }
 
     int BatchServerImp::server_pid(void) const


### PR DESCRIPTION
- Also unlink in BatchServer destructor in case BatchClient never connects.
- Fixes #2012