### PR TITLE
Updated reporter to use new GPU signal names

### DIFF
--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -398,7 +398,7 @@ namespace geopm
         std::vector<m_sync_field_s> conditional_sync_fields = {
             {"gpu-energy (J)", {"GPU_ENERGY"}, sample_only},
             {"gpu-power (W)", {"GPU_POWER"}, sample_only},
-            {"gpu-frequency (Hz)", {"GPU_FREQUENCY_STATUS"}, sample_only},
+            {"gpu-frequency (Hz)", {"GPU_CORE_FREQUENCY_STATUS"}, sample_only},
             {"uncore-frequency (Hz)", {"CPU_UNCORE_FREQUENCY_STATUS"}, sample_only}
         };
 

--- a/test/ReporterTest.cpp
+++ b/test/ReporterTest.cpp
@@ -493,12 +493,12 @@ TEST_F(ReporterTest, generate_conditional)
         .WillOnce(Return(M_ENERGY_GPU_IDX));
     EXPECT_CALL(*m_sample_agg, push_signal("GPU_POWER", GEOPM_DOMAIN_BOARD, 0))
         .WillOnce(Return(M_POWER_GPU_IDX));
-    EXPECT_CALL(*m_sample_agg, push_signal("GPU_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0))
+    EXPECT_CALL(*m_sample_agg, push_signal("GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0))
         .WillOnce(Return(M_FREQUENCY_GPU_IDX));
     EXPECT_CALL(*m_sample_agg, push_signal("CPU_UNCORE_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0))
         .WillOnce(Return(M_FREQUENCY_CPU_UNCORE_IDX));
 
-    std::set<std::string> signal_names = {"GPU_ENERGY","GPU_POWER","GPU_FREQUENCY_STATUS","CPU_UNCORE_FREQUENCY_STATUS"};
+    std::set<std::string> signal_names = {"GPU_ENERGY","GPU_POWER","GPU_CORE_FREQUENCY_STATUS","CPU_UNCORE_FREQUENCY_STATUS"};
     EXPECT_CALL(m_platform_io, signal_names()).WillOnce(Return(signal_names));
 
     //setup default values for 'generate' tests


### PR DESCRIPTION
Signed-off-by: Lowren Lawson <lowren.h.lawson@intel.com>

- Relates to #2408 bug report from github issues
- Fixes #2408 change request from github issues.

The reporter tracking of gpu frequency was not updated with the 2.0 naming change, leading to the field being omitted from reports on GPU enabled systems.