### PR TITLE
Fix broken tutorial build

### DIFF
--- a/tutorial/tutorial_2.c
+++ b/tutorial/tutorial_2.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <mpi.h>
 #include <geopm_prof.h>
+#include <geopm_hint.h>
 
 #include "tutorial_region.h"
 

--- a/tutorial/tutorial_3.c
+++ b/tutorial/tutorial_3.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <mpi.h>
 #include <geopm_prof.h>
+#include <geopm_hint.h>
 
 #include "tutorial_region.h"
 

--- a/tutorial/tutorial_4.c
+++ b/tutorial/tutorial_4.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <mpi.h>
 #include <geopm_prof.h>
+#include <geopm_hint.h>
 
 #include "geopm_imbalancer.h"
 #include "tutorial_region.h"

--- a/tutorial/tutorial_region_prof.c
+++ b/tutorial/tutorial_region_prof.c
@@ -40,6 +40,7 @@
 #include <omp.h>
 #endif
 #include <geopm_prof.h>
+#include <geopm_hint.h>
 
 #include "tutorial_region.h"
 


### PR DESCRIPTION
The tutorials were inadvertently broken as a result of refactoring geopm.h
(due to enums being moved to different files).

Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>
- Fixes #2183 