### PR TITLE
Parse plugin MSR json files when generating the MSR allowlist

### DIFF
--- a/service/src/MSRIOGroup.cpp
+++ b/service/src/MSRIOGroup.cpp
@@ -1505,7 +1505,7 @@ namespace geopm
         }
         auto custom = msr_data_files();
         for (const auto &filename : custom) {
-            parse_json_msrs_allowlist(filename, allowlist_data);
+            parse_json_msrs_allowlist(read_file(filename), allowlist_data);
         }
         return format_allowlist(allowlist_data);
     }


### PR DESCRIPTION
- Resolves #2088
- Fixes an issue where the path to the plugin MSR file was being parsed instead
  of parsing the contents of the file.