### PR TITLE
L0: Refactor to support SaveControl

### DIFF
--- a/integration/test_skipped/test_levelzero_signals.py
+++ b/integration/test_skipped/test_levelzero_signals.py
@@ -71,8 +71,8 @@ class TestIntegrationLevelZeroSignals(unittest.TestCase):
     def test_power(self):
         #Query
         power = geopm_test_launcher.geopmread("LEVELZERO::POWER board_accelerator 0")
-        power_limit_max = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_MAX board_accelerator 0")
-        power_limit_min = geopm_test_launcher.geopmread("LEVELZERO::POWER_LIMIT_MIN board_accelerator 0")
+        power_limit_max = geopm_test_launcher.geopmread("LEVELZERO::GPU_POWER_LIMIT_MAX_AVAIL board_accelerator 0")
+        power_limit_min = geopm_test_launcher.geopmread("LEVELZERO::GPU_POWER_LIMIT_MIN_AVAIL board_accelerator 0")
 
         #Info
         sys.stdout.write("Power:\n");
@@ -110,20 +110,20 @@ class TestIntegrationLevelZeroSignals(unittest.TestCase):
     def test_frequency(self):
         sys.stdout.write("Running LevelZero Frequency Test\n");
         #Query
-        frequency_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_GPU board_accelerator 0")
-        frequency_min_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_MIN_GPU board_accelerator 0")
-        frequency_max_gpu = geopm_test_launcher.geopmread("LEVELZERO::FREQUENCY_MAX_GPU board_accelerator 0")
+        frequency_gpu = geopm_test_launcher.geopmread("LEVELZERO::GPUCHIP_FREQUENCY board_accelerator 0")
+        gpu_min_frequency_limit = geopm_test_launcher.geopmread("LEVELZERO::GPUCHIP_FREQUENCY_MIN_AVAIL board_accelerator 0")
+        gpu_max_frequency_limit = geopm_test_launcher.geopmread("LEVELZERO::GPUCHIP_FREQUENCY_MAX_AVAIL board_accelerator 0")
 
         #Info
         sys.stdout.write("Frequency:\n");
         sys.stdout.write("\tFrequency GPU: {}\n".format(frequency_gpu));
-        sys.stdout.write("\tFrequency GPU Min: {}\n".format(frequency_min_gpu));
-        sys.stdout.write("\tFrequency GPU Max: {}\n".format(frequency_max_gpu));
+        sys.stdout.write("\tFrequency GPU Min Limit: {}\n".format(gpu_min_frequency_limit));
+        sys.stdout.write("\tFrequency GPU Max Limit: {}\n".format(gpu_max_frequency_limit));
 
         #TODO: standby mode check
-        self.assertGreaterEqual(frequency_gpu, frequency_min_gpu)
-        if(frequency_max_gpu > 0): #Negative value indicates max was not supported
-            self.assertLessEqual(frequency_gpu, frequency_max_gpu)
+        self.assertGreaterEqual(frequency_gpu, gpu_min_frequency_limit)
+        if(gpu_max_frequency_limit > 0): #Negative value indicates max was not supported
+            self.assertLessEqual(frequency_gpu, gpu_max_frequency_limit)
 
 
 if __name__ == '__main__':

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -70,8 +70,8 @@ namespace geopm
         : m_platform_topo(platform_topo)
         , m_levelzero_device_pool(device_pool)
         , m_is_batch_read(false)
-        , m_signal_available({{M_NAME_PREFIX + "FREQUENCY_GPU", {
-                                  "Accelerator compute/GPU domain frequency in hertz",
+        , m_signal_available({{M_NAME_PREFIX + "GPUCHIP_FREQUENCY_STATUS", {
+                                  "Compute/GPU chip domain current frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -91,8 +91,8 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "FREQUENCY_MAX_GPU", {
-                                  "Accelerator compute/GPU domain maximum frequency in hertz",
+                              {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MAX_AVAIL", {
+                                  "Compute/GPU chip domain maximum available frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -106,8 +106,8 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "FREQUENCY_MIN_GPU", {
-                                  "Accelerator compute/GPU domain minimum frequency in hertz",
+                              {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MIN_AVAIL", {
+                                  "Compute/GPU chip domain minimum available frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -121,8 +121,38 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "ENERGY", {
-                                  "Accelerator energy in Joules",
+                              {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MAX_CONTROL", {
+                                  "Compute/GPU chip domain current maximum frequency requested in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return (this->m_levelzero_device_pool.frequency_range(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE)).second;
+                                  },
+                                  1e6
+                                  }},
+                              {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MIN_CONTROL", {
+                                  "Compute/GPU chip domain current minimum frequency requested in hertz",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return (this->m_levelzero_device_pool.frequency_range(
+                                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE)).first;
+                                  },
+                                  1e6
+                                  }},
+                              {M_NAME_PREFIX + "GPU_ENERGY", {
+                                  "GPU energy in Joules",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
                                   string_format_double,
@@ -136,8 +166,8 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "ENERGY_TIMESTAMP", {
-                                  "Accelerator energy timestamp in seconds"
+                              {M_NAME_PREFIX + "GPU_ENERGY_TIMESTAMP", {
+                                  "GPU energy timestamp in seconds"
                                   "\nValue cached on LEVELZERO::ENERGY read",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
@@ -152,8 +182,8 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "FREQUENCY_MEMORY", {
-                                  "Accelerator memory domain frequency in hertz",
+                              {M_NAME_PREFIX + "GPUCHIP_MEMORY_FREQUENCY_STATUS", {
+                                  "Compute/GPU chip domain memory current frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -167,8 +197,8 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "FREQUENCY_MAX_MEMORY", {
-                                  "Accelerator memory domain maximum frequency in hertz",
+                              {M_NAME_PREFIX + "GPUCHIP_MEMORY_FREQUENCY_MAX_AVAIL", {
+                                  "Compute/GPU chip domain memory maximum frequency available in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -182,8 +212,8 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "FREQUENCY_MIN_MEMORY", {
-                                  "Accelerator memory domain minimum frequency in hertz",
+                              {M_NAME_PREFIX + "GPUCHIP_MEMORY_FREQUENCY_MIN_AVAIL", {
+                                  "Compute/GPU chip domain memory minimum frequency in hertz",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -197,7 +227,7 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "POWER_LIMIT_DEFAULT", {
+                              {M_NAME_PREFIX + "GPU_POWER_LIMIT_DEFAULT", {
                                   "Default power limit in Watts",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
@@ -212,8 +242,8 @@ namespace geopm
                                   },
                                   1 / 1e3
                                   }},
-                              {M_NAME_PREFIX + "POWER_LIMIT_MIN", {
-                                  "Minimum power limit in Watts",
+                              {M_NAME_PREFIX + "GPU_POWER_LIMIT_MIN_AVAIL", {
+                                  "Minimum available power limit in Watts",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
                                   string_format_double,
@@ -227,8 +257,8 @@ namespace geopm
                                   },
                                   1 / 1e3
                                   }},
-                              {M_NAME_PREFIX + "POWER_LIMIT_MAX", {
-                                  "Maximum power limit in Watts",
+                              {M_NAME_PREFIX + "GPU_POWER_LIMIT_MAX_AVAIL", {
+                                  "Maximum available power limit in Watts",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                   Agg::average,
                                   string_format_double,
@@ -242,8 +272,8 @@ namespace geopm
                                   },
                                   1 / 1e3
                                   }},
-                              {M_NAME_PREFIX + "ACTIVE_TIME", {
-                                  "GPU active time",
+                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME", {
+                                  "Compute/GPU chip active time",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -257,9 +287,9 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "ACTIVE_TIME_TIMESTAMP", {
-                                  "GPU active time reading timestamp"
-                                  "\nValue cached on LEVELZERO::ACTIVE_TIME read",
+                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_TIMESTAMP", {
+                                  "Compute/GPU chip active time reading timestamp"
+                                  "\nValue cached on LEVELZERO::GPUCHIP_ACTIVE_TIME read",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -273,8 +303,8 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "ACTIVE_TIME_COMPUTE", {
-                                  "GPU Compute engine active time",
+                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COMPUTE", {
+                                  "Compute/GPU chip domain compute engine active time",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -288,9 +318,9 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "ACTIVE_TIME_COMPUTE_TIMESTAMP", {
-                                  "GPU Compute engine active time reading timestamp"
-                                  "\nValue cached on LEVELZERO::ACTIVE_TIME_COMPUTE read",
+                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COMPUTE_TIMESTAMP", {
+                                  "Compute/GPU chip domain compute engine active time reading timestamp"
+                                  "\nValue cached on LEVELZERO::GPUCHIP_ACTIVE_TIME_COMPUTE read",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -304,8 +334,8 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "ACTIVE_TIME_COPY", {
-                                  "GPU Copy engine active time",
+                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY", {
+                                  "Compute/GPU chip domain copy engine active time",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -319,9 +349,9 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "ACTIVE_TIME_COPY_TIMESTAMP", {
-                                  "GPU Copy engine active time timestamp"
-                                  "\nValue cached on LEVELZERO::ACTIVE_TIME_COPY read",
+                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY_TIMESTAMP", {
+                                  "Compute/GPU chip domain copy engine active time timestamp"
+                                  "\nValue cached on LEVELZERO::GPUCHIP_ACTIVE_TIME_COPY read",
                                   GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                   Agg::average,
                                   string_format_double,
@@ -334,44 +364,76 @@ namespace geopm
                                                    geopm::LevelZero::M_DOMAIN_MEMORY);
                                   },
                                   1 / 1e6
+                                  }},
+                              {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_CONTROL", {
+                                  "Compute/GPU chip domain current requested frequency in hertz"
+                                  "\nReadings are valid only after writing to this control",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      auto range_pair =  this->m_levelzero_device_pool.frequency_range(
+                                                               GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                               domain_idx,
+                                                               geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                      return range_pair.first == range_pair.second ? range_pair.first
+                                                              : NAN;
+                                  },
+                                  1e6
                                   }}
                              })
-        , m_control_available({{M_NAME_PREFIX + "FREQUENCY_GPU_CONTROL", {
-                                    "Sets accelerator frequency (in hertz)",
+        , m_control_available({{M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MIN_CONTROL", {
+                                    "Sets the compute/GPU chip domain frequency minimum in hertz",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                    Agg::average,
+                                    string_format_double
+                                    }},
+                               {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MAX_CONTROL", {
+                                    "Sets the compute/GPU chip domain frequency maximum in hertz",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                    Agg::average,
+                                    string_format_double
+                                    }},
+                               {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_CONTROL", {
+                                    "Sets the compute/GPU chip fomain frequency both min and max in hertz",
                                     {},
                                     GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
                                     Agg::average,
                                     string_format_double
                                     }}
                               })
-        , m_special_signal_set({M_NAME_PREFIX + "ENERGY",
-                                M_NAME_PREFIX + "ACTIVE_TIME",
-                                M_NAME_PREFIX + "ACTIVE_TIME_COMPUTE",
-                                M_NAME_PREFIX + "ACTIVE_TIME_COPY"})
+        , m_special_signal_set({M_NAME_PREFIX + "GPU_ENERGY",
+                                M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME",
+                                M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COMPUTE",
+                                M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY"})
 
         , m_derivative_signal_map ({
-            {M_NAME_PREFIX + "POWER",
-                    {"Average accelerator power over 40 ms or 8 control loop iterations",
-                    M_NAME_PREFIX + "ENERGY",
-                    M_NAME_PREFIX + "ENERGY_TIMESTAMP"}},
-            {M_NAME_PREFIX + "UTILIZATION",
+            {M_NAME_PREFIX + "GPU_POWER",
+                    {"Average GPU power over 40 ms or 8 control loop iterations",
+                    M_NAME_PREFIX + "GPU_ENERGY",
+                    M_NAME_PREFIX + "GPU_ENERGY_TIMESTAMP"}},
+            {M_NAME_PREFIX + "GPU_UTILIZATION",
                     {"GPU utilization"
                         "n  Level Zero logical engines may map to the same hardware"
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
-                    M_NAME_PREFIX + "ACTIVE_TIME",
-                    M_NAME_PREFIX + "ACTIVE_TIME_TIMESTAMP"}},
-            {M_NAME_PREFIX + "UTILIZATION_COMPUTE",
+                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME",
+                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_TIMESTAMP"}},
+            {M_NAME_PREFIX + "GPU_UTILIZATION_COMPUTE",
                     {"Compute engine utilization"
                         "n  Level Zero logical engines may map to the same hardware"
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
-                    M_NAME_PREFIX + "ACTIVE_TIME_COMPUTE",
-                    M_NAME_PREFIX + "ACTIVE_TIME_COMPUTE_TIMESTAMP"}},
-            {M_NAME_PREFIX + "UTILIZATION_COPY",
+                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COMPUTE",
+                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COMPUTE_TIMESTAMP"}},
+            {M_NAME_PREFIX + "GPU_UTILIZATION_COPY",
                     {"Copy engine utilization"
                         "n  Level Zero logical engines may map to the same hardware"
                         "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
-                    M_NAME_PREFIX + "ACTIVE_TIME_COPY",
-                    M_NAME_PREFIX + "ACTIVE_TIME_COPY_TIMESTAMP"}},
+                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY",
+                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY_TIMESTAMP"}},
         })
     {
         // populate signals for each domain
@@ -390,10 +452,12 @@ namespace geopm
 
         register_derivative_signals();
 
-        register_signal_alias("FREQUENCY_ACCELERATOR", M_NAME_PREFIX + "FREQUENCY_GPU");
-        register_signal_alias("POWER_ACCELERATOR", M_NAME_PREFIX + "POWER");
-        register_control_alias("FREQUENCY_ACCELERATOR_CONTROL",
-                               M_NAME_PREFIX + "FREQUENCY_GPU_CONTROL");
+        register_signal_alias("GPUCHIP_FREQUENCY_STATUS", M_NAME_PREFIX + "GPUCHIP_FREQUENCY_STATUS");
+        register_signal_alias("GPU_POWER", M_NAME_PREFIX + "GPU_POWER");
+        register_signal_alias("GPUCHIP_FREQUENCY_CONTROL",
+                               M_NAME_PREFIX + "GPUCHIP_FREQUENCY_CONTROL");
+        register_control_alias("GPUCHIP_FREQUENCY_CONTROL",
+                               M_NAME_PREFIX + "GPUCHIP_FREQUENCY_CONTROL");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {
@@ -768,11 +832,25 @@ namespace geopm
                             __FILE__, __LINE__);
         }
 
-        if (control_name == M_NAME_PREFIX + "FREQUENCY_GPU_CONTROL" ||
-            control_name == "FREQUENCY_ACCELERATOR_CONTROL") {
+        if (control_name == M_NAME_PREFIX + "GPUCHIP_FREQUENCY_CONTROL" ||
+            control_name == "GPUCHIP_FREQUENCY_CONTROL") {
             m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
                                                       geopm::LevelZero::M_DOMAIN_COMPUTE,
                                                       setting / 1e6, setting / 1e6);
+        }
+        else if(control_name == M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MIN_CONTROL") {
+            double curr_max = read_signal(M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MAX_CONTROL",
+                                          domain_type, domain_idx);
+            m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
+                                                      geopm::LevelZero::M_DOMAIN_COMPUTE,
+                                                      setting / 1e6, curr_max / 1e6);
+        }
+        else if(control_name == M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MAX_CONTROL") {
+            double curr_min = read_signal(M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MIN_CONTROL",
+                                          domain_type, domain_idx);
+            m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
+                                                      geopm::LevelZero::M_DOMAIN_COMPUTE,
+                                                      curr_min / 1e6, setting / 1e6);
         }
         else {
     #ifdef GEOPM_DEBUG

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -193,9 +193,9 @@ TEST_F(LevelZeroIOGroupTest, push_control_adjust_write_batch)
     std::vector<double> mock_freq = {1530, 1320, 420, 135, 1620, 812, 199, 1700};
 
     for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
-        batch_value[(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL",
+        batch_value[(levelzero_io.push_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL",
                                         GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx))] = mock_freq.at(sub_idx)*1e6;
-        batch_value[(levelzero_io.push_control("FREQUENCY_ACCELERATOR_CONTROL",
+        batch_value[(levelzero_io.push_control("GPUCHIP_FREQUENCY_CONTROL",
                                         GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx))] = mock_freq.at(sub_idx)*1e6;
         EXPECT_CALL(*m_device_pool,
                     frequency_control(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, mock_freq.at(sub_idx), mock_freq.at(sub_idx))).Times(2);
@@ -219,11 +219,11 @@ TEST_F(LevelZeroIOGroupTest, write_control)
         EXPECT_CALL(*m_device_pool,
                     frequency_control(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, mock_freq.at(sub_idx), mock_freq.at(sub_idx))).Times(2);
 
-        EXPECT_NO_THROW(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL",
+        EXPECT_NO_THROW(levelzero_io.write_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL",
                                               GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx,
                                               mock_freq.at(sub_idx)*1e6));
 
-        EXPECT_NO_THROW(levelzero_io.write_control("FREQUENCY_ACCELERATOR_CONTROL",
+        EXPECT_NO_THROW(levelzero_io.write_control("GPUCHIP_FREQUENCY_CONTROL",
                                               GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx,
                                               mock_freq.at(sub_idx)*1e6));
     }
@@ -242,18 +242,18 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
 
     for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
         EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq.at(sub_idx)));
-        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
     }
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
-        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
     }
 
 
     levelzero_io.read_batch();
     for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
-        double frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        double frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         double frequency_batch = levelzero_io.sample(batch_idx.at(sub_idx));
 
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(sub_idx)*1e6);
@@ -261,7 +261,7 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     }
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        double energy = levelzero_io.read_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         double energy_batch = levelzero_io.sample(batch_idx.at(num_accelerator_subdevice+accel_idx));
 
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(accel_idx)/1e6);
@@ -280,14 +280,14 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
 
     levelzero_io.read_batch();
     for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
-        double frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        double frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         double frequency_batch = levelzero_io.sample(batch_idx.at(sub_idx));
 
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(sub_idx)*1e6);
         EXPECT_DOUBLE_EQ(frequency, frequency_batch);
     }
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
-        double energy = levelzero_io.read_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         double energy_batch = levelzero_io.sample(batch_idx.at(num_accelerator_subdevice+accel_idx));
 
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(accel_idx)/1e6);
@@ -325,16 +325,16 @@ TEST_F(LevelZeroIOGroupTest, read_timestamp_batch_reverse)
         EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_timestamp_compute.at(sub_idx)));
         EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_timestamp_copy.at(sub_idx)));
 
-        active_time_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
-        active_time_compute_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME_COMPUTE_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
-        active_time_copy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME_COPY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        active_time_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        active_time_compute_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COMPUTE_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        active_time_copy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COPY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
     }
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
         EXPECT_CALL(*m_device_pool, energy_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy_timestamp.at(accel_idx)));
 
-        energy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ENERGY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+        energy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
     }
 
     levelzero_io.read_batch();
@@ -397,16 +397,16 @@ TEST_F(LevelZeroIOGroupTest, read_timestamp_batch)
         EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_timestamp_compute.at(sub_idx)));
         EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_timestamp_copy.at(sub_idx)));
 
-        active_time_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
-        active_time_compute_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
-        active_time_copy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ACTIVE_TIME_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        active_time_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        active_time_compute_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
+        active_time_copy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx));
     }
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(accel_idx)));
         EXPECT_CALL(*m_device_pool, energy_timestamp(GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy_timestamp.at(accel_idx)));
 
-        energy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
+        energy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx));
     }
 
     levelzero_io.read_batch();
@@ -487,49 +487,49 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
 
     for (int sub_idx = 0; sub_idx < num_accelerator_subdevice; ++sub_idx) {
         //Frequency
-        double frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
-        double frequency_alias = levelzero_io.read_signal("FREQUENCY_ACCELERATOR", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        double frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        double frequency_alias = levelzero_io.read_signal("GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, frequency_alias);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_gpu.at(sub_idx)*1e6);
-        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_MEMORY_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_mem.at(sub_idx)*1e6);
-        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MIN_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_min_gpu.at(sub_idx)*1e6);
-        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MAX_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_max_gpu.at(sub_idx)*1e6);
-        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MIN_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_MEMORY_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_min_mem.at(sub_idx)*1e6);
-        frequency = levelzero_io.read_signal("LEVELZERO::FREQUENCY_MAX_MEMORY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_MEMORY_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_max_mem.at(sub_idx)*1e6);
 
         //Active time
-        double active_time = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        double active_time = levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx)/1e6);
-        double active_time_compute = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        double active_time_compute = levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COMPUTE", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(active_time_compute, mock_active_time_compute.at(sub_idx)/1e6);
-        double active_time_copy = levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
+        double active_time_copy = levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COPY", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time_copy.at(sub_idx)/1e6);
     }
 
     for (int accel_idx = 0; accel_idx < num_accelerator; ++accel_idx) {
         //Power & energy
-        double power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_MIN", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double power_lim = levelzero_io.read_signal("LEVELZERO::GPU_POWER_LIMIT_MIN_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_min.at(accel_idx)/1e3);
-        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_MAX", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        power_lim = levelzero_io.read_signal("LEVELZERO::GPU_POWER_LIMIT_MAX_AVAIL", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_max.at(accel_idx)/1e3);
-        power_lim = levelzero_io.read_signal("LEVELZERO::POWER_LIMIT_DEFAULT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        power_lim = levelzero_io.read_signal("LEVELZERO::GPU_POWER_LIMIT_DEFAULT", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_tdp.at(accel_idx)/1e3);
 
-        double energy = levelzero_io.read_signal("LEVELZERO::ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
+        double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_BOARD_ACCELERATOR, accel_idx);
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(accel_idx)/1e6);
     }
 
     // Assume DerivativeSignals class functions as expected
     // Just check validity of derived signals
-    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::POWER"));
-    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::UTILIZATION"));
-    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::UTILIZATION_COMPUTE"));
-    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::UTILIZATION_COPY"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_POWER"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_UTILIZATION"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_UTILIZATION_COMPUTE"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_UTILIZATION_COPY"));
 }
 
 //Test case: Error path testing including:
@@ -553,11 +553,11 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     }
     LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool);
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.sample(0),
                                GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
 
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
@@ -565,11 +565,11 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
                                GEOPM_ERROR_INVALID, "LEVELZERO::INVALID not valid for LevelZeroIOGroup");
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.adjust(0, 12345.6),
                                GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD, 0, 1530000000),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_type must be");
 
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0),
@@ -577,26 +577,26 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::INVALID", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0, 1530000000),
                                GEOPM_ERROR_INVALID, "LEVELZERO::INVALID not valid for LevelZeroIOGroup");
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::FREQUENCY_GPU", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1),
-                               GEOPM_ERROR_INVALID, "domain_idx out of range");
-
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice),
-                               GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1),
-                               GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice, 1530000000),
-                               GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::FREQUENCY_GPU_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1, 1530000000),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COPY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::ACTIVE_TIME_COMPUTE_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::ENERGY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, num_accelerator_subdevice, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, -1, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COPY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COMPUTE_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_BOARD_ACCELERATOR, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
 }


### PR DESCRIPTION
- Related to #2057.
- Related to #1671.
- These changes are required to support the following requirement for IOGroups implementing the new SaveControl object:
   - All low level Controls must be readable as Signals.
   - High level Controls (i.e. aliases) are exempt from this requirement.
- Rename Signals/Controls to conform to the form `<DEVICE_TYPE>_<METRIC>` with anything related to the control ending in `_CONTROL`.