### PR TITLE
Update SharedMemory's interface for const correctness

### DIFF
--- a/service/src/SharedMemory.cpp
+++ b/service/src/SharedMemory.cpp
@@ -257,7 +257,7 @@ namespace geopm
         m_do_unlink_check = true;
     }
 
-    void SharedMemoryImp::chown(const unsigned int uid, const unsigned int gid) {
+    void SharedMemoryImp::chown(const unsigned int uid, const unsigned int gid) const {
         int err = 0;
         int shm_id = -1;
         if (m_is_linked) {

--- a/service/src/SharedMemoryImp.hpp
+++ b/service/src/SharedMemoryImp.hpp
@@ -46,7 +46,7 @@ namespace geopm
             //         and uid if current permissions allow for the change.
             /// @param [in] uid User ID to become owner.
             /// @param [in] gid Group ID to become owner.
-            void chown(const unsigned int uid, const unsigned int gid) override;
+            void chown(const unsigned int uid, const unsigned int gid) const override;
 
         protected:
             /// @brief Construct the file path to use for the provided key.

--- a/service/src/geopm/SharedMemory.hpp
+++ b/service/src/geopm/SharedMemory.hpp
@@ -60,7 +60,7 @@ namespace geopm
             static std::unique_ptr<SharedMemory> make_unique_user(const std::string &shm_key, unsigned int timeout);
             /// @brief Modifies the shared memory to be owned by the specified gid
             //         and uid if current permissions allow for the change.
-            virtual void chown(const unsigned int uid, const unsigned int gid) = 0;
+            virtual void chown(const unsigned int uid, const unsigned int gid) const = 0;
     };
 }
 

--- a/service/test/MockSharedMemory.hpp
+++ b/service/test/MockSharedMemory.hpp
@@ -35,7 +35,7 @@ class MockSharedMemory : public geopm::SharedMemory
                     get_scoped_lock, (), (override));
         MOCK_METHOD(void, unlink, (), (override));
         MOCK_METHOD(void, chown, (const unsigned int gid, const unsigned int uid),
-                    (override));
+                    (const, override));
 
     protected:
         std::vector<char> m_buffer;


### PR DESCRIPTION
Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>

- Fixes #787

Make "chown" method const for consistency and const correctness (applying similar rationale as for "pointer" method).
