### PR TITLE
Enable reference counting for multiple nested open sessions

### DIFF
--- a/service/geopmdpy/dbus_xml.py
+++ b/service/geopmdpy/dbus_xml.py
@@ -242,15 +242,15 @@ def geopm_dbus_xml(TopoService=None, PlatformService=None):
     <method name="PlatformCloseSessionAdmin">
       <arg direction="in" name="client_pid" type="i">
         <doc:doc>
-          <doc:summary>{PlatformCloseSession_params0_description}
+          <doc:summary>{PlatformCloseSessionAdmin_params0_description}
           </doc:summary>
         </doc:doc>
       </arg>
       <doc:doc>
         <doc:description>
-          <doc:summary>{PlatformCloseSession_short_description}
+          <doc:summary>{PlatformCloseSessionAdmin_short_description}
           </doc:summary>
-          <doc:para>{PlatformCloseSession_long_description}
+          <doc:para>{PlatformCloseSessionAdmin_long_description}
           </doc:para>
         </doc:description>
       </doc:doc>
@@ -382,6 +382,7 @@ def geopm_dbus_xml(TopoService=None, PlatformService=None):
         PlatformUnlockControl = google.parse(PlatformService.unlock_control.__doc__)
         PlatformOpenSession = google.parse(PlatformService.open_session.__doc__)
         PlatformCloseSession = google.parse(PlatformService.close_session.__doc__)
+        PlatformCloseSessionAdmin = google.parse(PlatformService.close_session_admin.__doc__)
         PlatformStartBatch = google.parse(PlatformService.start_batch.__doc__)
         PlatformStopBatch = google.parse(PlatformService.stop_batch.__doc__)
         PlatformReadSignal = google.parse(PlatformService.read_signal.__doc__)
@@ -423,6 +424,9 @@ def geopm_dbus_xml(TopoService=None, PlatformService=None):
             PlatformCloseSession_params0_description=PlatformCloseSession.params[0].description,
             PlatformCloseSession_short_description=PlatformCloseSession.short_description,
             PlatformCloseSession_long_description=PlatformCloseSession.long_description,
+            PlatformCloseSessionAdmin_params0_description=PlatformCloseSessionAdmin.params[0].description,
+            PlatformCloseSessionAdmin_short_description=PlatformCloseSessionAdmin.short_description,
+            PlatformCloseSessionAdmin_long_description=PlatformCloseSessionAdmin.long_description,
             PlatformStartBatch_params0_description=PlatformStartBatch.params[1].description,
             PlatformStartBatch_params1_description=PlatformStartBatch.params[2].description,
             PlatformStartBatch_returns_description=PlatformStartBatch.returns.description,

--- a/service/geopmdpy/dbus_xml.py
+++ b/service/geopmdpy/dbus_xml.py
@@ -40,8 +40,9 @@ _module_doc=__doc__
 try:
     from docstring_parser import google
     _use_docstring_parser = True
-except ImportError:
+except ImportError as ex:
     _use_docstring_parser = False
+    _use_docstring_parser_err = str(ex)
 
 def geopm_dbus_xml(TopoService=None, PlatformService=None):
     do_parse_docs = _use_docstring_parser
@@ -470,6 +471,9 @@ def _remove_doc(xml_str):
 
 if __name__ == '__main__':
     from . import service
+
+    if not _use_docstring_parser:
+        raise ImportError(f'{_use_docstring_parser_err}: The docstring_parser python package is required to use CLI')
 
     print("""<!DOCTYPE node PUBLIC
     "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"

--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -358,12 +358,9 @@ class PlatformService(object):
                               the session.
 
         """
-        # if the connection already exists
         if self._active_sessions.is_client_active(client_pid):
             self._active_sessions.increment_reference_count(client_pid)
         else:
-            # Establish the connection and add an active session with
-            # the initial reference count of 1.
             signals, controls = self.get_user_access(user)
             watch_id = self._watch_client(client_pid)
             self._active_sessions.add_client(client_pid, signals, controls, watch_id)
@@ -399,21 +396,14 @@ class PlatformService(object):
         """
         self._active_sessions.check_client_active(client_pid, 'PlatformCloseSession')
         reference_count = self._active_sessions.get_reference_count(client_pid)
-        # A negative reference_count is impossible because this condition
-        # is enforced by the _session_schema.
         if reference_count == 0:
-            # this is the case that the geopm daemon was killed while
-            # that in the process of _close_Session_completely so we
-            # need to call _close_Session_completely() again. The
-            # daemon died, was restarted, and found a session with
+            # The daemon died, restarted, and found a session with
             # zero reference count.
             self._close_session_completely(client_pid)
         elif reference_count == 1:
-            # last reference, close the session completely
             self._active_sessions.decrement_reference_count(client_pid)
             self._close_session_completely(client_pid)
         else:  # reference_count > 1:
-            # more than one reference, decrement the reference count
             self._active_sessions.decrement_reference_count(client_pid)
 
     def close_session_admin(self, client_pid):

--- a/service/geopmdpy/system_files.py
+++ b/service/geopmdpy/system_files.py
@@ -591,7 +591,7 @@ class ActiveSessions(object):
             client_pid (int): Linux PID that opened the session
 
         Returns:
-            int: GLib watch ID to track the session lifetime
+            int: The reference count
 
         Raises:
             RuntimeError: Client does not have an open session

--- a/service/io.github.geopm.xml
+++ b/service/io.github.geopm.xml
@@ -291,7 +291,7 @@ enabled when this method is called.
     <method name="PlatformOpenSession">
      <doc:doc>
         <doc:description>
-          <doc:summary>Open a new session session for the client thread.
+          <doc:summary>Open a new session for the client thread.
           </doc:summary>
           <doc:para>The creation of a session is the first step that a client
 thread makes to interact with the GEOPM service.  Each Linux
@@ -301,8 +301,28 @@ passing the client PID to the close_session() method.  The
 session will also be ended if the client thread terminates for
 any reason.
 
-No action is taken and no error is raised if there is an existing
-session associated with the client PID.
+This method supports creating multiple nested open sessions.
+After creating a session a new session can be created on top of it.
+
+There is however a one to one mapping between client pid and open sessions,
+and we couple the lifetime of our session to the lifetime of the connection.
+A single client pid can have only one single connection, but this single
+connection can be shared among multiple independent components.
+The reference count keeps track of the number of open sessions,
+or the number of independent components that are using the same connection.
+
+So open_session() is like a singleton.
+The first time you call this method, it creates a new connection.
+Any subsequent calls to open_session() will just reuse the existing connection,
+they will just increment the reference count of the session.
+This is because generator prevents to add the same client pid twice.
+
+So incrementing the reference count is basically just an abstraction for the client.
+The client itself cannot have more than a single open connection at once,
+so when requesting a new session, other than incrementing the counter,
+nothing else happens. The reference count can be thought of as a shared pointers
+abstraction, because the connection is a kind of shared resource among
+the multiple different independent components that a client can have.
 
 All sessions are opened in read-mode, and may later be
 promoted to write-mode.  This promotion will occur with the
@@ -330,22 +350,28 @@ method to alter the policy will not affect active sessions.
         <doc:description>
           <doc:summary>Close an active session for the client process.
           </doc:summary>
-          <doc:para>After closing a session, the client process is required to
-call open_session() again before using any of the client-facing
-member functions.
+          <doc:para>This method takes into account multiple nested open sessions,
+meaning that it checks the reference count.
+If the reference count is zero, the session is closed already.
+If the reference count is one, then we really close the session,
+so close_session_admin() gets called.
+And if the reference count is more than one, then it means that there are
+multiple independent components attached to the singleton session,
+so we would just decrement the reference count to consider the
+independent component that just detached from the session.
 
-Closing an active session will remove the record of which
-signals and controls the client process has access to; thus,
-this record is updated to reflect changes to the policy when the
-next session is opened by the process.
+We have a process that is contingent based on the client_pid being alive of not.
+When the pid disappears, the connection itself disappears, and we need to
+clean up all the resources. The lifetime of our session is coupled to the
+lifetime of the connection.
 
-When closing a write-mode session, the control values that were
-recorded when the session was promoted to write-mode are restored.
-
-This method supports both the client and administrative DBus
-interfaces that are used to close a session.  The client DBus
-interface only allows users to close sessions that were created
-with their user ID.
+There are two possibilities of how the session can end:
+- all independent components in the process volunarily close their connections,
+  using close_session(), while the process is still alive.
+- involuntary crash of the process, the process dies,
+  the connection is closed automatically by the check_client(),
+  in which case close_session() is obviously not called by the client,
+  because there is no client to call.
 
 A RuntimeError is raised if the client_pid does not have an
 open session.
@@ -362,9 +388,11 @@ open session.
       </arg>
       <doc:doc>
         <doc:description>
-          <doc:summary>Close an active session for the client process.
+          <doc:summary>Close an active session for the client process completely.
           </doc:summary>
-          <doc:para>After closing a session, the client process is required to
+          <doc:para>This function is normally used by the admin.
+
+After closing a session, the client process is required to
 call open_session() again before using any of the client-facing
 member functions.
 
@@ -380,6 +408,9 @@ This method supports both the client and administrative DBus
 interfaces that are used to close a session.  The client DBus
 interface only allows users to close sessions that were created
 with their user ID.
+
+This method is called internally by close_session() and it is
+also called explicitly by check_client() when the process dies.
 
 A RuntimeError is raised if the client_pid does not have an
 open session.

--- a/service/io.github.geopm.xml
+++ b/service/io.github.geopm.xml
@@ -36,8 +36,7 @@ with CPUs.
     <method name="PlatformGetGroupAccess">
       <arg direction="in" name="group" type="s">
         <doc:doc>
-          <doc:summary>Unix group name to query. The default allowed
-lists are returned if group is the empty string.
+          <doc:summary>Name of group
           </doc:summary>
         </doc:doc>
       </arg>
@@ -49,16 +48,18 @@ lists are returned if group is the empty string.
       </arg>
       <doc:doc>
         <doc:description>
-          <doc:summary>Get the signals and controls in the allowed lists.
+          <doc:summary>Get the signal and control access lists
           </doc:summary>
-          <doc:para>Provides the default allowed lists or the allowed lists for a
-particular Unix group.  These lists correspond to values
-stored in the GEOPM service configuration files.  The
-configuration files are read with each call to this method.
-If no files exist that match the query, empty lists are
-returned.  Empty lines and lines that begin with the '#'
-character are ignored.  If the group name is not valid on the
-system a RuntimeError is raised.
+          <doc:para>Read the list of allowed signals and controls for the
+specified group.  If the group is None or the empty string
+then the default lists of allowed signals and controls are
+returned.
+
+The values are securely read from files located in
+/etc/geopm-service using the secure_read_file() interface.
+
+If no secure file exist for the specified group, then two
+empty lists are returned.
           </doc:para>
         </doc:description>
       </doc:doc>
@@ -66,9 +67,7 @@ system a RuntimeError is raised.
     <method name="PlatformSetGroupAccess">
       <arg direction="in" name="group" type="s">
         <doc:doc>
-          <doc:summary>Which Unix group name to query; if this is
-the empty string, the default allowed
-lists are written.
+          <doc:summary>Name of group
           </doc:summary>
         </doc:doc>
       </arg>
@@ -86,16 +85,18 @@ lists are written.
       </arg>
       <doc:doc>
         <doc:description>
-          <doc:summary>Get the signals and controls in the allowed lists.
+          <doc:summary>Get the signal and control access lists
           </doc:summary>
-          <doc:para>Provides the default allowed lists or the allowed lists for a
-particular Unix group.  These lists correspond to values
-stored in the GEOPM service configuration files.  The
-configuration files are read with each call to this method.
-If no files exist that match the query, empty lists are
-returned.  Empty lines and lines that begin with the '#'
-character are ignored.  If the group name is not valid on the
-system a RuntimeError is raised.
+          <doc:para>Read the list of allowed signals and controls for the
+specified group.  If the group is None or the empty string
+then the default lists of allowed signals and controls are
+returned.
+
+The values are securely read from files located in
+/etc/geopm-service using the secure_read_file() interface.
+
+If no secure file exist for the specified group, then two
+empty lists are returned.
           </doc:para>
         </doc:description>
       </doc:doc>
@@ -290,7 +291,7 @@ enabled when this method is called.
     <method name="PlatformOpenSession">
      <doc:doc>
         <doc:description>
-          <doc:summary>Open a new session session for the client process.
+          <doc:summary>Open a new session session for the client thread.
           </doc:summary>
           <doc:para>The creation of a session is the first step that a client
 thread makes to interact with the GEOPM service.  Each Linux
@@ -409,7 +410,7 @@ signal_name (str): The name of the signal to read.
 domain_idx (int): Specifies the particular domain
                   index to write to.
 
-signal_name (str): The name of the signal to read.
+control_name (str): The name of the control to write.
           </doc:summary>
         </doc:doc>
       </arg>

--- a/service/io.github.geopm.xml
+++ b/service/io.github.geopm.xml
@@ -301,28 +301,17 @@ passing the client PID to the close_session() method.  The
 session will also be ended if the client thread terminates for
 any reason.
 
-This method supports creating multiple nested open sessions.
-After creating a session a new session can be created on top of it.
+The client PID may attempt to open a new session multiple
+times.  In this case a reference count records the number of
+calls to open the session by the client PID.  Each call to
+open a session is expected to be paired with a call to close
+the session.  When the reference count falls to zero, all
+resources associated with the session are released.
 
-There is however a one to one mapping between client pid and open sessions,
-and we couple the lifetime of our session to the lifetime of the connection.
-A single client pid can have only one single connection, but this single
-connection can be shared among multiple independent components.
-The reference count keeps track of the number of open sessions,
-or the number of independent components that are using the same connection.
-
-So open_session() is like a singleton.
-The first time you call this method, it creates a new connection.
-Any subsequent calls to open_session() will just reuse the existing connection,
-they will just increment the reference count of the session.
-This is because generator prevents to add the same client pid twice.
-
-So incrementing the reference count is basically just an abstraction for the client.
-The client itself cannot have more than a single open connection at once,
-so when requesting a new session, other than incrementing the counter,
-nothing else happens. The reference count can be thought of as a shared pointers
-abstraction, because the connection is a kind of shared resource among
-the multiple different independent components that a client can have.
+Incrementing the reference count is an abstraction for the
+client.  The client itself cannot have more than a single open
+connection at once, so when requesting a new session, other
+than incrementing the counter, nothing else happens.
 
 All sessions are opened in read-mode, and may later be
 promoted to write-mode.  This promotion will occur with the
@@ -350,28 +339,24 @@ method to alter the policy will not affect active sessions.
         <doc:description>
           <doc:summary>Close an active session for the client process.
           </doc:summary>
-          <doc:para>This method takes into account multiple nested open sessions,
-meaning that it checks the reference count.
-If the reference count is zero, the session is closed already.
-If the reference count is one, then we really close the session,
-so close_session_admin() gets called.
-And if the reference count is more than one, then it means that there are
-multiple independent components attached to the singleton session,
-so we would just decrement the reference count to consider the
-independent component that just detached from the session.
+          <doc:para>After closing a session, the client process is required to
+call open_session() again before using any of the client-facing
+member functions.
 
-We have a process that is contingent based on the client_pid being alive of not.
-When the pid disappears, the connection itself disappears, and we need to
-clean up all the resources. The lifetime of our session is coupled to the
-lifetime of the connection.
+Closing an active session will remove the record of which
+signals and controls the client process has access to; thus,
+this record is updated to reflect changes to the policy when the
+next session is opened by the process.
 
-There are two possibilities of how the session can end:
-- all independent components in the process volunarily close their connections,
-  using close_session(), while the process is still alive.
-- involuntary crash of the process, the process dies,
-  the connection is closed automatically by the check_client(),
-  in which case close_session() is obviously not called by the client,
-  because there is no client to call.
+When closing a write-mode session, the control values that were
+recorded when the session was promoted to write-mode are restored.
+
+A client PID may attempt to open a session multiple times and
+this is tracked with a reference count as described in the
+documentation for opening a session.  In this case, calls to
+close the session will not actually release the resources
+associated with the session until the reference count falls to
+zero.
 
 A RuntimeError is raised if the client_pid does not have an
 open session.
@@ -390,28 +375,14 @@ open session.
         <doc:description>
           <doc:summary>Close an active session for the client process completely.
           </doc:summary>
-          <doc:para>This function is normally used by the admin.
-
-After closing a session, the client process is required to
-call open_session() again before using any of the client-facing
-member functions.
-
-Closing an active session will remove the record of which
-signals and controls the client process has access to; thus,
-this record is updated to reflect changes to the policy when the
-next session is opened by the process.
+          <doc:para>This administrative function is used to forcibly close an
+active session regardless of the client's reference count.
+Similarly, if a client process PID is no longer active, but an
+open session exists, this implementation is used to release
+the session resources.
 
 When closing a write-mode session, the control values that were
 recorded when the session was promoted to write-mode are restored.
-
-This method supports both the client and administrative DBus
-interfaces that are used to close a session.  The client DBus
-interface only allows users to close sessions that were created
-with their user ID.
-
-This method is called internally by close_session() and it is
-also called explicitly by check_client() when the process dies.
-
 A RuntimeError is raised if the client_pid does not have an
 open session.
           </doc:para>


### PR DESCRIPTION
Enable the PlatformService to support clients having multiple
independent components, which can concurrently use the single
connection. Establish a shared pointer-esque abstraction over
connections, a one to one mapping with the client process.

Add the reference count to the JSON active session schema.

Signed-off-by: Konstantin Rebrov <konstantin.rebrov@intel.com>

- Relates to #2011 
- Fixes #2011 
