### PR TITLE
Fix minor issue in PlatformIO sample()

### DIFF
--- a/service/docs/source/geopm_pio.3.rst
+++ b/service/docs/source/geopm_pio.3.rst
@@ -299,14 +299,14 @@ Batch Functions
   signal value stored in the internal state from the last update.  A
   distinct signal index will be returned for each unique combination
   of input parameters.  All signals must be pushed onto the stack
-  prior to the first call to ``geopm_pio_sample()`` or
-  ``geopm_pio_read_batch()``.  After calls to ``geopm_pio_sample()``
-  or ``geopm_pio_read_batch()`` have been made, signals may be pushed
-  again only after performing a reset by calling
-  ``geopm_pio_reset()`` and before calling ``geopm_pio_sample()`` or
-  ``geopm_pio_read_batch()`` again.  Attempts to push a signal onto
-  the stack after the first call to ``geopm_pio_sample()`` or
-  ``geopm_pio_read_batch()`` (and without performing a reset) or
+  prior to the first call to ``geopm_pio_read_batch()`` or
+  ``geopm_pio_adjust()``.  After calls to ``geopm_pio_read_batch()``
+  or ``geopm_pio_adjust()`` have been made, signals may be pushed
+  again only after performing a reset by calling ``geopm_pio_reset()``
+  and before calling ``geopm_pio_read_batch()`` or
+  ``geopm_pio_adjust()`` again.  Attempts to push a signal onto
+  the stack after the first call to ``geopm_pio_read_batch()`` or
+  ``geopm_pio_adjust()`` (and without performing a reset) or
   attempts to push a *signal_name* that is not a value provided by
   ``geopm_pio_signal_name()`` will result in a negative return value.
 
@@ -325,13 +325,13 @@ Batch Functions
   distinct control index will be returned for each unique
   combination of input parameters.  All controls must be pushed onto
   the stack prior to the first call to ``geopm_pio_adjust()`` or
-  ``geopm_pio_write_batch()``.  After calls to ``geopm_pio_adjust()``
-  or ``geopm_pio_write_batch()`` have been made, controls may be
+  ``geopm_pio_read_batch()``.  After calls to ``geopm_pio_adjust()``
+  or ``geopm_pio_read_batch()`` have been made, controls may be
   pushed again only after performing a reset by calling
   ``geopm_pio_reset()`` and before calling ``geopm_pio_adjust()`` or
-  ``geopm_pio_write_batch()`` again.  Attempts to push a controls
+  ``geopm_pio_read_batch()`` again.  Attempts to push a controls
   onto the stack after the first call to ``geopm_pio_adjust()`` or
-  ``geopm_pio_write_batch()`` (and without performing a reset) or
+  ``geopm_pio_read_batch()`` (and without performing a reset) or
   attempts to push a *control_name* that is not a value provided by
   ``geopm_pio_control_name()`` will result in a negative return value.
 

--- a/service/geopmdpy/pio.py
+++ b/service/geopmdpy/pio.py
@@ -271,11 +271,11 @@ def push_signal(signal_name, domain_type, domain_idx):
     function to access the signal value stored in the internal state
     from the last update.  A distinct signal index will be returned
     for each unique combination of input parameters.  All signals must
-    be pushed onto the stack prior to the fist call to sample() or
-    read_batch().  After calls to sample() or read_batch() have been
+    be pushed onto the stack prior to the fist call to read_batch()
+    or adjust().  After calls to read_batch() or adjust() have been
     made, signals may be pushed again only after calling reset() and
-    before caling sample() or read_batch() again.  Attempts to push a
-    signal onto the stack after the first call to sample() or
+    before caling read_batch() or adjust() again.  Attempts to push a
+    signal onto the stack after the first call to read_batch() or
     read_batch() (and without calling reset()) or attempts to push a
     signal_name that is not provided by signal_names() will result in
     a raised exception.
@@ -310,11 +310,11 @@ def push_control(control_name, domain_type, domain_idx):
     the hardware.  A distinct control index will be returned for each
     unique combination of input parameters.  All controls must be
     pushed onto the stack prior to the first call to the adjust() or
-    write_batch() functions.  After calls to adjust() or
-    write_batch() have been made, controls may be pushed again only
+    read_batch() functions.  After calls to adjust() or
+    read_batch() have been made, controls may be pushed again only
     after calling reset() and before calling adjust() or
-    write_batch() again.  Attempts to push a control onto the stack
-    after the first call to adjust() or write_batch() (and without
+    read_batch() again.  Attempts to push a control onto the stack
+    after the first call to adjust() or read_batch() (and without
     calling reset()) or attempts to push a control_name that is not
     a value provided by the control_names() function will result in a
     raised exception.

--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -232,7 +232,8 @@ namespace geopm
 
     PlatformIOImp::PlatformIOImp(std::list<std::shared_ptr<IOGroup> > iogroup_list,
                                  const PlatformTopo &topo)
-        : m_is_active(false)
+        : m_is_signal_active(false)
+        , m_is_control_active(false)
         , m_platform_topo(topo)
         , m_iogroup_list(iogroup_list)
         , m_do_restore(false)
@@ -378,7 +379,7 @@ namespace geopm
                                    int domain_type,
                                    int domain_idx)
     {
-        if (m_is_active) {
+        if (m_is_signal_active || m_is_control_active) {
             throw Exception("PlatformIOImp::push_signal(): pushing signals after read_batch() or adjust().",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -487,7 +488,7 @@ namespace geopm
                                     int domain_type,
                                     int domain_idx)
     {
-        if (m_is_active) {
+        if (m_is_signal_active || m_is_control_active) {
             throw Exception("PlatformIOImp::push_control(): pushing controls after read_batch() or adjust().",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -593,7 +594,7 @@ namespace geopm
             throw Exception("PlatformIOImp::sample(): signal_idx out of range",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        if (!m_is_active) {
+        if (!m_is_signal_active) {
             throw Exception("PlatformIOImp::sample(): read_batch() not called prior to call to sample()",
                             GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
         }
@@ -642,7 +643,7 @@ namespace geopm
         else {
             group_idx_pair.first->adjust(group_idx_pair.second, setting);
         }
-        m_is_active = true;
+        m_is_control_active = true;
     }
 
     void PlatformIOImp::read_batch(void)
@@ -650,7 +651,7 @@ namespace geopm
         for (auto &it : m_iogroup_list) {
             it->read_batch();
         }
-        m_is_active = true;
+        m_is_signal_active = true;
     }
 
     void PlatformIOImp::write_batch(void)

--- a/service/src/PlatformIOImp.hpp
+++ b/service/src/PlatformIOImp.hpp
@@ -117,7 +117,8 @@ namespace geopm
             std::vector<std::shared_ptr<IOGroup> > find_signal_iogroup(const std::string &signal_name) const;
             /// @brief Look up the IOGroup that provides the given control.
             std::vector<std::shared_ptr<IOGroup> > find_control_iogroup(const std::string &control_name) const;
-            bool m_is_active;
+            bool m_is_signal_active;
+            bool m_is_control_active;
             const PlatformTopo &m_platform_topo;
             std::list<std::shared_ptr<IOGroup> > m_iogroup_list;
             std::vector<std::pair<std::shared_ptr<IOGroup>, int> > m_active_signal;

--- a/service/src/geopm_pio.h
+++ b/service/src/geopm_pio.h
@@ -144,15 +144,16 @@ int geopm_pio_write_control(const char *control_name,
 /// @details Subsequent calls to the geopm_pio_read_batch() function
 ///          will read the signal and update the internal state used
 ///          to store batch signals.  All signals must be pushed onto
-///          the stack prior to the first call to geopm_pio_sample()
-///          or geopm_pio_read_batch().  After calls to
-///          geopm_pio_sample() or geopm_pio_read_batch() have been
-///          made, signals may be pushed again only after performing
-///          a reset by calling geopm_pio_reset() and before calling
-///          geopm_pio_sample() or geopm_pio_read_batch() again.
-///          Attempts to push a signal onto the stack after the first
-///          call to geopm_pio_sample() or geopm_pio_read_batch()
-///          (and without performing a reset) or attempts to push a
+///          the stack prior to the first call to
+///          geopm_pio_read_batch() or geopm_pio_adjust().  After
+///          calls to geopm_pio_read_batch() or geopm_pio_adjust()
+///          have been made, signals may be pushed again only after
+///          performing a reset by calling geopm_pio_reset() and
+///          before calling geopm_pio_read_batch() or
+///          geopm_pio_adjust() again.  Attempts to push a signal
+///          onto the stack after the first call to
+///          geopm_pio_read_batch() or geopm_pio_adjust() (and
+///          without performing a reset) or attempts to push a
 ///          signal_name that is not a value provided by
 ///          geopm_pio_signal_name() will result in a negative return
 ///          value.
@@ -187,18 +188,18 @@ int geopm_pio_push_signal(const char *signal_name,
 ///          access the control values in the internal state and write
 ///          the values to the hardware.  All controls must be pushed
 ///          onto the stack prior to the first call to
-///          geopm_pio_adjust() or geopm_pio_write_batch().  After
-///          calls to geopm_pio_adjust() or geopm_pio_write_batch()
+///          geopm_pio_adjust() or geopm_pio_read_batch().  After
+///          calls to geopm_pio_adjust() or geopm_pio_read_batch()
 ///          have been made, controls may be pushed again only after
 ///          performing a reset by calling geopm_pio_reset() and
 ///          before calling geopm_pio_adjust() or
-///          geopm_pio_write_batch() again.  Attempts to push a
+///          geopm_pio_read_batch() again.  Attempts to push a
 ///          control onto the stack after the first call to
-///          geopm_pio_adjust() or geopm_pio_write_batch() (and
+///          geopm_pio_adjust() or geopm_pio_read_batch() (and
 ///          without performing a reset) or attempts to push a
 ///          control_name that is not a value provided by
-///          geopm_pio_control_name() will result in a negative
-///          return value.
+///          geopm_pio_control_name() will result in a negative return
+///          value.
 ///
 /// @param [in] control_name The name of the control, coming from the
 ///        geopm_pio_control_name() function.

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -223,6 +223,7 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/PlatformIOTest.read_signal_iogroup_fallback \
               test/gtest_links/PlatformIOTest.read_signal_override \
               test/gtest_links/PlatformIOTest.sample \
+              test/gtest_links/PlatformIOTest.sample_not_active \
               test/gtest_links/PlatformIOTest.sample_agg \
               test/gtest_links/PlatformIOTest.save_restore \
               test/gtest_links/PlatformIOTest.signal_behavior \

--- a/service/test/PlatformIOTest.cpp
+++ b/service/test/PlatformIOTest.cpp
@@ -464,6 +464,21 @@ TEST_F(PlatformIOTest, sample)
     GEOPM_EXPECT_THROW_MESSAGE(m_platio->sample(10), GEOPM_ERROR_INVALID, "signal_idx out of range");
 }
 
+TEST_F(PlatformIOTest, sample_not_active)
+{
+    /*EXPECT_CALL(*m_control_iogroup, control_domain_type("FREQ")).Times(2);
+    EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, 0));
+    EXPECT_CALL(*m_control_iogroup, write_control("FREQ", GEOPM_DOMAIN_CPU, 0, _));
+    EXPECT_CALL(*m_control_iogroup, push_control("FREQ", _, _));*/
+    int freq_idx_ctrl = m_platio->push_control("FREQ", GEOPM_DOMAIN_CPU, 0);
+    int freq_idx_sig = m_platio->push_signal("FREQ", GEOPM_DOMAIN_CPU, 0);
+
+    //EXPECT_CALL(*m_control_iogroup, adjust(freq_idx_ctrl, 3e9));
+    m_platio->adjust(freq_idx_ctrl, 3e9);
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_platio->sample(freq_idx_sig), GEOPM_ERROR_RUNTIME, "read_batch() not called prior to call to sample()");
+}
+
 TEST_F(PlatformIOTest, sample_agg)
 {
     EXPECT_CALL(*m_topo, is_nested_domain(GEOPM_DOMAIN_CPU,


### PR DESCRIPTION
PlatformIO sample() may proceed even when read_batch() has not been
called. Also made some minor adjustments to related documentation for
pushing signals/controls.

Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>

- Fixes #2441