### PR TITLE
When using cffi bindings, load versioned .so file

### DIFF
--- a/service/geopmdpy/gffi.py
+++ b/service/geopmdpy/gffi.py
@@ -76,13 +76,13 @@ def get_dl_geopmpolicy():
 
 # Enforce load order of libgeopmpolicy.so and libgeopmd.so
 try:
-    _dl_geopmpolicy = gffi.dlopen('libgeopmpolicy.so',
+    _dl_geopmpolicy = gffi.dlopen('libgeopmpolicy.so.0',
                                   gffi.RTLD_GLOBAL|gffi.RTLD_LAZY)
 except OSError as err:
     _dl_geopmpolicy = err
 
 try:
-    _dl_geopmd =  gffi.dlopen('libgeopmd.so',
+    _dl_geopmd =  gffi.dlopen('libgeopmd.so.0',
                               gffi.RTLD_GLOBAL|gffi.RTLD_LAZY)
 except OSError as err:
     _dl_geopmd = err


### PR DESCRIPTION
- The unversioned symlink is packaged as part of the
  geopm-service-devel package.
- The devel package is not intended to be a dependency of the
  python-geopmdpy package.
- Fixes #2191
