### PR TITLE
Use the repo owner instead of the actor when pushing to OBS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,12 +150,12 @@ jobs:
     - name: set OSC credentials
       run: |
            echo -e "[general]\n\n[https://api.opensuse.org]\ncredentials_mgr_class=osc.credentials.ObfuscatedConfigFileCredentialsManager" > ~/.oscrc
-           echo "user = ${{ github.actor }}" >> ~/.oscrc
+           echo "user = ${{ github.repository_owner }}" >> ~/.oscrc
            echo "pass = ${{ secrets.OSC_CREDENTIALS }}" >> ~/.oscrc
            if [[ "${{ github.ref_name }}" == "release-v2.0-candidate" ]]; then
-               echo "OSC_PACKAGE=home:${{ github.actor }}:${{ github.ref_name }}/geopm-service" >> ${GITHUB_ENV}
+               echo "OSC_PACKAGE=home:${{ github.repository_owner }}:${{ github.ref_name }}/geopm-service" >> ${GITHUB_ENV}
            else
-               echo "OSC_PACKAGE=home:${{ github.actor }}/geopm-service" >> ${GITHUB_ENV}
+               echo "OSC_PACKAGE=home:${{ github.repository_owner }}/geopm-service" >> ${GITHUB_ENV}
            fi
     - name: publish
       working-directory: service


### PR DESCRIPTION
An error introduced in PR #2188 made it so that whomever submitted the PR would be the user that was used to push to OBS.  In this instance we want the 'geopm' user in all cases, which is captured in the `github.repository_owner` context.