### PR TITLE
Define master_doc in sphinx-build configuration

### DIFF
--- a/service/docs/source/conf.py
+++ b/service/docs/source/conf.py
@@ -75,6 +75,8 @@ def get_description(rst_file_name):
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+master_doc = 'index'
+
 extensions = [
     'sphinx.ext.napoleon',
     'sphinx_rtd_theme',

--- a/service/docs/source/requires.rst
+++ b/service/docs/source/requires.rst
@@ -37,7 +37,7 @@ Upstream SLES and OpenSUSE Package Requirements
 .. code-block:: bash
 
     zypper install python3 python3-devel python3-gobject \
-                   python3-sphinx python3-sphinx_rtd_theme \
+                   python3-Sphinx python3-sphinx_rtd_theme \
                    systemd-devel
 
 


### PR DESCRIPTION
- Fixes #2159
- Fixes the build when using sphinx-build version 1.8.5
