### PR TITLE
Add a tutorial that shows how to use a python agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,4 +171,5 @@ compile_commands.json
 /tutorial/tutorial_[0-9]*_report-*
 /tutorial/tutorial_[0-9]*_trace-*
 /tutorial/tutorial_4_imbalance.conf
+/tutorial/python_agents/*.report
 /VERSION

--- a/Makefile.am
+++ b/Makefile.am
@@ -275,6 +275,9 @@ TUTORIAL_DIST = tutorial/Makefile \
                 tutorial/plugin_load/bob/BobIOGroup.cpp \
                 tutorial/plugin_load/bob/BobIOGroup.hpp \
                 tutorial/plugin_load/README.md \
+                tutorial/python_agents/README.rst \
+                tutorial/python_agents/__init__.py \
+                tutorial/python_agents/static_agent.py \
                 tutorial/tutorial_0.c \
                 tutorial/tutorial_0.sh \
                 tutorial/tutorial_1.c \

--- a/copying_headers/MANIFEST.EXEMPT
+++ b/copying_headers/MANIFEST.EXEMPT
@@ -197,6 +197,7 @@ tutorial/agent/README.md
 tutorial/iogroup/README.md
 tutorial/plugin_load/README.md
 tutorial/README.md
+tutorial/python_agents/README.rst
 tutorial/tutorial_6_config.json
 tutorial/tutorial_power_policy.json
 json_schemas/geopmbench_config.schema.json

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,2 +1,3 @@
 matplotlib>=2.2.2
 flaky>=3.7.0
+docutils>=0.14

--- a/integration/test/Makefile.mk
+++ b/integration/test/Makefile.mk
@@ -14,6 +14,7 @@ EXTRA_DIST += integration/test/check_trace.py \
               integration/test/test_template.mk.in \
               integration/test/test_template.py.in \
               integration/test/util.py \
+              integration/test/test_tutorial_python_agents.py \
               # end
 
 include integration/test/test_enforce_policy.mk

--- a/integration/test/test_tutorial_python_agents.py
+++ b/integration/test/test_tutorial_python_agents.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2022, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+"""Run through the python agents tutorial as a user would.
+"""
+
+import sys
+import unittest
+import os
+import subprocess
+import yaml
+from integration.test import geopm_test_launcher
+from integration.test import util
+
+
+@util.skip_unless_do_launch()
+@util.skip_unless_stressng()
+class TestIntegration_tutorial_python_agents(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        sys.stdout.write('(' + os.path.basename(__file__).split('.')[0] +
+                         '.' + cls.__name__ + ') ...')
+        cls._test_name = 'python_agents_tutorial'
+        cls._skip_launch = not util.do_launch()
+        cls._script_dir = os.path.dirname(os.path.realpath(__file__))
+        cls._base_dir = os.path.dirname(os.path.dirname(cls._script_dir))
+        cls._tutorial_dir = os.path.join(cls._base_dir, 'tutorial', 'python_agents')
+        cls._readme_path = os.path.join(cls._tutorial_dir, 'README.rst')
+        cls._expected_stress_ng_timeout_seconds = 5
+        cls._expected_frequency_limit = 1.5e9
+
+        if not cls._skip_launch:
+            cls.launch()
+
+    def tearDown(self):
+        if sys.exc_info() != (None, None, None):
+            TestIntegration_tutorial_python_agents._keep_files = True
+
+    @classmethod
+    def launch(cls):
+        "Run the tutorial scripts"
+        script_bodies = util.get_scripts_from_readme(cls._readme_path)
+
+        cls._initial_frequency_control = geopm_test_launcher.geopmread(
+            'CPU_FREQUENCY_CONTROL board 0')
+
+        for script_body in script_bodies:
+            print('Executing:', script_body)
+            subprocess.check_call(script_body, shell=True, cwd=cls._tutorial_dir)
+
+        cls._final_frequency_control = geopm_test_launcher.geopmread(
+            'CPU_FREQUENCY_CONTROL board 0')
+
+    def test_monitor_report(self):
+        with open(os.path.join(self._tutorial_dir, 'stress-monitor.report')) as f:
+            report = yaml.load(f, Loader=yaml.SafeLoader)
+            self.assertEqual(dict(), report['Policy']['Initial Controls'])
+            host_data = next(iter(report['Hosts'].values()))
+            self.assertAlmostEqual(
+                self._expected_stress_ng_timeout_seconds,
+                host_data['Application Totals']['runtime (s)'],
+                places=1)
+
+    def test_package_energy_report(self):
+        with open(os.path.join(self._tutorial_dir, 'stress-package-energy.report')) as f:
+            report = yaml.load(f, Loader=yaml.SafeLoader)
+            self.assertEqual(dict(), report['Policy']['Initial Controls'])
+            host_data = next(iter(report['Hosts'].values()))
+            self.assertAlmostEqual(
+                self._expected_stress_ng_timeout_seconds,
+                host_data['Application Totals']['runtime (s)'],
+                places=1)
+            self.assertGreater(
+                host_data['Application Totals']['CPU_ENERGY@package-0'],
+                host_data['Application Totals']['CPU_ENERGY@package-1'])
+
+    def test_frequency_limit_report(self):
+        with open(os.path.join(self._tutorial_dir, 'stress-frequency-limit.report')) as f:
+            report = yaml.load(f, Loader=yaml.SafeLoader)
+            self.assertAlmostEqual(
+                self._expected_frequency_limit,
+                report['Policy']['Initial Controls']['CPU_FREQUENCY_CONTROL'],
+                places=0)
+            host_data = next(iter(report['Hosts'].values()))
+
+            self.assertAlmostEqual(
+                self._expected_stress_ng_timeout_seconds,
+                host_data['Application Totals']['runtime (s)'],
+                places=1)
+            self.assertGreater(
+                host_data['Application Totals']['CPU_ENERGY@package-0'],
+                host_data['Application Totals']['CPU_ENERGY@package-1'])
+
+            # Test that the frequency control had an effect for the duration of
+            # the reported application. This loosely tests that the next P-state
+            # above the request was not achieved.
+            self.assertLess(
+                host_data['Application Totals']['frequency (Hz)'],
+                self._expected_frequency_limit + 1e8)
+
+            # Test that the agent correctly applies controls between
+            # the controller's save/restore events.
+            self.assertEqual(self._initial_frequency_control, self._final_frequency_control)
+
+
+if __name__ == '__main__':
+    # Call do_launch to clear non-pyunit command line option
+    util.do_launch()
+    unittest.main()

--- a/integration/test/util.py
+++ b/integration/test/util.py
@@ -15,6 +15,9 @@ import subprocess
 from io import StringIO
 import argparse
 
+from docutils.nodes import literal_block
+from docutils.core import publish_doctree
+
 from integration.test import geopm_test_launcher
 
 
@@ -299,3 +302,15 @@ def assertNotNear(self, a, b, epsilon=0.05, msg=''):
     denom = a if a != 0 else 1
     if abs((a - b) / denom) < epsilon:
         self.fail('The fractional difference between {a} and {b} is less than {epsilon}.  {msg}'.format(a=a, b=b, epsilon=epsilon, msg=msg))
+
+
+def get_scripts_from_readme(rst_readme_path):
+    """Return a list of the sh-formatted scripts that are embedded in a .rst file.
+    """
+    script_bodies = list()
+    with open(rst_readme_path) as f:
+        doctree = publish_doctree(f.read())
+        for code_block in doctree.traverse(literal_block):
+            if 'sh' in code_block['classes']:
+                script_bodies.append(code_block.astext())
+    return script_bodies

--- a/tutorial/python_agents/README.rst
+++ b/tutorial/python_agents/README.rst
@@ -1,0 +1,184 @@
+Python Agent Tutorial
+=====================
+This tutorial demonstrates how to implement a python agent in geopm.
+Specifically, the tutorial shows how to use an agent that can monitor
+application state and can write platform settings that are applied for the
+duration of an application run.
+
+This directory includes an example implementation of a python agent that
+optionally writes one or more GEOPM controls at the start of a run, and only
+monitors execution for the rest of the run. Take a look at the implementation
+in `static_agent.py <./static_agent.py>`_.
+
+Monitor-only execution
+----------------------
+First, let's try running an application without modifying any GEOPM controls.
+In this example, we are using the stress-ng tool to stress 20 CPUs for 5 seconds.
+We'll run stress-ng with ``--taskset 0-19`` so we know which CPUs to expect will
+run ``stress-ng``. This isn't strictly necessary, and is only being done to help
+us know where to expect most of our CPU load when walking through this
+tutorial.
+
+.. code-block:: sh
+
+    ./static_agent.py --geopm-report stress-monitor.report -- \
+        stress-ng --cpu 20 --taskset 0-19 --timeout 5
+
+The resulting ``stress-monitor.report`` file is a YAML-formatted file containing the inputs
+to your agent and the observed GEOPM signals over your run. For example:
+
+.. raw:: html
+
+        <details><summary>Report file contents</summary><p>
+
+.. code:: yaml
+
+    GEOPM Version: 2.0.0~rc2+dev112g5c3c4597a
+    Start Time: Thu Aug 11 06:03:32 2022
+    Profile: stress-ng --cpu 20 --taskset 0-19 --timeout 5
+    Agent: StaticAgent
+    Policy:
+      Initial Controls: {}
+    Hosts:
+      tutorial-hostname:
+        Application Totals:
+          runtime (s): 5.00064
+          count: 0
+          sync-runtime (s): 5.00064
+          package-energy (J): 881.021
+          dram-energy (J): 60.7762
+          power (W): 176.182
+          frequency (%): 135.539
+          frequency (Hz): 2846320000.0
+          uncore-frequency (Hz): 2350000000.0
+          geopmctl memory HWM (B): 32380
+          geopmctl network BW (B/s): 0
+
+.. raw:: html
+
+        </p></details>
+
+Let's try looking at a per-package breakdown of the energy consumption. We'll
+expect that CPU 0 is on package 0 and should show more energy consumption since
+that's where we are running stress-ng.
+
+.. code-block:: sh
+
+    ./static_agent.py --geopm-report stress-package-energy.report \
+        --geopm-report-signals CPU_ENERGY@package -- \
+        stress-ng --cpu 20 --taskset 0-19 --timeout 5
+
+As expected, we can see that package 0 (running stress-ng) consumed more
+energy than package 1.
+
+.. raw:: html
+
+        <details><summary>Report file contents</summary><p>
+
+.. code:: yaml
+
+    GEOPM Version: 2.0.0~rc2+dev112g5c3c4597a
+    Start Time: Thu Aug 11 06:03:40 2022
+    Profile: stress-ng --cpu 20 --taskset 0-19 --timeout 5
+    Agent: StaticAgent
+    Policy:
+      Initial Controls: {}
+    Hosts:
+      tutorial-hostname:
+        Application Totals:
+          runtime (s): 5.00062
+          count: 0
+          sync-runtime (s): 5.00062
+          package-energy (J): 885.778
+          dram-energy (J): 61.3
+          power (W): 177.134
+          frequency (%): 135.091
+          frequency (Hz): 2836900000.0
+          uncore-frequency (Hz): 2350000000.0
+          CPU_ENERGY@package-0: 635.942
+          CPU_ENERGY@package-1: 249.837
+          geopmctl memory HWM (B): 32648
+          geopmctl network BW (B/s): 0
+
+.. raw:: html
+
+        </p></details>
+
+Limiting CPU Frequency During Execution
+---------------------------------------
+Now let's try applying a limit to the frequency on all CPU cores during the
+stress run. But before we do that, use ``geopmread`` to take note of the current
+frequency control value. We'll refer back to this value later.
+
+.. code-block:: sh
+
+    geopmread CPU_FREQUENCY_CONTROL board 0
+
+.. code-block:: sh
+
+    ./static_agent.py --geopm-report stress-frequency-limit.report \
+       --geopm-report-signals CPU_ENERGY@package \
+       --geopm-initialize-control CPU_FREQUENCY_CONTROL=1.5e9 -- \
+       stress-ng --cpu 20 --taskset 0-19 --timeout 5
+
+Notice a few changes in the report. First, we can see that the Policy section
+has been updated to indicate that a frequency control was applied by the agent,
+as requested by the agent's user. If you plan to implement your own agent
+that has user-configurable inputs, consider adding them to the Policy output in
+your agent's report. See how this is done in the agent's ``get_report()``
+function.
+
+Next, we can see that the requested frequency change actually impacted the
+average frequency that the CPU cores achieved in this run. This is visible
+as ``frequency (Hz)`` in the report. The ``CPU_ENERGY`` measurements decreased
+as a result of lowering the CPU frequency without impacting run time (since we
+configured stress-ng to run for 5 seconds regardless of how much work was
+actually done).
+
+.. raw:: html
+
+        <details><summary>Report file contents</summary><p>
+
+.. code:: yaml
+
+    GEOPM Version: 2.0.0~rc2+dev112g5c3c4597a
+    Start Time: Thu Aug 11 06:03:48 2022
+    Profile: stress-ng --cpu 20 --taskset 0-19 --timeout 5
+    Agent: StaticAgent
+    Policy:
+      Initial Controls:
+        CPU_FREQUENCY_CONTROL: 1500000000.0
+    Hosts:
+      tutorial-hostname:
+        Application Totals:
+          runtime (s): 5.00074
+          count: 0
+          sync-runtime (s): 5.00074
+          package-energy (J): 459.749
+          dram-energy (J): 61.3112
+          power (W): 91.9362
+          frequency (%): 71.4218
+          frequency (Hz): 1499860000.0
+          uncore-frequency (Hz): 1200000000.0
+          CPU_ENERGY@package-0: 294.2
+          CPU_ENERGY@package-1: 165.549
+          geopmctl memory HWM (B): 32820
+          geopmctl network BW (B/s): 0
+
+.. raw:: html
+
+        </p></details>
+
+Lastly, use ``geopmread`` to take a look at the current CPU frequency control.
+Notice that the current CPU frequency limit is the same as before our
+experiment, even though the application ran under a different limit! If you
+search through the agent's source code, you will not find any code that saves
+and restores this setting. The save/restore functionality comes from the
+GEOPM runtime that invokes your agent's code. If you implement your own
+agent, be sure that you do not modify GEOPM controls before your agent's
+``run_begin()`` function is called or after your ``run_end()`` is called. Or if
+you must, then know that you will have to implement your own save/restore code.
+
+Now you have an example implementation of a GEOPM python agent, and some
+expectations about how you can use an agent and its output. Try implementing
+your own agent!

--- a/tutorial/python_agents/__init__.py
+++ b/tutorial/python_agents/__init__.py
@@ -1,0 +1,4 @@
+#
+#  Copyright (c) 2015 - 2022, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#

--- a/tutorial/python_agents/static_agent.py
+++ b/tutorial/python_agents/static_agent.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2022, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+"""
+This package provides a StaticAgent class to monitor processes and optionally
+apply GEOPM control settings that last the duration of an application run.
+"""
+
+import os
+import argparse
+import yaml
+
+import geopmdpy
+import geopmdpy.runtime
+import geopmdpy.pio
+import geopmpy.reporter
+
+
+class StaticAgent(geopmdpy.runtime.Agent):
+    """GEOPM python agent that monitors an application and optionally writes
+    one or more controls that last the duration of the application run.
+    """
+
+    def __init__(self, period_seconds=1, initial_controls=None):
+        """Initialize the agent.
+
+        period_seconds (float): Agent sampling period, in seconds.
+        initial_controls (dict[str, float]): Dictionary mapping CONTROL_NAME to initial value
+        """
+        self._control_period = period_seconds
+        self._initial_controls = dict() if initial_controls is None else initial_controls
+        geopmpy.reporter.init()
+
+    def run_begin(self, policy):
+        # The GEOPM runtime already saved controls by now. It will take care of
+        # restoring the original values of these controls after our run finishes.
+        for control_name, value in self._initial_controls.items():
+            geopmdpy.pio.write_control(control_name, 'board', 0, value)
+
+    def run_end(self):
+        # Handle anything that should be managed after PlatformIO restores the
+        # platform's pre-launch state.
+        pass
+
+    def get_signals(self):
+        # This agent does not consume any PlatformIO signals.
+        # Otherwise, this would return a list of names of the signals that the
+        # agent needs to receive in its update() function.
+        return []
+
+    def update(self, signals):
+        # This agent doesn't dynamically make decisions based on any signals
+        # signals is a list of values corresponding to get_signals().
+        # E.g., to get a dict[signal_name, value], use dict(zip(self.get_signals(), signals))
+
+        # We only need to tell our reporter to update its snapshot of the
+        # state of PlatformIO.
+        geopmpy.reporter.update()
+
+        # This agent does not dynamically modify any controls.
+        # Otherwise, we would return a list of their *values* here.
+        return []
+
+    def get_controls(self):
+        # This agent does not dynamically modify any controls.
+        # Otherwise, we would return a list of their *names* here.
+        return []
+
+    def get_period(self):
+        return self._control_period
+
+    def get_report(self, profile):
+        report = yaml.load(geopmpy.reporter.generate(profile, self.__class__.__name__),
+                           Loader=yaml.SafeLoader)
+        report['Policy']['Initial Controls'] = self._initial_controls
+        # Optionally add more agent-specific contents to the report here. For
+        # example, if the agent makes any dynamic decisions at execution time,
+        # it might report a summary of its decisions or algorithmic state.
+        return yaml.dump(report, default_flow_style=False, sort_keys=False)
+
+
+def main():
+    """Launch an application under the StaticAgent.
+    """
+    parser = argparse.ArgumentParser(
+        description="Launch an application with a static agent. All positional "
+                    "arguments and unrecognized options are forwarded to the "
+                    "launched application's argv. Every option after '--' is "
+                    "treated as an option for the wrapped application.")
+    parser.add_argument('--geopm-control-period', default=1, type=float,
+                        help='GEOPM Agent control period, in seconds.')
+    parser.add_argument('--geopm-report', metavar='REPORT_FILE',
+                        help='Write report output to REPORT_FILE.')
+    parser.add_argument('--geopm-report-signals',
+                        help='Additional signals to include in the report.')
+    parser.add_argument('--geopm-initialize-control',
+                        action='append',
+                        help='Initialize a control to a given value, separated by an "=" '
+                             'symbol. e.g., to run at a cpu frequency of 2 GHz: '
+                             '--initialize-control CPU_FREQUENCY_CONTROL=2e9')
+    parser.add_argument('--geopm-profile',
+                        help='Override the report profile name. Default: the launched command')
+
+    args, app_args = parser.parse_known_args()
+
+    if len(app_args) == 0:
+        parser.error("Must specify something to execute.")
+
+    if app_args[0] == "--":
+        app_args = app_args[1:]
+
+    if len(app_args) == 0:
+        parser.error("Must specify something to execute.")
+
+    if args.geopm_report_signals:
+        os.environ['GEOPM_REPORT_SIGNALS'] = args.geopm_report_signals
+
+    initial_controls = dict()
+    if args.geopm_initialize_control is not None:
+        try:
+            # Convert the list of CONTROL=value pairs to a dict of CONTROL->value
+            for control_specification in args.geopm_initialize_control:
+                control_name, value = control_specification.split('=')
+                initial_controls[control_name] = float(value)
+        except ValueError as e:
+            parser.error(f'Invalid control specification for {control_specification}. Reason: {e}')
+
+    agent = StaticAgent(period_seconds=args.geopm_control_period,
+                        initial_controls=initial_controls)
+
+    controller = geopmdpy.runtime.Controller(agent)
+    report = controller.run(app_args, None)
+
+    if args.geopm_report:
+        with open(args.geopm_report, 'w') as f:
+            print(report, file=f)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Add a base python agent which can monitor signals for reports and traces,
  and can initialize controls with fixed values at the start of a run.
- Add a tutorial to to demonstrate how the base agent can be used to monitor
  signals, and initialize controls for a run.
- Resolves #2152

Co-authored-by: lowren.h.lawson@intel.com <lowren.h.lawson@intel.com>