### PR TITLE
Move schemas into separate python file

### DIFF
--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -74,8 +74,9 @@ EXTRA_DIST = .gitignore \
              geopmdpy/service.py \
              geopmdpy/session.py \
              geopmdpy/topo.py \
+             geopmdpy/schemas.py \
+             geopmdpy/schemas.py.in \
              geopmdpy/system_files.py \
-             geopmdpy/system_files.py.in \
              geopmdpy/version.py \
              geopmdpy/version.py.in \
              json_schemas/active_sessions.schema.json \

--- a/service/configure.ac
+++ b/service/configure.ac
@@ -342,7 +342,7 @@ JSON_SCHEMA_ACTIVE_SESSIONS=json_schemas/active_sessions.schema.json
 GEOPM_SOURCE_DIR=$(readlink -f $srcdir)
 AC_DEFINE_UNQUOTED([GEOPM_SOURCE_DIR], ["$GEOPM_SOURCE_DIR"], [Root of the GEOPM source directory])
 
-AC_CONFIG_FILES([Makefile geopm-service.spec geopmdpy/version.py geopmdpy/system_files.py])
+AC_CONFIG_FILES([Makefile geopm-service.spec geopmdpy/version.py geopmdpy/schemas.py])
 AC_OUTPUT
 
 # ============================================================================

--- a/service/docs/source/geopmdpy.7.rst
+++ b/service/docs/source/geopmdpy.7.rst
@@ -66,6 +66,14 @@ geopmdpy.runtime
    :undoc-members:
    :show-inheritance:
 
+geopmdpy.schemas
+----------------
+
+.. automodule:: geopmdpy.schemas
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 geopmdpy.service
 ----------------
 
@@ -82,18 +90,18 @@ geopmdpy.session
    :undoc-members:
    :show-inheritance:
 
-geopmdpy.topo
--------------
-
-.. automodule:: geopmdpy.topo
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 geopmdpy.system_files
 ---------------------
 
 .. automodule:: geopmdpy.system_files
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+geopmdpy.topo
+-------------
+
+.. automodule:: geopmdpy.topo
    :members:
    :undoc-members:
    :show-inheritance:

--- a/service/geopmdpy/schemas.py.in
+++ b/service/geopmdpy/schemas.py.in
@@ -5,6 +5,13 @@
 
 """Json schemas used by geopmdpy
 
+GEOPM_ACTIVE_SESSIONS_SCHEMA:
+
+.. code-block:: json
+
+    @JSON_SCHEMA_ACTIVE_SESSIONS@
+
+
 """
 
 GEOPM_ACTIVE_SESSIONS_SCHEMA = """

--- a/service/geopmdpy/schemas.py.in
+++ b/service/geopmdpy/schemas.py.in
@@ -1,0 +1,12 @@
+#
+#  Copyright (c) 2015 - 2022, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+"""Json schemas used by geopmdpy
+
+"""
+
+GEOPM_ACTIVE_SESSIONS_SCHEMA = """
+@JSON_SCHEMA_ACTIVE_SESSIONS@
+"""

--- a/service/geopmdpy/system_files.py
+++ b/service/geopmdpy/system_files.py
@@ -275,7 +275,8 @@ class ActiveSessions(object):
     creation.
 
     The session files are stored in JSON format and follow the
-    active session schema in geopmdpy.schemas.GEOPM_ACTIVE_SESSION_SCHEMA.
+    GEOPM_ACTIVE_SESSIONS_SCHEMA documented in the
+    ``geopmdpy.schemas`` module.
 
     """
 

--- a/service/geopmdpy/system_files.py
+++ b/service/geopmdpy/system_files.py
@@ -31,7 +31,7 @@ import pwd
 import fcntl
 
 from . import pio
-
+from . import schemas
 
 GEOPM_SERVICE_RUN_PATH = '/run/geopm-service'
 GEOPM_SERVICE_CONFIG_PATH = '/etc/geopm-service'
@@ -46,9 +46,6 @@ GEOPM_SERVICE_CONFIG_PATH_PERM = 0o700
 
 """
 
-GEOPM_ACTIVE_SESSIONS_SCHEMA = """
-@JSON_SCHEMA_ACTIVE_SESSIONS@
-"""
 
 def secure_make_dirs(path, perm_mode=0o700):
     """Securely create a directory
@@ -277,11 +274,8 @@ class ActiveSessions(object):
     responsible for managing file access permissions, and atomic file
     creation.
 
-    The session files are stored in JSON format and follow this schema:
-
-    .. code-block:: json
-
-        @JSON_SCHEMA_ACTIVE_SESSIONS@
+    The session files are stored in JSON format and follow the
+    active session schema in geopmdpy.schemas.GEOPM_ACTIVE_SESSION_SCHEMA.
 
     """
 
@@ -340,7 +334,7 @@ class ActiveSessions(object):
         self._daemon_uid = os.getuid()
         self._daemon_gid = os.getgid()
         self._sessions = dict()
-        self._session_schema = json.loads(GEOPM_ACTIVE_SESSIONS_SCHEMA)
+        self._session_schema = json.loads(schemas.GEOPM_ACTIVE_SESSIONS_SCHEMA)
         secure_make_dirs(self._RUN_PATH,
                          perm_mode=GEOPM_SERVICE_RUN_PATH_PERM)
 

--- a/service/json_schemas/active_sessions.schema.json
+++ b/service/json_schemas/active_sessions.schema.json
@@ -1,35 +1,35 @@
-        {
-            "$schema": "http://json-schema.org/draft-04/schema#",
-            "id": "https://geopm.github.io/active_sessions.schema.json",
-            "title": "ActiveSession",
-            "type": "object",
-            "properties": {
-              "client_pid": {
-                "type": "integer"
-              },
-              "reference_count": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "signals": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "controls": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "watch_id": {
-                "type": "integer"
-              },
-              "batch_server": {
-                "type": "integer"
-              }
-            },
-            "required": ["client_pid", "signals", "controls"],
-            "additionalProperties": false
-        }
+    {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "https://geopm.github.io/active_sessions.schema.json",
+        "title": "ActiveSession",
+        "type": "object",
+        "properties": {
+          "client_pid": {
+            "type": "integer"
+          },
+          "reference_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "signals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "controls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "watch_id": {
+            "type": "integer"
+          },
+          "batch_server": {
+            "type": "integer"
+          }
+        },
+        "required": ["client_pid", "signals", "controls"],
+        "additionalProperties": false
+    }


### PR DESCRIPTION
Unfortunately this solution does not enable displaying the json schema in the doc string.  It does avoid having a lot of python logic in the file with the .py.in suffix which is not rendered properly by most code viewers.  