### PR TITLE
Automatic removal of unsupported GPU signals and controls

### DIFF
--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -467,6 +467,7 @@ namespace geopm
                         throw;
                     }
                     unsupported_signal_names.push_back(sv.first);
+                    break;
                 }
             }
             sv.second.m_signals = result;
@@ -522,10 +523,9 @@ namespace geopm
                                                            control_domain_type(sv.first), domain_idx);
                             }
                         }
-                        else {
-                            //Try to write the signals
-                            write_control(sv.first, control_domain_type(sv.first), domain_idx, init_setting);
-                        }
+
+                        //Try to write the signals
+                        write_control(sv.first, control_domain_type(sv.first), domain_idx, init_setting);
                     }
                 }
             }

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -521,7 +521,8 @@ namespace geopm
                                 init_setting = read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL",
                                                            control_domain_type(sv.first), domain_idx);
                             }
-                        } else {
+                        }
+                        else {
                             //Try to write the signals
                             write_control(sv.first, control_domain_type(sv.first), domain_idx, init_setting);
                         }

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -499,6 +499,49 @@ namespace geopm
 
         // Cache the initial min and max frequencies
         save_control();
+
+        //check the ability to write all controls
+        std::vector <std::string> unsupported_control_names;
+        for (auto &sv : m_control_available) {
+            try {
+                double init_setting = NAN;
+                // read the default setting of the control from the corrolary signal
+                if(is_valid_signal(sv.first) &&
+                   signal_domain_type(sv.first) == control_domain_type(sv.first)) {
+                    for (int domain_idx = 0;
+                         domain_idx < m_platform_topo.num_domain(control_domain_type(sv.first));
+                         ++domain_idx) {
+                        init_setting = read_signal(sv.first, control_domain_type(sv.first), domain_idx);
+
+                        if(std::isnan(init_setting)) {
+                            // Specialized handling for signals that may be NAN
+                            if(sv.first == "GPU_CORE_FREQUENCY_CONTROL" ||
+                               sv.first == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL") {
+
+                                init_setting = read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL",
+                                                           control_domain_type(sv.first), domain_idx);
+                            }
+                        } else {
+                            //Try to write the signals
+                            write_control(sv.first, control_domain_type(sv.first), domain_idx, init_setting);
+                        }
+                    }
+                }
+            }
+            catch (const geopm::Exception &ex) {
+                if (ex.err_value() != GEOPM_ERROR_RUNTIME &&
+                    ex.err_value() != GEOPM_ERROR_INVALID) {
+                    throw;
+                }
+                unsupported_control_names.push_back(sv.first);
+            }
+        }
+
+        for(const auto &name : unsupported_control_names) {
+            m_control_available.erase(name);
+        }
+
+        restore_control();
     }
 
     void LevelZeroIOGroup::register_derivative_signals(void) {

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -44,7 +44,7 @@ namespace geopm
         : m_platform_topo(platform_topo)
         , m_nvml_device_pool(device_pool)
         , m_is_batch_read(false)
-        , m_frequency_control_request(m_platform_topo.num_domain(GEOPM_DOMAIN_GPU), 0)
+        , m_frequency_control_request(m_platform_topo.num_domain(GEOPM_DOMAIN_GPU), NAN)
         , m_signal_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", {
                                   "Streaming multiprocessor frequency in hertz",
                                   {},
@@ -292,15 +292,14 @@ namespace geopm
 
                         if(std::isnan(init_setting)) {
                             // Specialized handling for signals that may be NAN
-                            if (sv.first == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL") {
+                            if (sv.first == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL" ||
+                                 sv.first == "GPU_CORE_FREQUENCY_CONTROL") {
+                                init_setting = read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL",
+                                                           control_domain_type(sv.first), domain_idx);
+                            }
+                            else if (sv.first == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL") {
                                 init_setting = 0;
                             }
-                        }
-                        else if (init_setting == 0 &&
-                                 (sv.first == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL" ||
-                                 sv.first == "GPU_CORE_FREQUENCY_CONTROL")) {
-                            init_setting = read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL",
-                                                       control_domain_type(sv.first), domain_idx);
                         }
 
                         //Try to write the signals

--- a/service/src/NVMLIOGroup.hpp
+++ b/service/src/NVMLIOGroup.hpp
@@ -66,8 +66,8 @@ namespace geopm
             const PlatformTopo &m_platform_topo;
             const NVMLDevicePool &m_nvml_device_pool;
             bool m_is_batch_read;
-            std::vector<uint64_t> m_frequency_control_request;
-            std::vector<uint64_t> m_initial_power_limit;
+            std::vector<double> m_frequency_control_request;
+            std::vector<double> m_initial_power_limit;
             std::vector<std::vector<unsigned int> > m_supported_freq;
 
             struct signal_s

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -522,15 +522,40 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
 //              - Attempt to write a control at an invalid domain level
 TEST_F(LevelZeroIOGroupTest, error_path)
 {
-    const int num_gpu = m_platform_topo->num_domain(GEOPM_DOMAIN_GPU);
     const int num_gpu_subdevice = m_platform_topo->num_domain(GEOPM_DOMAIN_GPU_CHIP);
 
-    std::vector<int> batch_idx;
+    //Frequency
+    std::vector<double> mock_freq_gpu = {1530, 1320, 420, 135, 900, 927, 293, 400};
+    std::vector<double> mock_freq_mem = {130, 1020, 200, 150, 300, 442, 782, 1059};
+    std::vector<double> mock_freq_min_gpu = {200, 320, 400, 350, 111, 222, 333, 444};
+    std::vector<double> mock_freq_max_gpu = {2000, 3200, 4200, 1350, 555, 666, 777, 888};
+    std::vector<double> mock_freq_min_mem = {100, 220, 300, 450, 999, 1010, 1111, 1212};
+    std::vector<double> mock_freq_max_mem = {1000, 2200, 3200, 1450, 1313, 1414, 1515, 1616};
+    //Active time
+    std::vector<uint64_t> mock_active_time = {123, 970, 550, 20, 52, 567, 888, 923};
+    std::vector<uint64_t> mock_active_time_compute = {1, 90, 50, 0, 123, 144, 521, 445};
+    std::vector<uint64_t> mock_active_time_copy = {12, 20, 30, 40, 44, 55, 66, 77};
+    //Power & energy
+    std::vector<int32_t> mock_power_limit_min = {30000, 80000, 20000, 70000};
+    std::vector<int32_t> mock_power_limit_max = {310000, 280000, 320000, 270000};
+    std::vector<int32_t> mock_power_limit_tdp = {320000, 290000, 330000, 280000};
+    std::vector<uint64_t> mock_energy = {630000000, 280000000, 470000000, 950000000};
 
-    std::vector<double> mock_freq = {1530, 1320, 420, 135};
-    for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
-        EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, gpu_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq.at(gpu_idx)));
+    for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
+        //Frequency
+        EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq_gpu.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_freq_mem.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq_min_gpu.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq_max_gpu.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_freq_min_mem.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_freq_max_mem.at(sub_idx)));
+
+        //Active time
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_active_time.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_active_time_compute.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_active_time_copy.at(sub_idx)));
     }
+
     LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool, nullptr);
 
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.push_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_BOARD, 0),

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -677,7 +677,9 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming_writes)
 
 
         EXPECT_CALL(*m_device_pool, frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(std::pair<double, double>(mock_freq_min_gpu.at(sub_idx), mock_freq_max_gpu.at(sub_idx))));
+
         EXPECT_CALL(*m_device_pool, frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, mock_freq_min_gpu.at(sub_idx), mock_freq_max_gpu.at(sub_idx))).Times(3);
+        EXPECT_CALL(*m_device_pool, frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, mock_freq_max_gpu.at(sub_idx), mock_freq_max_gpu.at(sub_idx))).Times(2);
     }
 
     LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool, nullptr);

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -203,6 +203,8 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/NVMLIOGroupTest.push_control_adjust_write_batch \
               test/gtest_links/NVMLIOGroupTest.error_path \
               test/gtest_links/NVMLIOGroupTest.valid_signals \
+              test/gtest_links/NVMLIOGroupTest.signal_and_control_trimming \
+              test/gtest_links/NVMLIOGroupTest.signal_and_control_trimming_writes \
               test/gtest_links/PlatformIOTest.adjust \
               test/gtest_links/PlatformIOTest.adjust_agg \
               test/gtest_links/PlatformIOTest.agg_function \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -126,6 +126,8 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/LevelZeroIOGroupTest.valid_signals \
               test/gtest_links/LevelZeroIOGroupTest.read_signal \
               test/gtest_links/LevelZeroIOGroupTest.error_path \
+              test/gtest_links/LevelZeroIOGroupTest.signal_and_control_trimming \
+              test/gtest_links/LevelZeroIOGroupTest.signal_and_control_trimming_writes \
               test/gtest_links/LevelZeroIOGroupTest.write_control \
               test/gtest_links/LevelZeroIOGroupTest.save_restore \
               test/gtest_links/LevelZeroIOGroupTest.push_control_adjust_write_batch \


### PR DESCRIPTION
- Relates to #2386 bug report from github issues
- Fixes #2386 change request from github issues.

This PR checks for LevelZero signal and control availability at boot time and removes them from the available list if they cannot be accessed.

Live tested on a system with basic level zero support, unit tests for checking removal of signals also added.