### PR TITLE
Implement IOGroup fallback in PlatformIO

### DIFF
--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -68,7 +68,7 @@ namespace geopm
     // Set up mapping between signal and control names and corresponding indices
     LevelZeroIOGroup::LevelZeroIOGroup(const PlatformTopo &platform_topo,
                                        const LevelZeroDevicePool &device_pool,
-                                       std::shared_ptr<SaveControl> save_control)
+                                       std::shared_ptr<SaveControl> save_control_test)
         : m_platform_topo(platform_topo)
         , m_levelzero_device_pool(device_pool)
         , m_is_batch_read(false)
@@ -437,7 +437,7 @@ namespace geopm
                     M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY",
                     M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY_TIMESTAMP"}},
         })
-        , m_mock_save_ctl(save_control)
+        , m_mock_save_ctl(save_control_test)
     {
         // populate signals for each domain
         for (auto &sv : m_signal_available) {
@@ -475,24 +475,7 @@ namespace geopm
         }
 
         // Cache the initial min and max frequencies
-        for (int domain_idx = 0;
-             domain_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP);
-             ++domain_idx) {
-
-            try {
-                // Currently only the levelzero compute domain control is supported.
-                // As new controls are added they should be included
-                m_frequency_range.push_back(m_levelzero_device_pool.frequency_range(
-                                            GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, domain_idx,
-                                            geopm::LevelZero::M_DOMAIN_COMPUTE));
-            }
-            catch (const geopm::Exception &ex) {
-                throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
-                                + " Failed to fetch frequency control range for "
-                                " BOARD_ACCELERATOR_CHIP domain " + std::to_string(domain_idx),
-                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-            }
-        }
+        save_control();
     }
 
     void LevelZeroIOGroup::register_derivative_signals(void) {
@@ -896,7 +879,24 @@ namespace geopm
     // to adjust them
     void LevelZeroIOGroup::save_control(void)
     {
-        // No-op here as the initial frequency values are cached in the constructor
+        for (int domain_idx = 0;
+             domain_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP);
+             ++domain_idx) {
+
+            try {
+                // Currently only the levelzero compute domain control is supported.
+                // As new controls are added they should be included
+                m_frequency_range.push_back(m_levelzero_device_pool.frequency_range(
+                                            GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, domain_idx,
+                                            geopm::LevelZero::M_DOMAIN_COMPUTE));
+            }
+            catch (const geopm::Exception &ex) {
+                throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
+                                + " Failed to fetch frequency control range for "
+                                " BOARD_ACCELERATOR_CHIP domain " + std::to_string(domain_idx),
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+        }
     }
 
     // Implemented to allow an IOGroup to restore previously saved

--- a/service/src/LevelZeroIOGroup.hpp
+++ b/service/src/LevelZeroIOGroup.hpp
@@ -55,7 +55,7 @@ namespace geopm
             LevelZeroIOGroup();
             LevelZeroIOGroup(const PlatformTopo &platform_topo,
                              const LevelZeroDevicePool &device_pool,
-                             std::shared_ptr<SaveControl> save_control);
+                             std::shared_ptr<SaveControl> save_control_test);
             virtual ~LevelZeroIOGroup() = default;
             std::set<std::string> signal_names(void) const override;
             std::set<std::string> control_names(void) const override;

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -202,6 +202,14 @@ namespace geopm
                                   Agg::expect_same,
                                   IOGroup::M_SIGNAL_BEHAVIOR_CONSTANT,
                                   string_format_double
+                                  }},
+                              {M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL", {
+                                  "Resets streaming multiprocessor frequency min and max limits to default values.",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_CONSTANT,
+                                  string_format_double
                                   }}
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", {
@@ -606,6 +614,9 @@ namespace geopm
         }
         else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL" || signal_name == "GPU_FREQUENCY_CONTROL") {
             result = m_frequency_control_request.at(domain_idx);
+        }
+        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL") {
+            ; // No-op.  Nothing to return.
         }
         else {
     #ifdef GEOPM_DEBUG

--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -225,8 +225,13 @@ namespace geopm
                         read_signal_ok = true;
                     }
                     catch (const geopm::Exception &ex) {
-                        err_msg += std::string(ex.what()) + "\n";
-                        // TODO Modify EpochIOGroup to throw a known code so that push will succeed below
+                        if (ex.err_value() == GEOPM_ERROR_NOT_IMPLEMENTED) {
+                            // IOGroups may not support read_signal()
+                            read_signal_ok = true;
+                        }
+                        else {
+                            err_msg += std::string(ex.what()) + "\n";
+                        }
                     }
                     if (read_signal_ok == true) {
                         int group_signal_idx = ii->push_signal(signal_name, domain_type, domain_idx);
@@ -327,14 +332,19 @@ namespace geopm
                     try {
                         // Attempt to read then write the control to ensure batch writes will succeed
                         val = ii->read_signal(control_name, domain_type, domain_idx);
+                        ii->write_control(control_name, domain_type, domain_idx, val);
                         read_signal_ok = true;
                     }
                     catch (const geopm::Exception &ex) {
-                        err_msg += std::string(ex.what()) + "\n";
-                        // TODO Modify EpochIOGroup to throw a known code so that push will succeed below
+                        if (ex.err_value() == GEOPM_ERROR_NOT_IMPLEMENTED) {
+                            // IOGroups may not support read_signal()/write_control()
+                            read_signal_ok = true;
+                        }
+                        else {
+                            err_msg += std::string(ex.what()) + "\n";
+                        }
                     }
                     if (read_signal_ok == true) {
-                        ii->write_control(control_name, domain_type, domain_idx, val);
                         int group_control_idx = ii->push_control(control_name, domain_type, domain_idx);
                         result = m_active_control.size();
                         m_existing_control[ctl_tup] = result;

--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -318,7 +318,9 @@ namespace geopm
             for (auto ii : iogroups) {
                 try {
                     if (ii->control_domain_type(control_name) == domain_type) {
-                        // TODO: Try to read then write to ensure there's no permissions problem?
+                        // Attempt to read then write the control to ensure batch writes will succeed
+                        int val = ii->read_signal(control_name, domain_type, domain_idx);
+                        ii->write_control(control_name, domain_type, domain_idx, val);
                         int group_control_idx = ii->push_control(control_name, domain_type, domain_idx);
                         result = m_active_control.size();
                         m_existing_control[ctl_tup] = result;

--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -219,7 +219,8 @@ namespace geopm
             for (auto ii : iogroups) {
                 try {
                     if (domain_type == ii->signal_domain_type(signal_name)) {
-                        // TODO: Try to read signal to ensure there's no permissions problem?
+                        // Attempt to read before pushing to ensure batch reads will succeed
+                        (void)ii->read_signal(signal_name, domain_type, domain_idx);
                         int group_signal_idx = ii->push_signal(signal_name, domain_type, domain_idx);
                         result = m_active_signal.size();
                         m_existing_signal[sig_tup] = result;

--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -117,9 +117,16 @@ namespace geopm
                 else if ((*it)->signal_domain_type(signal_name) == native_domain) {
                     result.push_back(*it);
                 }
-                // GEOPM_DEBUG: If there is a mismatch, print a warning
-                // else {
-                // }
+#ifdef GEOPM_DEBUG
+                else {
+                    std::cerr << "Warning: <geopm> PlatformIO::find_signal_iogroup(): "
+                              << "Native domain changed between IOGroups for signal name \""
+                              << signal_name << "\".  Current cached domain is " << native_domain
+                              << ". Ignoring IOGroup \"" << (*it)->name() << "\" at domain "
+                              << (*it)->signal_domain_type(signal_name) << "."
+                              << std::endl;
+                }
+#endif
             }
         }
         return result;
@@ -140,9 +147,16 @@ namespace geopm
                 else if ((*it)->control_domain_type(control_name) == native_domain) {
                     result.push_back(*it);
                 }
-                // GEOPM_DEBUG: If there is a mismatch, print a warning
-                // else {
-                // }
+#ifdef GEOPM_DEBUG
+                else {
+                    std::cerr << "Warning: <geopm> PlatformIO::find_control_iogroup(): "
+                              << "Native domain changed between IOGroups for control name \""
+                              << control_name << "\".  Current cached domain is " << native_domain
+                              << ". Ignoring IOGroup \"" << (*it)->name() << "\" at domain "
+                              << (*it)->control_domain_type(control_name) << "."
+                              << std::endl;
+                }
+#endif
             }
         }
         return result;

--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -101,31 +101,27 @@ namespace geopm
         m_iogroup_list.push_back(iogroup);
     }
 
-    std::shared_ptr<IOGroup> PlatformIOImp::find_signal_iogroup(const std::string &signal_name) const
+    std::vector<std::shared_ptr<IOGroup> > PlatformIOImp::find_signal_iogroup(const std::string &signal_name) const
     {
-        std::shared_ptr<IOGroup> result = nullptr;
-        bool is_found = false;
+        std::vector<std::shared_ptr<IOGroup> > result;
         for (auto it = m_iogroup_list.rbegin();
-             !is_found && it != m_iogroup_list.rend();
+             it != m_iogroup_list.rend();
              ++it) {
             if ((*it)->is_valid_signal(signal_name)) {
-                result = *it;
-                is_found = true;
+                result.push_back(*it);
             }
         }
         return result;
     }
 
-    std::shared_ptr<IOGroup> PlatformIOImp::find_control_iogroup(const std::string &control_name) const
+    std::vector<std::shared_ptr<IOGroup> > PlatformIOImp::find_control_iogroup(const std::string &control_name) const
     {
-        std::shared_ptr<IOGroup> result = nullptr;
-        bool is_found = false;
+        std::vector<std::shared_ptr<IOGroup> > result;
         for (auto it = m_iogroup_list.rbegin();
-             !is_found && it != m_iogroup_list.rend();
+             it != m_iogroup_list.rend();
              ++it) {
             if ((*it)->is_valid_control(control_name)) {
-                result = *it;
-                is_found = true;
+                result.push_back(*it);
             }
         }
         return result;

--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -34,21 +34,22 @@
 
 #include "PlatformIOImp.hpp"
 
-#include <cmath>
-#include <algorithm>
-#include <iostream>
 #include <string.h>
 #include <sys/types.h>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
 #include <tuple>
 
-#include "geopm_pio.h"
-#include "geopm/PlatformTopo.hpp"
-#include "CombinedSignal.hpp"
-#include "BatchServer.hpp"
+#include "geopm/Agg.hpp"
 #include "geopm/Exception.hpp"
 #include "geopm/Helper.hpp"
-#include "geopm/Agg.hpp"
 #include "geopm/IOGroup.hpp"
+#include "geopm/PlatformTopo.hpp"
+
+#include "geopm_pio.h"
+#include "BatchServer.hpp"
+#include "CombinedSignal.hpp"
 
 namespace geopm
 {

--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -73,7 +73,7 @@ namespace geopm
         , m_iogroup_list(iogroup_list)
         , m_do_restore(false)
     {
-        if (m_iogroup_list.size() == 0) {
+        if (m_iogroup_list.empty()) {
             for (const auto &it : IOGroup::iogroup_names()) {
                 try {
                     register_iogroup(IOGroup::make_unique(it));
@@ -110,7 +110,7 @@ namespace geopm
              it != m_iogroup_list.rend();
              ++it) {
             if ((*it)->is_valid_signal(signal_name)) {
-                if (result.size() == 0) {
+                if (result.empty()) {
                     result.push_back(*it);
                     native_domain = (*it)->signal_domain_type(signal_name);
                 }
@@ -133,7 +133,7 @@ namespace geopm
              it != m_iogroup_list.rend();
              ++it) {
             if ((*it)->is_valid_control(control_name)) {
-                if (result.size() == 0) {
+                if (result.empty()) {
                     result.push_back(*it);
                     native_domain = (*it)->control_domain_type(control_name);
                 }
@@ -171,7 +171,7 @@ namespace geopm
     int PlatformIOImp::signal_domain_type(const std::string &signal_name) const
     {
         auto iogroups = find_signal_iogroup(signal_name);
-        if (iogroups.size() == 0) {
+        if (iogroups.empty()) {
             throw Exception("PlatformIOImp::signal_domain_type(): signal name \"" +
                             signal_name + "\" not found",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -182,7 +182,7 @@ namespace geopm
     int PlatformIOImp::control_domain_type(const std::string &control_name) const
     {
         auto iogroups = find_control_iogroup(control_name);
-        if (iogroups.size() == 0) {
+        if (iogroups.empty()) {
             throw Exception("PlatformIOImp::control_domain_type(): control name \"" +
                             control_name + "\" not found",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -467,7 +467,7 @@ namespace geopm
 
         double result = NAN;
         auto iogroups = find_signal_iogroup(signal_name);
-        if (iogroups.size() == 0) {
+        if (iogroups.empty()) {
             throw Exception("PlatformIOImp::read_signal(): signal name \"" + signal_name + "\" not found",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -539,7 +539,7 @@ namespace geopm
         }
 
         auto iogroups = find_control_iogroup(control_name);
-        if (iogroups.size() == 0) {
+        if (iogroups.empty()) {
             throw Exception("PlatformIOImp::write_control(): control name \"" + control_name + "\" not found",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -633,7 +633,7 @@ namespace geopm
     {
         // Special signals from PlatformIOImp are aggregated by underlying signals
         auto iogroups = find_signal_iogroup(signal_name);
-        if (iogroups.size() == 0) {
+        if (iogroups.empty()) {
             throw Exception("PlatformIOImp::agg_function(): unknown how to aggregate \"" + signal_name + "\"",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -646,7 +646,7 @@ namespace geopm
         std::function<std::string(double)> result;
         // PlatformIOImp forwards formatting request to underlying IOGroup
         auto iogroups = find_signal_iogroup(signal_name);
-        if (iogroups.size() == 0) {
+        if (iogroups.empty()) {
             throw Exception("PlatformIOImp::format_function(): unknown how to format \"" + signal_name + "\"",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -656,7 +656,7 @@ namespace geopm
     std::string PlatformIOImp::signal_description(const std::string &signal_name) const
     {
         auto iogroups = find_signal_iogroup(signal_name);
-        if (iogroups.size() == 0) {
+        if (iogroups.empty()) {
             throw Exception("PlatformIOImp::signal_description(): unknown signal \"" + signal_name + "\"",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -666,7 +666,7 @@ namespace geopm
     std::string PlatformIOImp::control_description(const std::string &control_name) const
     {
         auto iogroups = find_control_iogroup(control_name);
-        if (iogroups.size() == 0) {
+        if (iogroups.empty()) {
             throw Exception("PlatformIOImp::control_description(): unknown control \"" + control_name + "\"",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -676,7 +676,7 @@ namespace geopm
     int PlatformIOImp::signal_behavior(const std::string &signal_name) const
     {
         auto iogroups = find_signal_iogroup(signal_name);
-        if (iogroups.size() == 0) {
+        if (iogroups.empty()) {
             throw Exception("PlatformIOImp::signal_behavior(): unknown signal \"" + signal_name + "\"",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -689,7 +689,7 @@ namespace geopm
                                            int &server_pid,
                                            std::string &server_key)
     {
-        if (signal_config.size() == 0 && control_config.size() == 0) {
+        if (signal_config.empty() && control_config.empty()) {
             throw Exception("PlatformIOImp::start_batch_server(): Requested a batch server, but no signals or controls were specified",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }

--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -34,26 +34,21 @@
 
 #include "PlatformIOImp.hpp"
 
-#include <cpuid.h>
-#include <unistd.h>
-#include <iomanip>
 #include <cmath>
 #include <algorithm>
-#include <numeric>
 #include <iostream>
+#include <string.h>
+#include <sys/types.h>
+#include <tuple>
 
-#include "geopm_sched.h"
-#include "geopm_internal.h"
-#include "geopm.h"
 #include "geopm_pio.h"
 #include "geopm/PlatformTopo.hpp"
-#include "geopm/MSRIOGroup.hpp"
-#include "TimeIOGroup.hpp"
 #include "CombinedSignal.hpp"
 #include "BatchServer.hpp"
 #include "geopm/Exception.hpp"
 #include "geopm/Helper.hpp"
 #include "geopm/Agg.hpp"
+#include "geopm/IOGroup.hpp"
 
 namespace geopm
 {

--- a/service/src/PlatformIOImp.hpp
+++ b/service/src/PlatformIOImp.hpp
@@ -141,9 +141,9 @@ namespace geopm
             /// @brief Sample a combined signal using the saved function and operands.
             double sample_combined(int signal_idx);
             /// @brief Look up the IOGroup that provides the given signal.
-            std::shared_ptr<IOGroup> find_signal_iogroup(const std::string &signal_name) const;
+            std::vector<std::shared_ptr<IOGroup> > find_signal_iogroup(const std::string &signal_name) const;
             /// @brief Look up the IOGroup that provides the given control.
-            std::shared_ptr<IOGroup> find_control_iogroup(const std::string &control_name) const;
+            std::vector<std::shared_ptr<IOGroup> > find_control_iogroup(const std::string &control_name) const;
             bool m_is_active;
             const PlatformTopo &m_platform_topo;
             std::list<std::shared_ptr<IOGroup> > m_iogroup_list;

--- a/service/src/geopm/Exception.hpp
+++ b/service/src/geopm/Exception.hpp
@@ -33,7 +33,7 @@
 #define EXCEPTION_HPP_INCLUDE
 
 #include <string>
-#include <system_error>
+#include <stdexcept>
 #include "geopm_error.h"
 
 namespace geopm

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -226,6 +226,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/PlatformIOTest.push_control \
               test/gtest_links/PlatformIOTest.push_control_agg \
               test/gtest_links/PlatformIOTest.push_signal \
+              test/gtest_links/PlatformIOTest.push_signal_iogroup_fallback \
+              test/gtest_links/PlatformIOTest.push_signal_iogroup_fallback_domain_change \
               test/gtest_links/PlatformIOTest.push_signal_agg \
               test/gtest_links/PlatformIOTest.read_signal \
               test/gtest_links/PlatformIOTest.read_signal_agg \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -229,6 +229,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/PlatformIOTest.push_signal_agg \
               test/gtest_links/PlatformIOTest.read_signal \
               test/gtest_links/PlatformIOTest.read_signal_agg \
+              test/gtest_links/PlatformIOTest.read_signal_iogroup_fallback_domain_change \
+              test/gtest_links/PlatformIOTest.read_signal_iogroup_fallback \
               test/gtest_links/PlatformIOTest.read_signal_override \
               test/gtest_links/PlatformIOTest.sample \
               test/gtest_links/PlatformIOTest.sample_agg \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -225,6 +225,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/PlatformIOTest.domain_type \
               test/gtest_links/PlatformIOTest.push_control \
               test/gtest_links/PlatformIOTest.push_control_agg \
+              test/gtest_links/PlatformIOTest.push_control_iogroup_fallback \
+              test/gtest_links/PlatformIOTest.push_control_iogroup_fallback_domain_change \
               test/gtest_links/PlatformIOTest.push_signal \
               test/gtest_links/PlatformIOTest.push_signal_iogroup_fallback \
               test/gtest_links/PlatformIOTest.push_signal_iogroup_fallback_domain_change \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -241,6 +241,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/PlatformIOTest.signal_control_description \
               test/gtest_links/PlatformIOTest.signal_control_names \
               test/gtest_links/PlatformIOTest.write_control \
+              test/gtest_links/PlatformIOTest.write_control_iogroup_fallback_domain_change \
+              test/gtest_links/PlatformIOTest.write_control_iogroup_fallback \
               test/gtest_links/PlatformIOTest.write_control_override \
               test/gtest_links/PlatformIOTest.write_control_agg \
               test/gtest_links/PlatformTopoTest.bdx_domain_idx \

--- a/service/test/PlatformIOTest.cpp
+++ b/service/test/PlatformIOTest.cpp
@@ -305,6 +305,8 @@ TEST_F(PlatformIOTest, push_control)
     EXPECT_EQ(0, m_platio->num_control_pushed());
 
     EXPECT_CALL(*m_control_iogroup, control_domain_type("FREQ")).Times(2);
+    EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, 0));
+    EXPECT_CALL(*m_control_iogroup, write_control("FREQ", GEOPM_DOMAIN_CPU, 0, _));
     EXPECT_CALL(*m_control_iogroup, push_control("FREQ", GEOPM_DOMAIN_CPU, 0));
     int idx = m_platio->push_control("FREQ", GEOPM_DOMAIN_CPU, 0);
     EXPECT_EQ(0, idx);
@@ -370,6 +372,8 @@ TEST_F(PlatformIOTest, push_control_agg)
     EXPECT_EQ(0, m_platio->num_control_pushed());
     EXPECT_CALL(*m_control_iogroup, control_domain_type("FREQ")).Times(AtLeast(1));
     for (auto cpu : m_cpu_set0) {
+        EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, cpu));
+        EXPECT_CALL(*m_control_iogroup, write_control("FREQ", GEOPM_DOMAIN_CPU, cpu, _));
         EXPECT_CALL(*m_control_iogroup, push_control("FREQ", GEOPM_DOMAIN_CPU, cpu));
     }
     m_platio->push_control("FREQ", GEOPM_DOMAIN_PACKAGE, 0);
@@ -443,6 +447,8 @@ TEST_F(PlatformIOTest, sample_agg)
 TEST_F(PlatformIOTest, adjust)
 {
     EXPECT_CALL(*m_control_iogroup, control_domain_type("FREQ")).Times(2);
+    EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, 0));
+    EXPECT_CALL(*m_control_iogroup, write_control("FREQ", GEOPM_DOMAIN_CPU, 0, _));
     EXPECT_CALL(*m_control_iogroup, push_control("FREQ", _, _));
     int freq_idx = m_platio->push_control("FREQ", GEOPM_DOMAIN_CPU, 0);
     EXPECT_EQ(0, freq_idx);
@@ -466,6 +472,8 @@ TEST_F(PlatformIOTest, adjust_agg)
     double value = 1.23e9;
     EXPECT_CALL(*m_control_iogroup, control_domain_type("FREQ")).Times(AtLeast(1));
     for (auto cpu : m_cpu_set0) {
+        EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, cpu));
+        EXPECT_CALL(*m_control_iogroup, write_control("FREQ", GEOPM_DOMAIN_CPU, cpu, _));
         EXPECT_CALL(*m_control_iogroup, push_control("FREQ", GEOPM_DOMAIN_CPU, cpu))
             .WillOnce(Return(cpu));
     }

--- a/service/test/PlatformIOTest.cpp
+++ b/service/test/PlatformIOTest.cpp
@@ -258,10 +258,12 @@ TEST_F(PlatformIOTest, push_signal)
     EXPECT_EQ(0, m_platio->num_signal_pushed());
     EXPECT_CALL(*m_control_iogroup, signal_domain_type("FREQ")).Times(2);
     EXPECT_CALL(*m_control_iogroup, push_signal("FREQ", GEOPM_DOMAIN_CPU, 0));
+    EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, 0));
     idx = m_platio->push_signal("FREQ", GEOPM_DOMAIN_CPU, 0);
     EXPECT_EQ(0, idx);
     EXPECT_CALL(*m_time_iogroup, signal_domain_type("TIME")).Times(2);
     EXPECT_CALL(*m_time_iogroup, push_signal("TIME", GEOPM_DOMAIN_BOARD, 0));
+    EXPECT_CALL(*m_time_iogroup, read_signal("TIME", GEOPM_DOMAIN_BOARD, 0));
     idx = m_platio->push_signal("TIME", GEOPM_DOMAIN_BOARD, 0);
     EXPECT_EQ(1, idx);
     EXPECT_EQ(idx, m_platio->push_signal("TIME", GEOPM_DOMAIN_BOARD, 0));
@@ -288,6 +290,7 @@ TEST_F(PlatformIOTest, push_signal_agg)
     EXPECT_CALL(*m_control_iogroup, signal_domain_type("FREQ")).Times(AtLeast(1));
     for (auto cpu : m_cpu_set0) {
         EXPECT_CALL(*m_control_iogroup, push_signal("FREQ", GEOPM_DOMAIN_CPU, cpu));
+        EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, cpu));
     }
     EXPECT_CALL(*m_control_iogroup, agg_function("FREQ"))
         .WillOnce(Return(geopm::Agg::average));
@@ -377,8 +380,10 @@ TEST_F(PlatformIOTest, sample)
 {
     EXPECT_CALL(*m_control_iogroup, signal_domain_type("FREQ")).Times(2);
     EXPECT_CALL(*m_control_iogroup, push_signal("FREQ", _, _));
+    EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", _, _));
     EXPECT_CALL(*m_time_iogroup, signal_domain_type("TIME")).Times(2);
     EXPECT_CALL(*m_time_iogroup, push_signal("TIME", _, _));
+    EXPECT_CALL(*m_time_iogroup, read_signal("TIME", _, _));
     int freq_idx = m_platio->push_signal("FREQ", GEOPM_DOMAIN_CPU, 0);
     int time_idx = m_platio->push_signal("TIME", GEOPM_DOMAIN_BOARD, 0);
 
@@ -414,6 +419,7 @@ TEST_F(PlatformIOTest, sample_agg)
     for (auto cpu : m_cpu_set0) {
         EXPECT_CALL(*m_control_iogroup, push_signal("FREQ", GEOPM_DOMAIN_CPU, cpu))
             .WillOnce(Return(cpu));
+        EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, cpu));
     }
     int freq_idx = m_platio->push_signal("FREQ", GEOPM_DOMAIN_PACKAGE, 0);
 

--- a/src/EpochIOGroup.cpp
+++ b/src/EpochIOGroup.cpp
@@ -204,13 +204,13 @@ namespace geopm
     double EpochIOGroup::read_signal(const std::string &signal_name, int domain_type, int domain_idx)
     {
         throw Exception("EpochIOGroup: read_signal() is not supported for this IOGroup.",
-                        GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+                        GEOPM_ERROR_NOT_IMPLEMENTED, __FILE__, __LINE__);
     }
 
     void EpochIOGroup::write_control(const std::string &control_name, int domain_type, int domain_idx, double setting)
     {
         throw Exception("EpochIOGroup::write_control(): there are no controls supported by the EpochIOGroup",
-                        GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                        GEOPM_ERROR_NOT_IMPLEMENTED, __FILE__, __LINE__);
     }
 
     void EpochIOGroup::save_control(void)

--- a/src/ProfileIOGroup.cpp
+++ b/src/ProfileIOGroup.cpp
@@ -328,7 +328,7 @@ namespace geopm
     void ProfileIOGroup::write_control(const std::string &control_name, int domain_type, int domain_idx, double setting)
     {
         throw Exception("ProfileIOGroup::write_control() there are no controls supported by the ProfileIOGroup",
-                        GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                        GEOPM_ERROR_NOT_IMPLEMENTED, __FILE__, __LINE__);
     }
 
     void ProfileIOGroup::save_control(void)


### PR DESCRIPTION
- Relates to #2130, #1690.
- Fixes #1813.

- This affects the following APIs: read_signal(), write_control(), push_signal(), push_control().
- When a signal or control is requested through one of the above APIs, all IOGroups will be evaluated to see if they support the request.
  + The domain of the last registered plugin in the IOGroupFactory that supports the control or signal is used to determine the "native domain".  Any subsequent IOGroups that do not match this domain exactly are disregarded.
  + When read_signal() or write_control() is invoked, if there is an issue with the attempted call with the first IOGroup, the next in the list will be evaluated until all IOGroups that have been previously identified are exhausted.  An exception is raised in this instance.
  + Otherwise the IOGroup that is able to service the request will do so.