### PR TITLE
Updated plugin names to follow all caps naming convention

### DIFF
--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -882,7 +882,7 @@ namespace geopm
     // Name used for registration with the IOGroup factory
     std::string LevelZeroIOGroup::plugin_name(void)
     {
-        return "levelzero";
+        return "LEVELZERO";
     }
 
     int LevelZeroIOGroup::signal_behavior(const std::string &signal_name) const

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -56,6 +56,9 @@
 namespace geopm
 {
 
+    const std::string LevelZeroIOGroup::M_PLUGIN_NAME = "LEVELZERO";
+    const std::string LevelZeroIOGroup::M_NAME_PREFIX = M_PLUGIN_NAME + "::";
+
     LevelZeroIOGroup::LevelZeroIOGroup()
         : LevelZeroIOGroup(platform_topo(), levelzero_device_pool())
     {
@@ -67,7 +70,7 @@ namespace geopm
         : m_platform_topo(platform_topo)
         , m_levelzero_device_pool(device_pool)
         , m_is_batch_read(false)
-        , m_signal_available({{"LEVELZERO::FREQUENCY_GPU", {
+        , m_signal_available({{M_NAME_PREFIX + "FREQUENCY_GPU", {
                                   "Accelerator compute/GPU domain frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
@@ -88,7 +91,7 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {"LEVELZERO::FREQUENCY_MAX_GPU", {
+                              {M_NAME_PREFIX + "FREQUENCY_MAX_GPU", {
                                   "Accelerator compute/GPU domain maximum frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
@@ -103,7 +106,7 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {"LEVELZERO::FREQUENCY_MIN_GPU", {
+                              {M_NAME_PREFIX + "FREQUENCY_MIN_GPU", {
                                   "Accelerator compute/GPU domain minimum frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
@@ -118,7 +121,7 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {"LEVELZERO::ENERGY", {
+                              {M_NAME_PREFIX + "ENERGY", {
                                   "Accelerator energy in Joules",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
@@ -133,7 +136,7 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {"LEVELZERO::ENERGY_TIMESTAMP", {
+                              {M_NAME_PREFIX + "ENERGY_TIMESTAMP", {
                                   "Accelerator energy timestamp in seconds"
                                   "\nValue cached on LEVELZERO::ENERGY read",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
@@ -149,7 +152,7 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {"LEVELZERO::FREQUENCY_MEMORY", {
+                              {M_NAME_PREFIX + "FREQUENCY_MEMORY", {
                                   "Accelerator memory domain frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
@@ -164,7 +167,7 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {"LEVELZERO::FREQUENCY_MAX_MEMORY", {
+                              {M_NAME_PREFIX + "FREQUENCY_MAX_MEMORY", {
                                   "Accelerator memory domain maximum frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
@@ -179,7 +182,7 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {"LEVELZERO::FREQUENCY_MIN_MEMORY", {
+                              {M_NAME_PREFIX + "FREQUENCY_MIN_MEMORY", {
                                   "Accelerator memory domain minimum frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
@@ -194,7 +197,7 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {"LEVELZERO::POWER_LIMIT_DEFAULT", {
+                              {M_NAME_PREFIX + "POWER_LIMIT_DEFAULT", {
                                   "Default power limit in Watts",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
@@ -209,7 +212,7 @@ namespace geopm
                                   },
                                   1 / 1e3
                                   }},
-                              {"LEVELZERO::POWER_LIMIT_MIN", {
+                              {M_NAME_PREFIX + "POWER_LIMIT_MIN", {
                                   "Minimum power limit in Watts",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
@@ -224,7 +227,7 @@ namespace geopm
                                   },
                                   1 / 1e3
                                   }},
-                              {"LEVELZERO::POWER_LIMIT_MAX", {
+                              {M_NAME_PREFIX + "POWER_LIMIT_MAX", {
                                   "Maximum power limit in Watts",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
@@ -239,7 +242,7 @@ namespace geopm
                                   },
                                   1 / 1e3
                                   }},
-                              {"LEVELZERO::ACTIVE_TIME", {
+                              {M_NAME_PREFIX + "ACTIVE_TIME", {
                                   "GPU active time",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
@@ -254,7 +257,7 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {"LEVELZERO::ACTIVE_TIME_TIMESTAMP", {
+                              {M_NAME_PREFIX + "ACTIVE_TIME_TIMESTAMP", {
                                   "GPU active time reading timestamp"
                                   "\nValue cached on LEVELZERO::ACTIVE_TIME read",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
@@ -270,7 +273,7 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {"LEVELZERO::ACTIVE_TIME_COMPUTE", {
+                              {M_NAME_PREFIX + "ACTIVE_TIME_COMPUTE", {
                                   "GPU Compute engine active time",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
@@ -285,7 +288,7 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {"LEVELZERO::ACTIVE_TIME_COMPUTE_TIMESTAMP", {
+                              {M_NAME_PREFIX + "ACTIVE_TIME_COMPUTE_TIMESTAMP", {
                                   "GPU Compute engine active time reading timestamp"
                                   "\nValue cached on LEVELZERO::ACTIVE_TIME_COMPUTE read",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
@@ -301,7 +304,7 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {"LEVELZERO::ACTIVE_TIME_COPY", {
+                              {M_NAME_PREFIX + "ACTIVE_TIME_COPY", {
                                   "GPU Copy engine active time",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
@@ -316,7 +319,7 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {"LEVELZERO::ACTIVE_TIME_COPY_TIMESTAMP", {
+                              {M_NAME_PREFIX + "ACTIVE_TIME_COPY_TIMESTAMP", {
                                   "GPU Copy engine active time timestamp"
                                   "\nValue cached on LEVELZERO::ACTIVE_TIME_COPY read",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
@@ -333,7 +336,7 @@ namespace geopm
                                   1 / 1e6
                                   }}
                              })
-        , m_control_available({{"LEVELZERO::FREQUENCY_GPU_CONTROL", {
+        , m_control_available({{M_NAME_PREFIX + "FREQUENCY_GPU_CONTROL", {
                                     "Sets accelerator frequency (in hertz)",
                                     {},
                                     GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
@@ -341,34 +344,34 @@ namespace geopm
                                     string_format_double
                                     }}
                               })
-        , m_special_signal_set({"LEVELZERO::ENERGY",
-                                "LEVELZERO::ACTIVE_TIME",
-                                "LEVELZERO::ACTIVE_TIME_COMPUTE",
-                                "LEVELZERO::ACTIVE_TIME_COPY"})
+        , m_special_signal_set({M_NAME_PREFIX + "ENERGY",
+                                M_NAME_PREFIX + "ACTIVE_TIME",
+                                M_NAME_PREFIX + "ACTIVE_TIME_COMPUTE",
+                                M_NAME_PREFIX + "ACTIVE_TIME_COPY"})
 
         , m_derivative_signal_map ({
-            {"LEVELZERO::POWER",
+            {M_NAME_PREFIX + "POWER",
                     {"Average accelerator power over 40 ms or 8 control loop iterations",
-                    "LEVELZERO::ENERGY",
-                    "LEVELZERO::ENERGY_TIMESTAMP"}},
-            {"LEVELZERO::UTILIZATION",
+                    M_NAME_PREFIX + "ENERGY",
+                    M_NAME_PREFIX + "ENERGY_TIMESTAMP"}},
+            {M_NAME_PREFIX + "UTILIZATION",
                     {"GPU utilization"
                         "n  Level Zero logical engines may map to the same hardware"
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
-                    "LEVELZERO::ACTIVE_TIME",
-                    "LEVELZERO::ACTIVE_TIME_TIMESTAMP"}},
-            {"LEVELZERO::UTILIZATION_COMPUTE",
+                    M_NAME_PREFIX + "ACTIVE_TIME",
+                    M_NAME_PREFIX + "ACTIVE_TIME_TIMESTAMP"}},
+            {M_NAME_PREFIX + "UTILIZATION_COMPUTE",
                     {"Compute engine utilization"
                         "n  Level Zero logical engines may map to the same hardware"
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
-                    "LEVELZERO::ACTIVE_TIME_COMPUTE",
-                    "LEVELZERO::ACTIVE_TIME_COMPUTE_TIMESTAMP"}},
-            {"LEVELZERO::UTILIZATION_COPY",
+                    M_NAME_PREFIX + "ACTIVE_TIME_COMPUTE",
+                    M_NAME_PREFIX + "ACTIVE_TIME_COMPUTE_TIMESTAMP"}},
+            {M_NAME_PREFIX + "UTILIZATION_COPY",
                     {"Copy engine utilization"
                         "n  Level Zero logical engines may map to the same hardware"
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
-                    "LEVELZERO::ACTIVE_TIME_COPY",
-                    "LEVELZERO::ACTIVE_TIME_COPY_TIMESTAMP"}},
+                    M_NAME_PREFIX + "ACTIVE_TIME_COPY",
+                    M_NAME_PREFIX + "ACTIVE_TIME_COPY_TIMESTAMP"}},
         })
     {
         // populate signals for each domain
@@ -387,10 +390,10 @@ namespace geopm
 
         register_derivative_signals();
 
-        register_signal_alias("FREQUENCY_ACCELERATOR", "LEVELZERO::FREQUENCY_GPU");
-        register_signal_alias("POWER_ACCELERATOR", "LEVELZERO::POWER");
+        register_signal_alias("FREQUENCY_ACCELERATOR", M_NAME_PREFIX + "FREQUENCY_GPU");
+        register_signal_alias("POWER_ACCELERATOR", M_NAME_PREFIX + "POWER");
         register_control_alias("FREQUENCY_ACCELERATOR_CONTROL",
-                               "LEVELZERO::FREQUENCY_GPU_CONTROL");
+                               M_NAME_PREFIX + "FREQUENCY_GPU_CONTROL");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {
@@ -765,7 +768,7 @@ namespace geopm
                             __FILE__, __LINE__);
         }
 
-        if (control_name == "LEVELZERO::FREQUENCY_GPU_CONTROL" ||
+        if (control_name == M_NAME_PREFIX + "FREQUENCY_GPU_CONTROL" ||
             control_name == "FREQUENCY_ACCELERATOR_CONTROL") {
             m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
                                                       geopm::LevelZero::M_DOMAIN_COMPUTE,
@@ -882,7 +885,7 @@ namespace geopm
     // Name used for registration with the IOGroup factory
     std::string LevelZeroIOGroup::plugin_name(void)
     {
-        return "LEVELZERO";
+        return M_PLUGIN_NAME;
     }
 
     int LevelZeroIOGroup::signal_behavior(const std::string &signal_name) const

--- a/service/src/LevelZeroIOGroup.hpp
+++ b/service/src/LevelZeroIOGroup.hpp
@@ -127,6 +127,8 @@ namespace geopm
                 std::string m_time_name;
             };
 
+            static const std::string M_PLUGIN_NAME;
+            static const std::string M_NAME_PREFIX;
             const PlatformTopo &m_platform_topo;
             const LevelZeroDevicePool &m_levelzero_device_pool;
             bool m_is_batch_read;

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -687,7 +687,7 @@ namespace geopm
     // Name used for registration with the IOGroup factory
     std::string NVMLIOGroup::plugin_name(void)
     {
-        return "nvml";
+        return "NVML";
     }
 
     // Function used by the factory to create objects of this type

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -53,6 +53,9 @@
 
 namespace geopm
 {
+    const std::string NVMLIOGroup::M_PLUGIN_NAME = "NVML";
+    const std::string NVMLIOGroup::M_NAME_PREFIX = M_PLUGIN_NAME + "::";
+
     NVMLIOGroup::NVMLIOGroup()
         : NVMLIOGroup(platform_topo(), nvml_device_pool(platform_topo().num_domain(GEOPM_DOMAIN_CPU)))
     {
@@ -63,63 +66,63 @@ namespace geopm
         : m_platform_topo(platform_topo)
         , m_nvml_device_pool(device_pool)
         , m_is_batch_read(false)
-        , m_signal_available({{"NVML::FREQUENCY", {
+        , m_signal_available({{M_NAME_PREFIX + "FREQUENCY", {
                                   "Streaming multiprocessor frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
                                   string_format_double
                                   }},
-                              {"NVML::UTILIZATION_ACCELERATOR", {
+                              {M_NAME_PREFIX + "UTILIZATION_ACCELERATOR", {
                                   "Fraction of time the accelerator operated on a kernel in the last set of driver samples",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
                                   string_format_double
                                   }},
-                              {"NVML::POWER", {
+                              {M_NAME_PREFIX + "POWER", {
                                   "Accelerator power usage in watts",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::sum,
                                   string_format_double
                                   }},
-                              {"NVML::POWER_LIMIT", {
+                              {M_NAME_PREFIX + "POWER_LIMIT", {
                                   "Accelerator power limit in watts",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::sum,
                                   string_format_double
                                   }},
-                              {"NVML::FREQUENCY_MEMORY", {
+                              {M_NAME_PREFIX + "FREQUENCY_MEMORY", {
                                   "Accelerator memory frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
                                   string_format_double
                                   }},
-                              {"NVML::THROTTLE_REASONS", {
+                              {M_NAME_PREFIX + "THROTTLE_REASONS", {
                                   "Accelerator clock throttling reasons",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::expect_same,
                                   string_format_double
                                   }},
-                              {"NVML::TEMPERATURE", {
+                              {M_NAME_PREFIX + "TEMPERATURE", {
                                   "Accelerator temperature in degrees Celsius",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
                                   string_format_double
                                   }},
-                              {"NVML::TOTAL_ENERGY_CONSUMPTION", {
+                              {M_NAME_PREFIX + "TOTAL_ENERGY_CONSUMPTION", {
                                   "Accelerator energy consumption in joules since the driver was loaded",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::sum,
                                   string_format_double
                                   }},
-                              {"NVML::PERFORMANCE_STATE", {
+                              {M_NAME_PREFIX + "PERFORMANCE_STATE", {
                                   "Accelerator performance state, defined by the NVML API as a value from 0 to 15"
                                   "\n  with 0 being maximum performance, 15 being minimum performance, and 32 being unknown",
                                   {},
@@ -127,21 +130,21 @@ namespace geopm
                                   Agg::expect_same,
                                   string_format_double
                                   }},
-                              {"NVML::PCIE_RX_THROUGHPUT", {
+                              {M_NAME_PREFIX + "PCIE_RX_THROUGHPUT", {
                                   "Accelerator PCIE receive throughput in bytes per second over a 20 millisecond period",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::sum,
                                   string_format_double
                                   }},
-                              {"NVML::PCIE_TX_THROUGHPUT", {
+                              {M_NAME_PREFIX + "PCIE_TX_THROUGHPUT", {
                                   "Accelerator PCIE transmit throughput in bytes per second over a 20 millisecond period",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::sum,
                                   string_format_double
                                   }},
-                              {"NVML::CPU_ACCELERATOR_ACTIVE_AFFINITIZATION", {
+                              {M_NAME_PREFIX + "CPU_ACCELERATOR_ACTIVE_AFFINITIZATION", {
                                   "Returns the associated accelerator for a given CPU as determined by running processes."
                                   "\n  If no accelerators map to the CPU then -1 is returned"
                                   "\n  If multiple accelerators map to the CPU NAN is returned",
@@ -150,21 +153,21 @@ namespace geopm
                                   Agg::expect_same,
                                   string_format_double
                                   }},
-                              {"NVML::UTILIZATION_MEMORY", {
+                              {M_NAME_PREFIX + "UTILIZATION_MEMORY", {
                                   "Fraction of time the accelerator memory was accessed in the last set of driver samples",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::max,
                                   string_format_double
                                   }},
-                              {"NVML::FREQUENCY_MAX", {
+                              {M_NAME_PREFIX + "FREQUENCY_MAX", {
                                   "Streaming multiprocessor Maximum frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::expect_same,
                                   string_format_double
                                   }},
-                              {"NVML::FREQUENCY_MIN", {
+                              {M_NAME_PREFIX + "FREQUENCY_MIN", {
                                   "Streaming multiprocessor Minimum frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
@@ -172,14 +175,14 @@ namespace geopm
                                   string_format_double
                                   }}
                              })
-        , m_control_available({{"NVML::FREQUENCY_CONTROL", {
+        , m_control_available({{M_NAME_PREFIX + "FREQUENCY_CONTROL", {
                                     "Sets streaming multiprocessor frequency min and max to the same limit (in hertz)",
                                     {},
                                     GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                     Agg::average,
                                     string_format_double
                                     }},
-                               {"NVML::FREQUENCY_RESET_CONTROL", {
+                               {M_NAME_PREFIX + "FREQUENCY_RESET_CONTROL", {
                                     "Resets streaming multiprocessor frequency min and max limits to default values."
                                     "\n  Parameter provided is unused.",
                                     {},
@@ -187,7 +190,7 @@ namespace geopm
                                     Agg::average,
                                     string_format_double
                                     }},
-                               {"NVML::POWER_LIMIT_CONTROL", {
+                               {M_NAME_PREFIX + "POWER_LIMIT_CONTROL", {
                                     "Sets accelerator power limit in watts",
                                     {},
                                     GEOPM_DOMAIN_BOARD_ACCELERATOR,
@@ -205,8 +208,8 @@ namespace geopm
             }
             sv.second.signals = result;
         }
-        register_signal_alias("POWER_ACCELERATOR", "NVML::POWER");
-        register_signal_alias("FREQUENCY_ACCELERATOR", "NVML::FREQUENCY");
+        register_signal_alias("POWER_ACCELERATOR", M_NAME_PREFIX + "POWER");
+        register_signal_alias("FREQUENCY_ACCELERATOR", M_NAME_PREFIX + "FREQUENCY");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {
@@ -217,8 +220,8 @@ namespace geopm
             }
             sv.second.controls = result;
         }
-        register_control_alias("POWER_ACCELERATOR_LIMIT_CONTROL", "NVML::POWER_LIMIT_CONTROL");
-        register_control_alias("FREQUENCY_ACCELERATOR_CONTROL", "NVML::FREQUENCY_CONTROL");
+        register_control_alias("POWER_ACCELERATOR_LIMIT_CONTROL", M_NAME_PREFIX + "POWER_LIMIT_CONTROL");
+        register_control_alias("FREQUENCY_ACCELERATOR_CONTROL", M_NAME_PREFIX + "FREQUENCY_CONTROL");
 
         for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR); ++domain_idx) {
             std::vector<unsigned int> supported_frequency = m_nvml_device_pool.frequency_supported_sm(domain_idx);
@@ -428,7 +431,7 @@ namespace geopm
     {
         m_is_batch_read = true;
         for (auto &sv : m_signal_available) {
-            if (sv.first == "NVML::CPU_ACCELERATOR_ACTIVE_AFFINITIZATION") {
+            if (sv.first == M_NAME_PREFIX + "CPU_ACCELERATOR_ACTIVE_AFFINITIZATION") {
                 std::map<pid_t, double> process_map = accelerator_process_map();
 
                 for (unsigned int domain_idx = 0; domain_idx < sv.second.signals.size(); ++domain_idx) {
@@ -506,53 +509,53 @@ namespace geopm
         }
 
         double result = NAN;
-        if (signal_name == "NVML::FREQUENCY" || signal_name == "FREQUENCY_ACCELERATOR") {
+        if (signal_name == M_NAME_PREFIX + "FREQUENCY" || signal_name == "FREQUENCY_ACCELERATOR") {
             result = (double) m_nvml_device_pool.frequency_status_sm(domain_idx) * 1e6;
         }
-        else if (signal_name == "NVML::FREQUENCY_MIN") {
+        else if (signal_name == M_NAME_PREFIX + "FREQUENCY_MIN") {
             if (m_supported_freq.at(domain_idx).size() != 0) {
                 result = 1e6 * m_supported_freq.at(domain_idx).front();
             }
         }
-        else if (signal_name == "NVML::FREQUENCY_MAX") {
+        else if (signal_name == M_NAME_PREFIX + "FREQUENCY_MAX") {
             if (m_supported_freq.at(domain_idx).size() != 0) {
                 result = 1e6 * m_supported_freq.at(domain_idx).back();
             }
         }
-        else if (signal_name == "NVML::UTILIZATION_ACCELERATOR") {
+        else if (signal_name == M_NAME_PREFIX + "UTILIZATION_ACCELERATOR") {
             result = (double) m_nvml_device_pool.utilization(domain_idx) / 100;
         }
-        else if (signal_name == "NVML::THROTTLE_REASONS") {
+        else if (signal_name == M_NAME_PREFIX + "THROTTLE_REASONS") {
             result = (double) m_nvml_device_pool.throttle_reasons(domain_idx);
         }
-        else if (signal_name == "NVML::POWER" || signal_name == "POWER_ACCELERATOR") {
+        else if (signal_name == M_NAME_PREFIX + "POWER" || signal_name == "POWER_ACCELERATOR") {
             result = (double) m_nvml_device_pool.power(domain_idx) / 1e3;
         }
-        else if (signal_name == "NVML::POWER_LIMIT") {
+        else if (signal_name == M_NAME_PREFIX + "POWER_LIMIT") {
             result = (double) m_nvml_device_pool.power_limit(domain_idx) / 1e3;
         }
-        else if (signal_name == "NVML::FREQUENCY_MEMORY") {
+        else if (signal_name == M_NAME_PREFIX + "FREQUENCY_MEMORY") {
             result = (double) m_nvml_device_pool.frequency_status_mem(domain_idx) * 1e6;
         }
-        else if (signal_name == "NVML::TEMPERATURE") {
+        else if (signal_name == M_NAME_PREFIX + "TEMPERATURE") {
             result = (double) m_nvml_device_pool.temperature(domain_idx);
         }
-        else if (signal_name == "NVML::TOTAL_ENERGY_CONSUMPTION" ) {
+        else if (signal_name == M_NAME_PREFIX + "TOTAL_ENERGY_CONSUMPTION" ) {
             result = (double) m_nvml_device_pool.energy(domain_idx) / 1e3;
         }
-        else if (signal_name == "NVML::PERFORMANCE_STATE") {
+        else if (signal_name == M_NAME_PREFIX + "PERFORMANCE_STATE") {
             result = (double) m_nvml_device_pool.performance_state(domain_idx);
         }
-        else if (signal_name == "NVML::PCIE_RX_THROUGHPUT") {
+        else if (signal_name == M_NAME_PREFIX + "PCIE_RX_THROUGHPUT") {
             result = (double) m_nvml_device_pool.throughput_rx_pcie(domain_idx) * 1024;
         }
-        else if (signal_name == "NVML::PCIE_TX_THROUGHPUT") {
+        else if (signal_name == M_NAME_PREFIX + "PCIE_TX_THROUGHPUT") {
             result = (double) m_nvml_device_pool.throughput_tx_pcie(domain_idx) * 1024;
         }
-        else if (signal_name == "NVML::UTILIZATION_MEMORY") {
+        else if (signal_name == M_NAME_PREFIX + "UTILIZATION_MEMORY") {
             result = (double) m_nvml_device_pool.utilization_mem(domain_idx) / 100;
         }
-        else if (signal_name == "NVML::CPU_ACCELERATOR_ACTIVE_AFFINITIZATION") {
+        else if (signal_name == M_NAME_PREFIX + "CPU_ACCELERATOR_ACTIVE_AFFINITIZATION") {
             std::map<pid_t, double> process_map = accelerator_process_map();
             result = cpu_accelerator_affinity(domain_idx, process_map);
         }
@@ -584,13 +587,13 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (control_name == "NVML::FREQUENCY_CONTROL" || control_name == "FREQUENCY_ACCELERATOR_CONTROL") {
+        if (control_name == M_NAME_PREFIX + "FREQUENCY_CONTROL" || control_name == "FREQUENCY_ACCELERATOR_CONTROL") {
             m_nvml_device_pool.frequency_control_sm(domain_idx, setting / 1e6, setting / 1e6);
         }
-        else if (control_name == "NVML::FREQUENCY_RESET_CONTROL") {
+        else if (control_name == M_NAME_PREFIX + "FREQUENCY_RESET_CONTROL") {
             m_nvml_device_pool.frequency_reset_control(domain_idx);
         }
-        else if (control_name == "NVML::POWER_LIMIT_CONTROL" || control_name == "POWER_ACCELERATOR_LIMIT_CONTROL") {
+        else if (control_name == M_NAME_PREFIX + "POWER_LIMIT_CONTROL" || control_name == "POWER_ACCELERATOR_LIMIT_CONTROL") {
             m_nvml_device_pool.power_control(domain_idx, setting * 1e3);
         }
         else {
@@ -687,7 +690,7 @@ namespace geopm
     // Name used for registration with the IOGroup factory
     std::string NVMLIOGroup::plugin_name(void)
     {
-        return "NVML";
+        return M_PLUGIN_NAME;
     }
 
     // Function used by the factory to create objects of this type

--- a/service/src/NVMLIOGroup.hpp
+++ b/service/src/NVMLIOGroup.hpp
@@ -84,6 +84,8 @@ namespace geopm
             std::map<pid_t, double> accelerator_process_map(void) const;
             double cpu_accelerator_affinity(int cpu_idx, std::map<pid_t, double> process_map) const;
 
+            static const std::string M_PLUGIN_NAME;
+            static const std::string M_NAME_PREFIX;
             const PlatformTopo &m_platform_topo;
             const NVMLDevicePool &m_nvml_device_pool;
             bool m_is_batch_read;


### PR DESCRIPTION
Signed-off-by: lowren.h.lawson@intel.com <lowren.h.lawson@intel.com>

- Relates to #2065 bug report from github issues
- Fixes #2065 change request from github issues.

[Brief description of the change]
Changes plugin_name for accelerator classes to follow all caps naming convention. 