### PR TITLE
Update IOGroups to use SaveControl

### DIFF
--- a/service/src/LevelZeroIOGroup.hpp
+++ b/service/src/LevelZeroIOGroup.hpp
@@ -46,6 +46,7 @@ namespace geopm
 {
     class PlatformTopo;
     class LevelZeroDevicePool;
+    class SaveControl;
 
     /// @brief IOGroup that provides signals and controls for Accelerators
     class LevelZeroIOGroup : public IOGroup
@@ -53,7 +54,8 @@ namespace geopm
         public:
             LevelZeroIOGroup();
             LevelZeroIOGroup(const PlatformTopo &platform_topo,
-                             const LevelZeroDevicePool &device_pool);
+                             const LevelZeroDevicePool &device_pool,
+                             std::shared_ptr<SaveControl> save_control);
             virtual ~LevelZeroIOGroup() = default;
             std::set<std::string> signal_names(void) const override;
             std::set<std::string> control_names(void) const override;
@@ -144,6 +146,8 @@ namespace geopm
 
             //GEOPM Domain indexed
             std::vector<std::pair<double,double> > m_frequency_range;
+
+            std::shared_ptr<SaveControl> m_mock_save_ctl;
     };
 }
 #endif

--- a/service/src/SSTIOGroup.hpp
+++ b/service/src/SSTIOGroup.hpp
@@ -45,12 +45,16 @@ namespace geopm
     class SSTIO;
     class Signal;
     class Control;
+    class SaveControl;
 
     /// @brief IOGroup that provides a signal for the time since GEOPM startup.
     class SSTIOGroup : public IOGroup
     {
         public:
-            SSTIOGroup(const PlatformTopo &topo, std::shared_ptr<SSTIO> sstio);
+            SSTIOGroup();
+            SSTIOGroup(const PlatformTopo &topo,
+                       std::shared_ptr<SSTIO> sstio,
+                       std::shared_ptr<SaveControl> save_control);
             virtual ~SSTIOGroup() = default;
             std::set<std::string> signal_names(void) const override;
             std::set<std::string> control_names(void) const override;
@@ -282,6 +286,8 @@ namespace geopm
 
             // Mapping of control index to pushed controls
             std::vector<std::shared_ptr<Control> > m_control_pushed;
+
+            std::shared_ptr<SaveControl> m_mock_save_ctl;
     };
 }
 

--- a/service/src/geopm/MSRIOGroup.hpp
+++ b/service/src/geopm/MSRIOGroup.hpp
@@ -50,6 +50,7 @@ namespace geopm
     class PlatformTopo;
     class Signal;
     class Control;
+    class SaveControl;
 
     /// @brief IOGroup that provides signals and controls based on MSRs.
     class MSRIOGroup : public IOGroup
@@ -69,7 +70,8 @@ namespace geopm
             MSRIOGroup(const PlatformTopo &platform_topo,
                        std::shared_ptr<MSRIO> msrio,
                        int cpuid,
-                       int num_cpu);
+                       int num_cpu,
+                       std::shared_ptr<SaveControl> save_control);
             virtual ~MSRIOGroup() = default;
             std::set<std::string> signal_names(void) const override;
             std::set<std::string> control_names(void) const override;
@@ -265,6 +267,8 @@ namespace geopm
             std::vector<std::shared_ptr<Signal> > m_signal_pushed;
             // Mapping of control index to pushed controls
             std::vector<std::shared_ptr<Control> > m_control_pushed;
+
+            std::shared_ptr<SaveControl> m_mock_save_ctl;
     };
 }
 

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -150,6 +150,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/LevelZeroIOGroupTest.read_signal_and_batch \
               test/gtest_links/LevelZeroIOGroupTest.read_timestamp_batch \
               test/gtest_links/LevelZeroIOGroupTest.read_timestamp_batch_reverse \
+              test/gtest_links/LevelZeroIOGroupTest.save_restore_control \
               test/gtest_links/MSRIOGroupTest.adjust \
               test/gtest_links/MSRIOGroupTest.control_error \
               test/gtest_links/MSRIOGroupTest.cpuid \
@@ -176,6 +177,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/MSRIOGroupTest.allowlist \
               test/gtest_links/MSRIOGroupTest.write_control \
               test/gtest_links/MSRIOGroupTest.batch_calls_no_push \
+              test/gtest_links/MSRIOGroupTest.save_restore_control \
               test/gtest_links/MSRIOTest.read_aligned \
               test/gtest_links/MSRIOTest.read_batch \
               test/gtest_links/MSRIOTest.read_unaligned \
@@ -322,6 +324,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/SSTIOGroupTest.valid_control_names \
               test/gtest_links/SSTIOGroupTest.valid_signal_domains \
               test/gtest_links/SSTIOGroupTest.valid_signal_names \
+              test/gtest_links/SSTIOGroupTest.save_restore_control \
               test/gtest_links/SSTSignalTest.mailbox_read_batch \
               test/gtest_links/SSTSignalTest.mmio_read_batch \
               test/gtest_links/SSTIOTest.mbox_batch_reads \
@@ -390,6 +393,7 @@ test_geopm_test_SOURCES = test/AcceleratorTopoNullTest.cpp \
                           test/MockPlatformIO.hpp \
                           test/MockPlatformTopo.cpp \
                           test/MockPlatformTopo.hpp \
+                          test/MockSaveControl.hpp \
                           test/MockSDBus.hpp \
                           test/MockSDBusMessage.hpp \
                           test/MockServiceProxy.hpp \

--- a/service/test/MockSaveControl.hpp
+++ b/service/test/MockSaveControl.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MOCKSAVECONTROL_HPP_INCLUDE
+#define MOCKSAVECONTROL_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "SaveControl.hpp"
+#include "geopm/IOGroup.hpp"
+
+
+class MockSaveControl : public geopm::SaveControl
+{
+    public:
+        MOCK_METHOD(std::string, json, (), (const, override));
+        MOCK_METHOD(std::vector<m_setting_s>, settings, (), (const, override));
+        MOCK_METHOD(void, write_json, (const std::string &save_path), (const, override));
+        MOCK_METHOD(void, restore, (geopm::IOGroup &io_group), (const, override));
+};
+
+#endif


### PR DESCRIPTION
- Related to #2057.
- Includes updates for MSRIOGroup, SSTIOGroup, and LevelZeroIOGroup.

