### PR TITLE
Addressed issue 2206 - mapping aliased levelzero derivative signals

### DIFF
--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -1018,8 +1018,7 @@ namespace geopm
             "\n    alias_for: " + signal_name;
 
         auto der_it = m_derivative_signal_map.find(signal_name);
-        if (der_it != m_derivative_signal_map.end())
-        {
+        if (der_it != m_derivative_signal_map.end()) {
             m_derivative_signal_map[alias_name] = der_it->second;
         }
     }

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -1010,11 +1010,18 @@ namespace geopm
             // skip adding an alias if underlying signal is not found
             return;
         }
+
         // copy signal info but append to description
         m_signal_available[alias_name] = it->second;
         m_signal_available[alias_name].m_description =
             m_signal_available[signal_name].m_description +
             "\n    alias_for: " + signal_name;
+
+        auto der_it = m_derivative_signal_map.find(signal_name);
+        if (der_it != m_derivative_signal_map.end())
+        {
+            m_derivative_signal_map[alias_name] = der_it->second;
+        }
     }
 
     void LevelZeroIOGroup::register_control_alias(const std::string &alias_name,

--- a/service/src/LevelZeroIOGroup.hpp
+++ b/service/src/LevelZeroIOGroup.hpp
@@ -141,7 +141,7 @@ namespace geopm
             std::vector<std::shared_ptr<Signal> > m_signal_pushed;
             std::vector<std::shared_ptr<control_s> > m_control_pushed;
             const std::set<std::string> m_special_signal_set;
-            const std::map<std::string, derivative_signal_info> m_derivative_signal_map;
+            std::map<std::string, derivative_signal_info> m_derivative_signal_map;
             std::set<int> m_derivative_signal_pushed_set;
 
             //GEOPM Domain indexed


### PR DESCRIPTION
Signed-off-by: lhlawson <lowren.h.lawson@intel.com>

- Relates to #2206 
- Fixes #2206 

Added code so any alias of a derivative signal is added to the derivative signals list.  This prevents the derivative signal from directly calling read() in the read_batch case.  

Tested using a geopmread_main.cpp modified to do repeated read_batch() calls (as described in #2206):
```
:~> ZES_ENABLE_SYSMAN=1 geopmread LEVELZERO::GPU_POWER board 0
time: 0 ms, result: nan
time: 0 ms, result: <number>
time: 0 ms, result: <number>
time: 0 ms, result: <number>

:~> ZES_ENABLE_SYSMAN=1 geopmread GPU_POWER board 0
time: 0 ms, result: nan
time: 0 ms, result: <number>
time: 0 ms, result: <number>
time: 0 ms, result: <number>
```