### PR TITLE
Remove extra include in `Reporter.cpp`

### DIFF
--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -34,7 +34,6 @@
 #include "geopm_version.h"
 #include "geopm_debug.hpp"
 #include "Environment.hpp"
-#include "geopm_debug.hpp"
 #include "PlatformIOProf.hpp"
 #include "geopm_time.h"
 


### PR DESCRIPTION
Signed-off-by: Konstantin Rebrov <konstantin.rebrov@intel.com>

- Relates to #2107  from github issues
- Fixes #2107  change request from github issues.

Removes the line

```cpp
#include "geopm_debug.hpp" 
```