### PR TITLE
Make SharedMemory implementation more secure

### DIFF
--- a/service/docs/source/GEOPM_CXX_MAN_SharedMemory.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_SharedMemory.3.rst
@@ -58,8 +58,8 @@ DESCRIPTION
 The ``SharedMemory`` class encapsulates the creation and use of
 inter-process shared memory.  In the GEOPM runtime, shared memory is
 used to communicate between the user application's MPI calls and calls
-to `geopm_prof_c(3) <geopm_prof_c.3.html>`_ methods, and the Controller running on the same
-node.
+to `geopm_prof_c(3) <geopm_prof_c.3.html>`_ methods, and the Controller
+running on the same node.
 
 ``SharedMemory`` is a pure virtual abstract base class.
 

--- a/service/docs/source/security.rst
+++ b/service/docs/source/security.rst
@@ -171,9 +171,8 @@ this interface may enable the creation of a batch server. The access
 rights of this batch server are verified prior to its creation, and
 the user may then interact with this batch server through faster
 mechanisms than DBus provides. In particular, the user interfaces with
-the batch server over inter-process shared memory through the
-``/dev/shm`` device, and sends commands through FIFO special files in
-``/tmp``.
+the batch server over inter-process shared memory and FIFO special files,
+both of which are created in ``/var/run/geopm-service``.
 
 The DBus interface provides a layer of security that is leveraged
 throughout Linux services to verify the user identity of requests made

--- a/service/src/BatchClient.cpp
+++ b/service/src/BatchClient.cpp
@@ -60,13 +60,13 @@ namespace geopm
         : BatchClientImp(num_signal, num_control,
                          BatchStatus::make_unique_client(server_key),
                          num_signal == 0 ? nullptr :
-                         SharedMemory::make_unique_user(BatchServer::M_SHMEM_PREFIX +
-                                                        server_key + "-signal",
-                                                        timeout),
+                            SharedMemory::make_unique_user(
+                                BatchServer::get_signal_shmem_key(
+                                    server_key), timeout),
                          num_control == 0 ? nullptr :
-                         SharedMemory::make_unique_user(BatchServer::M_SHMEM_PREFIX +
-                                                        server_key + "-control",
-                                                        timeout))
+                            SharedMemory::make_unique_user(
+                                BatchServer::get_control_shmem_key(
+                                    server_key), timeout))
     {
 
     }

--- a/service/src/BatchServer.hpp
+++ b/service/src/BatchServer.hpp
@@ -77,8 +77,8 @@ namespace geopm
             /// for signals and one for controls.  The shm keys
             /// created will be of the form:
             ///
-            ///     "/geopm-service-batch-buffer-<KEY>-signals"
-            ///     "/geopm-service-batch-buffer-<KEY>-controls"
+            ///     "<prefix>/geopm-service-batch-buffer-<KEY>-signals"
+            ///     "<prefix>/geopm-service-batch-buffer-<KEY>-controls"
             ///
             /// where <KEY> is the "server_key".  This key is used by
             /// the client side with the
@@ -95,6 +95,14 @@ namespace geopm
             static std::unique_ptr<BatchServer> make_unique(int client_pid,
                                                             const std::vector<geopm_request_s> &signal_config,
                                                             const std::vector<geopm_request_s> &control_config);
+            /// @return The shm key to use for the signal shared memory
+            ///         region.
+            static std::string get_signal_shmem_key(
+                const std::string &server_key);
+            /// @return The shm key to use for the control shared memory
+            ///         region.
+            static std::string get_control_shmem_key(
+                const std::string &server_key);
             /// @return The Unix process ID of the server process
             ///        created.
             virtual int server_pid(void) const = 0;
@@ -111,7 +119,10 @@ namespace geopm
             virtual void stop_batch(void) = 0;
             /// @brief Returns true if the batch server is running
             virtual bool is_active(void) = 0;
-            static constexpr const char* M_SHMEM_PREFIX = "/geopm-service-batch-buffer-";
+
+        protected:
+            static constexpr const char* M_SHMEM_PREFIX =
+                "/var/run/geopm-service/geopm-service-batch-buffer-";
     };
 
     class BatchServerImp : public BatchServer
@@ -123,6 +134,8 @@ namespace geopm
             BatchServerImp(int client_pid,
                            const std::vector<geopm_request_s> &signal_config,
                            const std::vector<geopm_request_s> &control_config,
+                           const std::string &signal_shmem_key,
+                           const std::string &control_shmem_key,
                            PlatformIO &pio,
                            std::shared_ptr<BatchStatus> batch_status,
                            std::shared_ptr<POSIXSignal> posix_signal,
@@ -157,6 +170,8 @@ namespace geopm
             const std::string m_server_key;
             const std::vector<geopm_request_s> m_signal_config;
             const std::vector<geopm_request_s> m_control_config;
+            const std::string m_signal_shmem_key;
+            const std::string m_control_shmem_key;
             PlatformIO &m_pio;
             std::shared_ptr<SharedMemory> m_signal_shmem;
             std::shared_ptr<SharedMemory> m_control_shmem;

--- a/service/src/SharedMemory.cpp
+++ b/service/src/SharedMemory.cpp
@@ -51,6 +51,7 @@
 
 namespace geopm
 {
+
     /// @brief Size of the lock in memory.
     static constexpr size_t M_LOCK_SIZE = geopm::hardware_destructive_interference_size;
     static_assert(sizeof(pthread_mutex_t) <= M_LOCK_SIZE, "M_LOCK_SIZE not large enough for mutex type");
@@ -120,14 +121,20 @@ namespace geopm
         }
         m_shm_key = shm_key;
         m_size = size + M_LOCK_SIZE;
+        shm_func = make_shared_mem_func(shm_key);
 
         mode_t old_mask = umask(0);
         int shm_id = 0;
         if (is_secure) {
-            shm_id = shm_open(m_shm_key.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+            shm_id = shm_func.open(m_shm_key.c_str(),
+                                   O_RDWR | O_CREAT | O_EXCL,
+                                   S_IRUSR | S_IWUSR);
         }
         else {
-            shm_id = shm_open(m_shm_key.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+            shm_id = shm_func.open(m_shm_key.c_str(),
+                                   O_RDWR | O_CREAT | O_EXCL,
+                                   S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP |
+                                   S_IROTH | S_IWOTH);
         }
         if (shm_id < 0) {
             std::ostringstream ex_str;
@@ -137,7 +144,7 @@ namespace geopm
         int err = ftruncate(shm_id, m_size);
         if (err) {
             (void) close(shm_id);
-            (void) shm_unlink(m_shm_key.c_str());
+            (void) shm_func.unlink(m_shm_key.c_str());
             (void) umask(old_mask);
             std::ostringstream ex_str;
             ex_str << "SharedMemoryImp: Could not extend shared memory to size " << m_size;
@@ -146,7 +153,7 @@ namespace geopm
         m_ptr = mmap(NULL, m_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_id, 0);
         if (m_ptr == MAP_FAILED) {
             (void) close(shm_id);
-            (void) shm_unlink(m_shm_key.c_str());
+            (void) shm_func.unlink(m_shm_key.c_str());
             (void) umask(old_mask);
             throw Exception("SharedMemoryImp: Could not mmap shared memory region", errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
         }
@@ -179,7 +186,7 @@ namespace geopm
         // ProfileSampler destructor calls unlink, so don't throw if constructed
         // as owner
         if (m_is_linked) {
-            int err = shm_unlink(m_shm_key.c_str());
+            int err = shm_func.unlink(m_shm_key.c_str());
             if (err && m_do_unlink_check) {
                 std::ostringstream tmp_str;
                 tmp_str << "SharedMemoryImp::unlink() Call to shm_unlink(" << m_shm_key  << ") failed";
@@ -217,9 +224,10 @@ namespace geopm
         int shm_id = -1;
         struct stat stat_struct;
         int err = 0;
+        shm_func = make_shared_mem_func(shm_key);
 
         if (!timeout) {
-            shm_id = shm_open(shm_key.c_str(), O_RDWR, 0);
+            shm_id = shm_func.open(shm_key.c_str(), O_RDWR, 0);
             if (shm_id < 0) {
                 std::ostringstream ex_str;
                 ex_str << "SharedMemoryImp: Could not open shared memory with key \""  <<  shm_key << "\"";
@@ -244,7 +252,7 @@ namespace geopm
             struct geopm_time_s begin_time;
             geopm_time(&begin_time);
             while (shm_id < 0 && geopm_time_since(&begin_time) < (double)timeout) {
-                shm_id = shm_open(shm_key.c_str(), O_RDWR, 0);
+                shm_id = shm_func.open(shm_key.c_str(), O_RDWR, 0);
             }
             if (shm_id < 0) {
                 std::ostringstream ex_str;
@@ -282,7 +290,7 @@ namespace geopm
         int err = 0;
         int shm_id = -1;
         if (m_is_linked) {
-            shm_id = shm_open(m_shm_key.c_str(), O_RDWR, 0);
+            shm_id = shm_func.open(m_shm_key.c_str(), O_RDWR, 0);
         }
         else {
             throw Exception("SharedMemoryImp: Cannot chown shm that has been unlinked.", GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
@@ -307,5 +315,35 @@ namespace geopm
         if (err) {
             throw Exception("SharedMemoryImp: Could not close shared memory file", errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
         }
+    }
+
+    SharedMemoryImp::SharedMemFunc::SharedMemFunc(
+        std::function<int(const char *, int, mode_t)> open_fn,
+        std::function<int(const char *)> unlink_fn)
+        : open(open_fn),
+          unlink(unlink_fn)
+    {
+    }
+
+    SharedMemoryImp::SharedMemFunc SharedMemoryImp::make_shared_mem_func(
+        const std::string &key)
+    {
+        std::function<int(const char *, int, mode_t)> open_fn;
+        std::function<int(const char *name)> unlink_fn;
+        if (key.length() > 1) {
+            if (key[0] == '/' && key.find('/', 1) == std::string::npos) {
+                open_fn = &shm_open;
+                unlink_fn = &shm_unlink;
+            }
+            else {
+                open_fn = &open;
+                unlink_fn = &::unlink;
+            }
+        }
+        else {
+            open_fn = &open;
+            unlink_fn = &::unlink;
+        }
+        return SharedMemFunc(open_fn, unlink_fn);
     }
 }

--- a/service/src/SharedMemoryImp.hpp
+++ b/service/src/SharedMemoryImp.hpp
@@ -75,28 +75,16 @@ namespace geopm
             /// @param [in] uid User ID to become owner.
             /// @param [in] gid Group ID to become owner.
             void chown(const unsigned int uid, const unsigned int gid) override;
+
+        protected:
+            /// @brief Construct the file path to use for the provided key.
+            static std::string construct_shm_path(const std::string &key);
+
         private:
-            /// @brief Helper struct to track the key functions for the
-            ///        particular shared memory object implementation being
-            ///        used: shmem or file.
-            struct SharedMemFunc
-            {
-                SharedMemFunc() = default;
-                SharedMemFunc(
-                    std::function<int(const char *, int, mode_t)> open_fn,
-                    std::function<int(const char *)> unlink_fn);
-
-                std::function<int(const char *, int, mode_t)> open;
-                std::function<int(const char *)> unlink;
-            };
-
-            /// @brief Construct a SharedMemFunc object based on the type of
-            ///        shared memory key: shmem key or file path.
-            static SharedMemFunc make_shared_mem_func(
-                const std::string &key);
-            
             /// @brief Shared memory key for the region.
             std::string m_shm_key;
+            /// @brief file path for shared memory object.
+            std::string m_shm_path;
             /// @brief Size of the region.
             size_t m_size;
             /// @brief Pointer to the region.
@@ -108,8 +96,6 @@ namespace geopm
             ///        through make_unique_owner() may be unlinked in other
             ///        objects' destructors, and should not throw.
             bool m_do_unlink_check;
-
-            SharedMemFunc shm_func;
     };
 }
 

--- a/service/src/SharedMemoryImp.hpp
+++ b/service/src/SharedMemoryImp.hpp
@@ -37,7 +37,6 @@
 
 #include <pthread.h>
 
-#include <functional>
 
 namespace geopm
 {

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -63,6 +63,8 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/BatchServerTest.fork_and_terminate_parent \
               test/gtest_links/BatchServerTest.action_sigchld \
               test/gtest_links/BatchServerTest.action_sigchld_error \
+              test/gtest_links/BatchServerNameTest.signal_shmem_key \
+              test/gtest_links/BatchServerNameTest.control_shmem_key \
               test/gtest_links/BatchStatusTest.client_send_to_server_fifo_expect \
               test/gtest_links/BatchStatusTest.server_send_to_client_fifo_expect \
               test/gtest_links/BatchStatusTest.server_send_to_client_fifo \
@@ -319,14 +321,21 @@ GTEST_TESTS = test/gtest_links/AcceleratorTopoNullTest.default_config \
               test/gtest_links/ServiceProxyTest.platform_stop_batch \
               test/gtest_links/ServiceProxyTest.platform_read_signal \
               test/gtest_links/ServiceProxyTest.platform_write_control \
-              test/gtest_links/SharedMemoryTest.fd_check \
+              test/gtest_links/SharedMemoryTest.fd_check_shm \
+              test/gtest_links/SharedMemoryTest.fd_check_file \
               test/gtest_links/SharedMemoryTest.invalid_construction \
-              test/gtest_links/SharedMemoryTest.lock_shmem \
-              test/gtest_links/SharedMemoryTest.lock_shmem_u \
-              test/gtest_links/SharedMemoryTest.share_data \
-              test/gtest_links/SharedMemoryTest.share_data_ipc \
-              test/gtest_links/SharedMemoryTest.default_permissions \
-              test/gtest_links/SharedMemoryTest.secure_permissions \
+              test/gtest_links/SharedMemoryTest.lock_shmem_shm \
+              test/gtest_links/SharedMemoryTest.lock_shmem_file \
+              test/gtest_links/SharedMemoryTest.lock_shmem_u_shm \
+              test/gtest_links/SharedMemoryTest.lock_shmem_u_file \
+              test/gtest_links/SharedMemoryTest.share_data_shm \
+              test/gtest_links/SharedMemoryTest.share_data_file \
+              test/gtest_links/SharedMemoryTest.share_data_ipc_shm \
+              test/gtest_links/SharedMemoryTest.share_data_ipc_file \
+              test/gtest_links/SharedMemoryTest.default_permissions_shm \
+              test/gtest_links/SharedMemoryTest.default_permissions_file \
+              test/gtest_links/SharedMemoryTest.secure_permissions_shm \
+              test/gtest_links/SharedMemoryTest.secure_permissions_file \
               test/gtest_links/SSTControlTest.mailbox_adjust_batch \
               test/gtest_links/SSTControlTest.mmio_adjust_batch \
               test/gtest_links/SSTControlTest.save_restore_mmio \

--- a/service/test/SharedMemoryTest.cpp
+++ b/service/test/SharedMemoryTest.cpp
@@ -41,13 +41,15 @@
 #include "geopm_error.h"
 #include "geopm/Exception.hpp"
 #include "geopm/SharedMemory.hpp"
+#include "SharedMemoryImp.hpp"
 #include "geopm/Helper.hpp"
 #include "geopm_test.hpp"
 
 using geopm::SharedMemory;
+using geopm::SharedMemoryImp;
 using testing::Throw;
 
-class SharedMemoryTest : public ::testing::Test
+class SharedMemoryTest : public ::testing::Test, public SharedMemoryImp
 {
     protected:
         void SetUp();
@@ -130,13 +132,13 @@ void SharedMemoryTest::fd_check_test(const std::string &shm_key,
 
 TEST_F(SharedMemoryTest, fd_check_shm)
 {
-    std::string key_path = "/dev/shm" + m_key_shm;
+    std::string key_path = construct_shm_path(m_key_shm);
     fd_check_test(m_key_shm, key_path);
 }
 
 TEST_F(SharedMemoryTest, fd_check_file)
 {
-    std::string key_path = m_key_file;
+    std::string key_path = construct_shm_path(m_key_file);
     fd_check_test(m_key_file, key_path);
 }
 
@@ -341,13 +343,13 @@ void SharedMemoryTest::default_permissions_test(const std::string &shm_key,
 
 TEST_F(SharedMemoryTest, default_permissions_shm)
 {
-    std::string key_path = "/dev/shm" + m_key_shm;
+    std::string key_path = construct_shm_path(m_key_shm);
     default_permissions_test(m_key_shm, key_path);
 }
 
 TEST_F(SharedMemoryTest, default_permissions_file)
 {
-    std::string key_path = m_key_file;
+    std::string key_path = construct_shm_path(m_key_file);
     default_permissions_test(m_key_file, key_path);
 }
 
@@ -371,12 +373,12 @@ void SharedMemoryTest::secure_permissions_test(const std::string &shm_key,
 
 TEST_F(SharedMemoryTest, secure_permissions_shm)
 {
-    std::string key_path = "/dev/shm" + m_key_shm;
+    std::string key_path = construct_shm_path(m_key_shm);
     secure_permissions_test(m_key_shm, key_path);
 }
 
 TEST_F(SharedMemoryTest, secure_permissions_file)
 {
-    std::string key_path = m_key_file;
+    std::string key_path = construct_shm_path(m_key_file);
     secure_permissions_test(m_key_file, key_path);
 }

--- a/service/test/SharedMemoryTest.cpp
+++ b/service/test/SharedMemoryTest.cpp
@@ -47,23 +47,40 @@
 using geopm::SharedMemory;
 using testing::Throw;
 
-class SharedMemoryTest : public :: testing :: Test
+class SharedMemoryTest : public ::testing::Test
 {
     protected:
         void SetUp();
         void TearDown();
-        void config_shmem();
-        void config_shmem_s();
-        void config_shmem_u();
-        std::string m_shm_key;
+        void config_shmem(const std::string &shm_key);
+        void config_shmem_s(const std::string &shm_key);
+        void config_shmem_u(const std::string &shm_key);
+
+        void fd_check_test(const std::string &shm_key,
+                           const std::string &key_path);
+        void share_data_test(const std::string &shm_key);
+        void share_data_ipc_test(const std::string &shm_key);
+        void lock_shmem_test(const std::string &shm_key);
+        void lock_shmem_u_test(const std::string &shm_key);
+        void chown_test(const std::string &shm_key);
+        void default_permissions_test(const std::string &shm_key,
+                                      const std::string &key_path);
+        void secure_permissions_test(const std::string &shm_key,
+                                     const std::string &key_path);
+
         size_t m_size;
         std::unique_ptr<SharedMemory> m_shmem;
         std::unique_ptr<SharedMemory> m_shmem_u;
+
+        std::string m_key_shm;
+        std::string m_key_file;
 };
 
 void SharedMemoryTest::SetUp()
 {
-    m_shm_key = "/geopm-shm-foo-SharedMemoryTest-" + std::to_string(getpid());
+    m_key_shm = "/geopm-shm-foo-SharedMemoryTest-" + std::to_string(getpid());
+    m_key_file = "/tmp/geopm-shm-foo-SharedMemoryTest-" +
+                 std::to_string(getpid());
     m_size = sizeof(size_t);
     m_shmem = nullptr;
     m_shmem_u = nullptr;
@@ -76,53 +93,71 @@ void SharedMemoryTest::TearDown()
     }
 }
 
-void SharedMemoryTest::config_shmem()
+void SharedMemoryTest::config_shmem(const std::string &shm_key)
 {
-    m_shmem = SharedMemory::make_unique_owner(m_shm_key, m_size);
+    m_shmem = SharedMemory::make_unique_owner(shm_key, m_size);
 }
 
-void SharedMemoryTest::config_shmem_s()
+void SharedMemoryTest::config_shmem_s(const std::string &shm_key)
 {
-    m_shmem = SharedMemory::make_unique_owner_secure(m_shm_key, m_size);
+    m_shmem = SharedMemory::make_unique_owner_secure(shm_key, m_size);
 }
 
-void SharedMemoryTest::config_shmem_u()
+void SharedMemoryTest::config_shmem_u(const std::string &shm_key)
 {
-    m_shmem_u = SharedMemory::make_unique_user(m_shm_key, 1); // 1 second timeout
+    m_shmem_u = SharedMemory::make_unique_user(shm_key, 1); // 1 second timeout
 }
 
-TEST_F(SharedMemoryTest, fd_check)
+void SharedMemoryTest::fd_check_test(const std::string &shm_key,
+                                     const std::string &key_path)
 {
     struct stat buf;
-    std::string key_path("/dev/shm");
-    m_shm_key += "-fd_check";
-    key_path += m_shm_key;
+    std::string key = shm_key + "-fd_check";
+    std::string path = key_path + "-fd_check";
 
-    config_shmem();
+    config_shmem(key);
     sleep(5);
-    EXPECT_EQ(stat(key_path.c_str(), &buf), 0) << "Something (likely systemd) is removing shmem entries after creation.\n"
-                                               << "See https://superuser.com/a/1179962 for more information.";
-    config_shmem_u();
+    EXPECT_EQ(stat(path.c_str(), &buf), 0)
+        << "Something (likely systemd) is removing shmem entries after "
+           "creation.\n"
+        << "See https://superuser.com/a/1179962 for more information.";
+    config_shmem_u(key);
     ASSERT_NE(nullptr, m_shmem_u);
     m_shmem_u->unlink();
-    EXPECT_EQ(stat(key_path.c_str(), &buf), -1);
+    EXPECT_EQ(stat(path.c_str(), &buf), -1);
     EXPECT_EQ(errno, ENOENT);
+}
+
+TEST_F(SharedMemoryTest, fd_check_shm)
+{
+    std::string key_path = "/dev/shm" + m_key_shm;
+    fd_check_test(m_key_shm, key_path);
+}
+
+TEST_F(SharedMemoryTest, fd_check_file)
+{
+    std::string key_path = m_key_file;
+    fd_check_test(m_key_file, key_path);
 }
 
 TEST_F(SharedMemoryTest, invalid_construction)
 {
-    m_shm_key += "-invalid_construction";
-    EXPECT_THROW((SharedMemory::make_unique_owner(m_shm_key, 0)), geopm::Exception);  // invalid memory region size
-    EXPECT_THROW((SharedMemory::make_unique_user(m_shm_key, 1)), geopm::Exception);
-    EXPECT_THROW((SharedMemory::make_unique_owner("", m_size)), geopm::Exception);  // invalid key
-    EXPECT_THROW((SharedMemory::make_unique_user("", 1)), geopm::Exception);
+    std::string shm_key = m_key_shm + "-invalid_construction";
+    EXPECT_THROW((SharedMemory::make_unique_owner(shm_key, 0)),
+                 geopm::Exception);  // invalid memory region size
+    EXPECT_THROW((SharedMemory::make_unique_user(shm_key, 1)),
+                 geopm::Exception);
+    EXPECT_THROW((SharedMemory::make_unique_owner("", m_size)),
+                 geopm::Exception);  // invalid key
+    EXPECT_THROW((SharedMemory::make_unique_user("", 1)),
+                 geopm::Exception);
 }
 
-TEST_F(SharedMemoryTest, share_data)
+void SharedMemoryTest::share_data_test(const std::string &shm_key)
 {
-    m_shm_key += "-share_data";
-    config_shmem();
-    config_shmem_u();
+    std::string key = shm_key + "-share_data";
+    config_shmem(key);
+    config_shmem_u(key);
     size_t shared_data = 0xDEADBEEFCAFED00D;
     void *alias1 = m_shmem->pointer();
     void *alias2 = m_shmem_u->pointer();
@@ -131,37 +166,59 @@ TEST_F(SharedMemoryTest, share_data)
     EXPECT_EQ(memcmp(alias2, &shared_data, m_size), 0);
 }
 
-TEST_F(SharedMemoryTest, share_data_ipc)
+TEST_F(SharedMemoryTest, share_data_shm)
 {
-    m_shm_key += "-share_data_ipc";
+    share_data_test(m_key_shm);
+}
+
+TEST_F(SharedMemoryTest, share_data_file)
+{
+    share_data_test(m_key_file);
+}
+
+void SharedMemoryTest::share_data_ipc_test(const std::string &shm_key)
+{
+    std::string key = shm_key + "-share_data_ipc";
     size_t shared_data = 0xDEADBEEFCAFED00D;
 
     pid_t pid = fork();
     if (pid) {
         // parent process
-        config_shmem_u();
+        config_shmem_u(key);
         sleep(1);
         EXPECT_EQ(memcmp(m_shmem_u->pointer(), &shared_data, m_size), 0);
     } else {
         // child process
-        config_shmem();
+        config_shmem(key);
         memcpy(m_shmem->pointer(), &shared_data, m_size);
         sleep(2);
         exit(0);
     }
 }
 
-TEST_F(SharedMemoryTest, lock_shmem)
+TEST_F(SharedMemoryTest, share_data_ipc_shm)
 {
-    config_shmem();
-    config_shmem_u();
+    share_data_ipc_test(m_key_shm);
+}
+
+TEST_F(SharedMemoryTest, share_data_ipc_file)
+{
+    share_data_ipc_test(m_key_file);
+}
+
+void SharedMemoryTest::lock_shmem_test(const std::string &shm_key)
+{
+    std::string key = shm_key;
+    config_shmem(key);
+    config_shmem_u(key);
 
     // mutex is hidden at address before the user memory region
     // normally, this mutex should not be accessed directly.  This test
     // checks that get_scoped_lock() has the expected side effects on the
     // mutex.
-    pthread_mutex_t *mutex = (pthread_mutex_t*)((char*)m_shmem->pointer() -
-                                                geopm::hardware_destructive_interference_size);
+    pthread_mutex_t *mutex =
+        (pthread_mutex_t*)((char*)m_shmem->pointer() -
+                           geopm::hardware_destructive_interference_size);
 
     // mutex starts out lockable
     EXPECT_EQ(0, pthread_mutex_trylock(mutex));
@@ -181,17 +238,29 @@ TEST_F(SharedMemoryTest, lock_shmem)
     EXPECT_EQ(0, pthread_mutex_unlock(mutex));
 }
 
-TEST_F(SharedMemoryTest, lock_shmem_u)
+TEST_F(SharedMemoryTest, lock_shmem_shm)
 {
-    config_shmem();
-    config_shmem_u();
+    lock_shmem_test(m_key_shm);
+}
+
+TEST_F(SharedMemoryTest, lock_shmem_file)
+{
+    lock_shmem_test(m_key_file);
+}
+
+void SharedMemoryTest::lock_shmem_u_test(const std::string &shm_key)
+{
+    std::string key = shm_key;
+    config_shmem(key);
+    config_shmem_u(key);
 
     // mutex is hidden at address before the user memory region
     // normally, this mutex should not be accessed directly.  This test
     // checks that get_scoped_lock() has the expected side effects on the
     // mutex.
-    pthread_mutex_t *mutex = (pthread_mutex_t*)((char*)m_shmem_u->pointer() -
-                                                geopm::hardware_destructive_interference_size);
+    pthread_mutex_t *mutex =
+        (pthread_mutex_t*)((char*)m_shmem_u->pointer() -
+                           geopm::hardware_destructive_interference_size);
 
     // mutex starts out lockable
     EXPECT_EQ(0, pthread_mutex_trylock(mutex));
@@ -211,9 +280,20 @@ TEST_F(SharedMemoryTest, lock_shmem_u)
     EXPECT_EQ(0, pthread_mutex_unlock(mutex));
 }
 
-TEST_F(SharedMemoryTest, chown)
+TEST_F(SharedMemoryTest, lock_shmem_u_shm)
 {
-    config_shmem();
+    lock_shmem_u_test(m_key_shm);
+}
+
+TEST_F(SharedMemoryTest, lock_shmem_u_file)
+{
+    lock_shmem_u_test(m_key_file);
+}
+
+void SharedMemoryTest::chown_test(const std::string &shm_key)
+{
+    std::string key = shm_key;
+    config_shmem(key);
     uid_t uid = getuid();
     gid_t gid = getgid();
 
@@ -230,32 +310,73 @@ TEST_F(SharedMemoryTest, chown)
                                GEOPM_ERROR_RUNTIME, "unlinked");
 }
 
-TEST_F(SharedMemoryTest, default_permissions)
+TEST_F(SharedMemoryTest, chown_shm)
 {
-    int shm_id = -1;
+    chown_test(m_key_shm);
+}
+
+TEST_F(SharedMemoryTest, chown_file)
+{
+    chown_test(m_key_file);
+}
+
+void SharedMemoryTest::default_permissions_test(const std::string &shm_key,
+                                                const std::string &key_path)
+{
+    std::string key = shm_key;
+    int fd = -1;
     uint32_t permissions_bits = 0;
-    uint32_t expected_permissions = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+    uint32_t expected_permissions = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP |
+                                    S_IROTH | S_IWOTH;
     struct stat stat_struct;
 
-    config_shmem();
-    shm_id = shm_open(m_shm_key.c_str(), O_RDWR, 0);
-    fstat(shm_id, &stat_struct);
-    permissions_bits = stat_struct.st_mode & ~(S_IFMT); // Mask off type bits, save mode bits
+    config_shmem(key);
+    fd = open(key_path.c_str(), O_RDWR, 0);
+    fstat(fd, &stat_struct);
+    // Mask off type bits, save mode bits
+    permissions_bits = stat_struct.st_mode & ~(S_IFMT);
     EXPECT_EQ(expected_permissions, permissions_bits);
     m_shmem->unlink(); // Manually unlink unless config_shmem_u() is called
 }
 
-TEST_F(SharedMemoryTest, secure_permissions)
+TEST_F(SharedMemoryTest, default_permissions_shm)
 {
-    int shm_id = -1;
+    std::string key_path = "/dev/shm" + m_key_shm;
+    default_permissions_test(m_key_shm, key_path);
+}
+
+TEST_F(SharedMemoryTest, default_permissions_file)
+{
+    std::string key_path = m_key_file;
+    default_permissions_test(m_key_file, key_path);
+}
+
+void SharedMemoryTest::secure_permissions_test(const std::string &shm_key,
+                                               const std::string &key_path)
+{
+    std::string key = shm_key;
+    int fd = -1;
     uint32_t permissions_bits = 0;
     uint32_t expected_permissions = S_IRUSR | S_IWUSR;
     struct stat stat_struct;
 
-    config_shmem_s();
-    shm_id = shm_open(m_shm_key.c_str(), O_RDWR, 0);
-    fstat(shm_id, &stat_struct);
-    permissions_bits = stat_struct.st_mode & ~(S_IFMT); // Mask off type bits, save mode bits
+    config_shmem_s(key);
+    fd = open(key_path.c_str(), O_RDWR, 0);
+    fstat(fd, &stat_struct);
+    // Mask off type bits, save mode bits
+    permissions_bits = stat_struct.st_mode & ~(S_IFMT);
     EXPECT_EQ(expected_permissions, permissions_bits);
     m_shmem->unlink(); // Manually unlink unless config_shmem_u() is called
+}
+
+TEST_F(SharedMemoryTest, secure_permissions_shm)
+{
+    std::string key_path = "/dev/shm" + m_key_shm;
+    secure_permissions_test(m_key_shm, key_path);
+}
+
+TEST_F(SharedMemoryTest, secure_permissions_file)
+{
+    std::string key_path = m_key_file;
+    secure_permissions_test(m_key_file, key_path);
 }


### PR DESCRIPTION
- Extended SharedMemory implementation to allow using files
- BatchServer and BatchClient now create their SharedMemory objects
  in a more secure location (/var/run/geopm-service)
- Updated documentation accordingly

Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>

- Relates to #2218
- Fixes #2248