### PR TITLE
Enable GEOPM service to automatically restart effectively

### DIFF
--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -101,6 +101,7 @@ EXTRA_DIST = .gitignore \
              geopmdpy/service.py \
              geopmdpy/session.py \
              geopmdpy/topo.py \
+             geopmdpy/varrun.py \
              geopmdpy/version.py \
              geopmdpy/version.py.in \
              geopmsession \

--- a/service/docs/source/geopmdpy.7.rst
+++ b/service/docs/source/geopmdpy.7.rst
@@ -42,6 +42,14 @@ geopmdpy.error
    :undoc-members:
    :show-inheritance:
 
+geopmdpy.gffi
+-------------
+
+.. automodule:: geopmdpy.gffi
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 geopmdpy.pio
 ------------
 
@@ -78,6 +86,14 @@ geopmdpy.topo
 -------------
 
 .. automodule:: geopmdpy.topo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+geopmdpy.varrun
+---------------
+
+.. automodule:: geopmdpy.varrun
    :members:
    :undoc-members:
    :show-inheritance:

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -56,6 +56,7 @@ Requires: python3-gobject
 Requires: python3-gobject-base
 %endif
 Requires: python3-dasbus
+Requires: python3-jsonschema
 
 Prefix: %{_prefix}
 

--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -765,10 +765,9 @@ class GEOPMService(object):
     """
     __dbus_xml__ = dbus_xml.geopm_dbus_xml(TopoService, PlatformService)
 
-    def __init__(self, topo=TopoService(),
-                 platform=PlatformService()):
-        self._topo = topo
-        self._platform = platform
+    def __init__(self):
+        self._topo = TopoService()
+        self._platform = PlatformService()
         self._dbus_proxy = SystemMessageBus().get_proxy('org.freedesktop.DBus',
                                                         '/org/freedesktop/DBus')
 

--- a/service/geopmdpy/varrun.py
+++ b/service/geopmdpy/varrun.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+
+#  Copyright (c) 2015 - 2021, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+"""Interface for /var/run/geopm-service
+
+Module used to read and write the files in /var/run/geopm-service.
+These files maintain the state used by geopmd to track ongoing client
+sessions.  These files are loaded at geopmd start-up time and enable
+the daemon to cleanly restart.
+
+"""
+
+import os
+import sys
+import stat
+import json
+import jsonschema
+import glob
+import psutil
+import uuid
+
+
+GEOPM_SERVICE_VAR_PATH = '/var/run/geopm-service'
+
+class ActiveSessions(object):
+    """Class that manages the session files for the service
+
+    The state about active sessions opened with geopmd by a client
+    processes is stored in files in /var/run/geopm-service.  These
+    files are loaded when the geopmd process starts.  The files are
+    modified each time a client opens a session, closes a session,
+    requests write permission, or starts a batch server.  The class is
+    responsible for managing file access permissions, and atomic file
+    creation.
+
+    """
+
+    def __init__(self, var_path=GEOPM_SERVICE_VAR_PATH):
+        """Create an ActiveSessions object that tracks geopmd session files
+
+        The geopmd session files are stored in the directory
+
+            "/var/run/geopm-service"
+
+        by default, but the user may specify a different path.  The
+        creation of an ActiveSessions object will make the directory
+        if it does not exist.  This directory is created with
+        restricted access permissions (mode: 0o700).
+
+        If the path points to a symbolic link, the link will be
+        deleted and a warning is printed to the syslog.  The directory
+        will then be created in its place.  The warning message will
+        display the user and group permissions of the directory being
+        deleteted.
+
+        When an ActiveSessions object is created and the directory
+        already exists the owner of the directory will be set to the
+        geopmd user and the permissions will be set to mode 0o700.
+        All files matching the pattern
+
+            "/var/run/geopm-service/session-*.json"
+
+        will be parsed and verified. These files must conform to the
+        session JSON schema, be owned by the geopmd user, and have
+        restricted access permissions (mode: 0o600).  Files matching
+        the session pattern which do not meet these criterion are not
+        parsed, will be deleted, and a warning is printed to standard
+        syslog.  The warning message will display the user and group
+        permissions of the file being deleted.
+
+        Args:
+            var_path (str): Optional argument to override the default
+                            path to the session files which is
+                            "/var/run/geopm-service"
+
+        Returns:
+            ActiveSessions: Object containing all valid sessions data
+                            read from the var_path directory
+
+        """
+        self._VAR_PATH = var_path
+        self._INVALID_PID = -1
+        self._daemon_uid = os.getuid()
+        self._daemon_gid = os.getgid()
+        self._sessions = dict()
+        self._session_schema = {
+            'type' : 'object',
+            'properties' : {
+                'client_pid' : {'type' : 'number'},
+                'mode' : {'type' : 'string'},
+                'signals' : {'type' : 'array', 'items' : {'type' : 'string'}},
+                'controls' : {'type' : 'array', 'items' : {'type' : 'string'}},
+                'watch_id' : {'type' : 'number'},
+                'batch_server': {'type' : 'number'}
+            },
+            'additionalProperties' : False,
+            'required' : ['client_pid', 'mode', 'signals', 'controls']
+        }
+        if os.path.islink(self._VAR_PATH):
+            # TODO enhance warning message to provide user and group
+            # ownership of the symbolic link that was deleted
+            sys.stderr.write(f'Warning: <geopm> {self._VAR_PATH} is a symbolic link, the link will be deleted')
+            os.unlink(self._VAR_PATH)
+        if not os.path.isdir(self._VAR_PATH):
+            os.mkdir(self._VAR_PATH, mode=0o700)
+        else:
+            # Do we need a chown? print a warning?
+            st = os.stat(self._VAR_PATH)
+            perm_mode = stat.S_IMODE(st.st_mode)
+            if perm_mode != 0o700:
+                sys.stderr.write(f'Warning: <geopm> {self._VAR_PATH} has wrong permissions, reseting to 0o700, current value: {oct(perm_mode)}')
+                os.chmod(self._VAR_PATH, mode=0o700)
+        for sess_path in glob.glob(self._get_session_path('*')):
+            self._load_session_file(sess_path)
+
+    def is_client_active(self, client_pid):
+        """Query if a Linux PID currently has an active session
+
+        If a session file matching the client_pid exists, but the file
+        was not parsed or created by geopmd, then a warning message is
+        printed to syslog and the file is deleted.  The warning
+        message will display the user and group permissions of the
+        file being deleteted.  In this case False is returned.
+
+        Args:
+            client_pid (int): Linux PID to query
+
+        Returns:
+            bool: True if the PID has an open session, False otherwise
+
+        """
+        result = client_pid in self._sessions
+        session_path = self._get_session_path(client_pid)
+        if not result and os.path.isfile(session_path):
+            # TODO print and delete, dont raise
+            raise RuntimeError(f'Session file exists, but client {client_pid} is not tracked: {session_file}')
+        return result
+
+    def check_client_active(self, client_pid, msg=''):
+        """Raise an exception if a PID does not have an active session
+
+        Args:
+            client_pid (int): Linux PID to query
+
+            msg (str): The operation that was attempted which requires
+                       an active session.  Used in error message
+
+        Raises:
+            RuntimeError: Operation not allowed without an open session
+
+        """
+        if not self.is_client_active(client_pid):
+            raise RuntimeError(f"Operation '{msg}' not allowed without an open session. Client PID: {client_pid}")
+
+    def add_client(self, client_pid, signals, controls, watch_id):
+        """Add an new client session to be tracked
+
+        Create a new session file that contains the JSON data provided
+        as the call parameters in a format that conforms to the
+        session file schema.
+
+        This file will be created atomically such that if this method
+        is interrupted before the session file is ready to be used,
+        then no file will be present that matches load pattern below.
+
+            /var/run/geopm-service/session-*.json
+
+        The session file is created with the JSON object property
+        "mode" set to "r" (read mode) and without the "batch_server"
+        property specified.  These properties may be modified by the
+        set_write_client() or set_batch_server() methods after the
+        client is added.
+
+        This operation creates the session file atomically, but does
+        not modify the session properties nor the session file if the
+        client PID already has an open session.
+
+        Args:
+            client_pid (int): Linux PID that opened the session
+
+            signals (list(str)): List of signal names that are allowed
+                                 to be read by the client
+
+            controls (list(str)): List of control names that are allowed
+                                  to be written by the client
+
+            watch_id (int): The watch ID handle returned by GLib for
+                            tracking that the PID is active
+
+        """
+        if self.is_client_active(client_pid):
+            return
+        session_data = {'client_pid': client_pid,
+                        'mode': 'r',
+                        'signals': list(signals),
+                        'controls': list(controls),
+                        'watch_id': watch_id}
+        self._sessions[client_pid] = session_data
+        self._update_session_file(client_pid)
+
+    def remove_client(self, client_pid):
+        """Delete the record of an active session
+
+        Remove the client session file and delete the state associated
+        with client.  Future requests about this client PID will raise
+        an exception until another call to add_client() is made.  This
+        exception will be raised for a second call to remove_client().
+
+        Args:
+            client_pid (int): Linux PID that opened the session
+
+        Raises:
+            RuntimeError: Client does not have an open session
+
+        """
+        self.check_client_active(client_pid, 'remove_client')
+        session_file = self._get_session_path(client_pid)
+        os.remove(session_file)
+        self._sessions.pop(client_pid)
+
+    def get_clients(self):
+        """Get list of the client PID values for all active sessions
+
+        Creates a list of the PID values for all active session clients.
+
+        Returns:
+            list(int): The Linux PID values for all active clients
+
+        """
+        return list(self._sessions.keys())
+
+    def is_write_client(self, client_pid):
+        """Query if the client PID currently holds the write lock
+
+        Returns:
+            bool: True if the client PID holds the write lock, and
+                  false otherwise
+
+        Raises:
+            RuntimeError: Client does not have an open session
+
+        """
+        self.check_client_active(client_pid, 'get_mode')
+        return self._sessions[client_pid]['mode'] == 'rw'
+
+    def get_signals(self, client_pid):
+        """Query all signal names that are available
+
+        Creates a list of all signal names that are available to the
+        session opened by the client PID.
+
+        Args:
+            client_pid (int): Linux PID that opened the session
+
+        Returns:
+            list(str): Signal name access list for the session
+
+        Raises:
+            RuntimeError: Client does not have an open session
+
+        """
+        self.check_client_active(client_pid, 'get_signals')
+        return list(self._sessions[client_pid]['signals'])
+
+    def get_controls(self, client_pid):
+        """Query all control names that are available
+
+        Creates a list of all control names that are available to the
+        session opened by the client PID.
+
+        Args:
+            client_pid (int): Linux PID that opened the session
+
+        Returns:
+            list(str): Control name access list for the session
+
+        Raises:
+            RuntimeError: Client does not have an open session
+
+        """
+        self.check_client_active(client_pid, 'get_controls')
+        return list(self._sessions[client_pid]['controls'])
+
+    def get_watch_id(self, client_pid):
+        """Query the GLib watch ID for tracking the session lifetime
+
+        The watch ID is not valid in the case where the geopmd process
+        restarts.  When a new geopmd process starts it will read files
+        that contain watch ID values, however, the set_watch_id()
+        method must be called with an updated watch ID for each active
+        client session when geopmd starts.
+
+        Args:
+            client_pid (int): Linux PID that opened the session
+
+        Returns:
+            int: GLib watch ID to track the session lifetime
+
+        Raises:
+            RuntimeError: Client does not have an open session
+
+        """
+        self.check_client_active(client_pid, 'get_watch_id')
+        return self._sessions[client_pid]['watch_id']
+
+    def set_watch_id(self, client_pid, watch_id):
+        """Set the GLib watch ID for tracking the session lifetime
+
+        Store the GLib watch ID after registering the callback with
+        GLib.timeout_add().
+
+        Args:
+            client_pid (int): Linux PID that opened the session
+
+            watch_id (int): GLib watch ID returned by the
+                            GLib.timeout_add() method
+
+        Raises:
+            RuntimeError: Client does not have an open session
+
+        """
+        self.check_client_active(client_pid, 'get_watch_id')
+        self._sessions[client_pid]['watch_id'] = watch_id
+        self._update_session_file(client_pid)
+
+    def get_batch_server(self, client_pid):
+        """Query the batch server for the client session
+
+        In the case where the client has an open batch server, this
+        method returns the Linux PID of the batch server.  If there is
+        no active batch server then None is returned.
+
+        Args:
+            client_pid (int): Linux PID that opened the session
+
+        Returns:
+            int: The Linux PID of the batch server or None
+
+        Raises:
+            RuntimeError: Client does not have an open session
+
+        """
+        self.check_client_active(client_pid, 'get_batch_server')
+        return self._sessions[client_pid].get('batch_server')
+
+    def set_write_client(self, client_pid):
+        """Mark a client session as the write mode client
+
+        This method identifies that the client session is able to
+        write through the service.  The file that stores this
+        information about the session will be updated atomically,
+        however it is the user's responsibility to maintain the
+        requirement for one write mode session at any one time.
+
+        Args:
+            client_pid (int): Linux PID that opened the session
+
+        Raises:
+            RuntimeError: Client does not have an open session
+
+        """
+        self.check_client_active(client_pid, 'set_write_client')
+        self._sessions[client_pid]['mode'] = 'rw'
+        self._update_session_file(client_pid)
+
+    def set_batch_server(self, client_pid, batch_pid):
+        """Set the Linux PID of the batch server supporting a client session
+
+        This method is used to store the PID after a batch server is created.
+
+        Args:
+            client_pid (int): Linux PID that opened the session
+
+            batch_pid (int): Linux PID of the batch server created for
+                             the client session
+
+        Raises:
+            RuntimeError: Client does not have an open session
+
+        """
+        self.check_client_active(client_pid, 'set_batch_server')
+        if 'batch_server' in self._sessions[client_pid]:
+            current_server = self._sessions[client_pid]['batch_server']
+            raise RuntimeError(f'Client {client_pid} has already started a batch server: {current_server}')
+        self._sessions[client_pid]['batch_server'] = batch_pid
+        self._update_session_file(client_pid)
+
+    def remove_batch_server(self, client_pid):
+        """Remove the record for the batch server supporting a client session
+
+        This method is used to remove the record of a batch server
+        after it is closed.
+
+        Args:
+            client_pid (int): Linux PID that opened the session
+
+        Raises:
+            RuntimeError: Client does not have an open session
+
+        """
+        self.check_client_active(client_pid, 'remove_batch_server')
+        self._sessions[client_pid].pop('batch_server')
+        self._update_session_file(client_pid)
+
+    def _get_session_path(self, client_pid):
+        return f'{self._VAR_PATH}/session-{client_pid}.json'
+
+    def _update_session_file(self, client_pid):
+        sess = self._sessions[client_pid]
+        jsonschema.validate(sess, schema=self._session_schema)
+        session_path = self._get_session_path(client_pid)
+        tmp_id = uuid.uuid4()
+        session_path_tmp = f'{session_path}-tmp-{tmp_id}'
+        os.umask(0o077)
+        with open(session_path_tmp, 'w') as fid:
+            json.dump(sess, fid)
+        os.rename(session_path_tmp, session_path)
+
+    def _load_session_file(self, sess_path):
+        with open(sess_path) as fid:
+            sess_stat = os.stat(fid.fileno())
+            # Check required permissions
+            if not (stat.S_ISREG(sess_stat.st_mode) and
+                    stat.S_IMODE(sess_stat.st_mode) == 0o600 and
+                    sess_stat.st_uid == self._daemon_uid and
+                    sess_stat.st_gid == self._daemon_gid):
+                # TODO: more verbose logging of user and group id
+                err_msg = f'Warning: <geopm-service> session file was discovered with invalid permissions, will be ignored and removed: {sess_path}\n'
+                sys.stderr.write(err_msg)
+                os.unlink(sess_path)
+                return  # Bad permissions return early
+            sess = json.load(fid)
+        file_time = sess_stat.st_ctime
+        jsonschema.validate(sess, schema=self._session_schema)
+        client_pid = sess['client_pid']
+        if client_pid != self._INVALID_PID:
+            try:
+                proc_time = psutil.Process(client_pid).create_time()
+                # TODO: Write test to check this comparison logic
+                if proc_time >= file_time:
+                    # PID has been recycled, so set it to invalid
+                    sess['client_pid'] = self._INVALID_PID
+            except psutil.NoSuchProcess:
+                # PID is no longer active, so set it to invalid
+                sess['client_pid'] = self._INVALID_PID
+        self._sessions[client_pid] = dict(sess)

--- a/service/geopmdpy/varrun.py
+++ b/service/geopmdpy/varrun.py
@@ -195,7 +195,7 @@ class ActiveSessions(object):
         session_path = self._get_session_path(client_pid)
         if not result and os.path.isfile(session_path):
             # TODO print and delete, dont raise
-            raise RuntimeError(f'Session file exists, but client {client_pid} is not tracked: {session_file}')
+            raise RuntimeError(f'Session file exists, but client {client_pid} is not tracked: {session_path}')
         return result
 
     def check_client_active(self, client_pid, msg=''):
@@ -497,13 +497,13 @@ class ActiveSessions(object):
 
                 os.rename(sess_path, renamed_path)
                 return  # Bad permissions return early
-            sess = json.load(fid)
-        try:
-            jsonschema.validate(sess, schema=self._session_schema)
-        except:
-            sys.stderr.write(f'Warning: <geopm-service> Invalid JSON file, unable to parse, renamed{sess_path} to {renamed_path} and will ignore')
-            os.rename(sess_path, renamed_path)
-            return # Invalid JSON return early
+            try:
+                sess = json.load(fid)
+                jsonschema.validate(sess, schema=self._session_schema)
+            except:
+                sys.stderr.write(f'Warning: <geopm-service> Invalid JSON file, unable to parse, renamed{sess_path} to {renamed_path} and will ignore')
+                os.rename(sess_path, renamed_path)
+                return # Invalid JSON return early
         file_time = sess_stat.st_ctime
         client_pid = sess['client_pid']
         if client_pid != self._INVALID_PID:

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -29,7 +29,8 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-EXTRA_DIST += geopmdpy_test/__main__.py \
+EXTRA_DIST += geopmdpy_test/__init__.py \
+              geopmdpy_test/__main__.py \
               geopmdpy_test/geopmdpy_test.sh \
               geopmdpy_test/TestAccess.py \
               geopmdpy_test/TestPlatformService.py \
@@ -122,15 +123,16 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestPlatformService.test__read_allow
                  geopmdpy_test/pytest_links/TestTimedLoop.test_timed_loop_fixed \
                  geopmdpy_test/pytest_links/TestTimedLoop.test_timed_loop_infinite \
                  geopmdpy_test/pytest_links/TestTimedLoop.test_timed_loop_invalid \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_default_creation \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_link_not_dir \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_file_not_dir \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_perms \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_user_owner \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_group_owner \
-                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_sessions \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_session_perms \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_session_user_owner \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_session_group_owner \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_json \
                  # end
 
 TESTS += $(GEOPMDPY_TESTS)

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -122,11 +122,15 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestPlatformService.test__read_allow
                  geopmdpy_test/pytest_links/TestTimedLoop.test_timed_loop_fixed \
                  geopmdpy_test/pytest_links/TestTimedLoop.test_timed_loop_infinite \
                  geopmdpy_test/pytest_links/TestTimedLoop.test_timed_loop_invalid \
-                 geopmdpy_test/pytest_links/TestActiveSessions.test_default_creation \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_link_not_dir \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_file_not_dir \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_perms \
-                 geopmdpy_test/pytest_links/TestActiveSessions.test_watch_id \
-                 geopmdpy_test/pytest_links/TestActiveSessions.test_batch_server \
-                 geopmdpy_test/pytest_links/TestActiveSessions.test_write_client \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_user_owner \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_group_owner \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_sessions \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_session_perms \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_session_user_owner \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_session_group_owner \
                  # end
 
 TESTS += $(GEOPMDPY_TESTS)

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -125,6 +125,8 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestPlatformService.test__read_allow
                  geopmdpy_test/pytest_links/TestActiveSessions.test_default_creation \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_perms \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_watch_id \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_batch_server \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_write_client \
                  # end
 
 TESTS += $(GEOPMDPY_TESTS)

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -133,6 +133,11 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestPlatformService.test__read_allow
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_session_user_owner \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_session_group_owner \
                  geopmdpy_test/pytest_links/TestActiveSessions.test_creation_json \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_update_reload \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_add_remove_client \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_write_client \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_batch_server \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_watch_id \
                  # end
 
 TESTS += $(GEOPMDPY_TESTS)

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -41,6 +41,7 @@ EXTRA_DIST += geopmdpy_test/__main__.py \
               geopmdpy_test/TestSession.py \
               geopmdpy_test/TestTimedLoop.py \
               geopmdpy_test/TestController.py \
+              geopmdpy_test/TestActiveSessions.py \
               # end
 
 GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestPlatformService.test__read_allowed_invalid \
@@ -121,6 +122,9 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestPlatformService.test__read_allow
                  geopmdpy_test/pytest_links/TestTimedLoop.test_timed_loop_fixed \
                  geopmdpy_test/pytest_links/TestTimedLoop.test_timed_loop_infinite \
                  geopmdpy_test/pytest_links/TestTimedLoop.test_timed_loop_invalid \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_default_creation \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_creation_bad_perms \
+                 geopmdpy_test/pytest_links/TestActiveSessions.test_watch_id \
                  # end
 
 TESTS += $(GEOPMDPY_TESTS)

--- a/service/geopmdpy_test/TestActiveSessions.py
+++ b/service/geopmdpy_test/TestActiveSessions.py
@@ -152,7 +152,7 @@ class TestActiveSessions(unittest.TestCase):
         """Create a json file that  matches the ActiveSessions._session_schema
 
         """
-        os.makedirs(directory, exist_ok=True)
+        os.makedirs(directory, mode=0o700, exist_ok=True)
         full_path = os.path.join(directory, filename)
         with open(os.open(full_path, os.O_CREAT | os.O_WRONLY, permissions), 'w') as file:
             # write a string to the file
@@ -466,7 +466,7 @@ class TestActiveSessions(unittest.TestCase):
                 mock.call(f'Warning: <geopm-service> Invalid JSON file, unable to parse, renamed{full_file_path} to {renamed_path} and will ignore')
             ]
             if is_valid:
-                self.assertTrue(mock_err.empty())
+                self.assertEqual(0, len(mock_err.call_args_list))
                 self.check_getters(
                     act_sess,
                     contents["client_pid"],

--- a/service/geopmdpy_test/TestActiveSessions.py
+++ b/service/geopmdpy_test/TestActiveSessions.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2021, Intel Corporation
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#      * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in
+#        the documentation and/or other materials provided with the
+#        distribution.
+#
+#      * Neither the name of Intel Corporation nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import unittest
+from unittest import mock
+import os
+import stat
+import tempfile
+
+from geopmdpy.varrun import ActiveSessions
+
+class TestActiveSessions(unittest.TestCase):
+    def setUp(self):
+        """Create temporary directory
+
+        """
+        self._test_name = 'TestActiveSessions'
+        self._TEMP_DIR = tempfile.TemporaryDirectory(self._test_name)
+
+    def tearDown(self):
+        """Clean up temporary directory
+
+        """
+        self._TEMP_DIR.cleanup()
+
+    def check_dir_perms(self, path):
+        """Assert that the path points to a file with mode 0o700
+
+        """
+        st = os.stat(path)
+        self.assertEqual(0o700, stat.S_IMODE(st.st_mode))
+
+    def test_default_creation(self):
+        """Default creation of an ActiveSessions object
+
+        Test creates an ActiveSessions object when the geopm-service
+        directory is not present.
+
+        """
+        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        act_sess = ActiveSessions(sess_path)
+        self.check_dir_perms(sess_path)
+
+    def test_creation_bad_perms(self):
+        """Directory exists with bad permissions
+
+        Test creates an ActiveSessions object when the geopm-service
+        directory is present with wrong permissions.  It asserts that
+        a warning message is printed to standard error and that the
+        permissions are changed.
+
+        """
+        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        os.umask(0o000)
+        os.mkdir(sess_path, mode=0o755)
+        with mock.patch('sys.stderr.write', return_value=None) as mock_err:
+            act_sess = ActiveSessions(sess_path)
+            mock_err.assert_called_once_with(f'Warning: <geopm> {sess_path} has wrong permissions, reseting to 0o700, current value: 0o755')
+        self.check_dir_perms(sess_path)
+
+    def test_creation_bad_owner(self):
+        """Directory exists with wrong owner
+
+        Test creates an ActiveSessions object when the geopm-service
+        directory is present with wrong ownership.  It asserts that
+        a warning message is printed to standard error and that the
+        ownership is changed.
+
+        """
+        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        os.umask(0o077)
+        os.mkdir(sess_path, mode=0o700)
+        bad_user = mock.MagicMock()
+        bad_user.st_uid = os.getuid() + 1
+        bad_user.st_gid = os.getgid()
+        bad_user.st_mode = 0o600
+        good_user = mock.MagicMock()
+        good_user.st_uid = os.getuid()
+        good_user.st_gid = os.getgid()
+        good_user.st_mode = 0o600
+        side_effect = lambda path: 'bad_user' in path and bad_user or good_user
+        with mock.patch('os.stat', side_effect=side_effect), \
+             mock.patch('stat.S_IMODE', return_value=0o600), \
+             mock.patch('stat.S_ISREG', return_value=True):
+            act_sess = ActiveSessions(sess_path)
+        with mock.patch('sys.stderr.write', return_value=None) as mock_err:
+            act_sess = ActiveSessions(sess_path)
+            mock_err.assert_called_once_with(f'Warning: <geopm> {sess_path} has wrong permissions, reseting to 0o700, current value: 0o755')
+        self.check_dir_perms(sess_path)
+
+
+    def test_creation_sessions(self):
+        """Valid session files are present in directory
+
+        Test creates an ActiveSessions object when the geopm-service
+        directory has two JSON session files that both have valid
+        contents.  The test calls the get_*() interfaces to verify
+        that the files data reflects the contents of the session
+        files.
+
+        """
+        pass
+
+    def test_creation_bad_session_perms(self):
+        """Bad permissions on session file
+
+        Test creates an ActiveSessions object when the geopm-service
+        directory has two JSON session files, one that meets all
+        requirements and another that has permissions mode 0o644.  The
+        test asserts that the valid file is parsed properly.  The test
+        also asserts that the invalid file is not used, deleted and a
+        warning message is printed.  This message should contain the
+        user and group IDs of the file with invalid permissions as
+        well as the file creation time.
+
+        """
+
+        pass
+
+    def test_creation_bad_session_owner(self):
+        """Bad owner of session file
+
+        Test creates an ActiveSessions object when the geopm-service
+        directory has two JSON session files, one that meets all
+        requirements and another that apears to be owned by a
+        different user through a mock patch of os.stat().  The test
+        asserts that the valid file is parsed properly.  The test also
+        asserts that the invalid file is not used, deleted and a
+        warning message is printed.  This message should contain the
+        user and group IDs of the file with invalid ownership as well
+        as the file creation time.
+
+        """
+        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        # TODO: Add files including one with 'bad_user' in name
+        bad_user = mock.MagicMock()
+        bad_user.st_uid = os.getuid() + 1
+        bad_user.st_gid = os.getgid()
+        bad_user.st_mode = 0o600
+        good_user = mock.MagicMock()
+        good_user.st_uid = os.getuid()
+        good_user.st_gid = os.getgid()
+        good_user.st_mode = 0o600
+        side_effect = lambda path: 'bad_user' in path and bad_user or good_user
+        with mock.patch('os.stat', side_effect=side_effect), \
+             mock.patch('stat.S_IMODE', return_value=0o600), \
+             mock.patch('stat.S_ISREG', return_value=True):
+            act_sess = ActiveSessions(sess_path)
+        # TODO: Add assertions
+
+    def test_update_reload(self):
+        """Create add clients and create again
+
+        Create an ActiveSessions object with no directory present.
+        Add two clients to the object.  Create a new ActiveSessions
+        object pointing to the same path and check that the new object
+        returns the same values for the get_*() methods as the first
+        object.
+
+        """
+        pass
+
+    def test_add_remove_client(self):
+        """Add client session and remove it
+
+        Test that adding a client is reflected in the get_clients()
+        and is_client_active() methods.  Checks that the get_*()
+        reflect the values passed when adding the client.  Also checks
+        that when the remove_client() method is called the client PID
+        is no longer returned by get_clients() and is_client_active()
+        returns False.
+
+        """
+        pass
+
+    def test_write_client(self):
+        """Assign the write privileges to a client session
+
+        Test that when set_write_client() is called that the result of
+        is_write_client() changes to reflect this.  Checks that a
+        second ApplicationSessions object loaded after the write
+        client was assigned reflects this change when calling
+        is_write_client() on the second object.
+
+        """
+        pass
+
+    def test_batch_server(self):
+        """Assign the batch server PID to a client session
+
+        Test that when set_batch_server() is called that the result of
+        get_batch_server() changes to reflect this.  Checks that a
+        second ApplicationSessions object loaded after the batch
+        server was assigned reflects this change when calling
+        get_batch_server() on the second object.
+
+        """
+        pass
+
+    def test_watch_id(self):
+        """Assign the watch_id to a client session
+
+        Test that when set_watch_id() is called that the result of
+        get_watch_id() changes to reflect this.
+
+        """
+        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        act_sess = ActiveSessions(sess_path)
+        client_pid = 1234
+        signals = ['INSTRUCTIONS_RETIRED', 'CPU_FREQUENCY']
+        controls = ['CORE_FREQUENCY', 'POWER_LIMIT']
+        watch_id = 4321
+        act_sess.add_client(client_pid, signals, controls, watch_id)
+        actual_watch_id = act_sess.get_watch_id(client_pid)
+        self.assertEqual(watch_id, actual_watch_id)
+        watch_id += 1
+        act_sess.set_watch_id(client_pid, watch_id)
+        actual_watch_id = act_sess.get_watch_id(client_pid)
+        self.assertEqual(watch_id, actual_watch_id)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/service/geopmdpy_test/TestPlatformService.py
+++ b/service/geopmdpy_test/TestPlatformService.py
@@ -368,7 +368,7 @@ default
     def test_open_session_twice(self):
         client_pid = 999
         with mock.patch('geopmdpy.service.PlatformService._get_user_groups', return_value=[]), \
-             mock.patch('geopmdpy.service.PlatformService._watch_client', return_value=[]):
+             mock.patch('geopmdpy.service.PlatformService._watch_client', return_value=888):
             self._platform_service.open_session('', client_pid)
             session_file = self._session_file_format.format(client_pid=client_pid)
             self.assertTrue(os.path.isfile(session_file),
@@ -387,8 +387,7 @@ default
                         'mode': 'r',
                         'signals': signals_default,
                         'controls': controls_default,
-                        'watch_id': watch_id,
-                        'batch_server': None}
+                        'watch_id': watch_id}
         return session_data
 
     def open_mock_session(self, session_key, client_pid=-999):
@@ -553,7 +552,8 @@ default
         self.assertTrue(os.path.isdir(save_dir),
                         msg = 'Directory does not exist: {}'.format(save_dir))
 
-        with mock.patch('geopmdpy.pio.stop_batch_server', return_value=[]) as mock_stop_batch_server:
+        with mock.patch('geopmdpy.pio.stop_batch_server', return_value=[]) as mock_stop_batch_server, \
+             mock.patch('psutil.pid_exists', return_value=True) as mock_pid_exists:
             self._platform_service.stop_batch(client_pid, expected_result[0])
             mock_stop_batch_server.assert_called_once_with(expected_result[0])
 

--- a/service/geopmdpy_test/__init__.py
+++ b/service/geopmdpy_test/__init__.py
@@ -28,18 +28,3 @@
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-[Unit]
-Description=Global Extensible Open Power Manager Service
-StartLimitIntervalSec=0
-StartLimitBurst=3
-
-[Service]
-Environment=PYTHONUNBUFFERED=true
-Type=dbus
-BusName=io.github.geopm
-ExecStart=/usr/bin/geopmd
-Restart=always
-
-[Install]
-WantedBy=default.target

--- a/service/geopmdpy_test/__main__.py
+++ b/service/geopmdpy_test/__main__.py
@@ -43,6 +43,7 @@ from TestRequestQueue import *
 from TestSession import *
 from TestTimedLoop import *
 from TestTopo import *
+from TestActiveSessions import *
 
 if __name__ == '__main__':
     unittest.main()

--- a/service/integration/test/check_write_session.sh
+++ b/service/integration/test/check_write_session.sh
@@ -73,7 +73,7 @@ test ${SETTING} != ${START_VALUE} ||
 # START A SESSION THAT WRITES THE CONTROL VALUE
 echo "${REQUEST} ${SETTING}" | setsid geopmsession -w -t 10 &
 SESSION_ID=$!
-sleep 1
+sleep 4
 
 # READ THE CONTROLLED REGISTER
 SESSION_VALUE=$(echo ${REQUEST} | geopmsession)

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -5,3 +5,4 @@ psutil>=5.4.8
 docstring_parser>=0.8.1
 sphinx>=4.1.0
 sphinx_rtd_theme>=0.5.2
+jsonschema>=2.6.0

--- a/service/setup.py
+++ b/service/setup.py
@@ -76,7 +76,8 @@ install_requires = ['cffi>=1.6.0',
                     'setuptools>=39.2.0',
                     'future>=0.17.1',
                     'psutil>=5.6.2',
-                    'dasbus>=1.5.0']
+                    'dasbus>=1.5.0',
+                    'jsonschema>=2.6.0']
 
 setup(name='geopmdpy',
       version=__version__,


### PR DESCRIPTION
- Fixes #2077
- Fixes #2078 
- Fixes #2085

Unit tests:
- [x] test_default_creation
- [x] test_creation_bad_perms
- [x] test_creation_bad_owner
- [x] test_creation_sessions
- [x] test_creation_bad_session_perms
- [x] test_creation_bad_session_owner
- [x] test_update_reload f8948fcae
- [x] test_add_remove_client ad40d2a
- [x] test_write_client c582750
- [x] test_batch_server 823bb34
- [x] test_watch_id b5e407b 