### PR TITLE
Fix for the tutorial build

### DIFF
--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -57,37 +57,37 @@ tutorial_0.o: tutorial_0.c
 	$(MPICC) $(CFLAGS) -c $^ -o $@
 
 tutorial_0: tutorial_0.o
-	$(MPICC) $(LDFLAGS) $^ -o $@
+	$(MPICC) $^ -o $@ $(LDFLAGS)
 
 tutorial_1.o: tutorial_1.c
 	$(MPICC) $(CFLAGS) -c $^ -o $@
 
 tutorial_1: tutorial_1.o tutorial_region.o
-	$(MPICC) $(LDFLAGS) $^ -o $@
+	$(MPICC) $^ -o $@ $(LDFLAGS)
 
 tutorial_2.o: tutorial_2.c
 	$(MPICC) $(CFLAGS) -c $^ -o $@
 
 tutorial_2: tutorial_2.o tutorial_region.o
-	$(MPICC) $(LDFLAGS) -lgeopm $^ -o $@
+	$(MPICC) $^ -o $@ $(LDFLAGS) -lgeopm
 
 tutorial_3.o: tutorial_3.c
 	$(MPICC) $(CFLAGS) -c $^ -o $@
 
 tutorial_3: tutorial_3.o tutorial_region.o
-	$(MPICC) $(LDFLAGS) -lgeopm $^ -o $@
+	$(MPICC) $^ -o $@ $(LDFLAGS) -lgeopm
 
 tutorial_4.o: tutorial_4.c
 	$(MPICC) $(CFLAGS) -c $^ -o $@
 
 tutorial_4: tutorial_4.o tutorial_region.o
-	$(MPICC) $(LDFLAGS) -lgeopm -lstdc++ $^ -o $@
+	$(MPICC) $^ -o $@ $(LDFLAGS) -lgeopm -lstdc++
 
 tutorial_5.o: tutorial_5.c
 	$(MPICC) $(CFLAGS) -c $^ -o $@
 
 tutorial_5: tutorial_5.o tutorial_region.o tutorial_region_prof.o
-	$(MPICC) $(LDFLAGS) -lgeopm -lstdc++ $^ -o $@
+	$(MPICC) $^ -o $@ $(LDFLAGS) -lgeopm -lstdc++
 
 tutorial_region.o: tutorial_region.c tutorial_region.h
 	$(MPICC) $(CFLAGS) -c tutorial_region.c -o $@

--- a/tutorial/iogroup/ExampleIOGroup.cpp
+++ b/tutorial/iogroup/ExampleIOGroup.cpp
@@ -469,6 +469,11 @@ int ExampleIOGroup::signal_behavior(const std::string &signal_name) const
     return M_SIGNAL_BEHAVIOR_MONOTONE;
 }
 
+std::string ExampleIOGroup::name(void) const
+{
+    return plugin_name();
+}
+
 // Name used for registration with the IOGroup factory
 std::string ExampleIOGroup::plugin_name(void)
 {

--- a/tutorial/iogroup/ExampleIOGroup.hpp
+++ b/tutorial/iogroup/ExampleIOGroup.hpp
@@ -76,6 +76,7 @@ class ExampleIOGroup : public geopm::IOGroup
         std::string signal_description(const std::string &signal_name) const;
         std::string control_description(const std::string &control_name) const;
         int signal_behavior(const std::string &signal_name) const override;
+        std::string name(void) const override;
         static std::string plugin_name(void);
         static std::unique_ptr<geopm::IOGroup> make_plugin(void);
     private:

--- a/tutorial/plugin_load/alice/AliceIOGroup.cpp
+++ b/tutorial/plugin_load/alice/AliceIOGroup.cpp
@@ -50,6 +50,11 @@ static void __attribute__((constructor)) example_iogroup_load(void)
                                              AliceIOGroup::make_plugin);
 }
 
+std::string AliceIOGroup::name(void) const
+{
+    return plugin_name();
+}
+
 // Name used for registration with the IOGroup factory
 std::string AliceIOGroup::plugin_name(void)
 {

--- a/tutorial/plugin_load/alice/AliceIOGroup.hpp
+++ b/tutorial/plugin_load/alice/AliceIOGroup.hpp
@@ -67,6 +67,7 @@ class AliceIOGroup : public geopm::IOGroup
         std::string signal_description(const std::string &signal_name) const;
         std::string control_description(const std::string &control_name) const;
         int signal_behavior(const std::string &signal_name) const override;
+        std::string name(void) const override;
         static std::string plugin_name(void);
         static std::unique_ptr<geopm::IOGroup> make_plugin(void);
     private:

--- a/tutorial/plugin_load/bob/BobIOGroup.cpp
+++ b/tutorial/plugin_load/bob/BobIOGroup.cpp
@@ -50,6 +50,11 @@ static void __attribute__((constructor)) example_iogroup_load(void)
                                              BobIOGroup::make_plugin);
 }
 
+std::string BobIOGroup::name(void) const
+{
+    return plugin_name();
+}
+
 // Name used for registration with the IOGroup factory
 std::string BobIOGroup::plugin_name(void)
 {

--- a/tutorial/plugin_load/bob/BobIOGroup.hpp
+++ b/tutorial/plugin_load/bob/BobIOGroup.hpp
@@ -67,6 +67,7 @@ class BobIOGroup : public geopm::IOGroup
         std::string signal_description(const std::string &signal_name) const;
         std::string control_description(const std::string &control_name) const;
         int signal_behavior(const std::string &signal_name) const override;
+        std::string name(void) const override;
         static std::string plugin_name(void);
         static std::unique_ptr<geopm::IOGroup> make_plugin(void);
     private:

--- a/tutorial/tutorial_region.c
+++ b/tutorial/tutorial_region.c
@@ -162,7 +162,7 @@ int tutorial_stream(double big_o, int do_report)
             }
 
             if (do_report) {
-                printf("Executing STREAM triad on length %d vectors.\n", num_stream);
+                printf("Executing STREAM triad on length %ld vectors.\n", num_stream);
                 fflush(stdout);
             }
 
@@ -202,7 +202,7 @@ int tutorial_all2all(double big_o, int do_report)
         }
         if (!err) {
             if (do_report) {
-                printf("Executing all2all of %d byte buffer on %d ranks.\n",
+                printf("Executing all2all of %ld byte buffer on %d ranks.\n",
                        num_send * sizeof(char), num_rank);
                 fflush(stdout);
             }

--- a/tutorial/tutorial_region_prof.c
+++ b/tutorial/tutorial_region_prof.c
@@ -65,8 +65,7 @@ static int stream_profiled_omp(uint64_t region_id, size_t num_stream, double sca
 
     return err;
 }
-#endif
-
+#else
 static int stream_profiled_serial(uint64_t region_id, size_t num_stream, double scalar, double *a, double *b, double *c)
 {
     const size_t block = 256;
@@ -86,6 +85,7 @@ static int stream_profiled_serial(uint64_t region_id, size_t num_stream, double 
 
     return 0;
 }
+#endif
 
 int tutorial_stream_profiled(double big_o, int do_report)
 {
@@ -122,7 +122,7 @@ int tutorial_stream_profiled(double big_o, int do_report)
             }
 
             if (do_report) {
-                printf("Executing profiled STREAM triad on length %d vectors.\n", num_stream);
+                printf("Executing profiled STREAM triad on length %ld vectors.\n", num_stream);
                 fflush(stdout);
             }
             err = geopm_prof_enter(stream_rid);
@@ -143,4 +143,5 @@ int tutorial_stream_profiled(double big_o, int do_report)
             free(a);
         }
     }
+    return err;
 }


### PR DESCRIPTION
- Broken since 32dbf1cb9 in #2063.
- These tutorial IOGroups were simply missed with the `name()` API updates.
- Additionally address compile time warnings generated with GNU around:
  - `%d` vs. `%ld` format specifiers to printf.
  - Defined but not used functions if OMP is available.
  - Missing return code.
- Address GNU/distro specific issues with linking.  On ubuntu with GNU/GCC, the libraries have to be last.  This does not impact other flavors tested (i.e. SLES).