### PR TITLE
GPU Compute Activity Agent updates for LevelZero GPUs supporting the gpu chip domain

### DIFF
--- a/integration/experiment/energy_efficiency/Makefile.mk
+++ b/integration/experiment/energy_efficiency/Makefile.mk
@@ -19,7 +19,9 @@ EXTRA_DIST += integration/experiment/energy_efficiency/barrier_frequency_sweep.p
               integration/experiment/energy_efficiency/run_cpu_activity_nekbone.py \
               integration/experiment/energy_efficiency/run_cpu_activity_pennant.py \
               integration/experiment/energy_efficiency/run_gpu_activity_parres_dgemm_cuda.py \
+              integration/experiment/energy_efficiency/run_gpu_activity_parres_dgemm_oneapi.py \
               integration/experiment/energy_efficiency/run_gpu_activity_parres_nstream_cuda.py \
+              integration/experiment/energy_efficiency/run_gpu_activity_parres_nstream_oneapi.py \
               integration/experiment/energy_efficiency/run_power_balancer_energy_amg.py \
               integration/experiment/energy_efficiency/run_power_balancer_energy_dgemm.py \
               integration/experiment/energy_efficiency/run_power_balancer_energy_hpcg.py \

--- a/integration/experiment/energy_efficiency/run_gpu_activity_parres_dgemm_oneapi.py
+++ b/integration/experiment/energy_efficiency/run_gpu_activity_parres_dgemm_oneapi.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2015 - 2022, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+'''
+Run ParRes dgemm with the gpu_activity agent.
+'''
+import argparse
+
+from experiment import machine
+from experiment.energy_efficiency import gpu_activity
+from apps.parres import parres
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    gpu_activity.setup_run_args(parser)
+    parres.setup_run_args(parser)
+    args, extra_args = parser.parse_known_args()
+    mach = machine.init_output_dir(args.output_dir)
+    app_conf = parres.create_dgemm_appconf_oneapi(mach, args)
+    gpu_activity.launch(app_conf=app_conf, args=args,
+                        experiment_cli_args=extra_args)

--- a/integration/experiment/energy_efficiency/run_gpu_activity_parres_nstream_oneapi.py
+++ b/integration/experiment/energy_efficiency/run_gpu_activity_parres_nstream_oneapi.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2015 - 2022, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+'''
+Run ParRes nstream with the gpu_activity agent.
+'''
+import argparse
+
+from experiment import machine
+from experiment.energy_efficiency import gpu_activity
+from apps.parres import parres
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    gpu_activity.setup_run_args(parser)
+    parres.setup_run_args(parser)
+    args, extra_args = parser.parse_known_args()
+    mach = machine.init_output_dir(args.output_dir)
+    app_conf = parres.create_nstream_appconf_oneapi(mach, args)
+    gpu_activity.launch(app_conf=app_conf, args=args,
+                        experiment_cli_args=extra_args)

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -150,7 +150,7 @@ namespace geopm
 
             // If we have more than one device confirm all devices have the same
             // number of subdevices
-            for (int idx = 1; idx < m_devices.size(); ++idx) {
+            for (unsigned int idx = 1; idx < m_devices.size(); ++idx) {
                 if (m_devices.at(idx).m_num_subdevice != m_devices.at(idx - 1).m_num_subdevice) {
                     throw Exception("LevelZero::" + std::string(__func__) +
                                     ": GEOPM Requires the number of subdevices to be" +

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -151,7 +151,7 @@ namespace geopm
             // If we have more than one device confirm all devices have the same
             // number of subdevices
             for (int idx = 1; idx < m_devices.size(); ++idx) {
-                if (m_devices.at(idx).m_num_subdevice != m_devices.at(idx-1).m_num_subdevice) {
+                if (m_devices.at(idx).m_num_subdevice != m_devices.at(idx - 1).m_num_subdevice) {
                     throw Exception("LevelZero::" + std::string(__func__) +
                                     ": GEOPM Requires the number of subdevices to be" +
                                     " the same on all devices. " +

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -147,6 +147,18 @@ namespace geopm
                                 " Please check ZE_AFFINITY_MASK enviroment variable settings",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
+
+            // If we have more than one device confirm all devices have the same
+            // number of subdevices
+            for (int idx = 1; idx < m_devices.size(); ++idx) {
+                if (m_devices.at(idx).m_num_subdevice != m_devices.at(idx-1).m_num_subdevice) {
+                    throw Exception("LevelZero::" + std::string(__func__) +
+                                    ": GEOPM Requires the number of subdevices to be" +
+                                    " the same on all devices. " +
+                                    " Please check ZE_AFFINITY_MASK enviroment variable settings",
+                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                }
+            }
         }
 
         // TODO: When additional device types such as FPGA, MCA, and Integrated GPU are supported by GEOPM

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -83,15 +83,15 @@ namespace geopm
 
         // We'll use the coarsest granularity supported by any of the controls or signals except Energy
         // i.e. GPU if one control supports GPU and another supports GPU_CHIP
-        int agent_domain = std::min(*std::min_element(std::begin(control_domains), std::end(control_domains)),
-                                    *std::min_element(std::begin(signal_domains), std::end(signal_domains)));
+        m_agent_domain = std::min(*std::min_element(std::begin(control_domains), std::end(control_domains)),
+                                  *std::min_element(std::begin(signal_domains), std::end(signal_domains)));
 
 #ifdef GEOPM_DEBUG
         {
             int max_agent_domain = std::max(*std::max_element(std::begin(control_domains), std::end(control_domains)),
                                             *std::max_element(std::begin(signal_domains), std::end(signal_domains)));
 
-            if (agent_domain != max_agent_domain) {
+            if (m_agent_domain != max_agent_domain) {
                 throw Exception("GPUActivityAgent::" + std::string(__func__) +
                                 "(): Required signals and controls do not all exist at the same domain.",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -99,31 +99,31 @@ namespace geopm
         }
 #endif
 
-        if (agent_domain != GEOPM_DOMAIN_GPU &&
-            agent_domain != GEOPM_DOMAIN_GPU_CHIP &&
-            agent_domain != GEOPM_DOMAIN_BOARD) {
+        if (m_agent_domain != GEOPM_DOMAIN_GPU &&
+            m_agent_domain != GEOPM_DOMAIN_GPU_CHIP &&
+            m_agent_domain != GEOPM_DOMAIN_BOARD) {
             throw Exception("GPUActivityAgent::" + std::string(__func__) +
                             "(): Required signals and controls do not exist at the " +
                             "GPU or GPU_CHIP domain!", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        m_agent_domain_count = m_platform_topo.num_domain(agent_domain);
+        m_agent_domain_count = m_platform_topo.num_domain(m_agent_domain);
 
         for (int domain_idx = 0; domain_idx < m_agent_domain_count; ++domain_idx) {
             // Signals
             m_gpu_core_activity.push_back({m_platform_io.push_signal("GPU_CORE_ACTIVITY",
-                                           agent_domain,
+                                           m_agent_domain,
                                            domain_idx), NAN});
             m_gpu_utilization.push_back({m_platform_io.push_signal("GPU_UTILIZATION",
-                                         agent_domain,
+                                         m_agent_domain,
                                          domain_idx), NAN});
 
             // Controls
             m_gpu_freq_min_control.push_back(m_control{m_platform_io.push_control("GPU_CORE_FREQUENCY_MIN_CONTROL",
-                                                       agent_domain,
+                                                       m_agent_domain,
                                                        domain_idx), NAN});
             m_gpu_freq_max_control.push_back(m_control{m_platform_io.push_control("GPU_CORE_FREQUENCY_MAX_CONTROL",
-                                                       agent_domain,
+                                                       m_agent_domain,
                                                        domain_idx), NAN});
         }
 
@@ -428,6 +428,7 @@ namespace geopm
     {
         std::vector<std::pair<std::string, std::string> > result;
 
+        result.push_back({"Agent Domain", std::to_string(m_agent_domain)});
         result.push_back({"GPU Frequency Requests", std::to_string(m_gpu_frequency_requests)});
         result.push_back({"GPU Clipped Frequency Requests", std::to_string(m_gpu_frequency_clipped)});
         result.push_back({"Resolved Max Frequency", std::to_string(m_f_max)});

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -103,7 +103,7 @@ namespace geopm
             m_agent_domain != GEOPM_DOMAIN_GPU_CHIP &&
             m_agent_domain != GEOPM_DOMAIN_BOARD) {
             throw Exception("GPUActivityAgent::" + std::string(__func__) +
-                            "(): Required signals and controls do not exist at the " +
+                            "(): Required signals and controls do not exist at the BOARD, " +
                             "GPU or GPU_CHIP domain!", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -165,7 +165,7 @@ namespace geopm
         // value provided by the policy may not be valid.  In this case approximating
         // f_efficient as midway between F_min and F_max is reasonable.
         if (std::isnan(in_policy[M_POLICY_GPU_FREQ_EFFICIENT])) {
-            auto all_names = m_platform_io.signal_names();
+            const auto all_names = m_platform_io.signal_names();
             std::string fe_sig_name = "LEVELZERO::GPU_CORE_FREQUENCY_EFFICIENT";
             if (all_names.count(fe_sig_name) != 0) {
                 in_policy[M_POLICY_GPU_FREQ_EFFICIENT] = m_platform_io.read_signal(fe_sig_name,

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -329,7 +329,6 @@ namespace geopm
                 // solution to the lack of GPU region support and may be
                 // removed when that support is added to GEOPM.
                 if (domain_idx % (M_NUM_CHIP_PER_GPU) == 0) {
-                    //int gpu_idx = domain_idx / M_NUM_CHIP_PER_GPU;
                     gpu_scoped_core_activity.push_back(gpu_core_activity);
                 }
             }

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -165,10 +165,10 @@ namespace geopm
         // value provided by the policy may not be valid.  In this case approximating
         // f_efficient as midway between F_min and F_max is reasonable.
         if (std::isnan(in_policy[M_POLICY_GPU_FREQ_EFFICIENT])) {
-            const auto all_names = m_platform_io.signal_names();
-            std::string fe_sig_name = "LEVELZERO::GPU_CORE_FREQUENCY_EFFICIENT";
-            if (all_names.count(fe_sig_name) != 0) {
-                in_policy[M_POLICY_GPU_FREQ_EFFICIENT] = m_platform_io.read_signal(fe_sig_name,
+            const std::set<std::string> &ALL_NAMES = m_platform_io.signal_names();
+            const std::string FE_SIG_NAME = "LEVELZERO::GPU_CORE_FREQUENCY_EFFICIENT";
+            if (ALL_NAMES.count(FE_SIG_NAME) != 0) {
+                in_policy[M_POLICY_GPU_FREQ_EFFICIENT] = m_platform_io.read_signal(FE_SIG_NAME,
                                                                                    GEOPM_DOMAIN_BOARD, 0);
             }
             else {

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -87,17 +87,21 @@ namespace geopm
                                     *std::min_element(std::begin(signal_domains), std::end(signal_domains)));
 
 #ifdef GEOPM_DEBUG
-        int max_agent_domain = std::max(*std::max_element(std::begin(control_domains), std::end(control_domains)),
-                                    *std::max_element(std::begin(signal_domains), std::end(signal_domains)));
+        {
+            int max_agent_domain = std::max(*std::max_element(std::begin(control_domains), std::end(control_domains)),
+                                            *std::max_element(std::begin(signal_domains), std::end(signal_domains)));
 
-        if (agent_domain != max_agent_domain) {
-            throw Exception("GPUActivityAgent::" + std::string(__func__) +
-                            "(): Required signals and controls do not all exist at the same domain.",
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            if (agent_domain != max_agent_domain) {
+                throw Exception("GPUActivityAgent::" + std::string(__func__) +
+                                "(): Required signals and controls do not all exist at the same domain.",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
         }
 #endif
 
-        if (agent_domain != GEOPM_DOMAIN_GPU && agent_domain != GEOPM_DOMAIN_GPU_CHIP) {
+        if (agent_domain != GEOPM_DOMAIN_GPU &&
+            agent_domain != GEOPM_DOMAIN_GPU_CHIP &&
+            agent_domain != GEOPM_DOMAIN_BOARD) {
             throw Exception("GPUActivityAgent::" + std::string(__func__) +
                             "(): Required signals and controls do not exist at the " +
                             "GPU or GPU_CHIP domain!", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -106,15 +110,15 @@ namespace geopm
         m_agent_domain_count = m_platform_topo.num_domain(agent_domain);
 
         for (int domain_idx = 0; domain_idx < m_agent_domain_count; ++domain_idx) {
+            // Signals
             m_gpu_core_activity.push_back({m_platform_io.push_signal("GPU_CORE_ACTIVITY",
                                            agent_domain,
                                            domain_idx), NAN});
             m_gpu_utilization.push_back({m_platform_io.push_signal("GPU_UTILIZATION",
                                          agent_domain,
                                          domain_idx), NAN});
-        }
 
-        for (int domain_idx = 0; domain_idx < m_agent_domain_count; ++domain_idx) {
+            // Controls
             m_gpu_freq_min_control.push_back(m_control{m_platform_io.push_control("GPU_CORE_FREQUENCY_MIN_CONTROL",
                                                        agent_domain,
                                                        domain_idx), NAN});

--- a/src/GPUActivityAgent.hpp
+++ b/src/GPUActivityAgent.hpp
@@ -56,8 +56,12 @@ namespace geopm
             const double M_POLICY_PHI_DEFAULT;
             const double M_GPU_ACTIVITY_CUTOFF;
             const int M_NUM_GPU;
+            const int M_NUM_GPU_CHIP;
+            const int M_NUM_CHIP_PER_GPU;
             bool m_do_write_batch;
             bool m_do_send_policy;
+
+            int m_agent_domain_count;
 
             struct m_signal
             {

--- a/src/GPUActivityAgent.hpp
+++ b/src/GPUActivityAgent.hpp
@@ -62,6 +62,7 @@ namespace geopm
             bool m_do_send_policy;
 
             int m_agent_domain_count;
+            int m_agent_domain;
 
             struct m_signal
             {


### PR DESCRIPTION
- Relates to #2287 from github issues
- Fixes #2287 change request from github issues.

Updates to the GPU-CA to support accelerators providing GPU CHIP level signals and controls.  

This change is intended to be fully backwards compatible with hardware previously supported by the GPU-CA.  

Testing of backwards compatibility using the integration infrastructure PARRES DGEMM and PARRES NSTREAM implementation matched expectations on systems using NVIDIA V100s.