### PR TITLE
Cleanup tmp files from test

### DIFF
--- a/service/test/MSRIOTest.cpp
+++ b/service/test/MSRIOTest.cpp
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <unistd.h>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
- MSRIOGroupTest:allowlist had been littering files in
  /tmp that impact subsequent runs across users.
- Missing includes.