### PR TITLE
Tie write lock access to the session leader PID

### DIFF
--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -756,11 +756,9 @@ class PlatformService(object):
             if self._write_pid is not None:
                 raise RuntimeError(f'The PID {client_pid} requested write access, but the geopm service already has write mode client with SID {self._write_pid}')
             if client_sid != client_pid:
-                self._active_sessions.add_client(
-                    client_sid,
-                    self._active_sessions.get_signals(client_pid),
-                    self._active_sessions.get_controls(client_pid),
-                    self._watch_client(client_sid))
+                uid = os.stat(f'/proc/{client_sid}/status').st_uid
+                user = pwd.getpwuid(uid).pw_name
+                self.open_session(user, client_sid)
             self._active_sessions.set_write_client(client_sid)
             self._write_pid = client_sid
             save_dir = os.path.join(self._VAR_PATH, self._SAVE_DIR)

--- a/service/geopmdpy_test/TestPlatformService.py
+++ b/service/geopmdpy_test/TestPlatformService.py
@@ -506,7 +506,7 @@ default
         valid_controls = session_data['controls']
         signal_config = [(0, 0, sig) for sig in valid_signals]
         control_config = [(0, 0, con) for con in valid_controls]
-        err_msg = f'The PID {client_pid} requested write access, but the geopm service already has write mode client with SID {other_pid}'
+        err_msg = f'The PID {client_pid} requested write access, but the geopm service already has write mode client with PID or SID of {other_pid}'
         with self.assertRaisesRegex(RuntimeError, err_msg), \
              mock.patch('geopmdpy.pio.start_batch_server', return_value = (2345, "2345")), \
              mock.patch('os.getsid', return_value=client_pid) as mock_getsid:


### PR DESCRIPTION
- Fixes #2037

Pretty simple change that will provide the feature described in issue #2037