### PR TITLE
Addition of a Platform Characterization IO Group

### DIFF
--- a/copying_headers/MANIFEST.EXEMPT
+++ b/copying_headers/MANIFEST.EXEMPT
@@ -134,6 +134,7 @@ service/docs/source/geopm_pio_dcgm.7.rst
 service/docs/source/geopm_pio_levelzero.7.rst
 service/docs/source/geopm_pio_msr.7.rst
 service/docs/source/geopm_pio_nvml.7.rst
+service/docs/source/geopm_pio_platformcharacterization.7.rst
 service/docs/source/geopm_pio_profile.7.rst
 service/docs/source/geopm_pio_service.7.rst
 service/docs/source/geopm_pio_sst.7.rst

--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -196,6 +196,8 @@ libgeopmd_la_SOURCES = $(include_HEADERS) \
                        src/NVMLDevicePool.hpp \
                        src/NVMLIOGroup.cpp \
                        src/NVMLIOGroup.hpp \
+                       src/PlatformCharacterizationIOGroup.cpp \
+                       src/PlatformCharacterizationIOGroup.hpp \
                        src/PlatformIO.cpp \
                        src/PlatformIOImp.hpp \
                        src/PlatformTopo.cpp \

--- a/service/docs/Makefile.mk
+++ b/service/docs/Makefile.mk
@@ -90,6 +90,7 @@ all_man_rst = docs/source/geopm.7.rst \
               docs/source/geopm_pio_levelzero.7.rst \
               docs/source/geopm_pio_msr.7.rst \
               docs/source/geopm_pio_nvml.7.rst \
+              docs/source/geopm_pio_platformcharacterization.7.rst \
               docs/source/geopm_pio_profile.7.rst \
               docs/source/geopm_pio_service.7.rst \
               docs/source/geopm_pio_sst.7.rst \
@@ -134,6 +135,7 @@ dist_man_MANS = docs/build/man/geopm.7 \
                 docs/build/man/geopm_pio_dcgm.7 \
                 docs/build/man/geopm_pio_levelzero.7 \
                 docs/build/man/geopm_pio_nvml.7 \
+                docs/build/man/geopm_pio_platformcharacterization.7 \
                 docs/build/man/geopm_pio_profile.7 \
                 docs/build/man/geopm_pio_service.7 \
                 docs/build/man/geopm_pio_sst.7 \

--- a/service/docs/source/conf.py
+++ b/service/docs/source/conf.py
@@ -181,6 +181,7 @@ rst_files = [
     "geopm_pio_dcgm.7",
     "geopm_pio_levelzero.7",
     "geopm_pio_nvml.7",
+    "geopm_pio_platformcharacterization.7",
     "geopm_pio_profile.7",
     "geopm_pio_service.7",
     "geopm_pio_sst.7",

--- a/service/docs/source/geopm.7.rst
+++ b/service/docs/source/geopm.7.rst
@@ -95,7 +95,7 @@ The types of domains and their relationships with each other can be
 programmatically queried through :doc:`geopm_topo(3) <geopm_topo.3>`.
 
 GEOPM comes bundled with a synthetic benchmark application :doc:`geopmbench(1)
-<geopmbench.1>`, which can be used as an application workload for basic analysis 
+<geopmbench.1>`, which can be used as an application workload for basic analysis
 and to experiment with the impact that signals and controls have on applications
 under GEOPM.
 
@@ -385,6 +385,7 @@ See Also
 :doc:`geopm_pio_levelzero(7) <geopm_pio_levelzero.7>`,
 :doc:`geopm_pio_msr(7) <geopm_pio_msr.7>`,
 :doc:`geopm_pio_nvml(7) <geopm_pio_nvml.7>`,
+:doc:`geopm_pio_platformcharacterization(7) <geopm_pio_platformcharacterization.7>`,
 :doc:`geopm_pio_sst(7) <geopm_pio_sst.7>`,
 :doc:`geopm_pio_time(7) <geopm_pio_time.7>`,
 :doc:`geopm_report(7) <geopm_report.7>`,

--- a/service/docs/source/geopm_pio_platformcharacterization.7.rst
+++ b/service/docs/source/geopm_pio_platformcharacterization.7.rst
@@ -1,0 +1,98 @@
+geopm_pio_platformcharacterization(7) -- IOGroup providing signals and controls for Platform Characterization
+=============================================================================================================
+
+Description
+-----------
+
+
+
+The PlatformCharacterization IOGroup implements the :doc:`geopm::IOGroup(3) <GEOPM_CXX_MAN_IOGroup.3>`
+interface to provide signals and controls used to provide per-platform characterization information.
+
+This IOGroup provides signals that describe the energy efficient frequencies for Core,
+Uncore, and GPU domains on a per node basis. This information is stored in a persistent
+cached file per node, and is populated through writing the related IOGroup controls.
+
+Requirements
+^^^^^^^^^^^^
+
+No special library support is required to use the GEOPOM PlatformCharacterization signals and controls,
+however the signals will be un-initialized by default.  System administrators, researchers, or users
+are expected to use the GEOPM experiment infrastructure (or other frameworks) to characterize nodes in
+the system.  This information may then be written to the cache file through using the IOGroup controls.
+Subsequent signal reads will then provide the values written as part of characterization for use by GEOPM
+agents and users.
+
+For basic system characterization the integrated arithimetic intensity benchmark (AIB) workload is
+recommended.
+
+The CPU Compute Activity policy recommendation script may be used to provide basic
+recommendations for CPU domain characterization.
+
+The GPU Compute Activity policy recommendation script may be used to provide basic
+recommendations for GPU domain characterization.
+
+Signals
+-------
+
+``NODE_CHARACTERIZATION::GPU_CORE_FREQUENCY_EFFICIENT``
+    GPU Compute Domain energy efficient frequency in hertz.
+
+    *  **Aggregation**: average
+    *  **Domain**: board
+    *  **Format**: double
+    *  **Unit**: hertz
+
+``NODE_CHARACTERIZATION::CPU_CORE_FREQUENCY_EFFICIENT``
+    CPU Core Domain energy efficient frequency in hertz.
+
+    *  **Aggregation**: average
+    *  **Domain**: board
+    *  **Format**: double
+    *  **Unit**: hertz
+
+``NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_EFFICIENT``
+    CPU Uncore Domain energy efficient frequency in hertz.
+
+    *  **Aggregation**: average
+    *  **Domain**: board
+    *  **Format**: double
+    *  **Unit**: hertz
+
+``NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_[0-14]``
+    CPU Uncore frequency associated with CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_[0-14] in hertz.
+
+    *  **Aggregation**: average
+    *  **Domain**: board
+    *  **Format**: double
+    *  **Unit**: hertz
+
+``NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_[0-14]``
+    Maximum memory bandwidth associated with CPU_UNCORE_FREQUENCY_[0-14] in bytes/second.
+    This is intended to represent the maximum bandwidth achieved at the associated frequency.
+
+    *  **Aggregation**: average
+    *  **Domain**: board
+    *  **Format**: double
+    *  **Unit**: bytes/second
+
+Controls
+--------
+
+Every signal has a control of the same name.  Writing the control saves the written value to
+a cached file on the node of interest.
+
+Aliases
+-------
+
+This IOGroup provides no high-level aliases.
+
+See Also
+--------
+
+
+:doc:`geopm(7) <geopm.7>`\ ,
+:doc:`geopm::IOGroup(3) <GEOPM_CXX_MAN_IOGroup.3>`\ ,
+:doc:`geopmwrite(1) <geopmwrite.1>`\ ,
+:doc:`geopmread(1) <geopmread.1>`,
+:doc:`geopm::Agg(3) <GEOPM_CXX_MAN_Agg.3>`

--- a/service/src/IOGroup.cpp
+++ b/service/src/IOGroup.cpp
@@ -18,6 +18,7 @@
 #include "TimeIOGroup.hpp"
 #include "SSTIOGroup.hpp"
 #include "geopm/Helper.hpp"
+#include "PlatformCharacterizationIOGroup.hpp"
 #ifdef GEOPM_ENABLE_SYSTEMD
 #include "ServiceIOGroup.hpp"
 #endif
@@ -101,6 +102,8 @@ namespace geopm
                         CpuinfoIOGroup::make_plugin);
         register_plugin(SSTIOGroup::plugin_name(),
                         SSTIOGroup::make_plugin);
+        register_plugin(PlatformCharacterizationIOGroup::plugin_name(),
+                        PlatformCharacterizationIOGroup::make_plugin);
 #ifdef GEOPM_CNL_IOGROUP
         register_plugin(CNLIOGroup::plugin_name(),
                         CNLIOGroup::make_plugin);

--- a/service/src/PlatformCharacterizationIOGroup.cpp
+++ b/service/src/PlatformCharacterizationIOGroup.cpp
@@ -1,0 +1,727 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include "PlatformCharacterizationIOGroup.hpp"
+
+#include <cmath>
+
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <algorithm>
+#include <string>
+#include <sys/stat.h>
+#include <sys/sysinfo.h>
+#include <sys/time.h>
+#include <sched.h>
+#include <errno.h>
+#include <string.h>
+#include <limits.h>
+#include <unistd.h>
+
+#include "geopm_time.h"
+#include "geopm/IOGroup.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm/Exception.hpp"
+#include "geopm/Agg.hpp"
+#include "geopm/Helper.hpp"
+#include "SaveControl.hpp"
+
+namespace geopm
+{
+    const std::string PlatformCharacterizationIOGroup::M_PLUGIN_NAME = "NODE_CHARACTERIZATION";
+    const std::string PlatformCharacterizationIOGroup::M_NAME_PREFIX = M_PLUGIN_NAME + "::";
+    const std::string PlatformCharacterizationIOGroup::M_CACHE_FILE_NAME = "/tmp/geopm-characterization-cache-" +
+                                                                        std::to_string(getuid());
+    const std::string PlatformCharacterizationIOGroup::M_SERVICE_CACHE_FILE_NAME = "/run/geopm-service/geopm-characterization-cache";
+
+    PlatformCharacterizationIOGroup::PlatformCharacterizationIOGroup()
+        : PlatformCharacterizationIOGroup(platform_topo(), "",
+                      nullptr)
+    {
+    }
+
+    // Set up mapping between signal and control names and corresponding indices
+    PlatformCharacterizationIOGroup::PlatformCharacterizationIOGroup(const PlatformTopo &platform_topo,
+                             const std::string &test_cache_file_name,
+                             std::shared_ptr<SaveControl> save_control)
+        : m_platform_topo(platform_topo)
+        , M_TEST_CACHE_FILE_NAME(test_cache_file_name)
+        , m_is_batch_read(false)
+        , m_signal_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_EFFICIENT", {
+                                  "GPU Compute Domain energy efficient frequency in hertz.",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double
+                                  }},
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_EFFICIENT_CONTROL", {
+                                  "Last value written to the GPU_CORE_FREQUENCY_EFFICIENT entry.  NAN if not written",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double
+                                  }},
+                              {M_NAME_PREFIX + "CPU_CORE_FREQUENCY_EFFICIENT", {
+                                  "CPU Core Domain energy efficient frequency in hertz.",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double
+                                  }},
+                              {M_NAME_PREFIX + "CPU_CORE_FREQUENCY_EFFICIENT_CONTROL", {
+                                  "Last value written to the CPU_CORE_FREQUENCY_EFFICIENT entry.  NAN if not written",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double
+                                  }},
+                              {M_NAME_PREFIX + "CPU_UNCORE_FREQUENCY_EFFICIENT", {
+                                  "CPU Uncore Domain energy efficient frequency in hertz.",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double
+                                  }},
+                              {M_NAME_PREFIX + "CPU_UNCORE_FREQUENCY_EFFICIENT_CONTROL", {
+                                  "Last value written to the CPU_UNCORE_FREQUENCY_EFFICIENT entry.  NAN if not written",
+                                  {},
+                                  GEOPM_DOMAIN_BOARD,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double
+                                  }},
+                             })
+        , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_EFFICIENT_CONTROL", {
+                                    "GPU Compute Domain energy efficient frequency in hertz.",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD,
+                                    Agg::average,
+                                    string_format_double
+                                    }},
+                               {M_NAME_PREFIX + "CPU_CORE_FREQUENCY_EFFICIENT_CONTROL", {
+                                    "CPU Core Domain energy efficient frequency in hertz.",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD,
+                                    Agg::average,
+                                    string_format_double
+                                    }},
+                               {M_NAME_PREFIX + "CPU_UNCORE_FREQUENCY_EFFICIENT_CONTROL", {
+                                    "CPU Uncore Domain energy efficient frequency in hertz.",
+                                    {},
+                                    GEOPM_DOMAIN_BOARD,
+                                    Agg::average,
+                                    string_format_double
+                                    }},
+                              })
+        , m_mock_save_ctl(save_control)
+    {
+        // TODO: Add CPU_UNCORE_FREQ_0 & CPU_UNCORE_MAX_MEMORY_BANDWIDTH_0 signals
+
+        // populate signals for each domain
+        for (auto &sv : m_signal_available) {
+            std::vector<std::shared_ptr<signal_s> > result;
+            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(signal_domain_type(sv.first)); ++domain_idx) {
+                std::shared_ptr<signal_s> sgnl = std::make_shared<signal_s>(signal_s{0, false});
+                result.push_back(sgnl);
+            }
+            sv.second.signals = result;
+        }
+
+        // populate controls for each domain
+        for (auto &sv : m_control_available) {
+            std::vector<std::shared_ptr<control_s> > result;
+            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(control_domain_type(sv.first)); ++domain_idx) {
+                std::shared_ptr<control_s> ctrl = std::make_shared<control_s>(control_s{0, false});
+                result.push_back(ctrl);
+            }
+            sv.second.controls = result;
+        }
+
+        // TODO: the primary reason to cache this as a member variable is to use it for writing later.
+        //       right now I'm still directly writing all values to file using ofstream in the write_control
+        //       function, so this does not currently need to be a member variable
+        m_cache_contents = read_cache();
+        parse_cache(m_cache_contents);
+    }
+
+    void PlatformCharacterizationIOGroup::parse_cache(const std::string cache_contents) {
+        //TODO:
+        std::istringstream content_stream (cache_contents);
+
+        // parse each line
+        std::string line;
+        while (std::getline(content_stream, line)) {
+            // split each space delimited line into a vector
+            std::stringstream ss_line(line);
+            std::vector<std::string> content = std::vector<std::string> (std::istream_iterator<std::string>(ss_line),
+                                             std::istream_iterator<std::string>());
+
+            // The file format is 'SIGNAL DOMAIN DOMAIN_IDX STORED_VALUE'.
+            // Any deviations from this should cause an exception
+            if (content.size() != 4 || // wrong number of entries in a line
+                m_signal_available.find(content.at(0)) == m_signal_available.end() || // signal in file not supported
+                m_signal_available.at(content.at(0)).domain != std::stoi(content.at(1)) || // domain in file mismatches signal domain
+                m_signal_available.at(content.at(0)).signals.size() < std::stoi(content.at(2)) ){ // file domain value exceeds domain count
+                throw Exception("PlatformCharacterization::parse_cache(): Invalid characterization line: " +
+                                line, GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+            }
+            else {
+                m_signal_available.at(content.at(0)).signals.at(std::stoi(content.at(2)))->m_value = std::stod(content.at(3));
+            }
+        }
+
+    }
+
+    std::string PlatformCharacterizationIOGroup::read_cache(void) {
+        std::string result;
+        if (M_TEST_CACHE_FILE_NAME.size()) {
+            create_cache(M_TEST_CACHE_FILE_NAME);
+            result = geopm::read_file(M_TEST_CACHE_FILE_NAME);
+            active_cache_file = M_TEST_CACHE_FILE_NAME;
+        }
+        else {
+            try {
+                create_cache(M_SERVICE_CACHE_FILE_NAME);
+                result = geopm::read_file(M_SERVICE_CACHE_FILE_NAME);
+                active_cache_file = M_SERVICE_CACHE_FILE_NAME;
+            }
+            catch (const geopm::Exception &ex) {
+                create_cache(M_CACHE_FILE_NAME);
+                result = geopm::read_file(M_CACHE_FILE_NAME);
+                active_cache_file = M_CACHE_FILE_NAME;
+            }
+        }
+        return result;
+    }
+
+    void PlatformCharacterizationIOGroup::create_cache(void)
+    {
+        try {
+            PlatformCharacterizationIOGroup::create_cache(M_SERVICE_CACHE_FILE_NAME);
+        }
+        catch (const geopm::Exception &ex) {
+            PlatformCharacterizationIOGroup::create_cache(M_CACHE_FILE_NAME);
+        }
+    }
+
+    void PlatformCharacterizationIOGroup::create_cache(const std::string &cache_file_name)
+    {
+        // If cache file is not present, or is too old, create it
+        bool is_file_ok = false;
+        try {
+            is_file_ok = check_file(cache_file_name);
+        }
+        catch (const geopm::Exception &ex) {
+            // sysinfo or stat failed; file does not exist (2) or permission denied (13)
+            if (ex.err_value() == EACCES) {
+                throw; // Permission was denied; Cannot create files at the desired path
+            }
+        }
+
+        if (is_file_ok == false) {
+            mode_t perms;
+            if (cache_file_name == M_SERVICE_CACHE_FILE_NAME) {
+                perms = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH; // 0o644
+            }
+            else {
+                perms = S_IRUSR | S_IWUSR; // 0o600
+            }
+
+            std::string tmp_string = cache_file_name + "XXXXXX";
+            char tmp_path[NAME_MAX];
+            tmp_path[NAME_MAX - 1] = '\0';
+            strncpy(tmp_path, tmp_string.c_str(), NAME_MAX - 1);
+            int tmp_fd = mkstemp(tmp_path);
+            if (tmp_fd == -1) {
+                throw Exception("PlatformCharacterization::create_cache(): Could not create temp file: ",
+                                errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+            }
+            int err = fchmod(tmp_fd, perms);
+            if (err) {
+                close(tmp_fd);
+                throw Exception("PlatformCharacterization::create_cache(): Could not chmod tmp_path: ",
+                                errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+            }
+            close(tmp_fd);
+
+            // TODO: do we care about saving as temp and renaming for this?  It made sense for the
+            //       platformtopo since lscpu populates it here, but we're not modifying the file
+            std::ofstream tmp_file(tmp_path);
+            for (auto &sv : m_signal_available) {
+                // Only save signals, excluding any that are related to controls
+                if (sv.first.find("_CONTROL") == std::string::npos) {
+                    for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(signal_domain_type(sv.first)); ++domain_idx) {
+                        // TODO: should this use the default signal value instead of 0?
+                        tmp_file << sv.first << " " <<  sv.second.domain <<
+                                    " " << domain_idx << " " <<  "0" << std::endl;
+                    }
+                }
+            }
+            tmp_file.close();
+
+            err = rename(tmp_path, cache_file_name.c_str());
+            if (err) {
+                throw Exception("PlatformCharacterization::create_cache(): Could not rename tmp_path: ",
+                                errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+            }
+        }
+    }
+
+    bool PlatformCharacterizationIOGroup::check_file(const std::string &file_path)
+    {
+        struct sysinfo si;
+        int err = sysinfo(&si);
+        if (err) {
+            throw Exception("PlatformCharacterizationIOGroup::check_file(): sysinfo err: ",
+                            errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+
+        struct stat file_stat;
+        err = stat(file_path.c_str(), &file_stat);
+        if (err) {
+            throw Exception("PlatformCharacterizationIOGroup::create_cache(): stat failure:",
+                            errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+        }
+
+        struct geopm_time_s current_time;
+        geopm_time_real(&current_time);
+
+        // TODO: we don't want to overwrite with every reboot.
+        //       we do want to overwrite/remove entries for hardware
+        //       that doesn't match what's in the file (i.e. a piece of
+        //       hardware has been replaced).
+        unsigned int last_boot_time = current_time.t.tv_sec - si.uptime;
+        if (file_stat.st_mtime < last_boot_time) {
+            return false; // file is older than last boot
+        }
+        else {
+            mode_t expected_perms;
+            if (file_path == M_SERVICE_CACHE_FILE_NAME) {
+                expected_perms = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH; // 0o644
+            }
+            else {
+                expected_perms = S_IRUSR | S_IWUSR; // 0o600
+            }
+
+            mode_t actual_perms = file_stat.st_mode & ~S_IFMT;
+            if (expected_perms == actual_perms) {
+                return true; // file has been created since boot with the right permissions
+            }
+            else {
+                return false;
+            }
+        }
+    }
+
+
+    // Extract the set of all signal names from the index map
+    std::set<std::string> PlatformCharacterizationIOGroup::signal_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &sv : m_signal_available) {
+            result.insert(sv.first);
+        }
+        return result;
+    }
+
+    // Extract the set of all control names from the index map
+    std::set<std::string> PlatformCharacterizationIOGroup::control_names(void) const
+    {
+        std::set<std::string> result;
+        for (const auto &sv : m_control_available) {
+            result.insert(sv.first);
+        }
+        return result;
+    }
+
+    // Check signal name using index map
+    bool PlatformCharacterizationIOGroup::is_valid_signal(const std::string &signal_name) const
+    {
+        return m_signal_available.find(signal_name) != m_signal_available.end();
+    }
+
+    // Check control name using index map
+    bool PlatformCharacterizationIOGroup::is_valid_control(const std::string &control_name) const
+    {
+        return m_control_available.find(control_name) != m_control_available.end();
+    }
+
+    // Return domain for all valid signals
+    int PlatformCharacterizationIOGroup::signal_domain_type(const std::string &signal_name) const
+    {
+        int result = GEOPM_DOMAIN_INVALID;
+        auto it = m_signal_available.find(signal_name);
+        if (it != m_signal_available.end()) {
+            result = it->second.domain;
+        }
+        return result;
+    }
+
+    // Return domain for all valid controls
+    int PlatformCharacterizationIOGroup::control_domain_type(const std::string &control_name) const
+    {
+        int result = GEOPM_DOMAIN_INVALID;
+        auto it = m_control_available.find(control_name);
+        if (it != m_control_available.end()) {
+            result = it->second.domain;
+        }
+        return result;
+    }
+
+    // Mark the given signal to be read by read_batch()
+    int PlatformCharacterizationIOGroup::push_signal(const std::string &signal_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": signal_name " + signal_name +
+                            " not valid for PlatformCharacterizationIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != signal_domain_type(signal_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": " + signal_name + ": domain_type must be " +
+                            std::to_string(signal_domain_type(signal_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(signal_domain_type(signal_name))) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (m_is_batch_read) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": cannot push signal after call to read_batch().",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        int result = -1;
+        bool is_found = false;
+        std::shared_ptr<signal_s> signal = m_signal_available.at(signal_name).signals.at(domain_idx);
+
+        // Check if signal was already pushed
+        for (size_t ii = 0; !is_found && ii < m_signal_pushed.size(); ++ii) {
+            // same location means this signal or its alias was already pushed
+            if (m_signal_pushed[ii].get() == signal.get()) {
+                result = ii;
+                is_found = true;
+            }
+        }
+        if (!is_found) {
+            // If not pushed, add to pushed signals and configure for batch reads
+            result = m_signal_pushed.size();
+            signal->m_do_read = true;
+            m_signal_pushed.push_back(signal);
+        }
+
+        return result;
+    }
+
+    // Mark the given control to be written by write_batch()
+    int PlatformCharacterizationIOGroup::push_control(const std::string &control_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": control_name " + control_name +
+                            " not valid for PlatformCharacterizationIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != control_domain_type(control_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": " + control_name + ": domain_type must be " +
+                            std::to_string(control_domain_type(control_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(domain_type)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        int result = -1;
+        bool is_found = false;
+        std::shared_ptr<control_s> control = m_control_available.at(control_name).controls.at(domain_idx);
+
+        // Check if control was already pushed
+        for (size_t ii = 0; !is_found && ii < m_control_pushed.size(); ++ii) {
+            // same location means this control or its alias was already pushed
+            if (m_control_pushed[ii] == control) {
+                result = ii;
+                is_found = true;
+            }
+        }
+        if (!is_found) {
+            // If not pushed, add to pushed control
+            result = m_control_pushed.size();
+            m_control_pushed.push_back(control);
+        }
+
+        return result;
+    }
+
+    // Parse and update saved values for signals
+    void PlatformCharacterizationIOGroup::read_batch(void)
+    {
+        m_is_batch_read = true;
+        for (auto &sv : m_signal_available) {
+            for (unsigned int domain_idx = 0; domain_idx < sv.second.signals.size(); ++domain_idx) {
+                if (sv.second.signals.at(domain_idx)->m_do_read) {
+                    sv.second.signals.at(domain_idx)->m_value = read_signal(sv.first, sv.second.domain, domain_idx);
+                }
+            }
+        }
+    }
+
+    // Write all controls that have been pushed and adjusted
+    void PlatformCharacterizationIOGroup::write_batch(void)
+    {
+        for (auto &sv : m_control_available) {
+            for (unsigned int domain_idx = 0; domain_idx < sv.second.controls.size(); ++domain_idx) {
+                if (sv.second.controls.at(domain_idx)->m_is_adjusted) {
+                    write_control(sv.first, sv.second.domain, domain_idx, sv.second.controls.at(domain_idx)->m_setting);
+                }
+            }
+        }
+    }
+
+    // Return the latest value read by read_batch()
+    double PlatformCharacterizationIOGroup::sample(int batch_idx)
+    {
+        // Do conversion of signal values stored in read batch
+        if (batch_idx < 0 || batch_idx >= (int)m_signal_pushed.size()) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": batch_idx " +std::to_string(batch_idx)+ " out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (!m_is_batch_read) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": signal has not been read.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_signal_pushed[batch_idx]->m_value;
+    }
+
+    // Save a setting to be written by a future write_batch()
+    void PlatformCharacterizationIOGroup::adjust(int batch_idx, double setting)
+    {
+        if (batch_idx < 0 || (unsigned)batch_idx >= m_control_pushed.size()) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + "(): batch_idx " +std::to_string(batch_idx)+ " out of range",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        m_control_pushed.at(batch_idx)->m_setting = setting;
+        m_control_pushed.at(batch_idx)->m_is_adjusted = true;
+    }
+
+    // Read the value of a signal immediately, bypassing read_batch().  Should not modify m_signal_value
+    double PlatformCharacterizationIOGroup::read_signal(const std::string &signal_name, int domain_type, int domain_idx)
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            " not valid for PlatformCharacterizationIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != signal_domain_type(signal_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": " + signal_name + ": domain_type must be " +
+                            std::to_string(signal_domain_type(signal_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(signal_domain_type(signal_name))) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        double result = NAN;
+        result = m_signal_available.at(signal_name).signals.at(domain_idx)->m_value;
+        return result;
+    }
+
+    // Write to the control immediately, bypassing write_batch()
+    void PlatformCharacterizationIOGroup::write_control(const std::string &control_name, int domain_type, int domain_idx, double setting)
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": " + control_name +
+                            " not valid for PlatformCharacterizationIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_type != control_domain_type(control_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": " + control_name + ": domain_type must be " +
+                            std::to_string(control_domain_type(control_name)),
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (domain_idx < 0 || domain_idx >= m_platform_topo.num_domain(control_domain_type(control_name))) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": domain_idx out of range.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        bool update_cache = true;
+        if (control_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_EFFICIENT_CONTROL") {
+            m_signal_available.at(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_EFFICIENT_CONTROL").signals.at(domain_idx)->m_value = setting;
+            m_signal_available.at(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_EFFICIENT").signals.at(domain_idx)->m_value = setting;
+        }
+        else if (control_name == M_NAME_PREFIX + "CPU_CORE_FREQUENCY_EFFICIENT_CONTROL") {
+            m_signal_available.at(M_NAME_PREFIX + "CPU_CORE_FREQUENCY_EFFICIENT_CONTROL").signals.at(domain_idx)->m_value = setting;
+            m_signal_available.at(M_NAME_PREFIX + "CPU_CORE_FREQUENCY_EFFICIENT").signals.at(domain_idx)->m_value = setting;
+        }
+        else if (control_name == M_NAME_PREFIX + "CPU_UNCORE_FREQUENCY_EFFICIENT_CONTROL") {
+            m_signal_available.at(M_NAME_PREFIX + "CPU_UNCORE_FREQUENCY_EFFICIENT_CONTROL").signals.at(domain_idx)->m_value = setting;
+            m_signal_available.at(M_NAME_PREFIX + "CPU_UNCORE_FREQUENCY_EFFICIENT").signals.at(domain_idx)->m_value = setting;
+        }
+        else {
+            update_cache = false;
+    #ifdef GEOPM_DEBUG
+                throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + "Handling not defined for "
+                                + control_name, GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+    #endif
+        }
+
+        // Make sure the cached file reflects local changes made
+        if (update_cache) {
+            std::ofstream tmp_file(active_cache_file);
+            for (auto &sv : m_signal_available) {
+                if (sv.first.find("_CONTROL") == std::string::npos) {
+                    for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(signal_domain_type(sv.first)); ++domain_idx) {
+                        tmp_file << sv.first << " " <<  sv.second.domain << " " <<
+                                    domain_idx << " " << sv.second.signals.at(domain_idx)->m_value <<
+                                    std::endl;
+                    }
+                }
+            }
+            tmp_file.close();
+        }
+    }
+
+    // Implemented to allow an IOGroup to save platform settings before starting
+    // to adjust them
+    void PlatformCharacterizationIOGroup::save_control(void)
+    {
+    }
+
+    // Implemented to allow an IOGroup to restore previously saved
+    // platform settings
+    void PlatformCharacterizationIOGroup::restore_control(void)
+    {
+    }
+
+    // Hint to Agent about how to aggregate signals from this IOGroup
+    std::function<double(const std::vector<double> &)> PlatformCharacterizationIOGroup::agg_function(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            "not valid for PlatformCharacterizationIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return it->second.agg_function;
+    }
+
+    // Specifies how to print signals from this IOGroup
+    std::function<std::string(double)> PlatformCharacterizationIOGroup::format_function(const std::string &signal_name) const
+    {
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": " + signal_name +
+                            "not valid for PlatformCharacterizationIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return it->second.format_function;
+    }
+
+    // A user-friendly description of each signal
+    std::string PlatformCharacterizationIOGroup::signal_description(const std::string &signal_name) const
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": signal_name " + signal_name +
+                            " not valid for PlatformCharacterizationIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return m_signal_available.at(signal_name).m_description;
+    }
+
+    // A user-friendly description of each control
+    std::string PlatformCharacterizationIOGroup::control_description(const std::string &control_name) const
+    {
+        if (!is_valid_control(control_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": " + control_name +
+                            "not valid for PlatformCharacterizationIOGroup",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_control_available.at(control_name).m_description;
+    }
+
+    int PlatformCharacterizationIOGroup::signal_behavior(const std::string &signal_name) const
+    {
+        if (!is_valid_signal(signal_name)) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": signal_name " + signal_name +
+                            " not valid for PlatformCharacterizationIOGroup.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return m_signal_available.at(signal_name).behavior;
+    }
+
+    void PlatformCharacterizationIOGroup::save_control(const std::string &save_path)
+    {
+    }
+
+    void PlatformCharacterizationIOGroup::restore_control(const std::string &save_path)
+    {
+    }
+
+    std::string PlatformCharacterizationIOGroup::name(void) const
+    {
+        return plugin_name();
+    }
+
+    // Name used for registration with the IOGroup factory
+    std::string PlatformCharacterizationIOGroup::plugin_name(void)
+    {
+        return M_PLUGIN_NAME;
+    }
+
+    // Function used by the factory to create objects of this type
+    std::unique_ptr<IOGroup> PlatformCharacterizationIOGroup::make_plugin(void)
+    {
+        return geopm::make_unique<PlatformCharacterizationIOGroup>();
+    }
+
+    void PlatformCharacterizationIOGroup::register_signal_alias(const std::string &alias_name,
+                                            const std::string &signal_name)
+    {
+        if (m_signal_available.find(alias_name) != m_signal_available.end()) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": signal_name " + alias_name +
+                            " was previously registered.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto it = m_signal_available.find(signal_name);
+        if (it == m_signal_available.end()) {
+            // skip adding an alias if underlying signal is not found
+            return;
+        }
+        // copy signal info but append to description
+        m_signal_available[alias_name] = it->second;
+        m_signal_available[alias_name].m_description =
+            m_signal_available[signal_name].m_description + '\n' + "    alias_for: " + signal_name;
+    }
+
+    void PlatformCharacterizationIOGroup::register_control_alias(const std::string &alias_name,
+                                           const std::string &control_name)
+    {
+        if (m_control_available.find(alias_name) != m_control_available.end()) {
+            throw Exception("PlatformCharacterizationIOGroup::" + std::string(__func__) + ": contro1_name " + alias_name +
+                            " was previously registered.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto it = m_control_available.find(control_name);
+        if (it == m_control_available.end()) {
+            // skip adding an alias if underlying control is not found
+            return;
+        }
+        // copy control info but append to description
+        m_control_available[alias_name] = it->second;
+        m_control_available[alias_name].m_description =
+        m_control_available[control_name].m_description + '\n' + "    alias_for: " + control_name;
+    }
+}

--- a/service/src/PlatformCharacterizationIOGroup.cpp
+++ b/service/src/PlatformCharacterizationIOGroup.cpp
@@ -41,15 +41,13 @@ namespace geopm
     const std::string PlatformCharacterizationIOGroup::M_SERVICE_CACHE_FILE_NAME = "/run/geopm-service/geopm-characterization-cache";
 
     PlatformCharacterizationIOGroup::PlatformCharacterizationIOGroup()
-        : PlatformCharacterizationIOGroup(platform_topo(), "",
-                      nullptr)
+        : PlatformCharacterizationIOGroup(platform_topo(), "")
     {
     }
 
     // Set up mapping between signal and control names and corresponding indices
     PlatformCharacterizationIOGroup::PlatformCharacterizationIOGroup(const PlatformTopo &platform_topo,
-                             const std::string &test_cache_file_name,
-                             std::shared_ptr<SaveControl> save_control)
+                                                                     const std::string &test_cache_file_name)
         : m_platform_topo(platform_topo)
         , M_TEST_CACHE_FILE_NAME(test_cache_file_name)
         , m_is_batch_read(false)
@@ -78,7 +76,6 @@ namespace geopm
                                   string_format_double
                                   }},
                              })
-        , m_mock_save_ctl(save_control)
     {
         for (int unc_entry = 0; unc_entry < 15; unc_entry++) {
             m_signal_available[M_NAME_PREFIX + "CPU_UNCORE_FREQUENCY_" + std::to_string(unc_entry)] = {

--- a/service/src/PlatformCharacterizationIOGroup.hpp
+++ b/service/src/PlatformCharacterizationIOGroup.hpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PLATFORMCHARACTERIZATIONIOGROUP_HPP_INCLUDE
+#define PLATFORMCHARACTERIZATIONIOGROUP_HPP_INCLUDE
+
+#include <map>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "geopm/IOGroup.hpp"
+
+namespace geopm
+{
+    class PlatformTopo;
+    class SaveControl;
+
+    /// @brief IOGroup that provides signals and controls for PlatformCharacterization GPUs
+    class PlatformCharacterizationIOGroup : public IOGroup
+    {
+        public:
+            PlatformCharacterizationIOGroup();
+            PlatformCharacterizationIOGroup(const PlatformTopo &platform_topo,
+                        const std::string &test_cache_file_name,
+                        std::shared_ptr<SaveControl> save_control);
+            virtual ~PlatformCharacterizationIOGroup() = default;
+            std::set<std::string> signal_names(void) const override;
+            std::set<std::string> control_names(void) const override;
+            bool is_valid_signal(const std::string &signal_name) const override;
+            bool is_valid_control(const std::string &control_name) const override;
+            int signal_domain_type(const std::string &signal_name) const override;
+            int control_domain_type(const std::string &control_name) const override;
+            int push_signal(const std::string &signal_name, int domain_type, int domain_idx)  override;
+            int push_control(const std::string &control_name, int domain_type, int domain_idx) override;
+            void read_batch(void) override;
+            void write_batch(void) override;
+            double sample(int batch_idx) override;
+            void adjust(int batch_idx, double setting) override;
+            double read_signal(const std::string &signal_name, int domain_type, int domain_idx) override;
+            void write_control(const std::string &control_name, int domain_type, int domain_idx, double setting) override;
+            void save_control(void) override;
+            void restore_control(void) override;
+            std::function<double(const std::vector<double> &)> agg_function(const std::string &signal_name) const override;
+            std::function<std::string(double)> format_function(const std::string &signal_name) const override;
+            std::string signal_description(const std::string &signal_name) const override;
+            std::string control_description(const std::string &control_name) const override;
+            int signal_behavior(const std::string &signal_name) const override;
+            void save_control(const std::string &save_path) override;
+            void restore_control(const std::string &save_path) override;
+            std::string name(void) const override;
+            static std::string plugin_name(void);
+            static std::unique_ptr<geopm::IOGroup> make_plugin(void);
+        private:
+            void create_cache();
+            void create_cache(const std::string &cache_file_name);
+            bool check_file(const std::string &file_name);
+            void parse_cache(const std::string cache_contents);
+            std::string read_cache(void);
+
+            void register_signal_alias(const std::string &alias_name, const std::string &signal_name);
+            void register_control_alias(const std::string &alias_name, const std::string &control_name);
+
+            static const std::string M_PLUGIN_NAME;
+            static const std::string M_NAME_PREFIX;
+            static const std::string M_CACHE_FILE_NAME;
+            static const std::string M_SERVICE_CACHE_FILE_NAME;
+            const std::string M_TEST_CACHE_FILE_NAME;
+            const PlatformTopo &m_platform_topo;
+            bool m_is_batch_read;
+
+            std::string m_cache_contents;
+            std::string active_cache_file;
+
+            struct signal_s
+            {
+                double m_value;
+                bool m_do_read;
+            };
+
+            struct control_s
+            {
+                double m_setting;
+                bool m_is_adjusted;
+            };
+
+            struct signal_info {
+                std::string m_description;
+                std::vector<std::shared_ptr<signal_s> > signals;
+                int domain;
+                std::function<double(const std::vector<double> &)> agg_function;
+                int behavior;
+                std::function<std::string(double)> format_function;
+            };
+
+            struct control_info {
+                std::string m_description;
+                std::vector<std::shared_ptr<control_s> > controls;
+                int domain;
+                std::function<double(const std::vector<double> &)> agg_function;
+                std::function<std::string(double)> format_function;
+            };
+
+            std::map<std::string, signal_info> m_signal_available;
+            std::map<std::string, control_info> m_control_available;
+            std::vector<std::shared_ptr<signal_s> > m_signal_pushed;
+            std::vector<std::shared_ptr<control_s> > m_control_pushed;
+
+            std::shared_ptr<SaveControl> m_mock_save_ctl;
+    };
+}
+#endif

--- a/service/src/PlatformCharacterizationIOGroup.hpp
+++ b/service/src/PlatformCharacterizationIOGroup.hpp
@@ -24,8 +24,7 @@ namespace geopm
         public:
             PlatformCharacterizationIOGroup();
             PlatformCharacterizationIOGroup(const PlatformTopo &platform_topo,
-                        const std::string &test_cache_file_name,
-                        std::shared_ptr<SaveControl> save_control);
+                                            const std::string &test_cache_file_name);
             virtual ~PlatformCharacterizationIOGroup() = default;
             std::set<std::string> signal_names(void) const override;
             std::set<std::string> control_names(void) const override;
@@ -107,8 +106,6 @@ namespace geopm
             std::map<std::string, control_info> m_control_available;
             std::vector<std::shared_ptr<signal_s> > m_signal_pushed;
             std::vector<std::shared_ptr<control_s> > m_control_pushed;
-
-            std::shared_ptr<SaveControl> m_mock_save_ctl;
     };
 }
 #endif

--- a/service/src/PlatformCharacterizationIOGroup.hpp
+++ b/service/src/PlatformCharacterizationIOGroup.hpp
@@ -67,8 +67,8 @@ namespace geopm
             static const std::string M_NAME_PREFIX;
             static const std::string M_CACHE_FILE_NAME;
             static const std::string M_SERVICE_CACHE_FILE_NAME;
-            const std::string M_TEST_CACHE_FILE_NAME;
             const PlatformTopo &m_platform_topo;
+            const std::string M_TEST_CACHE_FILE_NAME;
             bool m_is_batch_read;
 
             std::string m_cache_contents;

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -232,6 +232,15 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/PlatformIOTest.write_control_override \
               test/gtest_links/PlatformIOTest.write_control_agg \
               test/gtest_links/PlatformIOTest.write_control_agg_sum \
+              test/gtest_links/PlatformCharacterizationIOGroupTest.read_signal_and_batch \
+              test/gtest_links/PlatformCharacterizationIOGroupTest.push_control_adjust_write_batch \
+              test/gtest_links/PlatformCharacterizationIOGroupTest.error_path \
+              test/gtest_links/PlatformCharacterizationIOGroupTest.check_file_bad_perms \
+              test/gtest_links/PlatformCharacterizationIOGroupTest.check_file_too_old \
+              test/gtest_links/PlatformCharacterizationIOGroupTest.valid_signals_and_controls \
+              test/gtest_links/PlatformCharacterizationIOGroupTest.read_default_signal \
+              test/gtest_links/PlatformCharacterizationIOGroupTest.write_control_read_signal \
+              test/gtest_links/PlatformCharacterizationIOGroupTest.read_signal \
               test/gtest_links/PlatformTopoTest.bdx_domain_idx \
               test/gtest_links/PlatformTopoTest.bdx_is_nested_domain \
               test/gtest_links/PlatformTopoTest.bdx_domain_nested \
@@ -418,6 +427,7 @@ test_geopm_test_SOURCES = test/GPUTopoNullTest.cpp \
                           test/NVMLIOGroupTest.cpp \
                           test/POSIXSignalTest.cpp \
                           test/PlatformIOTest.cpp \
+                          test/PlatformCharacterizationIOGroupTest.cpp \
                           test/PlatformTopoTest.cpp \
                           test/RawMSRSignalTest.cpp \
                           test/SharedMemoryTest.cpp \

--- a/service/test/PlatformCharacterizationIOGroupTest.cpp
+++ b/service/test/PlatformCharacterizationIOGroupTest.cpp
@@ -1,0 +1,650 @@
+/*
+ * Copyright (c) 2015 - 2021, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#include <unistd.h>
+#include <limits.h>
+#include <utime.h>
+#include <sys/sysinfo.h>
+#include <sys/stat.h>
+
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "config.h"
+#include "geopm/Helper.hpp"
+#include "geopm/Exception.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm/PluginFactory.hpp"
+#include "PlatformCharacterizationIOGroup.hpp"
+#include "geopm_test.hpp"
+#include "MockDCGMDevicePool.hpp"
+#include "MockPlatformTopo.hpp"
+
+#include "geopm_time.h"
+
+using geopm::PlatformCharacterizationIOGroup;
+using geopm::PlatformTopo;
+using geopm::Exception;
+using testing::Return;
+
+class PlatformCharacterizationIOGroupTest : public :: testing :: Test
+{
+    protected:
+        void SetUp();
+        void TearDown();
+        void write_characterization(const std::string &characterization_str);
+
+        std::unique_ptr<MockPlatformTopo> m_platform_topo;
+
+        std::string m_characterization_file_name;
+        std::string m_default_characterization_str;
+};
+
+void PlatformCharacterizationIOGroupTest::write_characterization(const std::string &characterization_str)
+{
+    std::ofstream characterization_fid(m_characterization_file_name);
+    characterization_fid << characterization_str;
+    characterization_fid.close();
+    // Set perms to 0o600 to ensure test file is used and not regenerated
+    mode_t default_perms = S_IRUSR | S_IWUSR;
+    chmod(m_characterization_file_name.c_str(), default_perms);
+}
+
+void PlatformCharacterizationIOGroupTest::SetUp()
+{
+    const int num_board = 1;
+    const int num_package = 2;
+    const int num_gpu = 4;
+    const int num_core = 20;
+    const int num_cpu = 40;
+
+    m_platform_topo = geopm::make_unique<MockPlatformTopo>();
+
+    //Platform Topo prep
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD))
+        .WillByDefault(Return(num_board));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .WillByDefault(Return(num_package));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_GPU))
+        .WillByDefault(Return(num_gpu));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_CPU))
+        .WillByDefault(Return(num_cpu));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_CORE))
+        .WillByDefault(Return(num_core));
+
+    m_default_characterization_str = "NODE_CHARACTERIZATION::CPU_CORE_FREQUENCY_EFFICIENT 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_0 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_1 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_10 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_11 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_12 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_13 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_14 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_2 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_3 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_4 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_5 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_6 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_7 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_8 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_9 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_EFFICIENT 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_0 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_1 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_10 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_11 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_12 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_13 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_14 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_2 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_3 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_4 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_5 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_6 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_7 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_8 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_9 0 0 0\n"
+                                     "NODE_CHARACTERIZATION::GPU_CORE_FREQUENCY_EFFICIENT 0 0 0\n";
+
+
+    m_characterization_file_name = "PlatCharIOGroupTest-cache";
+}
+
+void PlatformCharacterizationIOGroupTest::TearDown()
+{
+    unlink(m_characterization_file_name.c_str());
+}
+
+TEST_F(PlatformCharacterizationIOGroupTest, valid_signals_and_controls)
+{
+    PlatformCharacterizationIOGroup nodechar_io(*m_platform_topo, m_characterization_file_name);
+    for (const auto &sig : nodechar_io.signal_names()) {
+        EXPECT_TRUE(nodechar_io.is_valid_signal(sig));
+        EXPECT_NE(GEOPM_DOMAIN_INVALID, nodechar_io.signal_domain_type(sig));
+        EXPECT_LT(-1, nodechar_io.signal_behavior(sig));
+
+        // Every signal should have a control of the same name
+        EXPECT_TRUE(nodechar_io.is_valid_control(sig));
+        // Every signal & corrolary control should have the same domain type
+        EXPECT_EQ(nodechar_io.signal_domain_type(sig), nodechar_io.control_domain_type(sig));
+    }
+
+    // Every signal having a control of the same name implies
+    // there should be an equal number of signals and controls
+    EXPECT_EQ(nodechar_io.control_names().size(), nodechar_io.signal_names().size());
+}
+
+TEST_F(PlatformCharacterizationIOGroupTest, read_default_signal)
+{
+    PlatformCharacterizationIOGroup nodechar_io(*m_platform_topo, m_characterization_file_name);
+    for (const auto &sig : nodechar_io.signal_names()) {
+        int domain_type = nodechar_io.signal_domain_type(sig);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            EXPECT_EQ(0, nodechar_io.read_signal(sig,
+                                                 domain_type,
+                                                 domain_idx));
+        }
+    }
+}
+
+TEST_F(PlatformCharacterizationIOGroupTest, read_signal)
+{
+    std::string characterization_str = "NODE_CHARACTERIZATION::CPU_CORE_FREQUENCY_EFFICIENT 0 0 1.45e9 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_0 0 0 223 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_1 0 0 212 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_10 0 0 920 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_11 0 0 181 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_12 0 0 617 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_13 0 0 151 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_14 0 0 314 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_2 0 0 121 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_3 0 0 101 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_4 0 0 789 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_5 0 0 456 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_6 0 0 123 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_7 0 0 321 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_8 0 0 654 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_9 0 0 987 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_EFFICIENT 0 0 2.22e+09 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_0 0 0 123 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_1 0 0 4 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_10 0 0 5 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_11 0 0 6 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_12 0 0 7 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_13 0 0 8 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_14 0 0 9 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_2 0 0 10 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_3 0 0 11 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_4 0 0 12 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_5 0 0 13 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_6 0 0 14 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_7 0 0 15 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_8 0 0 16 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_9 0 0 17 \n"
+                                       "NODE_CHARACTERIZATION::GPU_CORE_FREQUENCY_EFFICIENT 0 0 1e+09 \n";
+
+    write_characterization(characterization_str);
+    PlatformCharacterizationIOGroup nodechar_io(*m_platform_topo, m_characterization_file_name);
+    //No zero values
+    for (const auto &sig : nodechar_io.signal_names()) {
+        int domain_type = nodechar_io.signal_domain_type(sig);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            EXPECT_NE(0, nodechar_io.read_signal(sig,
+                                                 domain_type,
+                                                 domain_idx));
+        }
+    }
+
+    std::map<std::string, double> sig_val_map = {{"NODE_CHARACTERIZATION::CPU_CORE_FREQUENCY_EFFICIENT", 1.45e9},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_0", 223},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_1", 212},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_10", 920},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_11", 181},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_12", 617},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_13", 151},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_14", 314},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_2", 121},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_3", 101},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_4", 789},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_5", 456},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_6", 123},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_7", 321},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_8", 654},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_9", 987},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_EFFICIENT", 2.22e09},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_0", 123},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_1", 4},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_10", 5},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_11", 6},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_12", 7},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_13", 8},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_14", 9},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_2", 10},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_3", 11},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_4", 12},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_5", 13},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_6", 14},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_7", 15},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_8", 16},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_9", 17},
+                                                {"NODE_CHARACTERIZATION::GPU_CORE_FREQUENCY_EFFICIENT", 1e9}};
+
+    for (const auto &sig : sig_val_map) {
+        int domain_type = nodechar_io.signal_domain_type(sig.first);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            EXPECT_FLOAT_EQ(sig.second, nodechar_io.read_signal(sig.first,
+                                                                domain_type,
+                                                                domain_idx));
+        }
+    }
+
+}
+
+TEST_F(PlatformCharacterizationIOGroupTest, write_control_read_signal)
+{
+    PlatformCharacterizationIOGroup nodechar_io(*m_platform_topo, m_characterization_file_name);
+    int sig_idx = 0;
+
+    // Every signal should have a control of the same name,
+    // so we use the signal name list to write a value for
+    // each signal
+    for (const auto &sig : nodechar_io.signal_names()) {
+        int domain_type = nodechar_io.signal_domain_type(sig);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            // Expect 0 to start
+            EXPECT_EQ(0, nodechar_io.read_signal(sig,
+                                                 domain_type,
+                                                 domain_idx));
+
+            nodechar_io.write_control(sig, domain_type, domain_idx, domain_idx+sig_idx);
+        }
+        ++sig_idx;
+    }
+
+    sig_idx = 0;
+    for (const auto &sig : nodechar_io.signal_names()) {
+        int domain_type = nodechar_io.control_domain_type(sig);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            EXPECT_EQ(sig_idx + domain_idx, nodechar_io.read_signal(sig,
+                                                                    domain_type,
+                                                                    domain_idx));
+
+        }
+        ++sig_idx;
+    }
+}
+
+TEST_F(PlatformCharacterizationIOGroupTest, push_control_adjust_write_batch)
+{
+    PlatformCharacterizationIOGroup nodechar_io(*m_platform_topo, m_characterization_file_name);
+    int sig_idx = 99;
+    std::map<int, double> batch_value;
+
+    // setup batch values
+    for (const auto &ctrl : nodechar_io.control_names()) {
+        int domain_type = nodechar_io.control_domain_type(ctrl);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            batch_value[nodechar_io.push_control(ctrl, domain_type, domain_idx)] = sig_idx + domain_idx;
+        }
+        ++sig_idx;
+    }
+
+    // adjust
+    for (auto& sv: batch_value) {
+        EXPECT_NO_THROW(nodechar_io.adjust(sv.first, sv.second));
+    }
+
+    //Check results prior to write batch
+    for (const auto &ctrl : nodechar_io.control_names()) {
+        int domain_type = nodechar_io.control_domain_type(ctrl);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            EXPECT_EQ(0, nodechar_io.read_signal(ctrl,
+                                                 domain_type,
+                                                 domain_idx));
+        }
+    }
+
+    EXPECT_NO_THROW(nodechar_io.write_batch());
+    // Check results after write batch
+    sig_idx = 99;
+    for (const auto &ctrl : nodechar_io.control_names()) {
+        int domain_type = nodechar_io.control_domain_type(ctrl);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            EXPECT_EQ(sig_idx + domain_idx, nodechar_io.read_signal(ctrl,
+                                                                    domain_type,
+                                                                    domain_idx));
+        }
+        ++sig_idx;
+    }
+}
+
+TEST_F(PlatformCharacterizationIOGroupTest, read_signal_and_batch)
+{
+    std::string characterization_str = "NODE_CHARACTERIZATION::CPU_CORE_FREQUENCY_EFFICIENT 0 0 1.45e9 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_0 0 0 223 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_1 0 0 212 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_10 0 0 920 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_11 0 0 181 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_12 0 0 617 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_13 0 0 151 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_14 0 0 314 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_2 0 0 121 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_3 0 0 101 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_4 0 0 789 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_5 0 0 456 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_6 0 0 123 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_7 0 0 321 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_8 0 0 654 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_9 0 0 987 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_EFFICIENT 0 0 2.22e+09 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_0 0 0 123 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_1 0 0 4 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_10 0 0 5 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_11 0 0 6 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_12 0 0 7 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_13 0 0 8 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_14 0 0 9 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_2 0 0 10 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_3 0 0 11 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_4 0 0 12 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_5 0 0 13 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_6 0 0 14 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_7 0 0 15 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_8 0 0 16 \n"
+                                       "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_9 0 0 17 \n"
+                                       "NODE_CHARACTERIZATION::GPU_CORE_FREQUENCY_EFFICIENT 0 0 1e+09 \n";
+
+    write_characterization(characterization_str);
+    PlatformCharacterizationIOGroup nodechar_io(*m_platform_topo, m_characterization_file_name);
+
+    std::map<std::string, int> batch_idx;
+    for (const auto &sig : nodechar_io.signal_names()) {
+        int domain_type = nodechar_io.signal_domain_type(sig);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            // Check that it's the non-default map specified
+            EXPECT_NE(0, nodechar_io.read_signal(sig,
+                                                 domain_type,
+                                                 domain_idx));
+            // save the batch id from push_signal
+            batch_idx[sig] = nodechar_io.push_signal(sig, domain_type, domain_idx);
+        }
+    }
+    nodechar_io.read_batch();
+
+    //Expected values
+    std::map<std::string, double> sig_val_map = {{"NODE_CHARACTERIZATION::CPU_CORE_FREQUENCY_EFFICIENT", 1.45e9},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_0", 223},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_1", 212},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_10", 920},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_11", 181},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_12", 617},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_13", 151},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_14", 314},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_2", 121},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_3", 101},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_4", 789},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_5", 456},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_6", 123},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_7", 321},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_8", 654},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_9", 987},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_FREQUENCY_EFFICIENT", 2.22e09},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_0", 123},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_1", 4},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_10", 5},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_11", 6},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_12", 7},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_13", 8},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_14", 9},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_2", 10},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_3", 11},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_4", 12},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_5", 13},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_6", 14},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_7", 15},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_8", 16},
+                                                {"NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_9", 17},
+                                                {"NODE_CHARACTERIZATION::GPU_CORE_FREQUENCY_EFFICIENT", 1e9}};
+
+    for (const auto &sv : batch_idx) {
+        double read_batch_val = nodechar_io.sample(sv.second);
+
+        int domain_type = nodechar_io.signal_domain_type(sv.first);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            // Check read_signal provides expected value
+            double read_signal_val =  nodechar_io.read_signal(sv.first, domain_type, domain_idx);
+            EXPECT_EQ(sig_val_map[sv.first], read_signal_val);
+
+            // Check that read_signal & read_batch/sample values match
+            EXPECT_EQ(read_batch_val, read_signal_val);
+        }
+    }
+}
+
+//Test case: Error path testing
+TEST_F(PlatformCharacterizationIOGroupTest, error_path)
+{
+    // Invalid signal, invalid string format
+    std::string bad_str = "FOO BAR BAZ IS AN INVALID STRING";
+    write_characterization(bad_str);
+    GEOPM_EXPECT_THROW_MESSAGE(PlatformCharacterizationIOGroup
+                               nodechar_io(*m_platform_topo, m_characterization_file_name),
+                               GEOPM_ERROR_RUNTIME,
+                               "Invalid characterization line");
+
+    // Invalid signal, valid string format <SIGNAL> <DOMAIN> <DOMAIN_IDX> <VALUE>
+    bad_str = "NIDA_CHERICTUROZUTEAN::CPY_YNCARO_MAXAMOM_MIMURY_BYNDWODTH_11 0 0 6";
+    write_characterization(bad_str);
+    GEOPM_EXPECT_THROW_MESSAGE(PlatformCharacterizationIOGroup
+                               nodechar_io(*m_platform_topo, m_characterization_file_name),
+                               GEOPM_ERROR_RUNTIME,
+                               "Invalid characterization line");
+
+    // Valid signal, invalid domain size
+    bad_str = "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_9 0 10000000 17";
+    write_characterization(bad_str);
+    GEOPM_EXPECT_THROW_MESSAGE(PlatformCharacterizationIOGroup
+                               nodechar_io(*m_platform_topo, m_characterization_file_name),
+                               GEOPM_ERROR_RUNTIME,
+                               "Invalid characterization line");
+
+    // Valid signal, Invalid domain
+    bad_str = "NODE_CHARACTERIZATION::CPU_UNCORE_MAXIMUM_MEMORY_BANDWIDTH_9 9999 0 17";
+    write_characterization(bad_str);
+    GEOPM_EXPECT_THROW_MESSAGE(PlatformCharacterizationIOGroup
+                               nodechar_io(*m_platform_topo, m_characterization_file_name),
+                               GEOPM_ERROR_RUNTIME,
+                               "Invalid characterization line");
+
+    // Construct the IOGroup without error
+    write_characterization(m_default_characterization_str);
+    PlatformCharacterizationIOGroup nodechar_io(*m_platform_topo, m_characterization_file_name);
+
+    // Setup read batch
+    std::map<std::string, int> batch_idx;
+    for (const auto &sig : nodechar_io.signal_names()) {
+        int domain_type = nodechar_io.signal_domain_type(sig);
+        int num_domain = m_platform_topo->num_domain(domain_type);
+        for (int domain_idx = 0; domain_idx < num_domain; ++domain_idx) {
+            // Check that it's the default map specified
+            EXPECT_EQ(0, nodechar_io.read_signal(sig,
+                                                 domain_type,
+                                                 domain_idx));
+            // save the batch id from push_signal
+            batch_idx[sig] = nodechar_io.push_signal(sig, domain_type, domain_idx);
+        }
+    }
+
+    // sample batch idx prior to read_batch
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.sample(0),
+                               GEOPM_ERROR_INVALID,
+                               "signal has not been read");
+
+    // sample batch idx out of range
+    nodechar_io.read_batch();
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.sample(batch_idx.size()),
+                               GEOPM_ERROR_INVALID,
+                               "out of range");
+
+    // adjust out of range - prior to any settings
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.adjust(0, -1),
+                               GEOPM_ERROR_INVALID,
+                               "out of range");
+
+    // read invalid signal
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.read_signal("INVALID", 0, 0),
+                               GEOPM_ERROR_INVALID,
+                               "not valid for PlatformCharacterizationIOGroup");
+
+    // read valid signal, invalid domain
+    std::string valid_sig = "NODE_CHARACTERIZATION::GPU_CORE_FREQUENCY_EFFICIENT";
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.read_signal(valid_sig, GEOPM_DOMAIN_INVALID, 0),
+                               GEOPM_ERROR_INVALID,
+                               "domain_type must be");
+
+    // read valid signal, valid domain, invalid domain idx
+    int domain_type = nodechar_io.signal_domain_type(valid_sig);
+    int num_domain = m_platform_topo->num_domain(domain_type);
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.read_signal(valid_sig, domain_type, num_domain),
+                               GEOPM_ERROR_INVALID,
+                               "domain_idx out of range.");
+
+    // Push invalid signal
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.push_signal("INVALID", 0, 0),
+                               GEOPM_ERROR_INVALID,
+                               "not valid for PlatformCharacterizationIOGroup");
+
+    // Push valid signal, invalid domain
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.push_signal(valid_sig, GEOPM_DOMAIN_INVALID, 0),
+                               GEOPM_ERROR_INVALID,
+                               "domain_type must be");
+
+    // Push valid signal, valid domain, invalid domain idx
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.push_signal(valid_sig, domain_type, num_domain),
+                               GEOPM_ERROR_INVALID,
+                               "domain_idx out of range.");
+
+    // Push invalid control
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.push_control("INVALID", 0, 0),
+                               GEOPM_ERROR_INVALID,
+                               "not valid for PlatformCharacterizationIOGroup");
+
+    // Push valid control, invalid domain
+    std::string valid_ctrl = "NODE_CHARACTERIZATION::GPU_CORE_FREQUENCY_EFFICIENT";
+    domain_type = nodechar_io.signal_domain_type(valid_ctrl);
+    num_domain = m_platform_topo->num_domain(domain_type);
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.push_control(valid_ctrl, GEOPM_DOMAIN_INVALID, num_domain),
+                               GEOPM_ERROR_INVALID,
+                               "domain_type must be");
+
+    // Push valid control, valid domain, invalid domain idx
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.push_control(valid_ctrl, domain_type, num_domain),
+                               GEOPM_ERROR_INVALID,
+                               "domain_idx out of range.");
+
+    // write invalid control
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.write_control("INVALID", 0, 0, -12345),
+                               GEOPM_ERROR_INVALID,
+                               "not valid for PlatformCharacterizationIOGroup");
+
+    // write valid control, invalid domain
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.write_control(valid_ctrl, GEOPM_DOMAIN_INVALID, 0, -12345),
+                               GEOPM_ERROR_INVALID,
+                               "domain_type must be");
+
+    // write valid control, valid domain, invalid domain idx
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.write_control(valid_ctrl, domain_type, num_domain, -12345),
+                               GEOPM_ERROR_INVALID,
+                               "domain_idx out of range.");
+
+    // Invalid signal tests
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.agg_function("INALID"),
+                               GEOPM_ERROR_INVALID,
+                               "not valid for PlatformCharacterizationIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.format_function("INALID"),
+                               GEOPM_ERROR_INVALID,
+                               "not valid for PlatformCharacterizationIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.signal_description("INALID"),
+                               GEOPM_ERROR_INVALID,
+                               "not valid for PlatformCharacterizationIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.control_description("INALID"),
+                               GEOPM_ERROR_INVALID,
+                               "not valid for PlatformCharacterizationIOGroup");
+    GEOPM_EXPECT_THROW_MESSAGE(nodechar_io.signal_behavior("INALID"),
+                               GEOPM_ERROR_INVALID,
+                               "not valid for PlatformCharacterizationIOGroup");
+}
+
+TEST_F(PlatformCharacterizationIOGroupTest, check_file_too_old)
+{
+    write_characterization(m_default_characterization_str);
+
+    struct sysinfo si;
+    sysinfo(&si);
+    struct geopm_time_s current_time;
+    geopm_time_real(&current_time);
+    unsigned int last_boot_time = current_time.t.tv_sec - si.uptime;
+
+    // Modify the last modified time to be prior to the last boot
+    unsigned int old_time = last_boot_time - 600; // 10 minutes before boot
+    struct utimbuf file_times = {old_time, old_time};
+    utime(m_characterization_file_name.c_str(), &file_times);
+
+    // Verify the modification worked
+    struct stat file_stat;
+    stat(m_characterization_file_name.c_str(), &file_stat);
+    ASSERT_EQ(old_time, file_stat.st_mtime);
+
+    PlatformCharacterizationIOGroup nodechar_io(*m_platform_topo, m_characterization_file_name);
+
+    // Verify the cache was regenerated because it was too old
+    stat(m_characterization_file_name.c_str(), &file_stat);
+    ASSERT_LT(last_boot_time, file_stat.st_mtime);
+
+    // Verify the new file contents
+    std::string new_file_contents = geopm::read_file(m_characterization_file_name);
+    ASSERT_EQ(m_default_characterization_str, new_file_contents);
+}
+
+TEST_F(PlatformCharacterizationIOGroupTest, check_file_bad_perms)
+{
+    write_characterization(m_default_characterization_str);
+
+    // Override the permissions to a known bad state: 0o644
+    mode_t bad_perms = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+    chmod(m_characterization_file_name.c_str(), bad_perms);
+
+    // Verify initial state
+    struct stat file_stat;
+    stat(m_characterization_file_name.c_str(), &file_stat);
+    mode_t actual_perms = file_stat.st_mode & ~S_IFMT;
+    ASSERT_EQ(bad_perms, actual_perms);
+
+    PlatformCharacterizationIOGroup nodechar_io(*m_platform_topo, m_characterization_file_name);
+
+    // Verify that the cache was regenerated because it had the wrong permissions
+    stat(m_characterization_file_name.c_str(), &file_stat);
+    mode_t expected_perms = S_IRUSR | S_IWUSR; // 0o600 by default
+    actual_perms = file_stat.st_mode & ~S_IFMT;
+    ASSERT_EQ(expected_perms, actual_perms);
+
+    // Verify the new file contents
+    std::string new_file_contents = geopm::read_file(m_characterization_file_name);
+    ASSERT_EQ(m_default_characterization_str, new_file_contents);
+}


### PR DESCRIPTION
- Relates to #2434 feature request from github issues
- Fixes #2434 change request from github issues.

This PR introduces a new Platform Characterization IO Group that saves per node characterization information to a cached file similar to the PlatformTopo geopm-topo cache file. 

The expectation is that researchers, administrators, or other users will characterize their systems (as discussed in the GPU-CA #2045 & CPU-CA #2364 PRs) and save the related values using the IO Group controls.  Future users & agents can then query these values on a per-node basis in order to identify node characteristics of interest.

Example signal & control:
- NODE_CHARACTERIZATION::GPU_CORE_FREQUENCY_EFFICIENT - a signal that indicates the energy efficient frequency for the GPU compute domain.  If the control of the same name is written it saves the value to the cache file.  

Tasks keeping this in draft:
- [x] IOGroup documentation
- [x] IOGroup tests for signal read, write, etc
- [ ] Refactoring of create_cache usage - the current code is a copy of @bgeltz implementation from PlatformTopo.  This should be refactored and moved into a common location (Helper.cpp)?

Additional context: 
Currently this IO Group is used by upcoming versions of the CPU-CA & GPU-CA agents, but is intended to be extended as needed.