### PR TITLE
Make FIFO files more secure

### DIFF
--- a/service/README.rst
+++ b/service/README.rst
@@ -257,8 +257,8 @@ controls.  When the first call to ``read_batch()`` or
 ``write_batch()`` is made to user's PlatformIO object, the geopmd
 process forks the batch server process and no more updates can be made
 to the configured requests.  The batch server uses inter-process
-shared memory and FIFO special files in tmpfs to enable fast access to
-the configured stack of GEOPM signals and controls.
+shared memory and FIFO special files to enable fast access to the
+configured stack of GEOPM signals and controls.
 
 To implement the ``read_batch()`` method, the ServiceIOGroup writes a
 character to a FIFO to notify the batch server that it would like the

--- a/service/docs/source/security.rst
+++ b/service/docs/source/security.rst
@@ -472,11 +472,19 @@ When making directories, if the path already exists checks are
 performed to ensure: the path is a regular directory, the path is not
 a link, the path is accessible by the caller, the path is owned by the
 calling process UID/GID, and the permissions on the directory are set
-to 0o700 (i.e. rwx only for the owner). If the path is determined to
-be insecure, the existing path is renamed to indicate it is invalid
-and preserved for later auditing. In this case a new directory will be
-created at the specified path. If the path did not already exist, a
-new directory is created with 0o700 permissions.
+to the right permissions (chosen to be as restrictive as possible). If
+the path is determined to be insecure, the existing path is renamed to
+indicate it is invalid and preserved for later auditing. In this case
+a new directory will be created at the specified path. If the path did
+not already exist, a new directory is created with the proper
+permissions.
+
+By default, directories are created with 0o700 permissions (i.e. rwx
+only for the owner). Some directories, for example
+``/var/run/geopm-service``, also require execution permissions (i.e.
+0o711). For more details on how directories are created and default
+permissions, please see the `system_files.py <http://geopm.github.io/geopmdpy.7.html#module-geopmdpy.system_files>`__
+documentation
 
 When making files, a temporary file is first created with 0o600 or
 owner rw only permissions. The desired contents are then written to

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -140,6 +140,7 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestAccessLists.test__read_allowed_i
                  geopmdpy_test/pytest_links/TestActiveSessions.test_watch_id \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_pre_exists \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_default_creation \
+                 geopmdpy_test/pytest_links/TestSecureFiles.test_creation_with_perm \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_creation_link_not_dir \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_creation_file_not_dir \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_creation_bad_perms \

--- a/service/geopmdpy_test/TestAccessLists.py
+++ b/service/geopmdpy_test/TestAccessLists.py
@@ -132,7 +132,7 @@ default
             signal_file = os.path.join(test_dir, 'allowed_signals')
             control_file = os.path.join(test_dir, 'allowed_controls')
 
-            mock_smd.assert_called_once_with(test_dir)
+            mock_smd.assert_called_once_with(test_dir, perm_mode=0o700)
             calls = [mock.call(signal_file, 'power\n'),
                      mock.call(control_file, 'frequency\n')]
             mock_smf.assert_has_calls(calls)

--- a/service/geopmdpy_test/TestActiveSessions.py
+++ b/service/geopmdpy_test/TestActiveSessions.py
@@ -40,6 +40,9 @@ import json
 import tempfile
 from pathlib import Path
 
+from geopmdpy.system_files import ActiveSessions
+from geopmdpy.system_files import GEOPM_SERVICE_VAR_PATH_PERM
+
 with mock.patch('cffi.FFI.dlopen', return_value=mock.MagicMock()):
     from geopmdpy.system_files import ActiveSessions
 
@@ -169,7 +172,9 @@ class TestActiveSessions(unittest.TestCase):
              mock.patch('uuid.uuid4', return_value='uuid4'), \
              mock.patch('sys.stderr.write', return_value=None) as mock_err:
             act_sess = ActiveSessions(sess_path)
-            mock_smd.assert_called_once_with(sess_path)
+            mock_smd.assert_called_once_with(
+                sess_path,
+                perm_mode=GEOPM_SERVICE_VAR_PATH_PERM)
             mock_srf.assert_called_once_with(full_file_path)
 
             if is_valid:
@@ -254,7 +259,8 @@ class TestActiveSessions(unittest.TestCase):
              mock.patch('glob.glob', return_value=[full_file_path_1, full_file_path_2]), \
              mock.patch('geopmdpy.system_files.ActiveSessions._is_pid_valid', return_value=True) as mock_pid_valid:
             act_sess = ActiveSessions(sess_path)
-            mock_smd.assert_called_once_with(sess_path)
+            mock_smd.assert_called_once_with(sess_path,
+                                             GEOPM_SERVICE_VAR_PATH_PERM)
             calls = [mock.call(full_file_path_1, json.dumps(self.json_good_example)),
                      mock.call(full_file_path_2, json.dumps(self.json_good_example_2))]
             mock_smf.assert_has_calls(calls)
@@ -293,7 +299,8 @@ class TestActiveSessions(unittest.TestCase):
             #   Should this be moved into secure_write_file()?
 
             act_sess = ActiveSessions(sess_path)
-            mock_smd.assert_called_once_with(sess_path)
+            mock_smd.assert_called_once_with(sess_path,
+                                             GEOPM_SERVICE_VAR_PATH_PERM)
 
             act_sess.add_client(client_pid, signals, controls, watch_id)
             self.assertTrue(act_sess.is_client_active(client_pid))
@@ -325,7 +332,8 @@ class TestActiveSessions(unittest.TestCase):
         with mock.patch('geopmdpy.system_files.secure_make_dirs', autospec=True, specset=True) as mock_smd, \
              mock.patch('geopmdpy.system_files.secure_make_file', autospec=True, specset=True) as mock_smf:
             act_sess = ActiveSessions(sess_path)
-            mock_smd.assert_called_once_with(sess_path)
+            mock_smd.assert_called_once_with(sess_path,
+                                             GEOPM_SERVICE_VAR_PATH_PERM)
 
             # Add client BEFORE adding batch PID
             act_sess.add_client(client_pid, signals, controls, watch_id)
@@ -369,7 +377,8 @@ class TestActiveSessions(unittest.TestCase):
              mock.patch('glob.glob', return_value=[full_file_path]), \
              mock.patch('geopmdpy.system_files.ActiveSessions._is_pid_valid', return_value=True) as mock_pid_valid:
             act_sess = ActiveSessions(sess_path)
-            mock_smd.assert_called_once_with(sess_path)
+            mock_smd.assert_called_once_with(sess_path,
+                                             GEOPM_SERVICE_VAR_PATH_PERM)
             mock_srf.assert_called_once_with(full_file_path)
             mock_stat.assert_called_once_with(full_file_path)
 
@@ -412,7 +421,8 @@ class TestActiveSessions(unittest.TestCase):
              mock.patch('glob.glob', return_value=[full_file_path]), \
              mock.patch('geopmdpy.system_files.ActiveSessions._is_pid_valid', side_effect=[True, False]) as mock_pid_valid:
             act_sess = ActiveSessions(sess_path)
-            mock_smd.assert_called_once_with(sess_path)
+            mock_smd.assert_called_once_with(sess_path,
+                                             GEOPM_SERVICE_VAR_PATH_PERM)
             mock_srf.assert_called_once_with(full_file_path)
             mock_stat.assert_called_once_with(full_file_path)
 
@@ -430,7 +440,8 @@ class TestActiveSessions(unittest.TestCase):
         sess_path = f'{self._TEMP_DIR.name}/geopm-service'
         with mock.patch('geopmdpy.system_files.secure_make_dirs', autospec=True, specset=True) as mock_smd:
             act_sess = ActiveSessions(sess_path)
-            mock_smd.assert_called_once_with(sess_path)
+            mock_smd.assert_called_once_with(sess_path,
+                                             GEOPM_SERVICE_VAR_PATH_PERM)
         fake_pid = 321
 
         with mock.patch('psutil.Process', autospec=True, spec_set=True) as mock_process:
@@ -472,7 +483,8 @@ class TestActiveSessions(unittest.TestCase):
         with mock.patch('geopmdpy.system_files.secure_make_dirs', autospec=True, specset=True) as mock_smd, \
              mock.patch('geopmdpy.system_files.secure_make_file', autospec=True, specset=True) as mock_smf:
             act_sess = ActiveSessions(sess_path)
-            mock_smd.assert_called_once_with(sess_path)
+            mock_smd.assert_called_once_with(sess_path,
+                                             GEOPM_SERVICE_VAR_PATH_PERM)
 
             act_sess.add_client(client_pid, signals, controls, watch_id)
             calls = [mock.call(full_file_path, json.dumps(json_good_example))]

--- a/service/geopmdpy_test/TestSecureFiles.py
+++ b/service/geopmdpy_test/TestSecureFiles.py
@@ -57,16 +57,16 @@ class TestSecureFiles(unittest.TestCase):
         """
         self._TEMP_DIR.cleanup()
 
-    def check_dir_perms(self, path):
+    def check_dir_perms(self, path, perm_mode=0o700):
         """Assert that the path points to a file with mode 0o700
         Assert that the user and group have the right permissions.
 
         """
         st = os.stat(path)
-        perm_mode = stat.S_IMODE(st.st_mode)
+        set_perm_mode = stat.S_IMODE(st.st_mode)
         user_owner = st.st_uid
         group_owner = st.st_gid
-        self.assertEqual(0o700, perm_mode)
+        self.assertEqual(perm_mode, set_perm_mode)
         self.assertEqual(os.getuid(), user_owner)
         self.assertEqual(os.getgid(), group_owner)
 
@@ -105,6 +105,19 @@ class TestSecureFiles(unittest.TestCase):
         sess_path = f'{self._TEMP_DIR.name}/geopm-service'
         secure_make_dirs(sess_path)
         self.check_dir_perms(sess_path)
+
+    def test_creation_with_perm(self):
+        """Creation of geopm-service directory with permissions
+
+        Test calls secure_make_dirs() when the geopm-service
+        directory is not present and specifies the permissions
+        to set.
+
+        """
+        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        perm_mode = 0o711
+        secure_make_dirs(sess_path, perm_mode)
+        self.check_dir_perms(sess_path, perm_mode)
 
     def test_creation_link_not_dir(self):
         """The path specified is a link not a directory.

--- a/service/geopmdpy_test/TestWriteLock.py
+++ b/service/geopmdpy_test/TestWriteLock.py
@@ -36,6 +36,10 @@ import unittest
 from unittest import mock
 import tempfile
 
+from geopmdpy.system_files import WriteLock
+from geopmdpy.system_files import secure_make_dirs
+from geopmdpy.system_files import GEOPM_SERVICE_VAR_PATH_PERM
+
 with mock.patch('cffi.FFI.dlopen', return_value=mock.MagicMock()):
     from geopmdpy.system_files import WriteLock
 
@@ -49,6 +53,8 @@ class TestWriteLock(unittest.TestCase):
         self._sess_path = f'{self._TEMP_DIR.name}'
         self._orig_pid = 1234
         self._other_pid = 4321
+
+        secure_make_dirs(self._sess_path, GEOPM_SERVICE_VAR_PATH_PERM)
 
     def tearDown(self):
         """Clean up temporary directory

--- a/service/src/BatchStatus.cpp
+++ b/service/src/BatchStatus.cpp
@@ -53,20 +53,17 @@ namespace geopm
 
     std::unique_ptr<BatchStatus>
     BatchStatus::make_unique_server(int client_pid,
-                                    const std::string &server_key,
-                                    const std::string &fifo_prefix)
+                                    const std::string &server_key)
     {
         // calling the server constructor
-        return geopm::make_unique<BatchStatusServer>(client_pid, server_key,
-                                                     fifo_prefix);
+        return geopm::make_unique<BatchStatusServer>(client_pid, server_key);
     }
 
     std::unique_ptr<BatchStatus>
-    BatchStatus::make_unique_client(const std::string &server_key,
-                                    const std::string &fifo_prefix)
+    BatchStatus::make_unique_client(const std::string &server_key)
     {
         // calling the client constructor
-        return geopm::make_unique<BatchStatusClient>(server_key, fifo_prefix);
+        return geopm::make_unique<BatchStatusClient>(server_key);
     }
 
     /***********************************
@@ -121,6 +118,12 @@ namespace geopm
      **************************************/
 
     // The constructor which is called by the server.
+    BatchStatusServer::BatchStatusServer(int client_pid,
+                                         const std::string &server_key)
+        : BatchStatusServer(client_pid, server_key, M_DEFAULT_FIFO_PREFIX)
+    {
+    }
+
     BatchStatusServer::BatchStatusServer(int client_pid,
                                          const std::string &server_key,
                                          const std::string &fifo_prefix)
@@ -182,6 +185,11 @@ namespace geopm
      **************************************/
 
     // The constructor which is called by the client.
+    BatchStatusClient::BatchStatusClient(const std::string &server_key)
+        : BatchStatusClient(server_key, M_DEFAULT_FIFO_PREFIX)
+    {
+    }
+
     BatchStatusClient::BatchStatusClient(const std::string &server_key,
                                          const std::string &fifo_prefix)
         : BatchStatusImp(-1, -1)

--- a/service/src/BatchStatus.cpp
+++ b/service/src/BatchStatus.cpp
@@ -53,28 +53,30 @@ namespace geopm
 
     std::unique_ptr<BatchStatus>
     BatchStatus::make_unique_server(int client_pid,
-                                    const std::string &server_key)
+                                    const std::string &server_key,
+                                    const std::string &fifo_prefix)
     {
         // calling the server constructor
-        return geopm::make_unique<BatchStatusServer>(client_pid, server_key);
+        return geopm::make_unique<BatchStatusServer>(client_pid, server_key,
+                                                     fifo_prefix);
     }
 
     std::unique_ptr<BatchStatus>
-    BatchStatus::make_unique_client(const std::string &server_key)
+    BatchStatus::make_unique_client(const std::string &server_key,
+                                    const std::string &fifo_prefix)
     {
         // calling the client constructor
-        return geopm::make_unique<BatchStatusClient>(server_key);
+        return geopm::make_unique<BatchStatusClient>(server_key, fifo_prefix);
     }
 
     /***********************************
      * Members of class BatchStatusImp *
      ***********************************/
 
-    BatchStatusImp::BatchStatusImp(int m_read_fd, int m_write_fd)
-        : m_read_fd{m_read_fd}
-        , m_write_fd{m_write_fd}
+    BatchStatusImp::BatchStatusImp(int read_fd, int write_fd)
+        : m_read_fd{read_fd}
+        , m_write_fd{write_fd}
     {
-
     }
 
     void BatchStatusImp::send_message(char msg)
@@ -119,10 +121,12 @@ namespace geopm
      **************************************/
 
     // The constructor which is called by the server.
-    BatchStatusServer::BatchStatusServer(int client_pid, const std::string &server_key)
+    BatchStatusServer::BatchStatusServer(int client_pid,
+                                         const std::string &server_key,
+                                         const std::string &fifo_prefix)
         : BatchStatusImp(-1, -1)
-        , m_read_fifo_path(M_FIFO_PREFIX + server_key + "-in")
-        , m_write_fifo_path(M_FIFO_PREFIX + server_key + "-out")
+        , m_read_fifo_path(fifo_prefix + server_key + "-in")
+        , m_write_fifo_path(fifo_prefix + server_key + "-out")
     {
         // The server first creates the fifo in the file system.
         check_return(
@@ -178,10 +182,11 @@ namespace geopm
      **************************************/
 
     // The constructor which is called by the client.
-    BatchStatusClient::BatchStatusClient(const std::string &server_key)
-    : BatchStatusImp(-1, -1)
-    , m_read_fifo_path(std::string(M_FIFO_PREFIX) +  server_key + "-out")
-    , m_write_fifo_path(std::string(M_FIFO_PREFIX) + server_key + "-in" )
+    BatchStatusClient::BatchStatusClient(const std::string &server_key,
+                                         const std::string &fifo_prefix)
+        : BatchStatusImp(-1, -1)
+        , m_read_fifo_path(fifo_prefix +  server_key + "-out")
+        , m_write_fifo_path(fifo_prefix + server_key + "-in" )
     {
         // Assume that the server itself will make the fifo.
     }

--- a/service/src/BatchStatus.hpp
+++ b/service/src/BatchStatus.hpp
@@ -52,8 +52,13 @@ namespace geopm
 
             BatchStatus() = default;
             virtual ~BatchStatus() = default;
-            static std::unique_ptr<BatchStatus> make_unique_server(int client_pid, const std::string &server_key);
-            static std::unique_ptr<BatchStatus> make_unique_client(const std::string &server_key);
+            static std::unique_ptr<BatchStatus> make_unique_server(
+                int client_pid,
+                const std::string &server_key,
+                const std::string &fifo_prefix = M_DEFAULT_FIFO_PREFIX);
+            static std::unique_ptr<BatchStatus> make_unique_client(
+                const std::string &server_key,
+                const std::string &fifo_prefix = M_DEFAULT_FIFO_PREFIX);
 
             /// @brief Send an integer to the other process
             ///
@@ -75,13 +80,14 @@ namespace geopm
 
             // This is the single place where the server prefix is located,
             // which is also accessed by BatchStatusTest.
-            static constexpr const char* M_FIFO_PREFIX = "/tmp/geopm-service-batch-status-";
+            static constexpr const char* M_DEFAULT_FIFO_PREFIX =
+                "/var/run/geopm-service/geopm-service-batch-status-";
     };
 
     class BatchStatusImp : public BatchStatus
     {
         public:
-            BatchStatusImp(int m_read_fd, int m_write_fd);
+            BatchStatusImp(int read_fd, int write_fd);
             virtual ~BatchStatusImp() = default;
             void send_message(char msg) override;
             char receive_message(void) override;
@@ -100,7 +106,8 @@ namespace geopm
             ///
             /// The constructor which is called by the server.
             ///
-            BatchStatusServer(int other_pid, const std::string &server_key);
+            BatchStatusServer(int other_pid, const std::string &server_key,
+                              const std::string &fifo_prefix);
             virtual ~BatchStatusServer();
 
         private:
@@ -115,7 +122,8 @@ namespace geopm
             ///
             /// The constructor which is called by the client.
             ///
-            BatchStatusClient(const std::string &server_key);
+            BatchStatusClient(const std::string &server_key,
+                              const std::string &fifo_prefix);
             virtual ~BatchStatusClient();
 
         private:

--- a/service/src/BatchStatus.hpp
+++ b/service/src/BatchStatus.hpp
@@ -95,7 +95,7 @@ namespace geopm
             // This is the single place where the server prefix is located,
             // which is also accessed by BatchStatusTest.
             static constexpr const char* M_DEFAULT_FIFO_PREFIX =
-                "/var/run/geopm-service/geopm-service-batch-status-";
+                "/var/run/geopm-service/batch-status-";
     };
 
     class BatchStatusServer : public BatchStatusImp

--- a/service/src/BatchStatus.hpp
+++ b/service/src/BatchStatus.hpp
@@ -54,11 +54,9 @@ namespace geopm
             virtual ~BatchStatus() = default;
             static std::unique_ptr<BatchStatus> make_unique_server(
                 int client_pid,
-                const std::string &server_key,
-                const std::string &fifo_prefix = M_DEFAULT_FIFO_PREFIX);
+                const std::string &server_key);
             static std::unique_ptr<BatchStatus> make_unique_client(
-                const std::string &server_key,
-                const std::string &fifo_prefix = M_DEFAULT_FIFO_PREFIX);
+                const std::string &server_key);
 
             /// @brief Send an integer to the other process
             ///
@@ -77,11 +75,6 @@ namespace geopm
             /// @throw Exception if a message is received, but the
             ///        message does not match the expected_message.
             virtual void receive_message(char expect) = 0;
-
-            // This is the single place where the server prefix is located,
-            // which is also accessed by BatchStatusTest.
-            static constexpr const char* M_DEFAULT_FIFO_PREFIX =
-                "/var/run/geopm-service/geopm-service-batch-status-";
     };
 
     class BatchStatusImp : public BatchStatus
@@ -98,6 +91,11 @@ namespace geopm
             void check_return(int ret, const std::string &func_name);
             int m_read_fd;
             int m_write_fd;
+
+            // This is the single place where the server prefix is located,
+            // which is also accessed by BatchStatusTest.
+            static constexpr const char* M_DEFAULT_FIFO_PREFIX =
+                "/var/run/geopm-service/geopm-service-batch-status-";
     };
 
     class BatchStatusServer : public BatchStatusImp
@@ -106,6 +104,7 @@ namespace geopm
             ///
             /// The constructor which is called by the server.
             ///
+            BatchStatusServer(int other_pid, const std::string &server_key);
             BatchStatusServer(int other_pid, const std::string &server_key,
                               const std::string &fifo_prefix);
             virtual ~BatchStatusServer();
@@ -122,6 +121,7 @@ namespace geopm
             ///
             /// The constructor which is called by the client.
             ///
+            BatchStatusClient(const std::string &server_key);
             BatchStatusClient(const std::string &server_key,
                               const std::string &fifo_prefix);
             virtual ~BatchStatusClient();

--- a/service/test/BatchStatusTest.cpp
+++ b/service/test/BatchStatusTest.cpp
@@ -65,7 +65,7 @@ class BatchStatusTest : public ::testing::Test
 
 void BatchStatusTest::SetUp(void)
 {
-    m_server_prefix = "/tmp/geopm-service-batch-status-";
+    m_server_prefix = "/tmp/geopm-test-service-batch-status-";
     m_server_key = "test-key";
 
     // Explicitly force the fifo to be removed if it is already existing.


### PR DESCRIPTION
- FIFO files are now created in geopm's runtime directory to avoid
security vulnerabilities related to using the tmp directory
- Documentation and tests updated accordingly

Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>

- Relates to #2136 
- Fixes #2210

Move FIFO files to geopm's runtime directory to make them more secure.
