### PR TITLE
Added Level Zero Throttle Reasons signal

### DIFF
--- a/service/src/Agg.cpp
+++ b/service/src/Agg.cpp
@@ -66,6 +66,21 @@ namespace geopm
         return result;
     }
 
+    double Agg::bitwise_or(const std::vector<double> &operand)
+    {
+        auto filtered = nan_filter(operand);
+        uint32_t result = 0;
+        if (filtered.size()) {
+            result = 0;
+            for (auto it : filtered) {
+                if (it >= 0) {
+                    result |= (uint32_t) it;
+                }
+            }
+        }
+        return result;
+    }
+
     double Agg::logical_and(const std::vector<double> &operand)
     {
         auto filtered = nan_filter(operand);

--- a/service/src/Agg.cpp
+++ b/service/src/Agg.cpp
@@ -69,14 +69,15 @@ namespace geopm
     double Agg::bitwise_or(const std::vector<double> &operand)
     {
         auto filtered = nan_filter(operand);
-        uint32_t result = 0;
+        double result = NAN;
+        uint64_t agg_tmp = 0;
         if (filtered.size()) {
-            result = 0;
             for (auto it : filtered) {
                 if (it >= 0) {
-                    result |= (uint32_t) it;
+                    agg_tmp |= (uint64_t) it;
                 }
             }
+            result = (double) agg_tmp;
         }
         return result;
     }

--- a/service/src/Agg.cpp
+++ b/service/src/Agg.cpp
@@ -66,16 +66,14 @@ namespace geopm
         return result;
     }
 
-    double Agg::bitwise_or(const std::vector<double> &operand)
+    double Agg::integer_bitwise_or(const std::vector<double> &operand)
     {
         auto filtered = nan_filter(operand);
         double result = NAN;
-        uint64_t agg_tmp = 0;
         if (filtered.size()) {
+            int64_t agg_tmp = 0;
             for (const auto &it : filtered) {
-                if (it >= 0) {
-                    agg_tmp |= (uint64_t) it;
-                }
+                agg_tmp |= (int64_t) it;
             }
             result = (double) agg_tmp;
         }
@@ -202,6 +200,7 @@ namespace geopm
             {"sum", sum},
             {"average", average},
             {"median", median},
+            {"integer_bitwise_or", integer_bitwise_or},
             {"logical_and", logical_and},
             {"logical_or", logical_or},
             {"region_hash", region_hash},
@@ -227,6 +226,7 @@ namespace geopm
             {sum, "sum"},
             {average, "average"},
             {median, "median"},
+            {integer_bitwise_or, "integer_bitwise_or"},
             {logical_and, "logical_and"},
             {logical_or, "logical_or"},
             {region_hash, "region_hash"},
@@ -253,6 +253,7 @@ namespace geopm
             {sum, M_SUM},
             {average, M_AVERAGE},
             {median, M_MEDIAN},
+            {integer_bitwise_or, M_INTEGER_BITWISE_OR},
             {logical_and, M_LOGICAL_AND},
             {logical_or, M_LOGICAL_OR},
             {region_hash, M_REGION_HASH},
@@ -279,6 +280,7 @@ namespace geopm
             {M_SUM, sum},
             {M_AVERAGE, average},
             {M_MEDIAN, median},
+            {M_INTEGER_BITWISE_OR, integer_bitwise_or},
             {M_LOGICAL_AND, logical_and},
             {M_LOGICAL_OR, logical_or},
             {M_REGION_HASH, region_hash},
@@ -303,6 +305,7 @@ namespace geopm
             {M_SUM, "sum"},
             {M_AVERAGE, "average"},
             {M_MEDIAN, "median"},
+            {M_INTEGER_BITWISE_OR, "integer_bitwise_or"},
             {M_LOGICAL_AND, "logical_and"},
             {M_LOGICAL_OR, "logical_or"},
             {M_REGION_HASH, "region_hash"},

--- a/service/src/Agg.cpp
+++ b/service/src/Agg.cpp
@@ -72,7 +72,7 @@ namespace geopm
         double result = NAN;
         uint64_t agg_tmp = 0;
         if (filtered.size()) {
-            for (auto it : filtered) {
+            for (const auto &it : filtered) {
                 if (it >= 0) {
                     agg_tmp |= (uint64_t) it;
                 }

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -393,6 +393,12 @@ namespace geopm
         return frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).actual;
     }
 
+    uint32_t LevelZeroImp::frequency_throttle_reasons(unsigned int l0_device_idx,
+                                                      int l0_domain, int l0_domain_idx) const
+    {
+        return frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).throttle_reasons;
+    }
+
     LevelZeroImp::m_frequency_s LevelZeroImp::frequency_status_helper(unsigned int l0_device_idx,
                                                                       int l0_domain, int l0_domain_idx) const
     {

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -67,6 +67,15 @@ namespace geopm
             /// @return GPU maximum frequency in MHz.
             virtual double frequency_max(unsigned int l0_device_idx, int l0_domain,
                                          int l0_domain_idx) const = 0;
+            /// @brief Get the LevelZero device frequency throttle reasons
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero GPU.
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @param [in] l0_domain_idx The LevelZero index indicating a particular
+            ///        domain of the GPU..
+            /// @return Frequency throttle reasons
+            virtual uint32_t frequency_throttle_reasons(unsigned int l0_device_idx, int l0_domain,
+                                                        int l0_domain_idx) const = 0;
             /// @brief Get the LevelZero device mininum and maximum frequency
             ///        control range in MHz
             /// @param [in] l0_device_idx The index indicating a particular

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -148,7 +148,7 @@ namespace geopm
         if (domain != GEOPM_DOMAIN_GPU_CHIP) {
             throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
                              ": domain " + std::to_string(domain) +
-                            " is not supported for the frequency domain.",
+                            " is not supported for reading the \"frequency throttle reason\"",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -142,6 +142,25 @@ namespace geopm
                                          dev_subdev_idx_pair.second);
     }
 
+    uint32_t LevelZeroDevicePoolImp::frequency_throttle_reasons(int domain, unsigned int domain_idx,
+                                                              int l0_domain) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                             ": domain " + std::to_string(domain) +
+                            " is not supported for the frequency domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        check_domain_exists(m_levelzero.frequency_domain_count(
+                                        dev_subdev_idx_pair.first, l0_domain), __func__, __LINE__);
+
+        return m_levelzero.frequency_throttle_reasons(dev_subdev_idx_pair.first, l0_domain,
+                                                      dev_subdev_idx_pair.second);
+    }
+
+
     std::pair<double, double> LevelZeroDevicePoolImp::frequency_range(int domain,
                                                                       unsigned int domain_idx,
                                                                       int l0_domain) const

--- a/service/src/LevelZeroDevicePool.hpp
+++ b/service/src/LevelZeroDevicePool.hpp
@@ -50,6 +50,14 @@ namespace geopm
             /// @return GPU maximum frequency in MHz.
             virtual double frequency_max(int domain, unsigned int domain_idx,
                                          int l0_domain) const = 0;
+            /// @brief Get the LevelZero device frequency throttle reasons
+            /// @param [in] domain The GEOPM domain type being targeted
+            /// @param [in] domain_idx The GEOPM domain index
+            ///             (i.e. gpu being targeted)
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return Frequency throttle reasons
+            virtual uint32_t frequency_throttle_reasons(int domain, unsigned int domain_idx,
+                                                        int l0_domain) const = 0;
             virtual std::pair<double, double> frequency_range(int domain,
                                                               unsigned int domain_idx,
                                                               int l0_domain) const = 0;

--- a/service/src/LevelZeroDevicePoolImp.hpp
+++ b/service/src/LevelZeroDevicePoolImp.hpp
@@ -30,6 +30,8 @@ namespace geopm
                                  int l0_domain) const override;
             double frequency_max(int domain, unsigned int domain_idx,
                                  int l0_domain) const override;
+            uint32_t frequency_throttle_reasons(int domain, unsigned int domain_idx,
+                                                int l0_domain) const override;
             std::pair <double, double> frequency_range(int domain,
                                                        unsigned int domain_idx,
                                                        int l0_domain) const override;

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -118,7 +118,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_CORE_THROTTLE_REASONS", {
                                   "GPU Compute Hardware throttle reasons.  See oneAPI Level Zero Sysman Spec for decoding",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::bitwise_or,
+                                  Agg::integer_bitwise_or,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_integer,
                                   {},

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -118,7 +118,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_CORE_THROTTLE_REASONS", {
                                   "GPU Compute Hardware throttle reasons.  See oneAPI Level Zero Sysman Spec for decoding",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::bitwise_or,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_integer,
                                   {},

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -115,6 +115,22 @@ namespace geopm
                                   },
                                   1e6
                                   }},
+                              {M_NAME_PREFIX + "GPU_CORE_THROTTLE_REASONS", {
+                                  "GPU Compute Hardware throttle reasons.  See oneAPI Level Zero Sysman Spec for decoding",
+                                  GEOPM_DOMAIN_GPU_CHIP,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_integer,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_throttle_reasons(
+                                                   GEOPM_DOMAIN_GPU_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  1
+                                  }},
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
                                   "The minimum frequency request for the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -33,6 +33,8 @@ namespace geopm
                                  int l0_domain_idx) const override;
             double frequency_max(unsigned int l0_device_idx, int l0_domain,
                                  int l0_domain_idx) const override;
+            uint32_t frequency_throttle_reasons(unsigned int l0_device_idx, int l0_domain,
+                                                int l0_domain_idx) const override;
             std::pair<double, double> frequency_range(unsigned int l0_device_idx,
                                                       int l0_domain,
                                                       int l0_domain_idx) const override;
@@ -63,7 +65,7 @@ namespace geopm
                 double tdp = 0;
                 double efficient = 0;
                 double actual = 0;
-                uint64_t throttle_reasons = 0;
+                uint32_t throttle_reasons = 0;
             };
             struct m_power_limit_s {
                 int32_t tdp = 0;

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -89,7 +89,7 @@ namespace geopm
                                   "GPU clock throttling reasons",
                                   {},
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::average,
+                                  Agg::bitwise_or,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double
                                   }},

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -89,7 +89,7 @@ namespace geopm
                                   "GPU clock throttling reasons",
                                   {},
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::bitwise_or,
+                                  Agg::integer_bitwise_or,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double
                                   }},

--- a/service/src/geopm/Agg.hpp
+++ b/service/src/geopm/Agg.hpp
@@ -38,6 +38,10 @@ namespace geopm
             static double average(const std::vector<double> &operand);
             /// @brief Returns the median of the input operands.
             static double median(const std::vector<double> &operand);
+            /// @brief Returns the output of bitwise OR over all the
+            ///        operands where 0 is false and all positive numbers
+            ///        are true
+            static double bitwise_or(const std::vector<double> &operand);
             /// @brief Returns the output of logical AND over all the
             ///        operands where 0.0 is false and all other
             ///        values are true.

--- a/service/src/geopm/Agg.hpp
+++ b/service/src/geopm/Agg.hpp
@@ -21,6 +21,7 @@ namespace geopm
                 M_SUM,
                 M_AVERAGE,
                 M_MEDIAN,
+                M_INTEGER_BITWISE_OR,
                 M_LOGICAL_AND,
                 M_LOGICAL_OR,
                 M_MIN,
@@ -39,9 +40,9 @@ namespace geopm
             /// @brief Returns the median of the input operands.
             static double median(const std::vector<double> &operand);
             /// @brief Returns the output of bitwise OR over all the
-            ///        operands where 0 is false and all positive numbers
-            ///        are true
-            static double bitwise_or(const std::vector<double> &operand);
+            ///        operands after casting them to int64_t where 0
+            ///        is false and all positive numbers are true
+            static double integer_bitwise_or(const std::vector<double> &operand);
             /// @brief Returns the output of logical AND over all the
             ///        operands where 0.0 is false and all other
             ///        values are true.

--- a/service/test/AggTest.cpp
+++ b/service/test/AggTest.cpp
@@ -43,13 +43,16 @@ TEST(AggTest, agg_function)
 
     EXPECT_EQ(1, Agg::bitwise_or({0.0, 0.0, 1.0, 0.0}));
     EXPECT_EQ(0, Agg::bitwise_or({0.0, 0.0}));
+    EXPECT_EQ(7, Agg::bitwise_or({5.0, 2.0}));
+    EXPECT_EQ(3, Agg::bitwise_or({3.0, 1.0}));
+    EXPECT_EQ(6, Agg::bitwise_or({4.0, 2.0}));
     EXPECT_EQ(0, Agg::bitwise_or({0.0, 0.0, NAN}));
     EXPECT_EQ(0, Agg::bitwise_or({0.1, 0}));
     EXPECT_EQ(0, Agg::bitwise_or({-1, 0}));
     EXPECT_EQ(1, Agg::bitwise_or({1, 0}));
     EXPECT_EQ(0, Agg::bitwise_or({NAN, 0.0}));
     EXPECT_EQ(1, Agg::bitwise_or({NAN, 1.0, NAN}));
-    EXPECT_EQ(0, Agg::bitwise_or({NAN, NAN}));
+    EXPECT_TRUE(std::isnan(Agg::bitwise_or({NAN, NAN})));
     EXPECT_EQ(1, Agg::bitwise_or({NAN, 1.0}));
 
     EXPECT_TRUE(std::isnan(Agg::region_hash({})));

--- a/service/test/AggTest.cpp
+++ b/service/test/AggTest.cpp
@@ -41,19 +41,19 @@ TEST(AggTest, agg_function)
     EXPECT_EQ(1.0, Agg::logical_or({1.0, 1.0, 0.0}));
     EXPECT_EQ(0.0, Agg::logical_or({0.0, 0.0}));
 
-    EXPECT_EQ(1, Agg::bitwise_or({0.0, 0.0, 1.0, 0.0}));
-    EXPECT_EQ(0, Agg::bitwise_or({0.0, 0.0}));
-    EXPECT_EQ(7, Agg::bitwise_or({5.0, 2.0}));
-    EXPECT_EQ(3, Agg::bitwise_or({3.0, 1.0}));
-    EXPECT_EQ(6, Agg::bitwise_or({4.0, 2.0}));
-    EXPECT_EQ(0, Agg::bitwise_or({0.0, 0.0, NAN}));
-    EXPECT_EQ(0, Agg::bitwise_or({0.1, 0}));
-    EXPECT_EQ(0, Agg::bitwise_or({-1, 0}));
-    EXPECT_EQ(1, Agg::bitwise_or({1, 0}));
-    EXPECT_EQ(0, Agg::bitwise_or({NAN, 0.0}));
-    EXPECT_EQ(1, Agg::bitwise_or({NAN, 1.0, NAN}));
-    EXPECT_TRUE(std::isnan(Agg::bitwise_or({NAN, NAN})));
-    EXPECT_EQ(1, Agg::bitwise_or({NAN, 1.0}));
+    EXPECT_EQ(1, Agg::integer_bitwise_or({0.0, 0.0, 1.0, 0.0}));
+    EXPECT_EQ(0, Agg::integer_bitwise_or({0.0, 0.0}));
+    EXPECT_EQ(7, Agg::integer_bitwise_or({5.0, 2.0}));
+    EXPECT_EQ(3, Agg::integer_bitwise_or({3.0, 1.0}));
+    EXPECT_EQ(6, Agg::integer_bitwise_or({4.0, 2.0}));
+    EXPECT_EQ(0, Agg::integer_bitwise_or({0.0, 0.0, NAN}));
+    EXPECT_EQ(0, Agg::integer_bitwise_or({0.1, 0}));
+    EXPECT_EQ(-1, Agg::integer_bitwise_or({-1, 0}));
+    EXPECT_EQ(1, Agg::integer_bitwise_or({1, 0}));
+    EXPECT_EQ(0, Agg::integer_bitwise_or({NAN, 0.0}));
+    EXPECT_EQ(1, Agg::integer_bitwise_or({NAN, 1.0, NAN}));
+    EXPECT_TRUE(std::isnan(Agg::integer_bitwise_or({NAN, NAN})));
+    EXPECT_EQ(1, Agg::integer_bitwise_or({NAN, 1.0}));
 
     EXPECT_TRUE(std::isnan(Agg::region_hash({})));
 
@@ -81,6 +81,7 @@ TEST(AggTest, function_strings)
     EXPECT_TRUE(is_agg_sum(Agg::name_to_function("sum")));
     EXPECT_TRUE(is_agg_average(Agg::name_to_function("average")));
     EXPECT_TRUE(is_agg_median(Agg::name_to_function("median")));
+    EXPECT_TRUE(is_agg_integer_bitwise_or(Agg::name_to_function("integer_bitwise_or")));
     EXPECT_TRUE(is_agg_logical_and(Agg::name_to_function("logical_and")));
     EXPECT_TRUE(is_agg_logical_or(Agg::name_to_function("logical_or")));
     EXPECT_TRUE(is_agg_region_hash(Agg::name_to_function("region_hash")));

--- a/service/test/AggTest.cpp
+++ b/service/test/AggTest.cpp
@@ -41,6 +41,17 @@ TEST(AggTest, agg_function)
     EXPECT_EQ(1.0, Agg::logical_or({1.0, 1.0, 0.0}));
     EXPECT_EQ(0.0, Agg::logical_or({0.0, 0.0}));
 
+    EXPECT_EQ(1, Agg::bitwise_or({0.0, 0.0, 1.0, 0.0}));
+    EXPECT_EQ(0, Agg::bitwise_or({0.0, 0.0}));
+    EXPECT_EQ(0, Agg::bitwise_or({0.0, 0.0, NAN}));
+    EXPECT_EQ(0, Agg::bitwise_or({0.1, 0}));
+    EXPECT_EQ(0, Agg::bitwise_or({-1, 0}));
+    EXPECT_EQ(1, Agg::bitwise_or({1, 0}));
+    EXPECT_EQ(0, Agg::bitwise_or({NAN, 0.0}));
+    EXPECT_EQ(1, Agg::bitwise_or({NAN, 1.0, NAN}));
+    EXPECT_EQ(0, Agg::bitwise_or({NAN, NAN}));
+    EXPECT_EQ(1, Agg::bitwise_or({NAN, 1.0}));
+
     EXPECT_TRUE(std::isnan(Agg::region_hash({})));
 
     EXPECT_TRUE(std::isnan(Agg::region_hash({NAN, NAN})));

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -216,6 +216,7 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     const int num_gpu_subdevice = m_platform_topo->num_domain(GEOPM_DOMAIN_GPU_CHIP);
 
     std::vector<double> mock_freq = {1530, 1630, 1320, 1420, 420, 520, 135, 235};
+    std::vector<double> mock_throttle = {0, 2, 4, 10, 1, 3, 9, 5};
     std::vector<double> mock_energy = {9000000, 11000000, 2300000, 5341000000};
     std::vector<int> batch_idx;
 
@@ -224,6 +225,11 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq.at(sub_idx)));
         batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+    }
+
+    for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_throttle.at(sub_idx)));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_CORE_THROTTLE_REASONS", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
 
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
@@ -236,25 +242,35 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         double frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         double frequency_batch = levelzero_io.sample(batch_idx.at(sub_idx));
-
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(sub_idx)*1e6);
         EXPECT_DOUBLE_EQ(frequency, frequency_batch);
+
+        double throttle = levelzero_io.read_signal("LEVELZERO::GPU_CORE_THROTTLE_REASONS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double throttle_batch = levelzero_io.sample(batch_idx.at(sub_idx + num_gpu_subdevice));
+        EXPECT_DOUBLE_EQ(throttle, mock_throttle.at(sub_idx));
+        EXPECT_DOUBLE_EQ(throttle, throttle_batch);
     }
 
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
         double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_GPU, gpu_idx);
-        double energy_batch = levelzero_io.sample(batch_idx.at(num_gpu_subdevice+gpu_idx));
-
+        double energy_batch = levelzero_io.sample(batch_idx.at(2*num_gpu_subdevice+gpu_idx));
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(gpu_idx)/1e6);
         EXPECT_DOUBLE_EQ(energy, energy_batch);
     }
 
     //second round of testing with a modified value
     mock_freq = {1730, 1830, 1520, 1620, 620, 720, 335, 435};
+    mock_throttle = {2, 6, 8, 4, 12, 16, 18, 22};
     mock_energy = {9320000, 12300000, 2360000, 3417000000};
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_throttle.at(sub_idx)));
     }
+
+    for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_throttle.at(sub_idx)));
+    }
+
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(gpu_idx)));
     }
@@ -263,13 +279,17 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         double frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         double frequency_batch = levelzero_io.sample(batch_idx.at(sub_idx));
-
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(sub_idx)*1e6);
         EXPECT_DOUBLE_EQ(frequency, frequency_batch);
+
+        double throttle = levelzero_io.read_signal("LEVELZERO::GPU_CORE_THROTTLE_REASONS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double throttle_batch = levelzero_io.sample(batch_idx.at(sub_idx + num_gpu_subdevice));
+        EXPECT_DOUBLE_EQ(throttle, mock_throttle.at(sub_idx));
+        EXPECT_DOUBLE_EQ(throttle, throttle_batch);
     }
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
         double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_GPU, gpu_idx);
-        double energy_batch = levelzero_io.sample(batch_idx.at(num_gpu_subdevice+gpu_idx));
+        double energy_batch = levelzero_io.sample(batch_idx.at(2*num_gpu_subdevice+gpu_idx));
 
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(gpu_idx)/1e6);
         EXPECT_DOUBLE_EQ(energy, energy_batch);

--- a/service/test/MockLevelZero.hpp
+++ b/service/test/MockLevelZero.hpp
@@ -25,6 +25,8 @@ class MockLevelZero : public geopm::LevelZero
                     (const, override));
         MOCK_METHOD(double, frequency_max, (unsigned int, int, int),
                     (const, override));
+        MOCK_METHOD(uint32_t, frequency_throttle_reasons, (unsigned int, int, int),
+                    (const, override));
         MOCK_METHOD((std::pair<double, double>), frequency_range,
                     (unsigned int, int, int), (const, override));
 

--- a/service/test/MockLevelZeroDevicePool.hpp
+++ b/service/test/MockLevelZeroDevicePool.hpp
@@ -22,6 +22,8 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
                     (int, unsigned int, int), (const, override));
         MOCK_METHOD(double, frequency_max,
                     (int, unsigned int, int), (const, override));
+        MOCK_METHOD(uint32_t, frequency_throttle_reasons,
+                    (int, unsigned int, int), (const, override));
         MOCK_METHOD((std::pair<double, double>), frequency_range,
                     (int, unsigned int, int), (const, override));
 

--- a/service/test/geopm_test.hpp
+++ b/service/test/geopm_test.hpp
@@ -21,6 +21,7 @@ bool is_format_raw64(std::function<std::string(double)> func);
 bool is_agg_sum(std::function<double(const std::vector<double> &)> func);
 bool is_agg_average(std::function<double(const std::vector<double> &)> func);
 bool is_agg_median(std::function<double(const std::vector<double> &)> func);
+bool is_agg_integer_bitwise_or(std::function<double(const std::vector<double> &)> func);
 bool is_agg_logical_and(std::function<double(const std::vector<double> &)> func);
 bool is_agg_logical_or(std::function<double(const std::vector<double> &)> func);
 bool is_agg_region_hash(std::function<double(const std::vector<double> &)> func);

--- a/service/test/geopm_test_helper.cpp
+++ b/service/test/geopm_test_helper.cpp
@@ -63,6 +63,15 @@ bool is_agg_median(std::function<double(const std::vector<double> &)> func)
     return func(example_data) == geopm::Agg::median(example_data);
 }
 
+bool is_agg_integer_bitwise_or(std::function<double(const std::vector<double> &)> func)
+{
+    return func({1, 2, 3}) == 3.0 &&
+           func({1, 0, 1}) == 1.0 &&
+           func({0, 0, 0}) == 0.0 &&
+           func({4, 2, 1}) == 7 &&
+           std::isnan(func({}));
+}
+
 bool is_agg_logical_and(std::function<double(const std::vector<double> &)> func)
 {
     return func({1, 1, 1}) == 1.0 &&


### PR DESCRIPTION
Signed-off-by: lhlawson <lowren.h.lawson@intel.com>

- Relates to #2368 feature request from github issues
- Fixes #2368 change request from github issues.

Provides GPU core domain throttle reasons as a LevelZeroIOGroup signal at a per chip level as covered in the Level Zero Sysman API - https://spec.oneapi.io/level-zero/latest/sysman/PROG.html#frequency

Future PRs for percentage of time throttled should be considered.  

Tasks before merge:
- [x] Add bitwise_or aggregration function for throttle reasons
- [x] Test bitwise_or agg on a live system
- [x] Retest after data type change (double --> uint32_t) on live system.  Complete on system at idle (reports 0) and hitting power cap (reports [ZES_FREQ_THROTTLE_REASON_FLAG_AVE_PWR_CAP ](https://spec.oneapi.io/level-zero/latest/sysman/api.html#zes__api_8h_1a03134de1353e4ecaa94d5ec76db12651))