### PR TITLE
LevelZero Performance Factor Support

### DIFF
--- a/service/docs/source/geopm_pio_levelzero.7.rst
+++ b/service/docs/source/geopm_pio_levelzero.7.rst
@@ -73,6 +73,14 @@ Signals
     *  **Format**: double
     *  **Unit**: seconds
 
+``LEVELZERO::GPU_CORE_PERFORMANCE_FACTOR``
+    Performance Factor of the GPU Compute Hardware Domain. Expresses a trade-off between energy provided to the GPU compute hardware and the supporting units.  A value of 1 indicates a compute focused energy trade-off, a value of 0 indicates a memory focused energy trade-off.  Default value is 0.5
+
+    *  **Aggregation**: averge
+    *  **Domain**: gpu_chip
+    *  **Format**: double
+    *  **Unit**: none
+
 ``LEVELZERO::GPU_UNCORE_FREQUENCY_STATUS``
     The current frequency of the GPU Memory hardware.
 
@@ -229,6 +237,15 @@ Every control is exposed as a signal with the same name.  The relevant signal ag
     *  **Format**: double
     *  **Unit**: hertz
 
+``LEVELZERO::GPU_CORE_PERFORMANCE_FACTOR_CONTROL``
+    Performance Factor of the GPU Compute Hardware Domain. Expresses a trade-off between energy provided to the GPU compute hardware and the supporting units.  A value of 1 indicates a compute focused energy trade-off, a value of 0 indicates a memory focused energy trade-off.  Default value is 0.5
+
+    *  **Aggregation**: averge
+    *  **Domain**: gpu_chip
+    *  **Format**: double
+    *  **Unit**: none
+
+
 Aliases
 -------
 
@@ -272,6 +289,11 @@ Signal Aliases
 
 ``GPU_CORE_FREQUENCY_MAX_CONTROL``
     Maps to ``LEVELZERO::GPU_CORE_FREQUENCY_MAX_CONTROL``.
+
+``LEVELZERO::GPU_CORE_PERFORMANCE_FACTOR_CONTROL``
+    Maps to ``LEVELZERO::GPU_CORE_PERFORMANCE_FACTOR``
+    Writes to performance factor may not be granted.  To confirm the actual
+    control setting the signal must be read.
 
 Control Aliases
 ^^^^^^^^^^^^^^^

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -341,7 +341,8 @@ namespace geopm
                     else if (property.engines == ZES_ENGINE_TYPE_FLAG_MEDIA) { //TODO: should this be _DMA?
                         m_devices.at(device_idx).perf_domain.at(geopm::LevelZero::M_DOMAIN_MEMORY) = handle;
                     }
-                    else if (property.engines == ZES_ENGINE_TYPE_FLAG_OTHER) { //TODO: Update to not rely on OTHER
+                    //TODO: Update to not rely on the OTHER enum if possible
+                    else if (property.engines == ZES_ENGINE_TYPE_FLAG_OTHER) {
                         m_devices.at(device_idx).perf_domain.at(geopm::LevelZero::M_DOMAIN_ALL) = handle;
                     }
                     else {
@@ -515,10 +516,10 @@ namespace geopm
     int LevelZeroImp::performance_domain_count(int geopm_domain, unsigned int l0_device_idx, int l0_domain) const
     {
         int result = 0;
-        if (geopm_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+        if (geopm_domain == GEOPM_DOMAIN_GPU) {
             result = m_devices.at(l0_device_idx).perf_domain.size();
         }
-        else if (geopm_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP) {
+        else if (geopm_domain == GEOPM_DOMAIN_GPU_CHIP) {
             result = m_devices.at(l0_device_idx).subdevice.perf_domain.at(l0_domain).size();
         }
         return result;
@@ -531,7 +532,7 @@ namespace geopm
         zes_perf_handle_t handle;
         ze_result_t ze_result;
 
-        if (geopm_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+        if (geopm_domain == GEOPM_DOMAIN_GPU) {
             handle = m_devices.at(l0_device_idx).perf_domain.at(l0_domain);
 
             ze_result = zesPerformanceFactorGetConfig(handle, &result);
@@ -539,7 +540,7 @@ namespace geopm
                             + std::string(__func__) +
                             ": Sysman failed to get performance factor values", __LINE__);
         }
-        else if (geopm_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP) {
+        else if (geopm_domain == GEOPM_DOMAIN_GPU_CHIP) {
             handle = m_devices.at(l0_device_idx).subdevice.perf_domain.at(l0_domain).at(l0_domain_idx);
 
             ze_result = zesPerformanceFactorGetConfig(handle, &result);
@@ -824,10 +825,10 @@ namespace geopm
         zes_perf_handle_t handle;
         ze_result_t ze_result;
 
-        if (geopm_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+        if (geopm_domain == GEOPM_DOMAIN_GPU) {
             handle = m_devices.at(l0_device_idx).perf_domain.at(l0_domain);
         }
-        else if (geopm_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP) {
+        else if (geopm_domain == GEOPM_DOMAIN_GPU_CHIP) {
             handle = m_devices.at(l0_device_idx).subdevice.perf_domain.at(l0_domain).at(l0_domain_idx);
         }
         else {

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -164,11 +164,14 @@ namespace geopm
         // TODO: When additional device types such as FPGA, MCA, and Integrated GPU are supported by GEOPM
         // This should be changed to a more general loop iterating over type and caching appropriately
         for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; gpu_idx++) {
-            domain_cache(gpu_idx);
+            frequency_domain_cache(gpu_idx);
+            power_domain_cache(gpu_idx);
+            perf_domain_cache(gpu_idx);
+            engine_domain_cache(gpu_idx);
        }
     }
 
-    void LevelZeroImp::domain_cache(unsigned int device_idx) {
+    void LevelZeroImp::frequency_domain_cache(unsigned int device_idx) {
         ze_result_t ze_result;
         uint32_t num_domain = 0;
 
@@ -223,6 +226,11 @@ namespace geopm
                 }
             }
         }
+    }
+
+    void LevelZeroImp::power_domain_cache(unsigned int device_idx) {
+        ze_result_t ze_result;
+        uint32_t num_domain = 0;
 
         //Cache power domains
         num_domain = 0;
@@ -297,6 +305,12 @@ namespace geopm
                       cached_energy_timestamp.resize(m_devices.at(device_idx).subdevice.power_domain.size());
         }
 
+    }
+
+    void LevelZeroImp::perf_domain_cache(unsigned int device_idx) {
+        ze_result_t ze_result;
+        uint32_t num_domain = 0;
+
         //Cache performance domains
         num_domain = 0;
         ze_result = zesDeviceEnumPerformanceFactorDomains(m_devices.at(
@@ -361,7 +375,11 @@ namespace geopm
                 }
             }
         }
+    }
 
+    void LevelZeroImp::engine_domain_cache(unsigned int device_idx) {
+        ze_result_t ze_result;
+        uint32_t num_domain = 0;
 
         //Cache engine domains
         num_domain = 0;

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -511,8 +511,6 @@ namespace geopm
     int LevelZeroImp::performance_domain_count(int geopm_domain, unsigned int l0_device_idx, int l0_domain) const
     {
         int result = 0;
-        if (geopm_domain == GEOPM_DOMAIN_GPU) {
-        }
         else if (geopm_domain == GEOPM_DOMAIN_GPU_CHIP) {
             result = m_devices.at(l0_device_idx).subdevice.perf_domain.at(l0_domain).size();
         }

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -512,7 +512,7 @@ namespace geopm
         return m_devices.at(l0_device_idx).subdevice.engine_domain.at(l0_domain).size();
     }
 
-    int LevelZeroImp::perf_domain_count(int geopm_domain, unsigned int l0_device_idx, int l0_domain) const
+    int LevelZeroImp::performance_domain_count(int geopm_domain, unsigned int l0_device_idx, int l0_domain) const
     {
         int result = 0;
         if (geopm_domain == GEOPM_DOMAIN_BOARD_ACCELERATOR) {

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -235,7 +235,7 @@ namespace geopm
         //Cache power domains
         num_domain = 0;
         ze_result = zesDeviceEnumPowerDomains(m_devices.at(
-                    device_idx).device_handle, &num_domain, nullptr);
+                        device_idx).device_handle, &num_domain, nullptr);
         if (ze_result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
 #ifdef GEOPM_DEBUG
             std::cerr << "Warning: <geopm> LevelZero: Power domain detection is "
@@ -314,7 +314,7 @@ namespace geopm
         //Cache performance domains
         num_domain = 0;
         ze_result = zesDeviceEnumPerformanceFactorDomains(m_devices.at(
-                    device_idx).device_handle, &num_domain, nullptr);
+                        device_idx).device_handle, &num_domain, nullptr);
         if (ze_result != ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
             check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                             "LevelZero::" + std::string(__func__) +
@@ -339,7 +339,7 @@ namespace geopm
                                 ": Sysman failed to get domain performance factor properties",
                                 __LINE__);
 
-                //Finding non-subdevice domain.
+                //Finding subdevice domain.
                 if (property.onSubdevice != 0) {
                     if (property.engines == ZES_ENGINE_TYPE_FLAG_COMPUTE) {
                         m_devices.at(device_idx).subdevice.perf_domain.at(

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -326,7 +326,7 @@ namespace geopm
                       perf_domain.resize(geopm::LevelZero::M_DOMAIN_SIZE);
 
             for (auto handle : perf_domain) {
-                zes_perf_properties_t property;
+                zes_perf_properties_t property = {};
                 ze_result = zesPerformanceFactorGetProperties(handle, &property);
                 check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                                 "LevelZero::" + std::string(__func__) +
@@ -338,35 +338,26 @@ namespace geopm
                     if (property.engines == ZES_ENGINE_TYPE_FLAG_COMPUTE) {
                         m_devices.at(device_idx).perf_domain.at(geopm::LevelZero::M_DOMAIN_COMPUTE) = handle;
                     }
-                    else if (property.engines == ZES_ENGINE_TYPE_FLAG_MEDIA) { //TODO: should this be _DMA?
-                        m_devices.at(device_idx).perf_domain.at(geopm::LevelZero::M_DOMAIN_MEMORY) = handle;
-                    }
-                    //TODO: Update to not rely on the OTHER enum if possible
-                    else if (property.engines == ZES_ENGINE_TYPE_FLAG_OTHER) {
-                        m_devices.at(device_idx).perf_domain.at(geopm::LevelZero::M_DOMAIN_ALL) = handle;
-                    }
+#ifdef GEOPM_DEBUG
                     else {
-                        throw Exception("LevelZero::" + std::string(__func__) +
-                                        ": Unsupported device level performance factor domain "
-                                        " factor domain ()" + std::to_string(property.engines) +
-                                        " detected.", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                        std::cerr << "Warning: <geopm> LevelZero:" <<
+                                     " Unsupported device level performance factor domain (" <<
+                                     std::to_string(property.engines) << ") detected." << std::endl;
                     }
+#endif
                 }
                 else {
                     if (property.engines == ZES_ENGINE_TYPE_FLAG_COMPUTE) {
                         m_devices.at(device_idx).subdevice.perf_domain.at(
                                  geopm::LevelZero::M_DOMAIN_COMPUTE).push_back(handle);
                     }
-                    else if (property.engines == ZES_ENGINE_TYPE_FLAG_MEDIA) { //TODO: should this be _DMA?
-                        m_devices.at(device_idx).subdevice.perf_domain.at(
-                                 geopm::LevelZero::M_DOMAIN_MEMORY).push_back(handle);
-                    }
+#ifdef GEOPM_DEBUG
                     else {
-                        throw Exception("LevelZero::" + std::string(__func__) +
-                                        ": Unsupported subdevice level performance factor domain "
-                                        " factor domain ()" + std::to_string(property.engines) +
-                                        " detected.", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                         std::cerr << "Warning: <geopm> LevelZero:" <<
+                                      " Unsupported sub-device level performance factor domain (" <<
+                                      std::to_string(property.engines) << ") detected." << std::endl;
                     }
+#endif
                 }
             }
         }

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -508,16 +508,12 @@ namespace geopm
         return m_devices.at(l0_device_idx).subdevice.engine_domain.at(l0_domain).size();
     }
 
-    int LevelZeroImp::performance_domain_count(int geopm_domain, unsigned int l0_device_idx, int l0_domain) const
+    int LevelZeroImp::performance_domain_count(unsigned int l0_device_idx, int l0_domain) const
     {
-        int result = 0;
-        else if (geopm_domain == GEOPM_DOMAIN_GPU_CHIP) {
-            result = m_devices.at(l0_device_idx).subdevice.perf_domain.at(l0_domain).size();
-        }
-        return result;
+        return m_devices.at(l0_device_idx).subdevice.perf_domain.at(l0_domain).size();
     }
 
-    double LevelZeroImp::performance_factor(int geopm_domain, unsigned int l0_device_idx,
+    double LevelZeroImp::performance_factor(unsigned int l0_device_idx,
                                             int l0_domain, int l0_domain_idx) const
     {
         double result = NAN;
@@ -798,8 +794,7 @@ namespace geopm
                         ": Sysman failed to set frequency.", __LINE__);
     }
 
-    void LevelZeroImp::performance_factor_control(int geopm_domain,
-                                                  unsigned int l0_device_idx,
+    void LevelZeroImp::performance_factor_control(unsigned int l0_device_idx,
                                                   int l0_domain,
                                                   int l0_domain_idx,
                                                   double setting) const

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -145,7 +145,7 @@ namespace geopm
             /// @param [in] l0_domain The LevelZero domain type being targeted
             /// @return GPU perf domain count.
             virtual int performance_domain_count(int geopm_domain, unsigned int l0_device_idx,
-                                          int l0_domain) const = 0;
+                                                 int l0_domain) const = 0;
             /// @brief Get the performance factor value of various LevelZero domains
             /// @param [in] geopm_domain The GEOPM domain being targeted
             /// @param [in] l0_device_idx The LevelZero device being targeted

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -135,7 +135,7 @@ namespace geopm
             /// @param [in] geopm_domain The GEOPM domain being targeted
             /// @param [in] l0_device_idx The LevelZero device being targeted
             /// @param [in] l0_domain The LevelZero domain type being targeted
-            /// @return Accelerator frequency domain count.
+            /// @return GPU frequency domain count.
             virtual int power_domain_count(int geopm_domain,
                                            unsigned int l0_device_idx,
                                            int l0_domain) const = 0;
@@ -150,7 +150,7 @@ namespace geopm
             /// @param [in] l0_domain The LevelZero domain type being targeted
             /// @param [in] l0_domain_idx The index indicating a particular
             ///        Level Zero domain.
-            /// @return Accelerator or subdevice performance factor value
+            /// @return Subdevice performance factor value
             virtual double performance_factor(unsigned int l0_device_idx,
                                               int l0_domain, int l0_domain_idx) const = 0;
 

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -204,8 +204,8 @@ namespace geopm
             /// @brief Set min and max frequency for LevelZero device.
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero GPU.
-            /// @param [in] domain The domain type being targeted
-            /// @param [in] domain_idx The domain being targeted
+            /// @param [in] l0_domain The domain type being targeted
+            /// @param [in] l0_domain_idx The domain being targeted
             /// @param [in] range_min Min target frequency in MHz.
             /// @param [in] range_max Max target frequency in MHz.
             virtual void frequency_control(unsigned int l0_device_idx, int l0_domain,
@@ -215,8 +215,8 @@ namespace geopm
             /// @brief Set the performance factor for the LevelZero device.
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero accelerator.
-            /// @param [in] domain The level zero domain type being targeted
-            /// @param [in] domain_idx The level zero domain being targeted
+            /// @param [in] l0_domain The level zero domain type being targeted
+            /// @param [in] l0_domain_idx The level zero domain being targeted
             /// @param [in] setting The performance factor value, 0-100
             virtual void performance_factor_control(unsigned int l0_device_idx,
                                                     int l0_domain,

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -143,9 +143,16 @@ namespace geopm
             /// @param [in] geopm_domain The GEOPM domain being targeted
             /// @param [in] l0_device_idx The LevelZero device being targeted
             /// @param [in] l0_domain The LevelZero domain type being targeted
-            /// @return perf domain count.
-            virtual int perf_domain_count(int geopm_domain, unsigned int l0_device_idx,
+            /// @return GPU perf domain count.
+            virtual int performance_domain_count(int geopm_domain, unsigned int l0_device_idx,
                                           int l0_domain) const = 0;
+            /// @brief Get the performance factor value of various LevelZero domains
+            /// @param [in] geopm_domain The GEOPM domain being targeted
+            /// @param [in] l0_device_idx The LevelZero device being targeted
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @param [in] l0_domain_idx The index indicating a particular
+            ///        Level Zero domain.
+            /// @return Accelerator or subdevice performance factor value
             virtual double performance_factor(int geopm_domain, unsigned int l0_device_idx,
                                               int l0_domain, int l0_domain_idx) const = 0;
 

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -140,20 +140,18 @@ namespace geopm
                                            unsigned int l0_device_idx,
                                            int l0_domain) const = 0;
             /// @brief Get the number of LevelZero perf domains of a certain type
-            /// @param [in] geopm_domain The GEOPM domain being targeted
             /// @param [in] l0_device_idx The LevelZero device being targeted
             /// @param [in] l0_domain The LevelZero domain type being targeted
             /// @return GPU perf domain count.
-            virtual int performance_domain_count(int geopm_domain, unsigned int l0_device_idx,
+            virtual int performance_domain_count(unsigned int l0_device_idx,
                                                  int l0_domain) const = 0;
             /// @brief Get the performance factor value of various LevelZero domains
-            /// @param [in] geopm_domain The GEOPM domain being targeted
             /// @param [in] l0_device_idx The LevelZero device being targeted
             /// @param [in] l0_domain The LevelZero domain type being targeted
             /// @param [in] l0_domain_idx The index indicating a particular
             ///        Level Zero domain.
             /// @return Accelerator or subdevice performance factor value
-            virtual double performance_factor(int geopm_domain, unsigned int l0_device_idx,
+            virtual double performance_factor(unsigned int l0_device_idx,
                                               int l0_domain, int l0_domain_idx) const = 0;
 
             /// @brief Get the LevelZero device default power limit in milliwatts
@@ -215,14 +213,12 @@ namespace geopm
                                            double range_max) const = 0;
 
             /// @brief Set the performance factor for the LevelZero device.
-            /// @param [in] geopm_domain The geopm domain type being targeted
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero accelerator.
             /// @param [in] domain The level zero domain type being targeted
             /// @param [in] domain_idx The level zero domain being targeted
             /// @param [in] setting The performance factor value, 0-100
-            virtual void performance_factor_control(int geopm_domain,
-                                                    unsigned int l0_device_idx,
+            virtual void performance_factor_control(unsigned int l0_device_idx,
                                                     int l0_domain,
                                                     int l0_domain_idx,
                                                     double setting) const = 0;

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -139,6 +139,14 @@ namespace geopm
             virtual int power_domain_count(int geopm_domain,
                                            unsigned int l0_device_idx,
                                            int l0_domain) const = 0;
+            /// @brief Get the number of LevelZero perf domains of a certain type
+            /// @param [in] geopm_domain The GEOPM domain being targeted
+            /// @param [in] l0_device_idx The LevelZero device being targeted
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return perf domain count.
+            virtual int perf_domain_count(int geopm_domain, unsigned int l0_device_idx,
+                                          int l0_domain) const = 0;
+
             /// @brief Get the LevelZero device default power limit in milliwatts
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero GPU.
@@ -190,11 +198,23 @@ namespace geopm
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero GPU.
             /// @param [in] domain The domain type being targeted
+            /// @param [in] domain_idx The domain being targeted
             /// @param [in] range_min Min target frequency in MHz.
             /// @param [in] range_max Max target frequency in MHz.
             virtual void frequency_control(unsigned int l0_device_idx, int l0_domain,
                                            int l0_domain_idx, double range_min,
                                            double range_max) const = 0;
+
+            /// @brief Set the performance factor for the LevelZero device.
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero accelerator.
+            /// @param [in] domain The domain type being targeted
+            /// @param [in] domain_idx The domain being targeted
+            /// @param [in] iseting The performance factor value, 0-1
+            virtual void performance_factor_control(unsigned int l0_device_idx,
+                                                    int l0_domain,
+                                                    int l0_domain_idx,
+                                                    double setting) const = 0;
     };
 
     const LevelZero &levelzero();

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -146,6 +146,8 @@ namespace geopm
             /// @return perf domain count.
             virtual int perf_domain_count(int geopm_domain, unsigned int l0_device_idx,
                                           int l0_domain) const = 0;
+            virtual double performance_factor(int geopm_domain, unsigned int l0_device_idx,
+                                              int l0_domain, int l0_domain_idx) const = 0;
 
             /// @brief Get the LevelZero device default power limit in milliwatts
             /// @param [in] l0_device_idx The index indicating a particular
@@ -206,12 +208,14 @@ namespace geopm
                                            double range_max) const = 0;
 
             /// @brief Set the performance factor for the LevelZero device.
+            /// @param [in] geopm_domain The geopm domain type being targeted
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero accelerator.
-            /// @param [in] domain The domain type being targeted
-            /// @param [in] domain_idx The domain being targeted
-            /// @param [in] iseting The performance factor value, 0-1
-            virtual void performance_factor_control(unsigned int l0_device_idx,
+            /// @param [in] domain The level zero domain type being targeted
+            /// @param [in] domain_idx The level zero domain being targeted
+            /// @param [in] setting The performance factor value, 0-100
+            virtual void performance_factor_control(int geopm_domain,
+                                                    unsigned int l0_device_idx,
                                                     int l0_domain,
                                                     int l0_domain_idx,
                                                     double setting) const = 0;

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -420,18 +420,18 @@ namespace geopm
         if (domain != GEOPM_DOMAIN_GPU_CHIP) {
             throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
                             ": domain " + std::to_string(domain) +
-                            " is not supported for the frequency domain.",
+                            " is not supported for the performance factor domain.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
         dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        check_domain_exists(m_levelzero.performance_domain_count(domain,
+        check_domain_exists(m_levelzero.performance_domain_count(
                                         dev_subdev_idx_pair.first, l0_domain),
                                         __func__, __LINE__);
 
-        result = m_levelzero.performance_factor(domain, dev_subdev_idx_pair.first,
+        result = m_levelzero.performance_factor(dev_subdev_idx_pair.first,
                                                 l0_domain, dev_subdev_idx_pair.second);
         return result;
     }
@@ -460,20 +460,20 @@ namespace geopm
     void LevelZeroDevicePoolImp::performance_factor_control(int domain, unsigned int domain_idx,
                                                             int l0_domain, double setting) const
     {
-        if (domain == GEOPM_DOMAIN_GPU) {
-            check_idx_range(domain, domain_idx);
-            m_levelzero.performance_factor_control(domain, domain_idx, l0_domain, 0, setting);
+        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for the performance factor domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        else if (domain == GEOPM_DOMAIN_GPU_CHIP) {
-            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            check_domain_exists(m_levelzero.performance_domain_count(domain,
-                                            dev_subdev_idx_pair.first, l0_domain),
-                                            __func__, __LINE__);
+        check_domain_exists(m_levelzero.performance_domain_count(
+                                        dev_subdev_idx_pair.first, l0_domain),
+                                        __func__, __LINE__);
 
-            m_levelzero.performance_factor_control(domain, dev_subdev_idx_pair.first,
-                                                   l0_domain, dev_subdev_idx_pair.second, setting);
-        }
+        m_levelzero.performance_factor_control(dev_subdev_idx_pair.first,
+                                               l0_domain, dev_subdev_idx_pair.second, setting);
     }
 }

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -5,6 +5,7 @@
 
 #include "config.h"
 
+#include <iostream>
 #include <string>
 #include <cstdint>
 
@@ -411,6 +412,30 @@ namespace geopm
         return energy;
     }
 
+    double LevelZeroDevicePoolImp::performance_factor(int domain,
+                                                      unsigned int domain_idx,
+                                                      int l0_domain) const
+    {
+        double result = NAN;
+        if (domain == GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+            check_idx_range(domain, domain_idx);
+
+            result = m_levelzero.performance_factor(domain, domain_idx, l0_domain, 0);
+        }
+        else if (domain == GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP) {
+            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+
+            check_domain_exists(m_levelzero.perf_domain_count(domain,
+                                            dev_subdev_idx_pair.first, l0_domain),
+                                            __func__, __LINE__);
+
+            result = m_levelzero.performance_factor(domain, dev_subdev_idx_pair.first,
+                                                    l0_domain, dev_subdev_idx_pair.second);
+        }
+        return result;
+    }
+
     void LevelZeroDevicePoolImp::frequency_control(int domain, unsigned int domain_idx,
                                                    int l0_domain, double range_min,
                                                    double range_max) const
@@ -430,5 +455,25 @@ namespace geopm
         m_levelzero.frequency_control(dev_subdev_idx_pair.first, l0_domain,
                                       dev_subdev_idx_pair.second, range_min,
                                       range_max);
+    }
+
+    void LevelZeroDevicePoolImp::performance_factor_control(int domain, unsigned int domain_idx,
+                                                            int l0_domain, double setting) const
+    {
+        if (domain == GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+            check_idx_range(domain, domain_idx);
+            m_levelzero.performance_factor_control(domain, domain_idx, l0_domain, 0, setting);
+        }
+        else if (domain == GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+
+            check_domain_exists(m_levelzero.perf_domain_count(domain,
+                                            dev_subdev_idx_pair.first, l0_domain),
+                                            __func__, __LINE__);
+
+            m_levelzero.performance_factor_control(domain, dev_subdev_idx_pair.first,
+                                                   l0_domain, dev_subdev_idx_pair.second, setting);
+        }
     }
 }

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -5,7 +5,6 @@
 
 #include "config.h"
 
-#include <iostream>
 #include <string>
 #include <cstdint>
 
@@ -427,9 +426,8 @@ namespace geopm
         std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
         dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        check_domain_exists(m_levelzero.performance_domain_count(
-                                        dev_subdev_idx_pair.first, l0_domain),
-                                        __func__, __LINE__);
+        check_domain_exists(m_levelzero.performance_domain_count(dev_subdev_idx_pair.first, l0_domain),
+                                                                 __func__, __LINE__);
 
         result = m_levelzero.performance_factor(dev_subdev_idx_pair.first,
                                                 l0_domain, dev_subdev_idx_pair.second);
@@ -469,9 +467,8 @@ namespace geopm
         std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
         dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        check_domain_exists(m_levelzero.performance_domain_count(
-                                        dev_subdev_idx_pair.first, l0_domain),
-                                        __func__, __LINE__);
+        check_domain_exists(m_levelzero.performance_domain_count(dev_subdev_idx_pair.first, l0_domain),
+                                                                 __func__, __LINE__);
 
         m_levelzero.performance_factor_control(dev_subdev_idx_pair.first,
                                                l0_domain, dev_subdev_idx_pair.second, setting);

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -417,22 +417,22 @@ namespace geopm
                                                       int l0_domain) const
     {
         double result = NAN;
-        if (domain == GEOPM_DOMAIN_GPU) {
-            check_idx_range(domain, domain_idx);
-
-            result = m_levelzero.performance_factor(domain, domain_idx, l0_domain, 0);
+        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for the frequency domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        else if (domain == GEOPM_DOMAIN_GPU_CHIP) {
-            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            check_domain_exists(m_levelzero.performance_domain_count(domain,
-                                            dev_subdev_idx_pair.first, l0_domain),
-                                            __func__, __LINE__);
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            result = m_levelzero.performance_factor(domain, dev_subdev_idx_pair.first,
-                                                    l0_domain, dev_subdev_idx_pair.second);
-        }
+        check_domain_exists(m_levelzero.performance_domain_count(domain,
+                                        dev_subdev_idx_pair.first, l0_domain),
+                                        __func__, __LINE__);
+
+        result = m_levelzero.performance_factor(domain, dev_subdev_idx_pair.first,
+                                                l0_domain, dev_subdev_idx_pair.second);
         return result;
     }
 

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -464,7 +464,7 @@ namespace geopm
             check_idx_range(domain, domain_idx);
             m_levelzero.performance_factor_control(domain, domain_idx, l0_domain, 0, setting);
         }
-        else if (domain == GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+        else if (domain == GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP) {
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -426,7 +426,7 @@ namespace geopm
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            check_domain_exists(m_levelzero.perf_domain_count(domain,
+            check_domain_exists(m_levelzero.performance_domain_count(domain,
                                             dev_subdev_idx_pair.first, l0_domain),
                                             __func__, __LINE__);
 
@@ -468,7 +468,7 @@ namespace geopm
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            check_domain_exists(m_levelzero.perf_domain_count(domain,
+            check_domain_exists(m_levelzero.performance_domain_count(domain,
                                             dev_subdev_idx_pair.first, l0_domain),
                                             __func__, __LINE__);
 

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -417,12 +417,12 @@ namespace geopm
                                                       int l0_domain) const
     {
         double result = NAN;
-        if (domain == GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+        if (domain == GEOPM_DOMAIN_GPU) {
             check_idx_range(domain, domain_idx);
 
             result = m_levelzero.performance_factor(domain, domain_idx, l0_domain, 0);
         }
-        else if (domain == GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP) {
+        else if (domain == GEOPM_DOMAIN_GPU_CHIP) {
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
@@ -460,11 +460,11 @@ namespace geopm
     void LevelZeroDevicePoolImp::performance_factor_control(int domain, unsigned int domain_idx,
                                                             int l0_domain, double setting) const
     {
-        if (domain == GEOPM_DOMAIN_BOARD_ACCELERATOR) {
+        if (domain == GEOPM_DOMAIN_GPU) {
             check_idx_range(domain, domain_idx);
             m_levelzero.performance_factor_control(domain, domain_idx, l0_domain, 0, setting);
         }
-        else if (domain == GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP) {
+        else if (domain == GEOPM_DOMAIN_GPU_CHIP) {
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 

--- a/service/src/LevelZeroDevicePool.hpp
+++ b/service/src/LevelZeroDevicePool.hpp
@@ -146,6 +146,10 @@ namespace geopm
             virtual uint64_t energy_timestamp(int domain, unsigned int domain_idx,
                                               int l0_domain) const = 0;
 
+            virtual double performance_factor(int domain,
+                                              unsigned int domain_idx,
+                                              int l0_domain) const = 0;
+
             // FREQUENCY CONTROL FUNCTIONS
             /// @brief Set min and max frequency for LevelZero device.
             /// @param [in] domain The GEOPM domain type being targeted
@@ -158,6 +162,9 @@ namespace geopm
                                            int l0_domain, double range_min,
                                            double range_max) const = 0;
 
+            virtual void performance_factor_control(int domain, unsigned int domain_idx,
+                                                    int l0_domain,
+                                                    double setting) const = 0;
         private:
     };
 

--- a/service/src/LevelZeroDevicePool.hpp
+++ b/service/src/LevelZeroDevicePool.hpp
@@ -146,6 +146,12 @@ namespace geopm
             virtual uint64_t energy_timestamp(int domain, unsigned int domain_idx,
                                               int l0_domain) const = 0;
 
+            /// @brief Get the LevelZero device performance factor
+            /// @param [in] domain The GEOPM domain type being targeted
+            /// @param [in] domain_idx The GEOPM domain index
+            ///             (i.e. accelerator or chip being targeted)
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return Accelerator or chip performance value, 0-1.0
             virtual double performance_factor(int domain,
                                               unsigned int domain_idx,
                                               int l0_domain) const = 0;
@@ -162,6 +168,12 @@ namespace geopm
                                            int l0_domain, double range_min,
                                            double range_max) const = 0;
 
+            /// @brief Set performance factor for LevelZero device.
+            /// @param [in] domain The GEOPM domain type being targeted
+            /// @param [in] domain_idx The GEOPM domain index
+            ///             (i.e. accelerator or chip being targeted)
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @param [in] setting Performance factor target, 0-1.0
             virtual void performance_factor_control(int domain, unsigned int domain_idx,
                                                     int l0_domain,
                                                     double setting) const = 0;

--- a/service/src/LevelZeroDevicePool.hpp
+++ b/service/src/LevelZeroDevicePool.hpp
@@ -149,9 +149,9 @@ namespace geopm
             /// @brief Get the LevelZero device performance factor
             /// @param [in] domain The GEOPM domain type being targeted
             /// @param [in] domain_idx The GEOPM domain index
-            ///             (i.e. accelerator or chip being targeted)
+            ///             (i.e. gpu or chip being targeted)
             /// @param [in] l0_domain The LevelZero domain type being targeted
-            /// @return Accelerator or chip performance value, 0-1.0
+            /// @return Chip performance value, 0 - 1.0
             virtual double performance_factor(int domain,
                                               unsigned int domain_idx,
                                               int l0_domain) const = 0;
@@ -173,7 +173,7 @@ namespace geopm
             /// @param [in] domain_idx The GEOPM domain index
             ///             (i.e. accelerator or chip being targeted)
             /// @param [in] l0_domain The LevelZero domain type being targeted
-            /// @param [in] setting Performance factor target, 0-1.0
+            /// @param [in] setting Performance factor target, 0 - 1.0
             virtual void performance_factor_control(int domain, unsigned int domain_idx,
                                                     int l0_domain,
                                                     double setting) const = 0;

--- a/service/src/LevelZeroDevicePoolImp.hpp
+++ b/service/src/LevelZeroDevicePoolImp.hpp
@@ -56,10 +56,16 @@ namespace geopm
             uint64_t energy(int domain, unsigned int domain_idx, int l0_domain) const override;
             uint64_t energy_timestamp(int domain, unsigned int domain_idx,
                                       int l0_domain) const override;
+            double performance_factor(int domain,
+                                      unsigned int domain_idx,
+                                      int l0_domain) const override;
 
             void frequency_control(int domain, unsigned int domain_idx,
                                    int l0_domain, double range_min,
                                    double range_max) const override;
+            void performance_factor_control(int domain, unsigned int domain_idx,
+                                            int l0_domain,
+                                            double setting) const override;
 
         private:
             const LevelZero &m_levelzero;

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -431,7 +431,7 @@ namespace geopm
                                   1 / 1e6
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR", {
-                                  "Performance Factor of the Per Tile compute domain",
+                                  "Performance Factor of the GPU Compute Hardware Domain",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -430,23 +430,7 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR", {
-                                  "Performance Factor of the Domain",
-                                  GEOPM_DOMAIN_GPU,
-                                  Agg::average,
-                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.performance_factor(
-                                                                  GEOPM_DOMAIN_GPU,
-                                                                  domain_idx,
-                                                                  geopm::LevelZero::M_DOMAIN_ALL);
-                                  },
-                                  .01
-                                  }},
-                              {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE", {
+                              {M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR", {
                                   "Performance Factor of the Per Tile compute domain",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
@@ -459,22 +443,6 @@ namespace geopm
                                                                   GEOPM_DOMAIN_GPU_CHIP,
                                                                   domain_idx,
                                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
-                                  },
-                                  .01
-                                  }},
-                              {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_MEMORY", {
-                                  "Performance Factor of the Per Tile memory domain",
-                                  GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
-                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
-                                  string_format_double,
-                                  {},
-                                  [this](unsigned int domain_idx) -> double
-                                  {
-                                      return this->m_levelzero_device_pool.performance_factor(
-                                                                  GEOPM_DOMAIN_GPU_CHIP,
-                                                                  domain_idx,
-                                                                  geopm::LevelZero::M_DOMAIN_MEMORY);
                                   },
                                   .01
                                   }},
@@ -493,21 +461,7 @@ namespace geopm
                                     Agg::expect_same,
                                     string_format_double
                                     }},
-                               {M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR_CONTROL", {
-                                    "Performance Factor",
-                                    {},
-                                    GEOPM_DOMAIN_GPU,
-                                    Agg::average,
-                                    string_format_double
-                                    }},
-                               {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE_CONTROL", {
-                                    "Performance Factor",
-                                    {},
-                                    GEOPM_DOMAIN_GPU_CHIP,
-                                    Agg::average,
-                                    string_format_double
-                                    }},
-                               {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_MEMORY_CONTROL", {
+                               {M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR_CONTROL", {
                                     "Performance Factor",
                                     {},
                                     GEOPM_DOMAIN_GPU_CHIP,
@@ -611,12 +565,8 @@ namespace geopm
         register_signal_alias("GPU_CORE_FREQUENCY_MAX_CONTROL",
                               M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL");
 
-        register_signal_alias(M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE_CONTROL",
-                              M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE");
-        register_signal_alias(M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_MEMORY_CONTROL",
-                              M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_MEMORY");
-        register_signal_alias(M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR_CONTROL",
-                              M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR");
+        register_signal_alias(M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR_CONTROL",
+                              M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {
@@ -1075,19 +1025,9 @@ namespace geopm
                                                       geopm::LevelZero::M_DOMAIN_COMPUTE,
                                                       curr_min / 1e6, setting / 1e6);
         }
-        else if(control_name == M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR_CONTROL") {
-            m_levelzero_device_pool.performance_factor_control(domain_type, domain_idx,
-                                                               geopm::LevelZero::M_DOMAIN_ALL,
-                                                               setting*100);
-        }
-        else if(control_name == M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE_CONTROL") {
+        else if(control_name == M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR_CONTROL") {
             m_levelzero_device_pool.performance_factor_control(domain_type, domain_idx,
                                                                geopm::LevelZero::M_DOMAIN_COMPUTE,
-                                                               setting*100);
-        }
-        else if(control_name == M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_MEMORY_CONTROL") {
-            m_levelzero_device_pool.performance_factor_control(domain_type, domain_idx,
-                                                               geopm::LevelZero::M_DOMAIN_MEMORY,
                                                                setting*100);
         }
         else {

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -429,6 +429,23 @@ namespace geopm
                                                    geopm::LevelZero::M_DOMAIN_MEMORY);
                                   },
                                   1 / 1e6
+                                  }},
+                              {M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR", {
+                                  "Performance Factor of the Domain",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      //return this->m_levelzero_device_pool.performance_factor(
+                                      //             GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                      //             domain_idx,
+                                      //             geopm::LevelZero::M_DOMAIN_ALL);
+                                      return 0;
+                                  },
+                                  1
                                   }}
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
@@ -443,6 +460,20 @@ namespace geopm
                                     {},
                                     GEOPM_DOMAIN_GPU_CHIP,
                                     Agg::expect_same,
+                                    string_format_double
+                                    }},
+                               {M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR", {
+                                    "Performance Factor",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                    Agg::average,
+                                    string_format_double
+                                    }},
+                               {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE", {
+                                    "Performance Factor",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                    Agg::average,
                                     string_format_double
                                     }}
                               })
@@ -998,6 +1029,16 @@ namespace geopm
             m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
                                                       geopm::LevelZero::M_DOMAIN_COMPUTE,
                                                       curr_min / 1e6, setting / 1e6);
+        }
+        else if(control_name == M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR") {
+            //m_levelzero_device_pool.performance_factor(domain_type, domain_idx,
+            //                                           geopm::LevelZero::M_DOMAIN_ALL,
+            //                                           setting);
+        }
+        else if(control_name == M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE") {
+            //m_levelzero_device_pool.performance_factor(domain_type, domain_idx,
+            //                                           geopm::LevelZero::M_DOMAIN_COMPUTE,
+            //                                           setting);
         }
         else {
     #ifdef GEOPM_DEBUG

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -1060,7 +1060,8 @@ namespace geopm
             catch (const geopm::Exception &ex) {
                 throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
                                 + " Failed to fetch frequency control range for "
-                                " GPU_CHIP domain " + std::to_string(domain_idx),
+                                " GPU_CHIP domain " + std::to_string(domain_idx) +
+                                "due to exception.  Exception: " + ex.what(),
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
 
@@ -1075,7 +1076,8 @@ namespace geopm
             catch (const geopm::Exception &ex) {
                 throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
                                 + " Failed to fetch performance factor value for "
-                                " GPU_CHIP domain " + std::to_string(domain_idx),
+                                " GPU_CHIP domain " + std::to_string(domain_idx) +
+                                "due to exception.  Exception: " + ex.what(),
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
         }

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -439,13 +439,27 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      //return this->m_levelzero_device_pool.performance_factor(
-                                      //             GEOPM_DOMAIN_BOARD_ACCELERATOR,
-                                      //             domain_idx,
-                                      //             geopm::LevelZero::M_DOMAIN_ALL);
-                                      return 0;
+                                      return this->m_levelzero_device_pool.performance_factor(
+                                                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                                                  domain_idx,
+                                                                  geopm::LevelZero::M_DOMAIN_ALL);
                                   },
-                                  1
+                                  .01
+                                  }},
+                              {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE", {
+                                  "Performance Factor of the Per Tile compute domain",
+                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  Agg::average,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.performance_factor(
+                                                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                                  domain_idx,
+                                                                  geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  .01
                                   }}
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
@@ -462,14 +476,14 @@ namespace geopm
                                     Agg::expect_same,
                                     string_format_double
                                     }},
-                               {M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR", {
+                               {M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR_CONTROL", {
                                     "Performance Factor",
                                     {},
                                     GEOPM_DOMAIN_BOARD_ACCELERATOR,
                                     Agg::average,
                                     string_format_double
                                     }},
-                               {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE", {
+                               {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE_CONTROL", {
                                     "Performance Factor",
                                     {},
                                     GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
@@ -1030,15 +1044,15 @@ namespace geopm
                                                       geopm::LevelZero::M_DOMAIN_COMPUTE,
                                                       curr_min / 1e6, setting / 1e6);
         }
-        else if(control_name == M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR") {
-            //m_levelzero_device_pool.performance_factor(domain_type, domain_idx,
-            //                                           geopm::LevelZero::M_DOMAIN_ALL,
-            //                                           setting);
+        else if(control_name == M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR_CONTROL") {
+            m_levelzero_device_pool.performance_factor_control(domain_type, domain_idx,
+                                                               geopm::LevelZero::M_DOMAIN_ALL,
+                                                               setting*100);
         }
-        else if(control_name == M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE") {
-            //m_levelzero_device_pool.performance_factor(domain_type, domain_idx,
-            //                                           geopm::LevelZero::M_DOMAIN_COMPUTE,
-            //                                           setting);
+        else if(control_name == M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE_CONTROL") {
+            m_levelzero_device_pool.performance_factor_control(domain_type, domain_idx,
+                                                               geopm::LevelZero::M_DOMAIN_COMPUTE,
+                                                               setting*100);
         }
         else {
     #ifdef GEOPM_DEBUG

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -611,6 +611,13 @@ namespace geopm
         register_signal_alias("GPU_CORE_FREQUENCY_MAX_CONTROL",
                               M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL");
 
+        register_signal_alias(M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE_CONTROL",
+                              M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE");
+        register_signal_alias(M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_MEMORY_CONTROL",
+                              M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_MEMORY");
+        register_signal_alias(M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR_CONTROL",
+                              M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR");
+
         // populate controls for each domain
         for (auto &sv : m_control_available) {
             std::vector<std::shared_ptr<control_s> > result;

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -1061,7 +1061,7 @@ namespace geopm
                 throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
                                 + " Failed to fetch frequency control range for "
                                 " GPU_CHIP domain " + std::to_string(domain_idx) +
-                                "due to exception.  Exception: " + ex.what(),
+                                "due to exception: " + ex.what(),
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
 
@@ -1077,7 +1077,7 @@ namespace geopm
                 throw Exception("LevelZeroIOGroup::" + std::string(__func__) + ": "
                                 + " Failed to fetch performance factor value for "
                                 " GPU_CHIP domain " + std::to_string(domain_idx) +
-                                "due to exception.  Exception: " + ex.what(),
+                                "due to exception: " + ex.what(),
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
         }

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -432,15 +432,15 @@ namespace geopm
                                   }},
                               {M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR", {
                                   "Performance Factor of the Domain",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                  GEOPM_DOMAIN_GPU,
                                   Agg::average,
-                                  IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
                                       return this->m_levelzero_device_pool.performance_factor(
-                                                                  GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                                                  GEOPM_DOMAIN_GPU,
                                                                   domain_idx,
                                                                   geopm::LevelZero::M_DOMAIN_ALL);
                                   },
@@ -448,19 +448,36 @@ namespace geopm
                                   }},
                               {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE", {
                                   "Performance Factor of the Per Tile compute domain",
-                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                  GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
                                       return this->m_levelzero_device_pool.performance_factor(
-                                                                  GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                                                  GEOPM_DOMAIN_GPU_CHIP,
                                                                   domain_idx,
                                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
                                   },
                                   .01
-                                  }}
+                                  }},
+                              {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_MEMORY", {
+                                  "Performance Factor of the Per Tile memory domain",
+                                  GEOPM_DOMAIN_GPU_CHIP,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.performance_factor(
+                                                                  GEOPM_DOMAIN_GPU_CHIP,
+                                                                  domain_idx,
+                                                                  geopm::LevelZero::M_DOMAIN_MEMORY);
+                                  },
+                                  .01
+                                  }},
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
                                     "Sets the minimum frequency request for the GPU Compute Hardware.",
@@ -479,14 +496,21 @@ namespace geopm
                                {M_NAME_PREFIX + "GPU_PERFORMANCE_FACTOR_CONTROL", {
                                     "Performance Factor",
                                     {},
-                                    GEOPM_DOMAIN_BOARD_ACCELERATOR,
+                                    GEOPM_DOMAIN_GPU,
                                     Agg::average,
                                     string_format_double
                                     }},
                                {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE_CONTROL", {
                                     "Performance Factor",
                                     {},
-                                    GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP,
+                                    GEOPM_DOMAIN_GPU_CHIP,
+                                    Agg::average,
+                                    string_format_double
+                                    }},
+                               {M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_MEMORY_CONTROL", {
+                                    "Performance Factor",
+                                    {},
+                                    GEOPM_DOMAIN_GPU_CHIP,
                                     Agg::average,
                                     string_format_double
                                     }}
@@ -1052,6 +1076,11 @@ namespace geopm
         else if(control_name == M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_COMPUTE_CONTROL") {
             m_levelzero_device_pool.performance_factor_control(domain_type, domain_idx,
                                                                geopm::LevelZero::M_DOMAIN_COMPUTE,
+                                                               setting*100);
+        }
+        else if(control_name == M_NAME_PREFIX + "GPUCHIP_PERFORMANCE_FACTOR_MEMORY_CONTROL") {
+            m_levelzero_device_pool.performance_factor_control(domain_type, domain_idx,
+                                                               geopm::LevelZero::M_DOMAIN_MEMORY,
                                                                setting*100);
         }
         else {

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -431,7 +431,8 @@ namespace geopm
                                   1 / 1e6
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR", {
-                                  "Performance Factor of the GPU Compute Hardware Domain",
+                                  "Performance Factor of the GPU Compute Hardware Domain.\n"
+                                  "Expresses a trade-off between energy provided to the GPU compute hardware and the supporting units",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -462,7 +463,8 @@ namespace geopm
                                     string_format_double
                                     }},
                                {M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR_CONTROL", {
-                                    "Performance Factor",
+                                    "Performance Factor of the GPU Compute Hardware Domain.\n"
+                                    "Expresses a trade-off between energy provided to the GPU compute hardware and the supporting units",
                                     {},
                                     GEOPM_DOMAIN_GPU_CHIP,
                                     Agg::average,
@@ -514,8 +516,6 @@ namespace geopm
                      IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
         })
         , m_frequency_range(m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP), std::make_pair(0, 0))
-        // https://spec.oneapi.io/level-zero/latest/sysman/PROG.html#tuning-workload-performance
-        // 'The default value is 50'
         , m_perf_factor(m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP), 0.5)
         , m_mock_save_ctl(save_control_test)
     {
@@ -568,6 +568,7 @@ namespace geopm
         register_signal_alias("GPU_CORE_FREQUENCY_MAX_CONTROL",
                               M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL");
 
+        // Used for control trimming and save/restore.  See man page for more info.
         register_signal_alias(M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR_CONTROL",
                               M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR");
 
@@ -1031,7 +1032,7 @@ namespace geopm
         else if(control_name == M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR_CONTROL") {
             m_levelzero_device_pool.performance_factor_control(domain_type, domain_idx,
                                                                geopm::LevelZero::M_DOMAIN_COMPUTE,
-                                                               setting*100);
+                                                               setting * 100);
         }
         else {
     #ifdef GEOPM_DEBUG

--- a/service/src/LevelZeroIOGroup.hpp
+++ b/service/src/LevelZeroIOGroup.hpp
@@ -122,6 +122,7 @@ namespace geopm
 
             //GEOPM Domain indexed
             std::vector<std::pair<double,double> > m_frequency_range;
+            std::vector<double> m_perf_factor;
 
             std::shared_ptr<SaveControl> m_mock_save_ctl;
     };

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -59,9 +59,9 @@ namespace geopm
                                       unsigned int l0_device_idx,
                                       int l0_domain,
                                       int l0_domain_idx) const override;
-            int performance_domain_count(int geopm_domain, unsigned int l0_device_idx,
+            int performance_domain_count(unsigned int l0_device_idx,
                                          int l0_domain) const override;
-            double performance_factor(int geopm_domain, unsigned int l0_device_idx,
+            double performance_factor(unsigned int l0_device_idx,
                                       int l0_domain, int l0_domain_idx) const override;
 
             int32_t power_limit_tdp(unsigned int l0_device_idx) const override;
@@ -72,8 +72,7 @@ namespace geopm
                                    int l0_domain_idx, double range_min,
                                    double range_max) const override;
 
-            void performance_factor_control(int geopm_domain,
-                                            unsigned int l0_device_idx,
+            void performance_factor_control(unsigned int l0_device_idx,
                                             int l0_domain,
                                             int l0_domain_idx,
                                             double setting) const override;

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -100,6 +100,7 @@ namespace geopm
                 std::vector<std::vector<zes_freq_handle_t> > freq_domain;
                 std::vector<std::vector<zes_engine_handle_t> > engine_domain;
                 mutable std::vector<std::vector<uint64_t> > cached_timestamp;
+
                 //uint32_t num_subdevice_perf_domain;
                 std::vector<std::vector<zes_perf_handle_t>> perf_domain;
 

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -61,6 +61,8 @@ namespace geopm
                                       int l0_domain_idx) const override;
             int perf_domain_count(int geopm_domain, unsigned int l0_device_idx,
                                   int l0_domain) const override;
+            double performance_factor(int geopm_domain, unsigned int l0_device_idx,
+                                      int l0_domain, int l0_domain_idx) const override;
 
             int32_t power_limit_tdp(unsigned int l0_device_idx) const override;
             int32_t power_limit_min(unsigned int l0_device_idx) const override;
@@ -70,7 +72,8 @@ namespace geopm
                                    int l0_domain_idx, double range_min,
                                    double range_max) const override;
 
-            void performance_factor_control(unsigned int l0_device_idx,
+            void performance_factor_control(int geopm_domain,
+                                            unsigned int l0_device_idx,
                                             int l0_domain,
                                             int l0_domain_idx,
                                             double setting) const override;

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -131,7 +131,10 @@ namespace geopm
             };
 
 
-            void domain_cache(unsigned int l0_device_idx);
+            void frequency_domain_cache(unsigned int l0_device_idx);
+            void power_domain_cache(unsigned int l0_device_idx);
+            void perf_domain_cache(unsigned int l0_device_idx);
+            void engine_domain_cache(unsigned int l0_device_idx);
             void check_ze_result(ze_result_t ze_result, int error, std::string message,
                                  int line) const;
 

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -61,6 +61,8 @@ namespace geopm
                                       int l0_domain_idx) const override;
             int perf_domain_count(int geopm_domain, unsigned int l0_device_idx,
                                   int l0_domain) const override;
+            int performance_domain_count(int geopm_domain, unsigned int l0_device_idx,
+                                         int l0_domain) const override;
             double performance_factor(int geopm_domain, unsigned int l0_device_idx,
                                       int l0_domain, int l0_domain_idx) const override;
 

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -59,8 +59,6 @@ namespace geopm
                                       unsigned int l0_device_idx,
                                       int l0_domain,
                                       int l0_domain_idx) const override;
-            int perf_domain_count(int geopm_domain, unsigned int l0_device_idx,
-                                  int l0_domain) const override;
             int performance_domain_count(int geopm_domain, unsigned int l0_device_idx,
                                          int l0_domain) const override;
             double performance_factor(int geopm_domain, unsigned int l0_device_idx,

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -123,8 +123,6 @@ namespace geopm
                 // Device/Package domains
                 uint32_t num_device_power_domain;
                 zes_pwr_handle_t power_domain;
-                //uint32_t num_device_perf_domain;
-                std::vector<zes_perf_handle_t> perf_domain;
                 mutable uint64_t cached_energy_timestamp;
             };
 

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -59,6 +59,9 @@ namespace geopm
                                       unsigned int l0_device_idx,
                                       int l0_domain,
                                       int l0_domain_idx) const override;
+            int perf_domain_count(int geopm_domain, unsigned int l0_device_idx,
+                                  int l0_domain) const override;
+
             int32_t power_limit_tdp(unsigned int l0_device_idx) const override;
             int32_t power_limit_min(unsigned int l0_device_idx) const override;
             int32_t power_limit_max(unsigned int l0_device_idx) const override;
@@ -66,6 +69,11 @@ namespace geopm
             void frequency_control(unsigned int l0_device_idx, int l0_domain,
                                    int l0_domain_idx, double range_min,
                                    double range_max) const override;
+
+            void performance_factor_control(unsigned int l0_device_idx,
+                                            int l0_domain,
+                                            int l0_domain_idx,
+                                            double setting) const override;
 
         private:
             struct m_frequency_s {
@@ -87,10 +95,13 @@ namespace geopm
                 std::vector<std::vector<zes_freq_handle_t> > freq_domain;
                 std::vector<std::vector<zes_engine_handle_t> > engine_domain;
                 mutable std::vector<std::vector<uint64_t> > cached_timestamp;
+                //uint32_t num_subdevice_perf_domain;
+                std::vector<std::vector<zes_perf_handle_t>> perf_domain;
 
                 uint32_t num_subdevice_power_domain;
                 std::vector<zes_pwr_handle_t> power_domain;
                 mutable std::vector<uint64_t> cached_energy_timestamp;
+
             };
 
             struct m_device_info_s {
@@ -108,6 +119,8 @@ namespace geopm
                 // Device/Package domains
                 uint32_t num_device_power_domain;
                 zes_pwr_handle_t power_domain;
+                //uint32_t num_device_perf_domain;
+                std::vector<zes_perf_handle_t> perf_domain;
                 mutable uint64_t cached_energy_timestamp;
             };
 

--- a/service/test/LevelZeroDevicePoolTest.cpp
+++ b/service/test/LevelZeroDevicePoolTest.cpp
@@ -76,13 +76,13 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
         EXPECT_CALL(*m_levelzero, performance_domain_count(dev_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(domain_count));
 
         for (int sub_idx = 0; sub_idx < num_subdevice_per_device; ++sub_idx) {
-            EXPECT_CALL(*m_levelzero, frequency_status(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset));
-            EXPECT_CALL(*m_levelzero, frequency_efficient(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*10));
-            EXPECT_CALL(*m_levelzero, frequency_min(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*20));
-            EXPECT_CALL(*m_levelzero, frequency_max(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*30));
+            EXPECT_CALL(*m_levelzero, frequency_status(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value + offset));
+            EXPECT_CALL(*m_levelzero, frequency_efficient(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value + offset + num_gpu_subdevice*10));
+            EXPECT_CALL(*m_levelzero, frequency_min(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value + offset + num_gpu_subdevice*20));
+            EXPECT_CALL(*m_levelzero, frequency_max(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value + offset + num_gpu_subdevice*30));
 
-            EXPECT_CALL(*m_levelzero, active_time(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*40));
-            EXPECT_CALL(*m_levelzero, active_time_timestamp(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*50));
+            EXPECT_CALL(*m_levelzero, active_time(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value + offset + num_gpu_subdevice*40));
+            EXPECT_CALL(*m_levelzero, active_time_timestamp(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value + offset + num_gpu_subdevice*50));
 
             EXPECT_CALL(*m_levelzero, performance_factor(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(perf_value_chip_compute[offset]));
             EXPECT_CALL(*m_levelzero, performance_factor(dev_idx, MockLevelZero::M_DOMAIN_MEMORY, sub_idx)).WillOnce(Return(perf_value_chip_mem[offset]));
@@ -92,25 +92,22 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
     LevelZeroDevicePoolImp m_device_pool(*m_levelzero);
 
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
-        EXPECT_EQ(value+sub_idx, m_device_pool.frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_EQ(value+sub_idx+num_gpu_subdevice*10, m_device_pool.frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_EQ(value+sub_idx+num_gpu_subdevice*20, m_device_pool.frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_EQ(value+sub_idx+num_gpu_subdevice*30, m_device_pool.frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ(value + sub_idx, m_device_pool.frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ(value + sub_idx + num_gpu_subdevice * 10, m_device_pool.frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ(value + sub_idx + num_gpu_subdevice * 20, m_device_pool.frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ(value + sub_idx + num_gpu_subdevice * 30, m_device_pool.frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
 
-        EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*40), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*50), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ((uint64_t)(value+sub_idx + num_gpu_subdevice * 40), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ((uint64_t)(value+sub_idx + num_gpu_subdevice * 50), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
 
-        EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*30), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*40), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-
-        EXPECT_NO_THROW(m_device_pool.frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, value, value));
+        EXPECT_EQ((uint64_t)(value + sub_idx + num_gpu_subdevice * 30), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ((uint64_t)(value + sub_idx + num_gpu_subdevice * 40), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
 
         EXPECT_NO_THROW(m_device_pool.frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, value, value));
 
         EXPECT_EQ(perf_value_chip_compute[sub_idx], m_device_pool.performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_EQ(perf_value_chip_mem[sub_idx], m_device_pool.performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
 
-        //TODO: Add SUBDEVICE perf factor calls
         EXPECT_NO_THROW(m_device_pool.performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0.5));
         EXPECT_NO_THROW(m_device_pool.performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY, 0.5));
     }
@@ -158,15 +155,15 @@ TEST_F(LevelZeroDevicePoolTest, domain_error)
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "Not supported on this hardware");
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.active_time_pair(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "Not supported on this hardware");
 
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.active_time(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the engine domain");
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the engine domain");
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.active_time_pair(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the engine domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.active_time(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for the engine domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for the engine domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.active_time_pair(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for the engine domain");
 
     //Energy & Power
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.energy_pair(GEOPM_DOMAIN_INVALID, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_INVALID)+" is not supported for the power domain");
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_tdp(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU_CHIP)+" is not supported for the power domain");
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_min(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU_CHIP)+" is not supported for the power domain");
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_max(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU_CHIP)+" is not supported for the power domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.energy_pair(GEOPM_DOMAIN_INVALID, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_INVALID) + " is not supported for the power domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_tdp(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU_CHIP) + " is not supported for the power domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_min(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU_CHIP) + " is not supported for the power domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_max(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU_CHIP) + " is not supported for the power domain");
 }
 
 TEST_F(LevelZeroDevicePoolTest, subdevice_range_check)
@@ -178,14 +175,14 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_range_check)
     EXPECT_CALL(*m_levelzero, num_gpu(GEOPM_DOMAIN_GPU_CHIP)).WillRepeatedly(Return(num_gpu_subdevice));
 
     LevelZeroDevicePoolImp m_device_pool(*m_levelzero);
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_status(GEOPM_DOMAIN_GPU_CHIP, num_gpu_subdevice, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "domain " +std::to_string(GEOPM_DOMAIN_GPU_CHIP)+ " idx "+std::to_string(num_gpu_subdevice)+" is out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_status(GEOPM_DOMAIN_GPU_CHIP, num_gpu_subdevice, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "domain "  + std::to_string(GEOPM_DOMAIN_GPU_CHIP) +  " idx " + std::to_string(num_gpu_subdevice) + " is out of range");
 }
 
 TEST_F(LevelZeroDevicePoolTest, device_range_check)
 {
     const int num_gpu = 4;
     LevelZeroDevicePoolImp m_device_pool(*m_levelzero);
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.energy(GEOPM_DOMAIN_GPU, num_gpu, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" idx "+std::to_string(num_gpu)+" is out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.energy(GEOPM_DOMAIN_GPU, num_gpu, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " idx " + std::to_string(num_gpu) + " is out of range");
 }
 
 TEST_F(LevelZeroDevicePoolTest, device_function_check)

--- a/service/test/LevelZeroDevicePoolTest.cpp
+++ b/service/test/LevelZeroDevicePoolTest.cpp
@@ -72,12 +72,12 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
     for (int dev_idx = 0; dev_idx < num_gpu; ++dev_idx) {
         EXPECT_CALL(*m_levelzero, frequency_domain_count(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
         EXPECT_CALL(*m_levelzero, engine_domain_count(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
-        EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_BOARD_ACCELERATOR, dev_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(domain_count));
+        EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(domain_count));
 
-        EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
-        EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_BOARD_ACCELERATOR_CHIP, dev_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(domain_count));
+        EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
+        EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(domain_count));
 
-        EXPECT_CALL(*m_levelzero, performance_factor(GEOPM_DOMAIN_BOARD_ACCELERATOR, dev_idx, MockLevelZero::M_DOMAIN_ALL, 0)).WillOnce(Return(perf_value_accel[dev_idx]));
+        EXPECT_CALL(*m_levelzero, performance_factor(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL, 0)).WillOnce(Return(perf_value_accel[dev_idx]));
 
         for (int sub_idx = 0; sub_idx < num_subdevice_per_device; ++sub_idx) {
             EXPECT_CALL(*m_levelzero, frequency_status(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset));
@@ -109,11 +109,17 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
         EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*40), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*50), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
 
+        EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*30), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*40), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+
+        EXPECT_NO_THROW(m_device_pool.frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, value, value));
+
         EXPECT_NO_THROW(m_device_pool.frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, value, value));
 
         EXPECT_EQ(perf_value_chip_compute[sub_idx], m_device_pool.performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_EQ(perf_value_chip_mem[sub_idx], m_device_pool.performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
 
+        //TODO: Add SUBDEVICE perf factor calls
         EXPECT_NO_THROW(m_device_pool.performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0.5));
         EXPECT_NO_THROW(m_device_pool.performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY, 0.5));
     }

--- a/service/test/LevelZeroDevicePoolTest.cpp
+++ b/service/test/LevelZeroDevicePoolTest.cpp
@@ -64,7 +64,6 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
     EXPECT_CALL(*m_levelzero, num_gpu(GEOPM_DOMAIN_GPU_CHIP)).WillRepeatedly(Return(num_gpu_subdevice));
 
     int value = 1500;
-    std::vector<double> perf_value_accel = {0.12, 0.23, 0.34, 0.77};
     std::vector<double> perf_value_chip_compute = {0.50, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57};
     std::vector<double> perf_value_chip_mem = {0.40, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47};
     int offset = 0;
@@ -72,12 +71,9 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
     for (int dev_idx = 0; dev_idx < num_gpu; ++dev_idx) {
         EXPECT_CALL(*m_levelzero, frequency_domain_count(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
         EXPECT_CALL(*m_levelzero, engine_domain_count(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
-        EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(domain_count));
 
         EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
         EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(domain_count));
-
-        EXPECT_CALL(*m_levelzero, performance_factor(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL, 0)).WillOnce(Return(perf_value_accel[dev_idx]));
 
         for (int sub_idx = 0; sub_idx < num_subdevice_per_device; ++sub_idx) {
             EXPECT_CALL(*m_levelzero, frequency_status(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset));
@@ -94,11 +90,6 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
         }
     }
     LevelZeroDevicePoolImp m_device_pool(*m_levelzero);
-
-    for (int dev_idx = 0; dev_idx < num_gpu; ++dev_idx) {
-        EXPECT_EQ(perf_value_accel[dev_idx], m_device_pool.performance_factor(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL));
-        EXPECT_NO_THROW(m_device_pool.performance_factor_control(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL, 0.5));
-    }
 
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         EXPECT_EQ(value+sub_idx, m_device_pool.frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));

--- a/service/test/LevelZeroDevicePoolTest.cpp
+++ b/service/test/LevelZeroDevicePoolTest.cpp
@@ -72,8 +72,8 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
         EXPECT_CALL(*m_levelzero, frequency_domain_count(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
         EXPECT_CALL(*m_levelzero, engine_domain_count(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
 
-        EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
-        EXPECT_CALL(*m_levelzero, performance_domain_count(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(domain_count));
+        EXPECT_CALL(*m_levelzero, performance_domain_count(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
+        EXPECT_CALL(*m_levelzero, performance_domain_count(dev_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(domain_count));
 
         for (int sub_idx = 0; sub_idx < num_subdevice_per_device; ++sub_idx) {
             EXPECT_CALL(*m_levelzero, frequency_status(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset));
@@ -84,8 +84,8 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
             EXPECT_CALL(*m_levelzero, active_time(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*40));
             EXPECT_CALL(*m_levelzero, active_time_timestamp(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*50));
 
-            EXPECT_CALL(*m_levelzero, performance_factor(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(perf_value_chip_compute[offset]));
-            EXPECT_CALL(*m_levelzero, performance_factor(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_MEMORY, sub_idx)).WillOnce(Return(perf_value_chip_mem[offset]));
+            EXPECT_CALL(*m_levelzero, performance_factor(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(perf_value_chip_compute[offset]));
+            EXPECT_CALL(*m_levelzero, performance_factor(dev_idx, MockLevelZero::M_DOMAIN_MEMORY, sub_idx)).WillOnce(Return(perf_value_chip_mem[offset]));
             ++offset;
         }
     }

--- a/service/test/LevelZeroDevicePoolTest.cpp
+++ b/service/test/LevelZeroDevicePoolTest.cpp
@@ -97,11 +97,8 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
         EXPECT_EQ(value + sub_idx + num_gpu_subdevice * 20, m_device_pool.frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_EQ(value + sub_idx + num_gpu_subdevice * 30, m_device_pool.frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
 
-        EXPECT_EQ((uint64_t)(value+sub_idx + num_gpu_subdevice * 40), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_EQ((uint64_t)(value+sub_idx + num_gpu_subdevice * 50), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-
-        EXPECT_EQ((uint64_t)(value + sub_idx + num_gpu_subdevice * 30), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_EQ((uint64_t)(value + sub_idx + num_gpu_subdevice * 40), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ((uint64_t)(value + sub_idx + num_gpu_subdevice * 40), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ((uint64_t)(value + sub_idx + num_gpu_subdevice * 50), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
 
         EXPECT_NO_THROW(m_device_pool.frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, value, value));
 
@@ -145,10 +142,10 @@ TEST_F(LevelZeroDevicePoolTest, domain_error)
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_min(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "Not supported on this hardware");
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_max(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "Not supported on this hardware");
 
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_status(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the frequency domain");
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_efficient(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the frequency domain");
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_min(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the frequency domain");
-    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_max(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the frequency domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_status(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for the frequency domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_efficient(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for the frequency domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_min(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for the frequency domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_max(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for the frequency domain");
 
     //Utilization
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "Not supported on this hardware");

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -177,12 +177,17 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
                     energy(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL));
         EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
                     energy_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL));
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
+                    performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(2);
 
         // control pruning expectations
         // GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL, and the restore_control() direct call.
         EXPECT_CALL(*m_device_pool,
                     frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE,
                                       0, 0)).Times(3);
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
+                    performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0));
+
     }
 
     // Expectations for signal pruning code in the constructor
@@ -798,6 +803,12 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
         // EXPECT_CALL(*m_device_pool,
         //             frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE,
         //                               0, 0)).Times(3);
+
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
+                    performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(2);
+
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
+                    performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0));
     }
 
     // Expectations for signal pruning code in the constructor

--- a/service/test/MockLevelZero.hpp
+++ b/service/test/MockLevelZero.hpp
@@ -44,10 +44,10 @@ class MockLevelZero : public geopm::LevelZero
 
         MOCK_METHOD(int, power_domain_count, (int, unsigned int, int),
                     (const, override));
-        MOCK_METHOD(int, performance_domain_count, (int, unsigned int, int),
+        MOCK_METHOD(int, performance_domain_count, (unsigned int, int),
                     (const, override));
         MOCK_METHOD(double, performance_factor,
-                    (int, unsigned int, int, int), (const, override));
+                    (unsigned int, int, int), (const, override));
         MOCK_METHOD((std::pair<uint64_t, uint64_t>), energy_pair,
                     (int, unsigned int, int), (const, override));
         MOCK_METHOD(uint64_t, energy,
@@ -64,7 +64,7 @@ class MockLevelZero : public geopm::LevelZero
         MOCK_METHOD(void, frequency_control,
                     (unsigned int, int, int, double, double), (const, override));
         MOCK_METHOD(void, performance_factor_control,
-                    (int, unsigned int, int, int, double), (const, override));
+                    (unsigned int, int, int, double), (const, override));
 };
 
 #endif

--- a/service/test/MockLevelZero.hpp
+++ b/service/test/MockLevelZero.hpp
@@ -44,6 +44,10 @@ class MockLevelZero : public geopm::LevelZero
 
         MOCK_METHOD(int, power_domain_count, (int, unsigned int, int),
                     (const, override));
+        MOCK_METHOD(int, performance_domain_count, (int, unsigned int, int),
+                    (const, override));
+        MOCK_METHOD(double, performance_factor,
+                    (int, unsigned int, int, int), (const, override));
         MOCK_METHOD((std::pair<uint64_t, uint64_t>), energy_pair,
                     (int, unsigned int, int), (const, override));
         MOCK_METHOD(uint64_t, energy,
@@ -59,6 +63,8 @@ class MockLevelZero : public geopm::LevelZero
 
         MOCK_METHOD(void, frequency_control,
                     (unsigned int, int, int, double, double), (const, override));
+        MOCK_METHOD(void, performance_factor_control,
+                    (int, unsigned int, int, int, double), (const, override));
 };
 
 #endif

--- a/service/test/MockLevelZeroDevicePool.hpp
+++ b/service/test/MockLevelZeroDevicePool.hpp
@@ -50,8 +50,13 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
         MOCK_METHOD(uint64_t, energy_timestamp,
                     (int, unsigned int, int), (const, override));
 
+        MOCK_METHOD(double, performance_factor,
+                    (int, unsigned int, int), (const, override));
+
         MOCK_METHOD(void, frequency_control,
                     (int, unsigned int, int, double, double),(const, override));
+        MOCK_METHOD(void, performance_factor_control,
+                    (int, unsigned int, int, double),(const, override));
 };
 
 #endif


### PR DESCRIPTION
- Relates to #2172 feature request from github issues
- Built on top of #2081 since it provides signals with similar Device/Chip split.   

Adds support for LevelZero sysman performance factor signals and controls.  
Feature documentation [here](https://spec.oneapi.io/level-zero/latest/sysman/PROG.html#performance-factor)

The high level is that this is a unitless value in Sysman from 0-100 that provides a tradeoff between the compute hardware and all other hardware.  100 favors compute, 0 favors support hardware.  

In the Level IO Group we support reading the associated signals and writing controls for:
- [x] The Chip Level Compute Domain

Items keeping this in draft:
- [x] Updates to MockLevelZero.hpp
- [x] Updates to LevelZeroDevicePoolTest.cpp 
- [x] Updates to LevelZeroIOGroupTest.cpp
- [x] Update signals and controls for save/restore - setconfig() may not be granted, so getconfig() may not contain the last value written as outlined [here](https://spec.oneapi.io/level-zero/latest/sysman/api.html#zesperformancefactorsetconfig)