### PR TITLE
CPU & GPU Alias name cleanup for 2.0

### DIFF
--- a/service/src/CpuinfoIOGroup.cpp
+++ b/service/src/CpuinfoIOGroup.cpp
@@ -157,7 +157,7 @@ namespace geopm
                                    Agg::expect_same,
                                    "Step size between process frequency settings"}}})
     {
-        register_signal_alias("CPU_FREQUENCY_MIN", "CPUINFO::FREQ_MIN");
+        register_signal_alias("CPU_FREQUENCY_MIN_AVAIL", "CPUINFO::FREQ_MIN");
         register_signal_alias("CPU_FREQUENCY_STICKER", "CPUINFO::FREQ_STICKER");
         register_signal_alias("CPU_FREQUENCY_STEP", "CPUINFO::FREQ_STEP");
     }

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -470,6 +470,8 @@ namespace geopm
                                M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL");
         register_control_alias("GPU_CORE_FREQUENCY_CONTROL",
                                M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL");
+        register_signal_alias("GPU_CORE_ACTIVITY", M_NAME_PREFIX + "GPU_CORE_UTILIZATION");
+        register_signal_alias("GPU_UNCORE_ACTIVITY", M_NAME_PREFIX + "GPU_UNCORE_UTILIZATION");
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -464,6 +464,7 @@ namespace geopm
         register_derivative_signals();
 
         register_signal_alias("GPU_CORE_FREQUENCY_STATUS", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS");
+        register_signal_alias("GPU_ENERGY", M_NAME_PREFIX + "GPU_ENERGY");
         register_signal_alias("GPU_POWER", M_NAME_PREFIX + "GPU_POWER");
         register_signal_alias("GPU_CORE_FREQUENCY_CONTROL",
                                M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL");

--- a/service/src/MSRIOGroup.cpp
+++ b/service/src/MSRIOGroup.cpp
@@ -237,15 +237,14 @@ namespace geopm
         }
 
         if (max_turbo_name != "") {
-            register_signal_alias("CPU_FREQUENCY_MAX", max_turbo_name);
-            set_signal_description("CPU_FREQUENCY_MAX", "Maximum processor frequency.");
+            register_signal_alias("CPU_FREQUENCY_MAX_AVAIL", max_turbo_name);
+            set_signal_description("CPU_FREQUENCY_MAX_AVAIL", "Maximum processor frequency.");
         }
 
         // Uncore signals
-        auto all_names = signal_names();
-        if (all_names.count("MSR::UNCORE_PERF_STATUS:FREQ") != 0) {
-            register_signal_alias("CPU_UNCORE_FREQUENCY_STATUS", "MSR::UNCORE_PERF_STATUS:FREQ");
-        }
+        register_signal_alias("CPU_UNCORE_FREQUENCY_STATUS", "MSR::UNCORE_PERF_STATUS:FREQ");
+        register_signal_alias("CPU_UNCORE_FREQUENCY_MIN_CONTROL", "MSR::UNCORE_RATIO_LIMIT:MIN_RATIO");
+        register_signal_alias("CPU_UNCORE_FREQUENCY_MAX_CONTROL", "MSR::UNCORE_RATIO_LIMIT:MAX_RATIO");
 
     }
 
@@ -264,6 +263,11 @@ namespace geopm
         else {
             register_control_alias("CPU_FREQUENCY_CONTROL", "MSR::PERF_CTL:FREQ");
         }
+
+        // Uncore controls
+        register_control_alias("CPU_UNCORE_FREQUENCY_MIN_CONTROL", "MSR::UNCORE_RATIO_LIMIT:MIN_RATIO");
+        register_control_alias("CPU_UNCORE_FREQUENCY_MAX_CONTROL", "MSR::UNCORE_RATIO_LIMIT:MAX_RATIO");
+
     }
 
     void MSRIOGroup::set_signal_description(const std::string &name,

--- a/service/test/CpuinfoIOGroupTest.cpp
+++ b/service/test/CpuinfoIOGroupTest.cpp
@@ -362,6 +362,8 @@ TEST_F(CpuinfoIOGroupTest, parse_cpu_freq)
     EXPECT_DOUBLE_EQ(1.0e9, freq);
     freq = freq_limits.read_signal("CPUINFO::FREQ_MAX", GEOPM_DOMAIN_BOARD, 0);
     EXPECT_DOUBLE_EQ(2.0e9, freq);
+
+    EXPECT_TRUE(freq_limits.is_valid_signal("CPU_FREQUENCY_MIN_AVAIL"));
 }
 
 TEST_F(CpuinfoIOGroupTest, plugin)

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -501,6 +501,8 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
         EXPECT_DOUBLE_EQ(power_lim, mock_power_limit_tdp.at(gpu_idx)/1e3);
 
         double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_GPU, gpu_idx);
+        double energy_alias = levelzero_io.read_signal("GPU_ENERGY", GEOPM_DOMAIN_GPU, gpu_idx);
+        EXPECT_DOUBLE_EQ(energy, energy_alias);
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(gpu_idx)/1e6);
     }
 

--- a/service/test/MSRIOGroupTest.cpp
+++ b/service/test/MSRIOGroupTest.cpp
@@ -175,7 +175,7 @@ TEST_F(MSRIOGroupTest, valid_signal_names)
     ASSERT_TRUE(m_msrio_group->is_valid_signal("MSR::PERF_STATUS:FREQ"));
     ASSERT_TRUE(m_msrio_group->is_valid_signal("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0"));
     signal_aliases.push_back("CPU_FREQUENCY_STATUS");
-    signal_aliases.push_back("CPU_FREQUENCY_MAX");
+    signal_aliases.push_back("CPU_FREQUENCY_MAX_AVAIL");
     // note: CPU_FREQUENCY_MIN and CPU_FREQUENCY_STICKER come from CpuinfoIOGroup.
 
     //// temperature signals
@@ -224,7 +224,7 @@ TEST_F(MSRIOGroupTest, valid_signal_domains)
 
     // frequency
     EXPECT_EQ(GEOPM_DOMAIN_CPU, m_msrio_group->signal_domain_type("CPU_FREQUENCY_STATUS"));
-    EXPECT_EQ(GEOPM_DOMAIN_PACKAGE, m_msrio_group->signal_domain_type("CPU_FREQUENCY_MAX"));
+    EXPECT_EQ(GEOPM_DOMAIN_PACKAGE, m_msrio_group->signal_domain_type("CPU_FREQUENCY_MAX_AVAIL"));
 
     // temperature
     EXPECT_EQ(GEOPM_DOMAIN_CORE,
@@ -302,7 +302,7 @@ TEST_F(MSRIOGroupTest, valid_signal_format)
     // most SI signals are printed as double
     std::vector<std::string> si_alias = {
         "CPU_ENERGY", "DRAM_ENERGY",
-        "CPU_FREQUENCY_STATUS", "CPU_FREQUENCY_MAX",
+        "CPU_FREQUENCY_STATUS", "CPU_FREQUENCY_MAX_AVAIL",
         "CPU_CORE_TEMPERATURE", "CPU_PACKAGE_TEMPERATURE",
         "CPU_POWER_MIN_AVAIL", "CPU_POWER_MAX_AVAIL", "CPU_POWER_LIMIT_DEFAULT",
         "CPU_POWER", "DRAM_POWER"
@@ -576,7 +576,7 @@ TEST_F(MSRIOGroupTest, read_signal_frequency)
     // For SKX: MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0 0:7
     EXPECT_CALL(*m_msrio, read_msr(0, limit_offset))
         .WillOnce(Return(0xF));
-    result = m_msrio_group->read_signal("CPU_FREQUENCY_MAX", GEOPM_DOMAIN_PACKAGE, 0);
+    result = m_msrio_group->read_signal("CPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_PACKAGE, 0);
     EXPECT_EQ(1.5e9, result);
 }
 


### PR DESCRIPTION
- Relates to #2420 feature request from github issues
- Fixes #2407 bug report from github issues.
- Fixes #2419 bug report from github issues.

Additional signal and control name cleanup in the LevelZero, MSR, and CpuInfo IO groups for 2.0