### PR TITLE
Pass profile information from the runtime to python agents when generating reports

### DIFF
--- a/integration/test/geopm_test_launcher.py
+++ b/integration/test/geopm_test_launcher.py
@@ -187,7 +187,7 @@ class TestLauncher(object):
                     self.msr_restore()
                 raise
 
-    def get_report(self):
+    def get_report(self, profile):
         return Report(self._report_path)
 
     def get_trace(self):

--- a/integration/test_skipped/test_controller.py
+++ b/integration/test_skipped/test_controller.py
@@ -69,7 +69,6 @@ class LocalAgent(geopmdpy.runtime.Agent):
     def run_end(self):
         self._loop_idx = 0
         self._cpu_freq = geopmdpy.pio.read_signal('CPU_FREQUENCY_MAX', 'board', 0)
-        self._report = geopmpy.reporter.generate('test_profile_name', 'test_agent')
 
     def update(self, signals):
         if self._loop_idx == 0:
@@ -83,8 +82,8 @@ class LocalAgent(geopmdpy.runtime.Agent):
     def get_period(self):
         return 0.005
 
-    def get_report(self):
-        return self._report
+    def get_report(self, profile):
+        return geopmpy.reporter.generate(profile, 'test_agent')
 
 def main():
     """Run the LocalAgent
@@ -100,7 +99,7 @@ def main():
     cpu_frequency_max = float(sys.argv[1])
     agent = LocalAgent()
     controller = geopmdpy.runtime.Controller(agent)
-    report = controller.run(sys.argv[2:], cpu_frequency_max)
+    report = controller.run(sys.argv[2:], cpu_frequency_max, profile='test_profile_name')
     with open('geopm.report', 'w') as fid:
         fid.write(report)
     return controller.returncode()

--- a/service/geopmdpy/runtime.py
+++ b/service/geopmdpy/runtime.py
@@ -41,6 +41,7 @@ import math
 import time
 import subprocess
 import sys
+import shlex
 from . import pio
 
 
@@ -235,7 +236,7 @@ class Agent:
         """
         raise NotImplementedError('Agent is an abstract base class')
 
-    def get_report(self):
+    def get_report(self, profile):
         """Summary of all data collected by calls to update()
 
         The report covers the interval of time between the last two calls to
@@ -243,6 +244,9 @@ class Agent:
         Agent.begin_run(), the same report will be returned by this method.
         The Controller.run() method will return this report upon completion of
         the run.
+
+        Args:
+            profile (str): Profile name to associate with the report
 
         Returns:
             str: Human readable report
@@ -309,7 +313,7 @@ class Controller:
             raise RuntimeError('App process is still running')
         return self._returncode
 
-    def run(self, argv, policy=None):
+    def run(self, argv, policy=None, profile=None):
         """Execute control loop defined by agent
 
         Interfaces with PlatformIO directly through the geopmdpy.pio module.
@@ -345,4 +349,6 @@ class Controller:
             self._agent.run_end()
         self._returncode = pid.returncode
         sys.stderr.write(f'<geopmdpy> RUN END, return: {self._returncode}\n')
-        return self._agent.get_report()
+        if profile is None:
+            profile = ' '.join([shlex.quote(arg) for arg in argv])
+        return self._agent.get_report(profile)

--- a/service/geopmdpy_test/TestController.py
+++ b/service/geopmdpy_test/TestController.py
@@ -68,7 +68,7 @@ class PassthroughAgent(Agent):
     def run_end(self):
         pass
 
-    def get_report(self):
+    def get_report(self, profile):
         return self._report_data
 
 
@@ -99,7 +99,7 @@ class TestController(unittest.TestCase):
         with self.assertRaisesRegex(NotImplementedError, err_msg):
             ca.get_period()
         with self.assertRaisesRegex(NotImplementedError, err_msg):
-            ca.get_report()
+            ca.get_report('test_profile')
 
     def test_controller_construction_invalid(self):
         err_msg = 'agent must be a subclass of Agent.'


### PR DESCRIPTION
- This change allows for default behavior where the controller uses the launched application as the profile name.
- Helps improve usability issues discovered while working on #1919 and #1920
- Resolves #2150