### PR TITLE
Skip unsupported tests

### DIFF
--- a/integration/test/test_enforce_policy.py
+++ b/integration/test/test_enforce_policy.py
@@ -47,6 +47,7 @@ import util
 import geopmdpy.topo
 
 
+@util.skip_unless_msr_access('Skipped pending resolution of issue #2017.')
 @util.skip_unless_do_launch()
 @util.skip_unless_batch()
 class TestIntegrationEnforcePolicy(unittest.TestCase):

--- a/integration/test/test_geopmio.py
+++ b/integration/test/test_geopmio.py
@@ -222,6 +222,7 @@ class TestIntegrationGeopmio(unittest.TestCase):
         self.check_output(['INVALID', 'board', '0', '0'], ['cannot write control'])
         self.check_output(['--domain', '--info'], ['info about domain not implemented'])
 
+    @util.skip_unless_msr_access()
     @util.skip_unless_batch()
     @util.skip_unless_stressng()
     def test_geopmwrite_set_freq(self):

--- a/integration/test/util.py
+++ b/integration/test/util.py
@@ -271,7 +271,7 @@ def skip_unless_library_in_ldconfig(library):
     return lambda func: func
 
 
-def skip_unless_msr_access():
+def skip_unless_msr_access(msg=None):
     """Skip the test if the user does not have direct access to msr-safe
     """
     if not g_util.skip_launch():
@@ -281,7 +281,9 @@ def skip_unless_msr_access():
             with open('/dev/null', 'w') as dev_null:
                 geopm_test_launcher.allocation_node_test(test_exec, dev_null, dev_null)
         except subprocess.CalledProcessError:
-            return unittest.skip('No msr-safe access.  Cannot write to ' + try_path)
+            if msg is None:
+                msg = 'No msr-safe access.  Cannot write to ' + try_path
+            return unittest.skip(msg)
     return lambda func: func
 
 


### PR DESCRIPTION
These tests are not currently supported with the service and w/o msr-safe access.

- The geopmio tests expect to be able to issue controls through the launcher and have them persist so the test expectations can verify the state.
- The enforce_policy tests expect the SLURM/SPANK plugin to work.  It is not presently.