### PR TITLE
Issue 1583

### DIFF
--- a/service/src/DerivativeSignal.cpp
+++ b/service/src/DerivativeSignal.cpp
@@ -97,9 +97,12 @@ namespace geopm
                 C += sig;
                 D += time * time;
             }
+
             double ssxx = D - B * B * E;
             double ssxy = A - B * C * E;
-            result = ssxy / ssxx;
+            if (ssxx != 0) {
+                result = ssxy / ssxx;
+            }
         }
         return result;
     }

--- a/service/src/msr_data_hsx.cpp
+++ b/service/src/msr_data_hsx.cpp
@@ -570,7 +570,7 @@ namespace geopm
         },
         "DRAM_ENERGY_STATUS": {
             "offset": "0x619",
-            "domain": "board_memory",
+            "domain": "package",
             "fields": {
                 "ENERGY": {
                     "begin_bit": 0,

--- a/service/src/msr_data_knl.cpp
+++ b/service/src/msr_data_knl.cpp
@@ -495,7 +495,7 @@ namespace geopm
         },
         "DRAM_ENERGY_STATUS": {
             "offset": "0x619",
-            "domain": "board_memory",
+            "domain": "package",
             "fields": {
                 "ENERGY": {
                     "begin_bit": 0,

--- a/service/src/msr_data_skx.cpp
+++ b/service/src/msr_data_skx.cpp
@@ -554,7 +554,7 @@ namespace geopm
         },
         "DRAM_ENERGY_STATUS": {
             "offset": "0x619",
-            "domain": "board_memory",
+            "domain": "package",
             "fields": {
                 "ENERGY": {
                     "begin_bit": 0,

--- a/service/src/msr_data_snb.cpp
+++ b/service/src/msr_data_snb.cpp
@@ -450,7 +450,7 @@ namespace geopm
         },
         "DRAM_ENERGY_STATUS": {
             "offset": "0x619",
-            "domain": "board_memory",
+            "domain": "package",
             "fields": {
                 "ENERGY": {
                     "begin_bit": 0,

--- a/service/test/MSRIOGroupTest.cpp
+++ b/service/test/MSRIOGroupTest.cpp
@@ -194,7 +194,7 @@ TEST_F(MSRIOGroupTest, valid_signal_domains)
 {
     // energy
     EXPECT_EQ(GEOPM_DOMAIN_PACKAGE, m_msrio_group->signal_domain_type("ENERGY_PACKAGE"));
-    EXPECT_EQ(GEOPM_DOMAIN_BOARD_MEMORY, m_msrio_group->signal_domain_type("ENERGY_DRAM"));
+    EXPECT_EQ(GEOPM_DOMAIN_PACKAGE, m_msrio_group->signal_domain_type("ENERGY_DRAM"));
 
     // counter
     EXPECT_EQ(GEOPM_DOMAIN_CPU, m_msrio_group->signal_domain_type("INSTRUCTIONS_RETIRED"));
@@ -221,7 +221,7 @@ TEST_F(MSRIOGroupTest, valid_signal_domains)
               m_msrio_group->signal_domain_type("POWER_PACKAGE_TDP"));
     EXPECT_EQ(GEOPM_DOMAIN_PACKAGE,
               m_msrio_group->signal_domain_type("POWER_PACKAGE"));
-    EXPECT_EQ(GEOPM_DOMAIN_BOARD_MEMORY,
+    EXPECT_EQ(GEOPM_DOMAIN_PACKAGE,
               m_msrio_group->signal_domain_type("POWER_DRAM"));
 }
 
@@ -494,7 +494,7 @@ TEST_F(MSRIOGroupTest, read_signal_energy)
 
     value = 3276799;  // 15uJ units
     EXPECT_CALL(*m_msrio, read_msr(0, dram_energy_offset)).WillOnce(Return(value));
-    result = m_msrio_group->read_signal("ENERGY_DRAM", GEOPM_DOMAIN_BOARD_MEMORY, 0);
+    result = m_msrio_group->read_signal("ENERGY_DRAM", GEOPM_DOMAIN_PACKAGE, 0);
     EXPECT_NEAR(50, result, 0.0001);
 }
 


### PR DESCRIPTION
- Relates to #1783
- Fixes #1783
- Fixes #1583
changed the domain of the `DRAM_ENERGY_STATUS` from `"board_memory"` to `"package"`.

Updated the respective tests