### PR TITLE
Get rid of imports from the __future__ module

### DIFF
--- a/integration/test/geopm_test_launcher.py
+++ b/integration/test/geopm_test_launcher.py
@@ -30,8 +30,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
-from __future__ import division
 
 import os
 import sys

--- a/integration/test/test_ee_timed_scaling_mix.py
+++ b/integration/test/test_ee_timed_scaling_mix.py
@@ -36,7 +36,6 @@
 
 """
 
-from __future__ import absolute_import
 
 import sys
 import re

--- a/integration/test/test_enforce_policy.py
+++ b/integration/test/test_enforce_policy.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import os
 import sys

--- a/integration/test/test_omp_outer_loop.py
+++ b/integration/test/test_omp_outer_loop.py
@@ -36,7 +36,6 @@
 
 """
 
-from __future__ import absolute_import
 
 import sys
 import re

--- a/integration/test/test_plugin_static_policy.py
+++ b/integration/test/test_plugin_static_policy.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import os
 import sys

--- a/integration/test/test_profile_policy.py
+++ b/integration/test/test_profile_policy.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import os
 import sys

--- a/integration/test/test_scaling_region.py
+++ b/integration/test/test_scaling_region.py
@@ -35,7 +35,6 @@
 
 """
 
-from __future__ import absolute_import
 
 import sys
 import re

--- a/integration/test/test_timed_scaling_region.py
+++ b/integration/test/test_timed_scaling_region.py
@@ -35,7 +35,6 @@
 
 """
 
-from __future__ import absolute_import
 
 import sys
 import re

--- a/integration/test/util.py
+++ b/integration/test/util.py
@@ -30,7 +30,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 from contextlib import contextmanager
 import os

--- a/integration/test_skipped/test_levelzero_signals.py
+++ b/integration/test_skipped/test_levelzero_signals.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import os
 import sys

--- a/scripts/geopmpy/__init__.py
+++ b/scripts/geopmpy/__init__.py
@@ -35,7 +35,6 @@ topo, agent, and version.
 
 """
 
-from __future__ import absolute_import
 import os
 
 __all__ = ['agent', 'error', 'hash', 'io', 'launcher',

--- a/scripts/geopmpy/agent.py
+++ b/scripts/geopmpy/agent.py
@@ -30,7 +30,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 from geopmdpy.gffi import gffi
 from geopmdpy.gffi import get_dl_geopmpolicy

--- a/scripts/geopmpy/hash.py
+++ b/scripts/geopmpy/hash.py
@@ -30,7 +30,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 from geopmdpy.gffi import gffi
 from geopmdpy.gffi import get_dl_geopmpolicy

--- a/scripts/geopmpy/io.py
+++ b/scripts/geopmpy/io.py
@@ -33,8 +33,6 @@
 GEOPM IO - Helper module for parsing/processing report and trace files.
 """
 
-from __future__ import absolute_import
-from __future__ import division
 
 from builtins import str
 from collections import OrderedDict

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -40,8 +40,6 @@ the geopmpy.launcher.main() function.  See the geopmlauncher(1) man
 page for details about the command line interface.
 """
 
-from __future__ import absolute_import
-from __future__ import division
 
 import sys
 import os

--- a/scripts/geopmpy/plotter.py
+++ b/scripts/geopmpy/plotter.py
@@ -33,8 +33,6 @@
 GEOPM Plotter - Used to produce plots and other analysis files from report and/or trace files.
 """
 
-from __future__ import absolute_import
-from __future__ import division
 
 from builtins import round
 import sys

--- a/scripts/geopmpy/policy_store.py
+++ b/scripts/geopmpy/policy_store.py
@@ -30,7 +30,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import math
 from geopmdpy.gffi import gffi

--- a/scripts/geopmpy/update_report.py
+++ b/scripts/geopmpy/update_report.py
@@ -30,7 +30,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 import sys
 import os
 import shutil

--- a/scripts/outlier/outlier_detection.py
+++ b/scripts/outlier/outlier_detection.py
@@ -32,8 +32,6 @@
 #
 
 # python 2 compatibility
-from __future__ import print_function
-from __future__ import division
 
 import math
 import numpy as np

--- a/scripts/outlier/outlier_detection.py
+++ b/scripts/outlier/outlier_detection.py
@@ -31,8 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-# python 2 compatibility
-
 import math
 import numpy as np
 import sys

--- a/scripts/test/TestAffinity.py
+++ b/scripts/test/TestAffinity.py
@@ -31,8 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
-from __future__ import division
 
 import unittest
 import math

--- a/scripts/test/TestAgent.py
+++ b/scripts/test/TestAgent.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import unittest
 import json

--- a/scripts/test/TestHash.py
+++ b/scripts/test/TestHash.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 
 import unittest

--- a/scripts/test/TestIO.py
+++ b/scripts/test/TestIO.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import unittest
 import os

--- a/scripts/test/TestLauncher.py
+++ b/scripts/test/TestLauncher.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import unittest
 import os

--- a/scripts/test/TestPolicyStore.py
+++ b/scripts/test/TestPolicyStore.py
@@ -34,11 +34,7 @@
 
 import unittest
 from unittest import mock
-try:
-    from importlib import reload
-except ImportError:
-    # reload is built-in in python 2, and is part of importlib in Python 3.4+
-    pass
+from importlib import reload
 
 mock_c = mock.MagicMock()
 import geopmpy.policy_store

--- a/scripts/test/TestPolicyStore.py
+++ b/scripts/test/TestPolicyStore.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import unittest
 from unittest import mock

--- a/scripts/test/TestPolicyStoreIntegration.py
+++ b/scripts/test/TestPolicyStoreIntegration.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import unittest
 import geopmpy.policy_store

--- a/service/geopmdpy/__init__.py
+++ b/service/geopmdpy/__init__.py
@@ -34,7 +34,6 @@
 
 """
 
-from __future__ import absolute_import
 import os
 
 try:

--- a/service/geopmdpy/__main__.py
+++ b/service/geopmdpy/__main__.py
@@ -29,7 +29,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 from dasbus.loop import EventLoop
 from dasbus.connection import SystemMessageBus
 from . import service

--- a/service/geopmdpy/access.py
+++ b/service/geopmdpy/access.py
@@ -33,7 +33,6 @@
 
 """
 
-from __future__ import absolute_import
 import sys
 import os
 from argparse import ArgumentParser

--- a/service/geopmdpy/dbus_xml.py
+++ b/service/geopmdpy/dbus_xml.py
@@ -30,7 +30,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 """The GEOPM DBus API enables a client to make measurements from the
 hardware platform and set hardware control parameters.  Fine grained

--- a/service/geopmdpy/error.py
+++ b/service/geopmdpy/error.py
@@ -30,7 +30,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import sys
 from . import gffi

--- a/service/geopmdpy/pio.py
+++ b/service/geopmdpy/pio.py
@@ -36,7 +36,6 @@ signals and writing controls from system components.
 
 """
 
-from __future__ import absolute_import
 
 from . import gffi
 from . import topo

--- a/service/geopmdpy/runtime.py
+++ b/service/geopmdpy/runtime.py
@@ -33,8 +33,6 @@
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
 import math
 import time
 import subprocess

--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -33,7 +33,6 @@
 """Module containing the implementations of the DBus interfaces
 exposed by geopmd."""
 
-from __future__ import absolute_import
 import os
 import sys
 import pwd

--- a/service/geopmdpy/session.py
+++ b/service/geopmdpy/session.py
@@ -33,8 +33,6 @@
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
 import sys
 import os
 import time

--- a/service/geopmdpy/topo.py
+++ b/service/geopmdpy/topo.py
@@ -30,7 +30,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 from . import gffi
 from . import error

--- a/service/geopmdpy_test/TestError.py
+++ b/service/geopmdpy_test/TestError.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import unittest
 from importlib import reload

--- a/service/geopmdpy_test/TestPIO.py
+++ b/service/geopmdpy_test/TestPIO.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import unittest
 import sys

--- a/service/geopmdpy_test/TestTopo.py
+++ b/service/geopmdpy_test/TestTopo.py
@@ -31,7 +31,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import absolute_import
 
 import unittest
 from importlib import reload

--- a/specs/geopm-gcc-mvapich2-toss.spec
+++ b/specs/geopm-gcc-mvapich2-toss.spec
@@ -36,7 +36,7 @@
 %define pname geopm
 %define PNAME GEOPM
 
-%define python_family python2
+%define python_family python3
 %define install_prefix %{install_parent_dir}/%{pname}/%{pname}-%{version}-%{compiler_name}-%{compiler_version}-%{mpi_name}-%{mpi_version}
 %define module_prefix %{module_parent_dir}/%{compiler_name}/%{compiler_version}/%{mpi_name}/%{mpi_version}/%{pname}
 %define module_name %{version}

--- a/specs/geopm-intel-mvapich2-toss.spec
+++ b/specs/geopm-intel-mvapich2-toss.spec
@@ -36,7 +36,7 @@
 %define pname geopm
 %define PNAME GEOPM
 
-%define python_family python2
+%define python_family python3
 %define install_prefix %{install_parent_dir}/%{pname}/%{pname}-%{version}-%{compiler_name}-%{compiler_version}-%{mpi_name}-%{mpi_version}
 %define module_prefix %{module_parent_dir}/%{compiler_name}/%{compiler_version}/%{mpi_name}/%{mpi_version}/%{pname}
 %define module_name %{version}

--- a/specs/geopm-theta.spec.in
+++ b/specs/geopm-theta.spec.in
@@ -43,7 +43,7 @@ CXXFLAGS='-xCORE-AVX2' \
 FCFLAGS='-dynamic -xCORE-AVX2' \
 FFLAGS='-dynamic -xCORE-AVX2' \
 ./configure --prefix=%{install_prefix} \
-            --with-python=%{__python2} \
+            --with-python=%{__python3} \
             || ( cat config.log && false )
 %{__make}
 


### PR DESCRIPTION
- These were added to enable backward compatibility
  with Python 2.0.
- GEOPM no longer supports python 2.0.
- Related to #1702

Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>