### PR TITLE
GPU Signal & Control cleanup to match documentation

### DIFF
--- a/service/src/DCGMIOGroup.cpp
+++ b/service/src/DCGMIOGroup.cpp
@@ -104,8 +104,8 @@ namespace geopm
             }
             sv.second.m_signals = result;
         }
-        register_signal_alias("GPU_COMPUTE_ACTIVITY", "DCGM::SM_ACTIVE");
-        register_signal_alias("GPU_MEMORY_ACTIVITY", "DCGM::DRAM_ACTIVE");
+        register_signal_alias("GPU_CORE_ACTIVITY", "DCGM::SM_ACTIVE");
+        register_signal_alias("GPU_UNCORE_ACTIVITY", "DCGM::DRAM_ACTIVE");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -463,7 +463,7 @@ namespace geopm
 
         register_derivative_signals();
 
-        register_signal_alias("GPU_FREQUENCY_STATUS", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS");
+        register_signal_alias("GPU_CORE_FREQUENCY_STATUS", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS");
         register_signal_alias("GPU_POWER", M_NAME_PREFIX + "GPU_POWER");
         register_signal_alias("GPU_CORE_FREQUENCY_CONTROL",
                                M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL");

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -45,8 +45,8 @@ namespace geopm
         : m_platform_topo(platform_topo)
         , m_levelzero_device_pool(device_pool)
         , m_is_batch_read(false)
-        , m_signal_available({{M_NAME_PREFIX + "GPUCHIP_FREQUENCY_STATUS", {
-                                  "Compute/GPU chip domain current frequency in hertz",
+        , m_signal_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", {
+                                  "The current frequency of the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -67,8 +67,8 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MAX_AVAIL", {
-                                  "Compute/GPU chip domain maximum available frequency in hertz",
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL", {
+                                  "The maximum supported frequency of the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -83,8 +83,8 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MIN_AVAIL", {
-                                  "Compute/GPU chip domain minimum available frequency in hertz",
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_AVAIL", {
+                                  "The minimum supported frequency of the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -99,8 +99,8 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MAX_CONTROL", {
-                                  "Compute/GPU chip domain current maximum frequency requested in hertz",
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL", {
+                                  "The maximum frequency request for the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -115,8 +115,8 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MIN_CONTROL", {
-                                  "Compute/GPU chip domain current minimum frequency requested in hertz",
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
+                                  "The minimum frequency request for the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -132,7 +132,7 @@ namespace geopm
                                   1e6
                                   }},
                               {M_NAME_PREFIX + "GPU_ENERGY", {
-                                  "GPU energy in Joules",
+                                  "GPU energy in joules.",
                                   GEOPM_DOMAIN_GPU,
                                   Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
@@ -148,8 +148,8 @@ namespace geopm
                                   1 / 1e6
                                   }},
                               {M_NAME_PREFIX + "GPU_ENERGY_TIMESTAMP", {
-                                  "GPU energy timestamp in seconds"
-                                  "\nValue cached on LEVELZERO::ENERGY read",
+                                  "Timestamp for the GPU energy read in seconds."
+                                  "\nValue is updated on LEVELZERO::ENERGY read."
                                   GEOPM_DOMAIN_GPU,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
@@ -164,8 +164,8 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_MEMORY_FREQUENCY_STATUS", {
-                                  "Compute/GPU chip domain memory current frequency in hertz",
+                              {M_NAME_PREFIX + "GPU_UNCORE_FREQUENCY_STATUS", {
+                                  "The current frequency of the GPU Memory Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -180,8 +180,8 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_MEMORY_FREQUENCY_MAX_AVAIL", {
-                                  "Compute/GPU chip domain memory maximum frequency available in hertz",
+                              {M_NAME_PREFIX + "GPU_UNCORE_FREQUENCY_MAX_AVAIL", {
+                                  "The maximum supported frequency of the GPU Memory Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -196,8 +196,8 @@ namespace geopm
                                   },
                                   1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_MEMORY_FREQUENCY_MIN_AVAIL", {
-                                  "Compute/GPU chip domain memory minimum frequency in hertz",
+                              {M_NAME_PREFIX + "GPU_UNCORE_FREQUENCY_MIN_AVAIL", {
+                                  "The minimum supported frequency of the GPU Memory Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -213,7 +213,7 @@ namespace geopm
                                   1e6
                                   }},
                               {M_NAME_PREFIX + "GPU_POWER_LIMIT_DEFAULT", {
-                                  "Default power limit in Watts",
+                                  "Default power limit of the GPU in watts.",
                                   GEOPM_DOMAIN_GPU,
                                   Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -229,7 +229,7 @@ namespace geopm
                                   1 / 1e3
                                   }},
                               {M_NAME_PREFIX + "GPU_POWER_LIMIT_MIN_AVAIL", {
-                                  "Minimum available power limit in Watts",
+                                  "The minimum supported power limit in watts.",
                                   GEOPM_DOMAIN_GPU,
                                   Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -245,7 +245,7 @@ namespace geopm
                                   1 / 1e3
                                   }},
                               {M_NAME_PREFIX + "GPU_POWER_LIMIT_MAX_AVAIL", {
-                                  "Maximum available power limit in Watts",
+                                  "The maximum supported power limit in watts.",
                                   GEOPM_DOMAIN_GPU,
                                   Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -260,8 +260,9 @@ namespace geopm
                                   },
                                   1 / 1e3
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME", {
-                                  "Compute/GPU chip active time",
+                              {M_NAME_PREFIX + "GPU_ACTIVE_TIME", {
+                                  "Time in seconds that this resource is actively running a workload."
+                                  "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
@@ -276,9 +277,10 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_TIMESTAMP", {
-                                  "Compute/GPU chip active time reading timestamp"
-                                  "\nValue cached on LEVELZERO::GPUCHIP_ACTIVE_TIME read",
+                              {M_NAME_PREFIX + "GPU_ACTIVE_TIME_TIMESTAMP", {
+                                  "The timestamp for the LEVELZERO::GPU_ACTIVE_TIME read in seconds."
+                                  "\nValue is updated on LEVELZERO::GPU_ACTIVE_TIME read."
+                                  "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
@@ -293,8 +295,9 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COMPUTE", {
-                                  "Compute/GPU chip domain compute engine active time",
+                              {M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME", {
+                                  "Time in seconds that the GPU compute engines (EUs) are actively running a workload."
+                                  "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
@@ -309,9 +312,10 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COMPUTE_TIMESTAMP", {
-                                  "Compute/GPU chip domain compute engine active time reading timestamp"
-                                  "\nValue cached on LEVELZERO::GPUCHIP_ACTIVE_TIME_COMPUTE read",
+                              {M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME_TIMESTAMP", {
+                                  "The timestamp for the LEVELZERO::GPU_CORE_ACTIVE_TIME signal read in seconds."
+                                  "\nValue is updated on LEVELZERO::GPU_CORE_ACTIVE_TIME read."
+                                  "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
@@ -326,8 +330,9 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY", {
-                                  "Compute/GPU chip domain copy engine active time",
+                              {M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME", {
+                                  "Time in seconds that the GPU copy engines are actively running a workload."
+                                  "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
@@ -342,9 +347,10 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY_TIMESTAMP", {
-                                  "Compute/GPU chip domain copy engine active time timestamp"
-                                  "\nValue cached on LEVELZERO::GPUCHIP_ACTIVE_TIME_COPY read",
+                              {M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", {
+                                  "The timestamp for the LEVELZERO::GPU_UNCORE_ACTIVE_TIME signal read in seconds."
+                                  "\nValue is updated on LEVELZERO::GPU_UNCORE_ACTIVE_TIME read."
+                                  "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
@@ -359,8 +365,10 @@ namespace geopm
                                   },
                                   1 / 1e6
                                   }},
-                              {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_CONTROL", {
-                                  "Compute/GPU chip domain current requested frequency in hertz"
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", {
+                                  "Last value written to both the minimum and maximum frequency request for "
+                                  "the GPU Compute Hardware to a single user provided value (min=max)."
+                                  "\nOnly valid as a signal after being written, NAN returned otherwise."
                                   "\nReadings are valid only after writing to this control",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::average,
@@ -379,22 +387,24 @@ namespace geopm
                                   1e6
                                   }}
                              })
-        , m_control_available({{M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MIN_CONTROL", {
-                                    "Sets the compute/GPU chip domain frequency minimum in hertz",
+        , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
+                                    "Sets the minimum frequency request for the GPU Compute Hardware.",
                                     {},
                                     GEOPM_DOMAIN_GPU_CHIP,
                                     Agg::average,
                                     string_format_double
                                     }},
-                               {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MAX_CONTROL", {
-                                    "Sets the compute/GPU chip domain frequency maximum in hertz",
+                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL", {
+                                    "Sets the maximum frequency request for the GPU Compute Hardware.",
                                     {},
                                     GEOPM_DOMAIN_GPU_CHIP,
                                     Agg::average,
                                     string_format_double
                                     }},
-                               {M_NAME_PREFIX + "GPUCHIP_FREQUENCY_CONTROL", {
-                                    "Sets the compute/GPU chip fomain frequency both min and max in hertz",
+                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", {
+                                    "Sets both the minimum and maximum frequency request for the GPU Compute Hardware"
+                                    " to a single user provided value (min=max)."
+                                    "\nOnly valid as a signal after being written, NAN returned otherwise.",
                                     {},
                                     GEOPM_DOMAIN_GPU_CHIP,
                                     Agg::average,
@@ -402,37 +412,38 @@ namespace geopm
                                     }}
                               })
         , m_special_signal_set({M_NAME_PREFIX + "GPU_ENERGY",
-                                M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME",
-                                M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COMPUTE",
-                                M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY"})
+                                M_NAME_PREFIX + "GPU_ACTIVE_TIME",
+                                M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME",
+                                M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME"})
 
         , m_derivative_signal_map ({
             {M_NAME_PREFIX + "GPU_POWER",
-                    {"Average GPU power over 40 ms or 8 control loop iterations",
-                    M_NAME_PREFIX + "GPU_ENERGY",
-                    M_NAME_PREFIX + "GPU_ENERGY_TIMESTAMP",
-                    IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
+                    {"Average GPU power over 40 ms or 8 control loop iterations."
+                     "  Derivative signal based on LEVELZERO::GPU_ENERGY.",
+                     M_NAME_PREFIX + "GPU_ENERGY",
+                     M_NAME_PREFIX + "GPU_ENERGY_TIMESTAMP",
+                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
             {M_NAME_PREFIX + "GPU_UTILIZATION",
-                    {"GPU utilization"
-                        "n  Level Zero logical engines may map to the same hardware"
-                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
-                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME",
-                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_TIMESTAMP",
-                    IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
-            {M_NAME_PREFIX + "GPU_UTILIZATION_COMPUTE",
-                    {"Compute engine utilization"
-                        "n  Level Zero logical engines may map to the same hardware"
-                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
-                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COMPUTE",
-                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COMPUTE_TIMESTAMP",
-                    IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
-            {M_NAME_PREFIX + "GPU_UTILIZATION_COPY",
-                    {"Copy engine utilization"
-                        "n  Level Zero logical engines may map to the same hardware"
-                        "\n  resulting in a reduced signal range (i.e. not 0 to 1)",
-                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY",
-                    M_NAME_PREFIX + "GPUCHIP_ACTIVE_TIME_COPY_TIMESTAMP",
-                    IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
+                    {"Utilization of all GPU engines. Level Zero logical engines may map to the same hardware,"
+                     " resulting in a reduced signal range (i.e. less than 0 to 1) in some cases."
+                     "\nSee the LevelZero Sysman Engine documentation for more info.",
+                     M_NAME_PREFIX + "GPU_ACTIVE_TIME",
+                     M_NAME_PREFIX + "GPU_ACTIVE_TIME_TIMESTAMP",
+                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
+            {M_NAME_PREFIX + "GPU_CORE_UTILIZATION",
+                    {"Utilization of the GPU Compute engines (EUs). Level Zero logical engines may map to the same hardware,"
+                     " resulting in a reduced signal range (i.e. less than 0 to 1) in some cases."
+                     "\nSee the LevelZero Sysman Engine documentation for more info.",
+                     M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME",
+                     M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME_TIMESTAMP",
+                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
+            {M_NAME_PREFIX + "GPU_UNCORE_UTILIZATION",
+                    {"Utilization of the GPU Copy engines. Level Zero logical engines may map to the same hardware,"
+                     " resulting in a reduced signal range (i.e. less than 0 to 1) in some cases."
+                     "\nSee the LevelZero Sysman Engine documentation for more info.",
+                     M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME",
+                     M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME_TIMESTAMP",
+                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
         })
         , m_mock_save_ctl(save_control_test)
     {
@@ -452,12 +463,12 @@ namespace geopm
 
         register_derivative_signals();
 
-        register_signal_alias("GPUCHIP_FREQUENCY_STATUS", M_NAME_PREFIX + "GPUCHIP_FREQUENCY_STATUS");
+        register_signal_alias("GPU_FREQUENCY_STATUS", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS");
         register_signal_alias("GPU_POWER", M_NAME_PREFIX + "GPU_POWER");
-        register_signal_alias("GPUCHIP_FREQUENCY_CONTROL",
-                               M_NAME_PREFIX + "GPUCHIP_FREQUENCY_CONTROL");
-        register_control_alias("GPUCHIP_FREQUENCY_CONTROL",
-                               M_NAME_PREFIX + "GPUCHIP_FREQUENCY_CONTROL");
+        register_signal_alias("GPU_CORE_FREQUENCY_CONTROL",
+                               M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL");
+        register_control_alias("GPU_CORE_FREQUENCY_CONTROL",
+                               M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {
@@ -836,8 +847,8 @@ namespace geopm
                             __FILE__, __LINE__);
         }
 
-        if (control_name == M_NAME_PREFIX + "GPUCHIP_FREQUENCY_CONTROL" ||
-            control_name == "GPUCHIP_FREQUENCY_CONTROL") {
+        if (control_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL" ||
+            control_name == "GPU_CORE_FREQUENCY_CONTROL") {
             if (std::isnan(setting)) {
                 // At initialization before this control has ever been written the "signal"
                 // version of this control will return NAN.  If this NAN is later used as the
@@ -850,15 +861,15 @@ namespace geopm
                                                           setting / 1e6, setting / 1e6);
             }
         }
-        else if(control_name == M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MIN_CONTROL") {
-            double curr_max = read_signal(M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MAX_CONTROL",
+        else if(control_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL") {
+            double curr_max = read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL",
                                           domain_type, domain_idx);
             m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
                                                       geopm::LevelZero::M_DOMAIN_COMPUTE,
                                                       setting / 1e6, curr_max / 1e6);
         }
-        else if(control_name == M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MAX_CONTROL") {
-            double curr_min = read_signal(M_NAME_PREFIX + "GPUCHIP_FREQUENCY_MIN_CONTROL",
+        else if(control_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL") {
+            double curr_min = read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL",
                                           domain_type, domain_idx);
             m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
                                                       geopm::LevelZero::M_DOMAIN_COMPUTE,

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -134,7 +134,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_ENERGY", {
                                   "GPU energy in Joules",
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
                                   string_format_double,
                                   {},
@@ -215,7 +215,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_POWER_LIMIT_DEFAULT", {
                                   "Default power limit in Watts",
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
@@ -231,7 +231,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_POWER_LIMIT_MIN_AVAIL", {
                                   "Minimum available power limit in Watts",
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
@@ -247,7 +247,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_POWER_LIMIT_MAX_AVAIL", {
                                   "Maximum available power limit in Watts",
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -149,7 +149,7 @@ namespace geopm
                                   }},
                               {M_NAME_PREFIX + "GPU_ENERGY_TIMESTAMP", {
                                   "Timestamp for the GPU energy read in seconds."
-                                  "\nValue is updated on LEVELZERO::ENERGY read."
+                                  "\nValue is updated on LEVELZERO::ENERGY read.",
                                   GEOPM_DOMAIN_GPU,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -45,7 +45,7 @@ namespace geopm
         , m_nvml_device_pool(device_pool)
         , m_is_batch_read(false)
         , m_frequency_control_request(m_platform_topo.num_domain(GEOPM_DOMAIN_GPU), 0)
-        , m_signal_available({{M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", {
+        , m_signal_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", {
                                   "Streaming multiprocessor frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_GPU,
@@ -77,7 +77,7 @@ namespace geopm
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double
                                   }},
-                              {M_NAME_PREFIX + "GPU_MEMORY_FREQUENCY_STATUS", {
+                              {M_NAME_PREFIX + "GPU_UNCORE_FREQUENCY_STATUS", {
                                   "GPU memory frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_GPU,
@@ -85,7 +85,7 @@ namespace geopm
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double
                                   }},
-                              {M_NAME_PREFIX + "GPU_THROTTLE_REASONS", {
+                              {M_NAME_PREFIX + "GPU_CORE_THROTTLE_REASONS", {
                                   "GPU clock throttling reasons",
                                   {},
                                   GEOPM_DOMAIN_GPU,
@@ -144,7 +144,7 @@ namespace geopm
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double
                                   }},
-                              {M_NAME_PREFIX + "GPU_MEMORY_UTILIZATION", {
+                              {M_NAME_PREFIX + "GPU_UNCORE_UTILIZATION", {
                                   "Fraction of time the GPU memory was accessed in the last set of driver samples",
                                   {},
                                   GEOPM_DOMAIN_GPU,
@@ -152,7 +152,7 @@ namespace geopm
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double
                                   }},
-                              {M_NAME_PREFIX + "GPU_FREQUENCY_MAX_AVAIL", {
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL", {
                                   "Streaming multiprocessor Maximum frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_GPU,
@@ -160,7 +160,7 @@ namespace geopm
                                   IOGroup::M_SIGNAL_BEHAVIOR_CONSTANT,
                                   string_format_double
                                   }},
-                              {M_NAME_PREFIX + "GPU_FREQUENCY_MIN_AVAIL", {
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_AVAIL", {
                                   "Streaming multiprocessor Minimum frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_GPU,
@@ -168,7 +168,7 @@ namespace geopm
                                   IOGroup::M_SIGNAL_BEHAVIOR_CONSTANT,
                                   string_format_double
                                   }},
-                              {M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", {
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", {
                                   "Latest frequency control request in hertz",
                                   {},
                                   GEOPM_DOMAIN_GPU,
@@ -176,7 +176,7 @@ namespace geopm
                                   IOGroup::M_SIGNAL_BEHAVIOR_CONSTANT,
                                   string_format_double
                                   }},
-                              {M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL", {
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL", {
                                   "Resets streaming multiprocessor frequency min and max limits to default values.",
                                   {},
                                   GEOPM_DOMAIN_GPU,
@@ -185,14 +185,14 @@ namespace geopm
                                   string_format_double
                                   }}
                              })
-        , m_control_available({{M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", {
+        , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", {
                                     "Sets streaming multiprocessor frequency min and max to the same limit (in hertz)",
                                     {},
                                     GEOPM_DOMAIN_GPU,
                                     Agg::average,
                                     string_format_double
                                     }},
-                               {M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL", {
+                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL", {
                                     "Resets streaming multiprocessor frequency min and max limits to default values."
                                     "\n  Parameter provided is unused.",
                                     {},
@@ -220,9 +220,9 @@ namespace geopm
             sv.second.signals = result;
         }
         register_signal_alias("GPU_POWER", M_NAME_PREFIX + "GPU_POWER");
-        register_signal_alias("GPU_FREQUENCY_STATUS", M_NAME_PREFIX + "GPU_FREQUENCY_STATUS");
-        register_signal_alias("GPU_FREQUENCY_MIN_AVAIL", M_NAME_PREFIX + "GPU_FREQUENCY_MIN_AVAIL");
-        register_signal_alias("GPU_FREQUENCY_MAX_AVAIL", M_NAME_PREFIX + "GPU_FREQUENCY_MAX_AVAIL");
+        register_signal_alias("GPU_CORE_FREQUENCY_STATUS", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS");
+        register_signal_alias("GPU_CORE_FREQUENCY_MIN_AVAIL", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_AVAIL");
+        register_signal_alias("GPU_CORE_FREQUENCY_MAX_AVAIL", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL");
         register_signal_alias("GPU_ENERGY", M_NAME_PREFIX + "GPU_ENERGY_CONSUMPTION_TOTAL");
         register_signal_alias("GPU_TEMPERATURE", M_NAME_PREFIX + "GPU_TEMPERATURE");
         register_signal_alias("GPU_UTILIZATION", M_NAME_PREFIX + "GPU_UTILIZATION");
@@ -238,8 +238,8 @@ namespace geopm
         }
         register_control_alias("GPU_POWER_LIMIT_CONTROL", M_NAME_PREFIX + "GPU_POWER_LIMIT_CONTROL");
         register_signal_alias("GPU_POWER_LIMIT_CONTROL", M_NAME_PREFIX + "GPU_POWER_LIMIT_CONTROL");
-        register_control_alias("GPU_FREQUENCY_CONTROL", M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL");
-        register_signal_alias("GPU_FREQUENCY_CONTROL", M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL");
+        register_control_alias("GPU_CORE_FREQUENCY_CONTROL", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL");
+        register_signal_alias("GPU_CORE_FREQUENCY_CONTROL", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL");
 
         for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
             std::vector<unsigned int> supported_frequency = m_nvml_device_pool.frequency_supported_sm(domain_idx);
@@ -534,15 +534,15 @@ namespace geopm
         }
 
         double result = NAN;
-        if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_STATUS" || signal_name == "GPU_FREQUENCY_STATUS") {
+        if (signal_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS" || signal_name == "GPU_CORE_FREQUENCY_STATUS") {
             result = (double) m_nvml_device_pool.frequency_status_sm(domain_idx) * 1e6;
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_MIN_AVAIL" || signal_name == "GPU_FREQUENCY_MIN_AVAIL") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_AVAIL" || signal_name == "GPU_CORE_FREQUENCY_MIN_AVAIL") {
             if (m_supported_freq.at(domain_idx).size() != 0) {
                 result = 1e6 * m_supported_freq.at(domain_idx).front();
             }
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_MAX_AVAIL" || signal_name == "GPU_FREQUENCY_MAX_AVAIL") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL" || signal_name == "GPU_CORE_FREQUENCY_MAX_AVAIL") {
             if (m_supported_freq.at(domain_idx).size() != 0) {
                 result = 1e6 * m_supported_freq.at(domain_idx).back();
             }
@@ -550,7 +550,7 @@ namespace geopm
         else if (signal_name == M_NAME_PREFIX + "GPU_UTILIZATION" || signal_name == "GPU_UTILIZATION") {
             result = (double) m_nvml_device_pool.utilization(domain_idx) / 100;
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_THROTTLE_REASONS") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_CORE_THROTTLE_REASONS") {
             result = (double) m_nvml_device_pool.throttle_reasons(domain_idx);
         }
         else if (signal_name == M_NAME_PREFIX + "GPU_POWER" || signal_name == "GPU_POWER") {
@@ -560,7 +560,7 @@ namespace geopm
                  signal_name == "GPU_POWER_LIMIT_CONTROL") {
             result = (double) m_nvml_device_pool.power_limit(domain_idx) / 1e3;
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_MEMORY_FREQUENCY_STATUS") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_UNCORE_FREQUENCY_STATUS") {
             result = (double) m_nvml_device_pool.frequency_status_mem(domain_idx) * 1e6;
         }
         else if (signal_name == M_NAME_PREFIX + "GPU_TEMPERATURE" || signal_name == "GPU_TEMPERATURE") {
@@ -578,17 +578,17 @@ namespace geopm
         else if (signal_name == M_NAME_PREFIX + "GPU_PCIE_TX_THROUGHPUT") {
             result = (double) m_nvml_device_pool.throughput_tx_pcie(domain_idx) * 1024;
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_MEMORY_UTILIZATION") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_UNCORE_UTILIZATION") {
             result = (double) m_nvml_device_pool.utilization_mem(domain_idx) / 100;
         }
         else if (signal_name == M_NAME_PREFIX + "GPU_CPU_ACTIVE_AFFINITIZATION") {
             std::map<pid_t, double> process_map = gpu_process_map();
             result = cpu_gpu_affinity(domain_idx, process_map);
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL" || signal_name == "GPU_FREQUENCY_CONTROL") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL" || signal_name == "GPU_CORE_FREQUENCY_CONTROL") {
             result = m_frequency_control_request.at(domain_idx);
         }
-        else if (signal_name == M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL") {
+        else if (signal_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL") {
             ; // No-op.  Nothing to return.
         }
         else {
@@ -619,11 +619,11 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (control_name == M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL" || control_name == "GPU_FREQUENCY_CONTROL") {
+        if (control_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL" || control_name == "GPU_CORE_FREQUENCY_CONTROL") {
             m_nvml_device_pool.frequency_control_sm(domain_idx, setting / 1e6, setting / 1e6);
             m_frequency_control_request.at(domain_idx) = setting;
         }
-        else if (control_name == M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL") {
+        else if (control_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL") {
             m_nvml_device_pool.frequency_reset_control(domain_idx);
         }
         else if (control_name == M_NAME_PREFIX + "GPU_POWER_LIMIT_CONTROL" || control_name == "GPU_POWER_LIMIT_CONTROL") {
@@ -722,7 +722,7 @@ namespace geopm
         std::vector<SaveControl::m_setting_s> settings;
         int num_domains = m_platform_topo.num_domain(GEOPM_DOMAIN_GPU);
         for (int domain_idx = 0; domain_idx < num_domains; ++domain_idx) {
-            settings.push_back({M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL",
+            settings.push_back({M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL",
                                 GEOPM_DOMAIN_GPU,
                                 domain_idx,
                                 0});

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -89,7 +89,7 @@ namespace geopm
                                   "GPU clock throttling reasons",
                                   {},
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::expect_same,
+                                  Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double
                                   }},

--- a/service/test/DCGMIOGroupTest.cpp
+++ b/service/test/DCGMIOGroupTest.cpp
@@ -217,7 +217,7 @@ TEST_F(DCGMIOGroupTest, read_signal)
 
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
         double sm_active = dcgm_io.read_signal("DCGM::SM_ACTIVE", GEOPM_DOMAIN_GPU, gpu_idx);
-        double sm_active_alias = dcgm_io.read_signal("GPU_COMPUTE_ACTIVITY", GEOPM_DOMAIN_GPU, gpu_idx);
+        double sm_active_alias = dcgm_io.read_signal("GPU_CORE_ACTIVITY", GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(sm_active, sm_active_alias);
         EXPECT_DOUBLE_EQ(sm_active, mock_sm_active.at(gpu_idx));
 
@@ -225,7 +225,7 @@ TEST_F(DCGMIOGroupTest, read_signal)
         EXPECT_DOUBLE_EQ(sm_occupancy, mock_sm_occupancy.at(gpu_idx));
 
         double dram_active = dcgm_io.read_signal("DCGM::DRAM_ACTIVE", GEOPM_DOMAIN_GPU, gpu_idx);
-        double dram_active_alias = dcgm_io.read_signal("GPU_MEMORY_ACTIVITY", GEOPM_DOMAIN_GPU, gpu_idx);
+        double dram_active_alias = dcgm_io.read_signal("GPU_UNCORE_ACTIVITY", GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(dram_active, dram_active_alias);
         EXPECT_DOUBLE_EQ(dram_active, mock_dram_active.at(gpu_idx));
     }

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -173,9 +173,9 @@ TEST_F(LevelZeroIOGroupTest, push_control_adjust_write_batch)
     std::vector<double> mock_freq = {1530, 1320, 420, 135, 1620, 812, 199, 1700};
 
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
-        batch_value[(levelzero_io.push_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL",
+        batch_value[(levelzero_io.push_control("LEVELZERO::GPU_CORE_FREQUENCY_CONTROL",
                                         GEOPM_DOMAIN_GPU_CHIP, sub_idx))] = mock_freq.at(sub_idx)*1e6;
-        batch_value[(levelzero_io.push_control("GPUCHIP_FREQUENCY_CONTROL",
+        batch_value[(levelzero_io.push_control("GPU_CORE_FREQUENCY_CONTROL",
                                         GEOPM_DOMAIN_GPU_CHIP, sub_idx))] = mock_freq.at(sub_idx)*1e6;
         EXPECT_CALL(*m_device_pool,
                     frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, mock_freq.at(sub_idx), mock_freq.at(sub_idx))).Times(2);
@@ -199,11 +199,11 @@ TEST_F(LevelZeroIOGroupTest, write_control)
         EXPECT_CALL(*m_device_pool,
                     frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, mock_freq.at(sub_idx), mock_freq.at(sub_idx))).Times(2);
 
-        EXPECT_NO_THROW(levelzero_io.write_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL",
+        EXPECT_NO_THROW(levelzero_io.write_control("LEVELZERO::GPU_CORE_FREQUENCY_CONTROL",
                                               GEOPM_DOMAIN_GPU_CHIP, sub_idx,
                                               mock_freq.at(sub_idx)*1e6));
 
-        EXPECT_NO_THROW(levelzero_io.write_control("GPUCHIP_FREQUENCY_CONTROL",
+        EXPECT_NO_THROW(levelzero_io.write_control("GPU_CORE_FREQUENCY_CONTROL",
                                               GEOPM_DOMAIN_GPU_CHIP, sub_idx,
                                               mock_freq.at(sub_idx)*1e6));
     }
@@ -222,7 +222,7 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
 
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq.at(sub_idx)));
-        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
 
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
@@ -233,7 +233,7 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
 
     levelzero_io.read_batch();
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
-        double frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         double frequency_batch = levelzero_io.sample(batch_idx.at(sub_idx));
 
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(sub_idx)*1e6);
@@ -260,7 +260,7 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
 
     levelzero_io.read_batch();
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
-        double frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         double frequency_batch = levelzero_io.sample(batch_idx.at(sub_idx));
 
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(sub_idx)*1e6);
@@ -305,9 +305,9 @@ TEST_F(LevelZeroIOGroupTest, read_timestamp_batch_reverse)
         EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_timestamp_compute.at(sub_idx)));
         EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_timestamp_copy.at(sub_idx)));
 
-        active_time_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
-        active_time_compute_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COMPUTE_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
-        active_time_copy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COPY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+        active_time_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+        active_time_compute_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+        active_time_copy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
 
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
@@ -377,9 +377,9 @@ TEST_F(LevelZeroIOGroupTest, read_timestamp_batch)
         EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_timestamp_compute.at(sub_idx)));
         EXPECT_CALL(*m_device_pool, active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_timestamp_copy.at(sub_idx)));
 
-        active_time_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
-        active_time_compute_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COMPUTE", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
-        active_time_copy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COPY", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+        active_time_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+        active_time_compute_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+        active_time_copy_batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
 
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
@@ -467,27 +467,27 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
 
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         //Frequency
-        double frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
-        double frequency_alias = levelzero_io.read_signal("GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double frequency_alias = levelzero_io.read_signal("GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, frequency_alias);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_gpu.at(sub_idx)*1e6);
-        frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_MEMORY_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_mem.at(sub_idx)*1e6);
-        frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_min_gpu.at(sub_idx)*1e6);
-        frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_max_gpu.at(sub_idx)*1e6);
-        frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_MEMORY_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_min_mem.at(sub_idx)*1e6);
-        frequency = levelzero_io.read_signal("LEVELZERO::GPUCHIP_MEMORY_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_max_mem.at(sub_idx)*1e6);
 
         //Active time
-        double active_time = levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double active_time = levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx)/1e6);
-        double active_time_compute = levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COMPUTE", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double active_time_compute = levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(active_time_compute, mock_active_time_compute.at(sub_idx)/1e6);
-        double active_time_copy = levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COPY", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double active_time_copy = levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time_copy.at(sub_idx)/1e6);
     }
 
@@ -508,8 +508,8 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
     // Just check validity of derived signals
     ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_POWER"));
     ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_UTILIZATION"));
-    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_UTILIZATION_COMPUTE"));
-    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_UTILIZATION_COPY"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_CORE_UTILIZATION"));
+    ASSERT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_UNCORE_UTILIZATION"));
 }
 
 //Test case: Error path testing including:
@@ -533,11 +533,11 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     }
     LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool, nullptr);
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.sample(0),
                                GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
 
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::INVALID", GEOPM_DOMAIN_GPU, 0),
@@ -545,11 +545,11 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::INVALID", GEOPM_DOMAIN_GPU, 0),
                                GEOPM_ERROR_INVALID, "LEVELZERO::INVALID not valid for LevelZeroIOGroup");
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.adjust(0, 12345.6),
                                GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0, 1530000000),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_type must be");
 
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::INVALID", GEOPM_DOMAIN_GPU, 0),
@@ -557,27 +557,27 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::INVALID", GEOPM_DOMAIN_GPU, 0, 1530000000),
                                GEOPM_ERROR_INVALID, "LEVELZERO::INVALID not valid for LevelZeroIOGroup");
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, num_gpu_subdevice),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, num_gpu_subdevice),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, -1),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, -1),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, num_gpu_subdevice),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, num_gpu_subdevice),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, -1),
-                               GEOPM_ERROR_INVALID, "domain_idx out of range");
-
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU_CHIP, num_gpu_subdevice),
-                               GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU_CHIP, -1),
-                               GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU_CHIP, num_gpu_subdevice, 1530000000),
-                               GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPUCHIP_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU_CHIP, -1, 1530000000),
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, -1),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COPY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPUCHIP_ACTIVE_TIME_COMPUTE_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU_CHIP, num_gpu_subdevice),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_control("LEVELZERO::GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU_CHIP, -1),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU_CHIP, num_gpu_subdevice, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU_CHIP, -1, 1530000000),
+                               GEOPM_ERROR_INVALID, "domain_idx out of range");
+
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
 }
 

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -468,7 +468,7 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         //Frequency
         double frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
-        double frequency_alias = levelzero_io.read_signal("GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double frequency_alias = levelzero_io.read_signal("GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, frequency_alias);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_gpu.at(sub_idx)*1e6);
         frequency = levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);

--- a/service/test/NVMLIOGroupTest.cpp
+++ b/service/test/NVMLIOGroupTest.cpp
@@ -122,15 +122,15 @@ TEST_F(NVMLIOGroupTest, push_control_adjust_write_batch)
     std::vector<double> mock_freq = {1530, 1320, 420, 135};
     std::vector<double> mock_power = {153600, 70000, 300000, 50000};
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
-        batch_value[(nvml_io.push_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL",
+        batch_value[(nvml_io.push_control(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL",
                                         GEOPM_DOMAIN_GPU, gpu_idx))] = mock_freq.at(gpu_idx) * 1e6;
-        batch_value[(nvml_io.push_control("GPU_FREQUENCY_CONTROL",
+        batch_value[(nvml_io.push_control("GPU_CORE_FREQUENCY_CONTROL",
                                         GEOPM_DOMAIN_GPU, gpu_idx))] = mock_freq.at(gpu_idx) * 1e6;
         EXPECT_CALL(*m_device_pool,
                     frequency_control_sm(gpu_idx, mock_freq.at(gpu_idx),
                                          mock_freq.at(gpu_idx))).Times(2);
 
-        batch_value[(nvml_io.push_control(M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL",
+        batch_value[(nvml_io.push_control(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL",
                                         GEOPM_DOMAIN_GPU, gpu_idx))] = mock_freq.at(gpu_idx);
         EXPECT_CALL(*m_device_pool, frequency_reset_control(gpu_idx)).Times(1);
 
@@ -160,20 +160,20 @@ TEST_F(NVMLIOGroupTest, write_control)
         EXPECT_CALL(*m_device_pool,
                     frequency_control_sm(gpu_idx, mock_freq.at(gpu_idx),
                                          mock_freq.at(gpu_idx))).Times(2);
-        EXPECT_NO_THROW(nvml_io.write_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL",
+        EXPECT_NO_THROW(nvml_io.write_control(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL",
                                               GEOPM_DOMAIN_GPU, gpu_idx,
                                               mock_freq.at(gpu_idx) * 1e6));
         // Verify the write was cached properly
-        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL",
+        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL",
                                                GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(gpu_idx) * 1e6);
 
-        EXPECT_NO_THROW(nvml_io.write_control("GPU_FREQUENCY_CONTROL",
+        EXPECT_NO_THROW(nvml_io.write_control("GPU_CORE_FREQUENCY_CONTROL",
                                               GEOPM_DOMAIN_GPU, gpu_idx,
                                               mock_freq.at(gpu_idx) * 1e6));
 
         EXPECT_CALL(*m_device_pool, frequency_reset_control(gpu_idx)).Times(1);
-        EXPECT_NO_THROW(nvml_io.write_control(M_NAME_PREFIX + "GPU_FREQUENCY_RESET_CONTROL",
+        EXPECT_NO_THROW(nvml_io.write_control(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL",
                                               GEOPM_DOMAIN_GPU, gpu_idx, 12345));
 
         EXPECT_CALL(*m_device_pool, power_control(gpu_idx, mock_power.at(gpu_idx))).Times(2);
@@ -199,11 +199,11 @@ TEST_F(NVMLIOGroupTest, read_signal_and_batch)
         EXPECT_CALL(*m_device_pool, frequency_status_sm(gpu_idx)).WillRepeatedly(Return(mock_freq.at(gpu_idx)));
     }
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
-        batch_idx.push_back(nvml_io.push_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx));
+        batch_idx.push_back(nvml_io.push_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx));
     }
     nvml_io.read_batch();
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
-        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx);
+        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx);
         double frequency_batch = nvml_io.sample(batch_idx.at(gpu_idx));
 
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(gpu_idx) * 1e6);
@@ -217,7 +217,7 @@ TEST_F(NVMLIOGroupTest, read_signal_and_batch)
     }
     nvml_io.read_batch();
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
-        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx);
+        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx);
         double frequency_batch = nvml_io.sample(batch_idx.at(gpu_idx));
 
         EXPECT_DOUBLE_EQ(frequency, (mock_freq.at(gpu_idx)) * 1e6);
@@ -270,18 +270,18 @@ TEST_F(NVMLIOGroupTest, read_signal)
     std::sort(mock_supported_freq.begin(), mock_supported_freq.end());
 
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
-        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx);
-        double frequency_alias = nvml_io.read_signal("GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx);
+        double frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx);
+        double frequency_alias = nvml_io.read_signal("GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(frequency, frequency_alias);
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(gpu_idx) * 1e6);
 
-        double frequency_min = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_GPU, gpu_idx);
-        double frequency_min_alias = nvml_io.read_signal("GPU_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_GPU, gpu_idx);
+        double frequency_min = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_GPU, gpu_idx);
+        double frequency_min_alias = nvml_io.read_signal("GPU_CORE_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(frequency_min, mock_supported_freq.front() * 1e6);
         EXPECT_DOUBLE_EQ(frequency_min, frequency_min_alias);
 
-        double frequency_max = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU, gpu_idx);
-        double frequency_max_alias = nvml_io.read_signal("GPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU, gpu_idx);
+        double frequency_max = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU, gpu_idx);
+        double frequency_max_alias = nvml_io.read_signal("GPU_CORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(frequency_max, mock_supported_freq.back() * 1e6);
         EXPECT_DOUBLE_EQ(frequency_max, frequency_max_alias);
 
@@ -290,7 +290,7 @@ TEST_F(NVMLIOGroupTest, read_signal)
         EXPECT_DOUBLE_EQ(utilization_gpu, mock_utilization_gpu.at(gpu_idx) / 100);
         EXPECT_DOUBLE_EQ(utilization_gpu, utilization_gpu_alias);
 
-        double throttle_reasons = nvml_io.read_signal(M_NAME_PREFIX + "GPU_THROTTLE_REASONS", GEOPM_DOMAIN_GPU, gpu_idx);
+        double throttle_reasons = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_THROTTLE_REASONS", GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(throttle_reasons, mock_throttle_reasons.at(gpu_idx));
 
         double power = nvml_io.read_signal(M_NAME_PREFIX + "GPU_POWER", GEOPM_DOMAIN_GPU, gpu_idx);
@@ -298,7 +298,7 @@ TEST_F(NVMLIOGroupTest, read_signal)
         EXPECT_DOUBLE_EQ(power, power_alias);
         EXPECT_DOUBLE_EQ(power, mock_power.at(gpu_idx) / 1e3);
 
-        double frequency_mem = nvml_io.read_signal(M_NAME_PREFIX + "GPU_MEMORY_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx);
+        double frequency_mem = nvml_io.read_signal(M_NAME_PREFIX + "GPU_UNCORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(frequency_mem, mock_freq_mem.at(gpu_idx) * 1e6);
 
         double temperature = nvml_io.read_signal(M_NAME_PREFIX + "GPU_TEMPERATURE", GEOPM_DOMAIN_GPU, gpu_idx);
@@ -320,10 +320,10 @@ TEST_F(NVMLIOGroupTest, read_signal)
         double pcie_tx_throughput = nvml_io.read_signal(M_NAME_PREFIX + "GPU_PCIE_TX_THROUGHPUT", GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(pcie_tx_throughput, mock_pcie_tx_throughput.at(gpu_idx) * 1024);
 
-        double utilization_mem = nvml_io.read_signal(M_NAME_PREFIX + "GPU_MEMORY_UTILIZATION", GEOPM_DOMAIN_GPU, gpu_idx);
+        double utilization_mem = nvml_io.read_signal(M_NAME_PREFIX + "GPU_UNCORE_UTILIZATION", GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(utilization_mem, mock_utilization_mem.at(gpu_idx) / 100);
 
-        frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL",
+        frequency = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL",
                                         GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(frequency, 0); // 0 until first write
     }
@@ -371,11 +371,11 @@ TEST_F(NVMLIOGroupTest, error_path)
 
     NVMLIOGroup nvml_io(*m_platform_topo, *m_device_pool, nullptr);
 
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
     GEOPM_EXPECT_THROW_MESSAGE(nvml_io.sample(0),
                                GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
 
     GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "INVALID", GEOPM_DOMAIN_GPU, 0),
@@ -383,11 +383,11 @@ TEST_F(NVMLIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "INVALID", GEOPM_DOMAIN_GPU, 0),
                                GEOPM_ERROR_INVALID, M_NAME_PREFIX + "INVALID not valid for NVMLIOGroup");
 
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0),
                                GEOPM_ERROR_INVALID, "domain_type must be");
     GEOPM_EXPECT_THROW_MESSAGE(nvml_io.adjust(0, 12345.6),
                                GEOPM_ERROR_INVALID, "batch_idx 0 out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0, 1530000000),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_BOARD, 0, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_type must be");
 
     GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "INVALID", GEOPM_DOMAIN_GPU, 0),
@@ -395,22 +395,22 @@ TEST_F(NVMLIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "INVALID", GEOPM_DOMAIN_GPU, 0, 1530000000),
                                GEOPM_ERROR_INVALID, M_NAME_PREFIX + "INVALID not valid for NVMLIOGroup");
 
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, num_gpu),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, num_gpu),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, -1),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, -1),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, num_gpu),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, num_gpu),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, -1),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU, -1),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU, num_gpu),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU, num_gpu),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU, -1),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.push_control(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU, -1),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU, num_gpu, 1530000000),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU, num_gpu, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
-    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "GPU_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU, -1, 1530000000),
+    GEOPM_EXPECT_THROW_MESSAGE(nvml_io.write_control(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", GEOPM_DOMAIN_GPU, -1, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 }
 


### PR DESCRIPTION
Signed-off-by: Lowren Lawson <lowren.h.lawson@intel.com>

- Relates to #2314 feature request from github issues
- Fixes #2360 bug from github issues.

This PR is intended to align the names used in our GPU documentation with those used in the IOGroups themselves, as well as address any issues around aggregation differences, domain differences, etc.

For a list of associated tasks see https://github.com/geopm/geopm/pull/2329#issuecomment-1136335207 
