### PR TITLE
Sysman env removal as discussed in issue-2205

### DIFF
--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -52,8 +52,6 @@ namespace geopm
 
     LevelZeroImp::LevelZeroImp()
     {
-        setenv("ZES_ENABLE_SYSMAN", "1", 1);
-
         ze_result_t ze_result;
         //Initialize
         ze_result = zeInit(0);


### PR DESCRIPTION
Signed-off-by: Lowren Lawson <lowren.h.lawson@intel.com>

- Relates to #2205 
- Fixes #2205 

Removed the ZES_ENABLE_SYSMAN set in LevelZero.cpp.

This does not fully address #2205 as the issue calls for expanded documentation to describe what settings must be used.  
That information is covered in the sysman API spec here: https://spec.oneapi.io/level-zero/latest/sysman/PROG.html#environment-variables
