### PR TITLE
Add check for division by zero in `DerivativeSignal::compute_next()`

### DIFF
--- a/service/src/DerivativeSignal.cpp
+++ b/service/src/DerivativeSignal.cpp
@@ -97,9 +97,12 @@ namespace geopm
                 C += sig;
                 D += time * time;
             }
+
             double ssxx = D - B * B * E;
             double ssxy = A - B * C * E;
-            result = ssxy / ssxx;
+            if (ssxx != 0) {
+                result = ssxy / ssxx;
+            }
         }
         return result;
     }


### PR DESCRIPTION
Signed-off-by: Konstantin Rebrov <konstantin.rebrov@intel.com>

- Relates to #1583
- Fixes #1583

Add check for division by zero in `DerivativeSignal::compute_next()`
