### PR TITLE
Expose turbo ratio limit controls when they are writable

### DIFF
--- a/service/docs/source/signals_SKX.rst
+++ b/service/docs/source/signals_SKX.rst
@@ -1026,7 +1026,7 @@ MSR::PLATFORM_INFO:MAX_NON_TURBO_RATIO
     - domain: package
     - iogroup: MSRIOGroup
 MSR::PLATFORM_INFO:PROGRAMMABLE_RATIO_LIMITS_TURBO_MODE
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Indicates whether the MSR::TURBO_RATIO_LIMIT:* signals are also available as controls.
     - units: none
     - aggregation: select_first
     - domain: package
@@ -1272,49 +1272,49 @@ MSR::TURBO_RATIO_LIMIT#
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum turbo frequency with up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_0 active cores.
     - units: hertz
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_1
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_0 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_1 active cores.
     - units: hertz
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_2
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_1 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_2 active cores.
     - units: hertz
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_3
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_2 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_3 active cores.
     - units: hertz
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_4
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_3 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_4 active cores.
     - units: hertz
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_5
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_4 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_5 active cores.
     - units: hertz
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_6
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_5 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_6 active cores.
     - units: hertz
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_7
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_6 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_7 active cores.
     - units: hertz
     - aggregation: select_first
     - domain: package
@@ -1326,49 +1326,49 @@ MSR::TURBO_RATIO_LIMIT_CORES#
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_0
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0.
     - units: none
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_1
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_1.
     - units: none
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_2
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_2.
     - units: none
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_3
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_3.
     - units: none
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_4
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_4.
     - units: none
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_5
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_5.
     - units: none
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_6
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_6.
     - units: none
     - aggregation: select_first
     - domain: package
     - iogroup: MSRIOGroup
 MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_7
-    - description: Refer to the Intel(R) 64 and IA-32 Architectures Software Developer's Manual for information about this MSR
+    - description: Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_7.
     - units: none
     - aggregation: select_first
     - domain: package

--- a/service/src/MSRIOGroup.cpp
+++ b/service/src/MSRIOGroup.cpp
@@ -250,7 +250,8 @@ namespace geopm
                                          GEOPM_DOMAIN_BOARD,
                                          IOGroup::M_UNITS_SECONDS,
                                          Agg::select_first,
-                                         "Time in seconds used to calculate power"};
+                                         "Time in seconds used to calculate power",
+                                         IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE};
 
         // Mapping of high-level signal name to description and
         // underlying energy MSR.  The domain will match that of the
@@ -346,7 +347,8 @@ namespace geopm
                                          GEOPM_DOMAIN_BOARD,
                                          IOGroup::M_UNITS_SECONDS,
                                          Agg::select_first,
-                                         "Time in seconds"};
+                                         "Time in seconds",
+                                         IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE};
 
         msr_name = "QM_CTR_SCALED";
         signal_name = "QM_CTR_SCALED_RATE";

--- a/service/src/MSRIOGroup.cpp
+++ b/service/src/MSRIOGroup.cpp
@@ -1435,6 +1435,7 @@ namespace geopm
                     string_begins_with(msr_field_name,
                                        "TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_")) {
                     is_control = true;
+                    behavior = IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE;
                 }
 
                 add_msr_field_signal(msr_name, sig_ctl_name, domain_type,

--- a/service/src/msr_data_skx.cpp
+++ b/service/src/msr_data_skx.cpp
@@ -61,7 +61,8 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Indicates whether the MSR::TURBO_RATIO_LIMIT:* signals are also available as controls."
                 },
                 "PROGRAMMABLE_TDP_LIMITS_TURBO_MODE": {
                     "begin_bit": 29,
@@ -161,7 +162,8 @@ namespace geopm
                     "units":     "hertz",
                     "scalar":    1e8,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum turbo frequency with up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_0 active cores."
                 },
                 "MAX_RATIO_LIMIT_1": {
                     "begin_bit": 8,
@@ -170,7 +172,8 @@ namespace geopm
                     "units":     "hertz",
                     "scalar":    1e8,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_0 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_1 active cores."
                 },
                 "MAX_RATIO_LIMIT_2": {
                     "begin_bit": 16,
@@ -179,7 +182,8 @@ namespace geopm
                     "units":     "hertz",
                     "scalar":    1e8,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_1 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_2 active cores."
                 },
                 "MAX_RATIO_LIMIT_3": {
                     "begin_bit": 24,
@@ -188,7 +192,8 @@ namespace geopm
                     "units":     "hertz",
                     "scalar":    1e8,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_2 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_3 active cores."
                 },
                 "MAX_RATIO_LIMIT_4": {
                     "begin_bit": 32,
@@ -197,7 +202,8 @@ namespace geopm
                     "units":     "hertz",
                     "scalar":    1e8,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_3 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_4 active cores."
                 },
                 "MAX_RATIO_LIMIT_5": {
                     "begin_bit": 40,
@@ -206,7 +212,8 @@ namespace geopm
                     "units":     "hertz",
                     "scalar":    1e8,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_4 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_5 active cores."
                 },
                 "MAX_RATIO_LIMIT_6": {
                     "begin_bit": 48,
@@ -215,7 +222,8 @@ namespace geopm
                     "units":     "hertz",
                     "scalar":    1e8,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_5 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_6 active cores."
                 },
                 "MAX_RATIO_LIMIT_7": {
                     "begin_bit": 56,
@@ -224,7 +232,8 @@ namespace geopm
                     "units":     "hertz",
                     "scalar":    1e8,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum turbo frequency with more than MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_6 and up to MSR::TURBO_RATIO_LIMIT_CORES:NUMCORE_7 active cores."
                 }
             }
         },
@@ -239,7 +248,8 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0."
                 },
                 "NUMCORE_1": {
                     "begin_bit": 8,
@@ -248,7 +258,8 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_1."
                 },
                 "NUMCORE_2": {
                     "begin_bit": 16,
@@ -257,7 +268,8 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_2."
                 },
                 "NUMCORE_3": {
                     "begin_bit": 24,
@@ -266,7 +278,8 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_3."
                 },
                 "NUMCORE_4": {
                     "begin_bit": 32,
@@ -275,7 +288,8 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_4."
                 },
                 "NUMCORE_5": {
                     "begin_bit": 40,
@@ -284,7 +298,8 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_5."
                 },
                 "NUMCORE_6": {
                     "begin_bit": 48,
@@ -293,7 +308,8 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_6."
                 },
                 "NUMCORE_7": {
                     "begin_bit": 56,
@@ -302,7 +318,8 @@ namespace geopm
                     "units":     "none",
                     "scalar":    1,
                     "behavior":  "constant",
-                    "writeable": false
+                    "writeable": false,
+                    "description": "Maximum number of active cores for a maximum turbo frequency of MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_7."
                 }
             }
         },

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -178,6 +178,7 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/MSRIOGroupTest.write_control \
               test/gtest_links/MSRIOGroupTest.batch_calls_no_push \
               test/gtest_links/MSRIOGroupTest.save_restore_control \
+              test/gtest_links/MSRIOGroupTest.turbo_ratio_limit_writability \
               test/gtest_links/MSRIOTest.read_aligned \
               test/gtest_links/MSRIOTest.read_batch \
               test/gtest_links/MSRIOTest.read_unaligned \


### PR DESCRIPTION
- Adds a check to the PLATFORM_INFO MSR when setting up MSRIOGroup. If
  the platform reports that turbo ratio limits are configurable, the
  turbo ratio limit MSRs are exposed as controls. Resolves https://github.com/geopm/geopm/issues/2143
- Adds documentation for turbo ratio limit MSRs. Related to https://github.com/geopm/geopm/issues/1670
