### PR TITLE
Eliminate redundancy in BatchServer shmem prefix

### DIFF
--- a/service/src/BatchServer.hpp
+++ b/service/src/BatchServer.hpp
@@ -95,7 +95,7 @@ namespace geopm
 
         protected:
             static constexpr const char* M_SHMEM_PREFIX =
-                "/run/geopm-service/geopm-service-batch-buffer-";
+                "/run/geopm-service/batch-buffer-";
     };
 
     class BatchServerImp : public BatchServer


### PR DESCRIPTION
Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>

- Fixes #2322 