### PR TITLE
Make the arithmetic_intensity benchmark default to new GEOPM headers

### DIFF
--- a/integration/apps/arithmetic_intensity/build.sh
+++ b/integration/apps/arithmetic_intensity/build.sh
@@ -10,7 +10,8 @@ set -e
 source ../build_func.sh
 
 if [[ $# -eq 0 ]]; then
-    echo 'Building from release'
+    echo 'Building from a1761f9'
+    TOPHASH=a1761f9
 elif [[ $# -eq 1 ]]; then
     echo 'Building from head of main'
     TOPHASH=$1
@@ -47,23 +48,13 @@ fi
 DIRNAME=ARITHMETIC_INTENSITY
 GITREPO=https://github.com/dannosliwcd/arithmetic-intensity
 clean_source ${DIRNAME}
-if [[ -z "$TOPHASH" ]]; then
-    # If a top hash is not specified, get the release version.
-    ARCHIVED_DIRNAME=arithmetic-intensity-1.0
-    ARCHIVE=v1.0.tar.gz
-    URL="${GITREPO}/archive/refs/tags/"
-    get_archive ${ARCHIVE} ${URL}
-    unpack_archive ${ARCHIVE}
-    mv "${ARCHIVED_DIRNAME}" "${DIRNAME}"
-else
-    # If a top hash is specified, get the latest commit.
-    ARCHIVE=${DIRNAME}_${TOPHASH}.tgz
-    get_archive ${ARCHIVE}
-    if [ -f ${ARCHIVE} ]; then
+
+ARCHIVE=${DIRNAME}_${TOPHASH}.tgz
+get_archive ${ARCHIVE}
+if [ -f ${ARCHIVE} ]; then
         unpack_archive ${ARCHIVE}
-    else
+else
         clone_repo_git ${GITREPO} ${DIRNAME} ${TOPHASH}
-    fi
 fi
 
 setup_source_git ${DIRNAME}


### PR DESCRIPTION
- Update the arithmetic_intensity build.sh script to default a newer
  commit hash that includes updates to use the new GEOPM public headers
- Fixes #2273