### PR TITLE
Added CPU_UNCORE_FREQUENCY_STATUS alias and report entry

### DIFF
--- a/service/src/MSRIOGroup.cpp
+++ b/service/src/MSRIOGroup.cpp
@@ -158,6 +158,11 @@ namespace geopm
         register_signal_alias("CPU_FREQUENCY_STATUS", "MSR::PERF_STATUS:FREQ");
         register_signal_alias("CPU_FREQUENCY_CONTROL", "MSR::PERF_CTL:FREQ");
 
+        auto all_names = signal_names();
+        if (all_names.count("MSR::UNCORE_PERF_STATUS:FREQ") != 0) {
+            register_signal_alias("CPU_UNCORE_FREQUENCY_STATUS", "MSR::UNCORE_PERF_STATUS:FREQ");
+        }
+
         std::string max_turbo_name;
         switch (m_cpuid) {
             case MSRIOGroup::M_CPUID_KNL:

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -396,13 +396,14 @@ namespace geopm
         };
 
         auto all_names = m_platform_io.signal_names();
-        std::vector<m_sync_field_s> gpu_sync_fields = {
+        std::vector<m_sync_field_s> conditional_sync_fields = {
             {"gpu-energy (J)", {"GPU_ENERGY"}, sample_only},
             {"gpu-power (W)", {"GPU_POWER"}, sample_only},
-            {"gpu-frequency (Hz)", {"GPU_FREQUENCY_STATUS"}, sample_only}
+            {"gpu-frequency (Hz)", {"GPU_FREQUENCY_STATUS"}, sample_only},
+            {"uncore-frequency (Hz)", {"CPU_UNCORE_FREQUENCY_STATUS"}, sample_only}
         };
 
-        for (const auto &field : gpu_sync_fields) {
+        for (const auto &field : conditional_sync_fields) {
             for (const auto &signal : field.supporting_signals) {
                 if (all_names.count(signal) != 0) {
                     m_sync_fields.push_back(field);

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -271,7 +271,7 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/RecordFilterTest.make_proxy_epoch \
               test/gtest_links/RecordFilterTest.make_edit_distance \
               test/gtest_links/ReporterTest.generate \
-              test/gtest_links/ReporterTest.generate_gpu \
+              test/gtest_links/ReporterTest.generate_conditional \
               test/gtest_links/SampleAggregatorTest.epoch_application_total \
               test/gtest_links/SampleAggregatorTest.sample_application \
               test/gtest_links/SchedTest.test_proc_cpuset_0 \


### PR DESCRIPTION
- Relates to #1057 from github issues

Added CPU_UNCORE_FREQUENCY_STATUS as an alias for MSR::UNCORE_PERF_STATUS:FREQ provided MSR::UNCORE_PERF_STATUS:FREQ is in the list of signal names after parsing the MSR json file.  

Similarly added ```uncore-frequency (Hz)``` to the report provided the CPU_UNCORE_FREQUENCY_STATUS alias is present when the report is generated.

Tested on mcfly via 
```
geopmlaunch srun -N 1 -n 1  --geopm-ctl=process --geopm-report=bench.report --geopm-agent=monitor -- geopmbench
```

Report:
```
    Epoch Totals:
      runtime (s): 22.7421
      count: 10
      sync-runtime (s): 22.7421
      package-energy (J): 3326.29
      dram-energy (J): 271.212
      power (W): 146.261
      frequency (%): 126.129
      frequency (Hz): 2.64872e+09
      <cut for space>
      uncore-frequency (Hz): 2.4e+09
```