### PR TITLE
Restore controls in reverse order to save

### DIFF
--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -630,8 +630,10 @@ namespace geopm
             throw Exception("PlatformIOImp::restore_control(): Called prior to save_control()",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        for (auto &it : m_iogroup_list) {
-            it->restore_control();
+        for (auto it = m_iogroup_list.rbegin();
+             it != m_iogroup_list.rend();
+             ++it) {
+            (*it)->restore_control();
         }
     }
 


### PR DESCRIPTION
- This will provide a more robust restoration in the case where
  an IOGroup modifies a control value at init, and another IOGroup
  provides the same underlying hardware control.
- Fixes #1407