### PR TITLE
LevelZero sustained power limit support

### DIFF
--- a/service/src/Agg.cpp
+++ b/service/src/Agg.cpp
@@ -66,6 +66,21 @@ namespace geopm
         return result;
     }
 
+    double Agg::bitwise_or(const std::vector<double> &operand)
+    {
+        auto filtered = nan_filter(operand);
+        uint32_t result = 0;
+        if (filtered.size()) {
+            result = 0;
+            for (auto it : filtered) {
+                if (it >= 0) {
+                    result |= (uint32_t) it;
+                }
+            }
+        }
+        return result;
+    }
+
     double Agg::logical_and(const std::vector<double> &operand)
     {
         auto filtered = nan_filter(operand);

--- a/service/src/Agg.cpp
+++ b/service/src/Agg.cpp
@@ -69,14 +69,15 @@ namespace geopm
     double Agg::bitwise_or(const std::vector<double> &operand)
     {
         auto filtered = nan_filter(operand);
-        uint32_t result = 0;
+        double result = NAN;
+        uint64_t agg_tmp = 0;
         if (filtered.size()) {
-            result = 0;
             for (auto it : filtered) {
                 if (it >= 0) {
-                    result |= (uint32_t) it;
+                    agg_tmp |= (uint64_t) it;
                 }
             }
+            result = (double) agg_tmp;
         }
         return result;
     }

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -393,6 +393,12 @@ namespace geopm
         return frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).actual;
     }
 
+    uint32_t LevelZeroImp::frequency_throttle_reasons(unsigned int l0_device_idx,
+                                                      int l0_domain, int l0_domain_idx) const
+    {
+        return frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).throttle_reasons;
+    }
+
     LevelZeroImp::m_frequency_s LevelZeroImp::frequency_status_helper(unsigned int l0_device_idx,
                                                                       int l0_domain, int l0_domain_idx) const
     {

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -138,6 +138,22 @@ namespace geopm
             /// @return GPU maximum power limit in milliwatts
             virtual int32_t power_limit_max(unsigned int l0_device_idx) const = 0;
 
+            /// @brief Get the LevelZero sustained power limit in milliwatts
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero GPU.
+            /// @return GPU sustained power limit in milliwatts
+            virtual int32_t power_limit_sustained(unsigned int l0_device_idx) const = 0;
+            /// @brief Get the LevelZero sustained power limit enable
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero GPU.
+            /// @return GPU sustained power limit enable status
+            virtual bool power_limit_enabled_sustained(unsigned int l0_device_idx) const = 0;
+            /// @brief Get the LevelZero sustained power limit interval in milliseconds
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero GPU.
+            /// @return GPU sustained power limit interval in milliseconds
+            virtual int32_t power_limit_interval_sustained(unsigned int l0_device_idx) const = 0;
+
             /// @brief Get the LevelZero device energy and timestamp
             ///        in microjoules and microseconds
             /// @param [in] l0_device_idx The index indicating a particular
@@ -164,6 +180,10 @@ namespace geopm
             virtual void frequency_control(unsigned int l0_device_idx, int l0_domain,
                                            int l0_domain_idx, double range_min,
                                            double range_max) const = 0;
+
+            virtual void power_limit_sustained_control(unsigned int l0_device_idx,
+                                                       bool enable, double limit,
+                                                       double interval) const = 0;
     };
 
     const LevelZero &levelzero();

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -67,6 +67,15 @@ namespace geopm
             /// @return GPU maximum frequency in MHz.
             virtual double frequency_max(unsigned int l0_device_idx, int l0_domain,
                                          int l0_domain_idx) const = 0;
+            /// @brief Get the LevelZero device frequency throttle reasons
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero GPU.
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @param [in] l0_domain_idx The LevelZero index indicating a particular
+            ///        domain of the GPU..
+            /// @return Frequency throttle reasons
+            virtual uint32_t frequency_throttle_reasons(unsigned int l0_device_idx, int l0_domain,
+                                                        int l0_domain_idx) const = 0;
             /// @brief Get the LevelZero device mininum and maximum frequency
             ///        control range in MHz
             /// @param [in] l0_device_idx The index indicating a particular

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -142,6 +142,25 @@ namespace geopm
                                          dev_subdev_idx_pair.second);
     }
 
+    uint32_t LevelZeroDevicePoolImp::frequency_throttle_reasons(int domain, unsigned int domain_idx,
+                                                              int l0_domain) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                             ": domain " + std::to_string(domain) +
+                            " is not supported for the frequency domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        check_domain_exists(m_levelzero.frequency_domain_count(
+                                        dev_subdev_idx_pair.first, l0_domain), __func__, __LINE__);
+
+        return m_levelzero.frequency_throttle_reasons(dev_subdev_idx_pair.first, l0_domain,
+                                                      dev_subdev_idx_pair.second);
+    }
+
+
     std::pair<double, double> LevelZeroDevicePoolImp::frequency_range(int domain,
                                                                       unsigned int domain_idx,
                                                                       int l0_domain) const

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -286,6 +286,48 @@ namespace geopm
         return m_levelzero.power_limit_tdp(domain_idx);
     }
 
+    int32_t LevelZeroDevicePoolImp::power_limit_sustained(int domain,
+                                                          unsigned int domain_idx,
+                                                          int l0_domain) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for the power domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        check_idx_range(domain, domain_idx);
+        return m_levelzero.power_limit_sustained(domain_idx);
+    }
+
+    bool LevelZeroDevicePoolImp::power_limit_enabled_sustained(int domain,
+                                                               unsigned int domain_idx,
+                                                               int l0_domain) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for the power domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        check_idx_range(domain, domain_idx);
+        return m_levelzero.power_limit_enabled_sustained(domain_idx);
+    }
+
+    int32_t LevelZeroDevicePoolImp::power_limit_interval_sustained(int domain,
+                                                                   unsigned int domain_idx,
+                                                                   int l0_domain) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for the power domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        check_idx_range(domain, domain_idx);
+        return m_levelzero.power_limit_interval_sustained(domain_idx);
+    }
+
     std::pair<uint64_t, uint64_t> LevelZeroDevicePoolImp::energy_pair(int domain,
                                                                       unsigned int domain_idx,
                                                                       int l0_domain) const
@@ -346,5 +388,46 @@ namespace geopm
         m_levelzero.frequency_control(dev_subdev_idx_pair.first, l0_domain,
                                       dev_subdev_idx_pair.second, range_min,
                                       range_max);
+    }
+
+    void LevelZeroDevicePoolImp::power_limit_enable_sustained_control(int domain, unsigned int domain_idx,
+                                                                      int l0_domain, double setting) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for the power domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        check_idx_range(domain, domain_idx);
+        m_levelzero.power_limit_sustained_control(domain_idx, setting, NAN, NAN);
+    }
+
+    void LevelZeroDevicePoolImp::power_limit_sustained_control(int domain, unsigned int domain_idx,
+                                                               int l0_domain, double setting) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for the power domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        check_idx_range(domain, domain_idx);
+        // If we're setting the limit, enable power limits as well
+        m_levelzero.power_limit_sustained_control(domain_idx, true, setting, NAN);
+    }
+
+    void LevelZeroDevicePoolImp::power_limit_interval_sustained_control(int domain, unsigned int domain_idx,
+                                                                        int l0_domain, double setting) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for the power domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        check_idx_range(domain, domain_idx);
+        // If we're setting the interval, enable power limits as well
+        m_levelzero.power_limit_sustained_control(domain_idx, true, NAN, setting);
     }
 }

--- a/service/src/LevelZeroDevicePool.hpp
+++ b/service/src/LevelZeroDevicePool.hpp
@@ -50,6 +50,14 @@ namespace geopm
             /// @return GPU maximum frequency in MHz.
             virtual double frequency_max(int domain, unsigned int domain_idx,
                                          int l0_domain) const = 0;
+            /// @brief Get the LevelZero device frequency throttle reasons
+            /// @param [in] domain The GEOPM domain type being targeted
+            /// @param [in] domain_idx The GEOPM domain index
+            ///             (i.e. gpu being targeted)
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return Frequency throttle reasons
+            virtual uint32_t frequency_throttle_reasons(int domain, unsigned int domain_idx,
+                                                        int l0_domain) const = 0;
             virtual std::pair<double, double> frequency_range(int domain,
                                                               unsigned int domain_idx,
                                                               int l0_domain) const = 0;

--- a/service/src/LevelZeroDevicePool.hpp
+++ b/service/src/LevelZeroDevicePool.hpp
@@ -111,6 +111,32 @@ namespace geopm
             /// @return GPU maximum power limit in milliwatts
             virtual int32_t power_limit_max(int domain, unsigned int domain_idx,
                                             int l0_domain) const = 0;
+            /// @brief Get the LevelZero device sustained power limit in milliwatts
+            /// @param [in] domain The GEOPM domain type being targeted
+            /// @param [in] domain_idx The GEOPM domain index
+            ///             (i.e. GPU being targeted)
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return GPU sustained power limit in milliwatts
+            virtual int32_t power_limit_sustained(int domain, unsigned int domain_idx,
+                                                  int l0_domain) const = 0;
+
+            /// @brief Get the LevelZero device sustained power limit enable
+            /// @param [in] domain The GEOPM domain type being targeted
+            /// @param [in] domain_idx The GEOPM domain index
+            ///             (i.e. GPU being targeted)
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return GPU sustained power limit enable
+            virtual bool power_limit_enabled_sustained(int domain, unsigned int domain_idx,
+                                                       int l0_domain) const = 0;
+
+            /// @brief Get the LevelZero device sustained power limit interval in milliseconds
+            /// @param [in] domain The GEOPM domain type being targeted
+            /// @param [in] domain_idx The GEOPM domain index
+            ///             (i.e. GPU being targeted)
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return GPU sustained power limit interval in milliseconds
+            virtual int32_t power_limit_interval_sustained(int domain, unsigned int domain_idx,
+                                                           int l0_domain) const = 0;
 
             // ENERGY SIGNAL FUNCTIONS
             /// @brief Get the LevelZero device energy in microjoules and timestamp in microseconds.
@@ -150,7 +176,14 @@ namespace geopm
                                            int l0_domain, double range_min,
                                            double range_max) const = 0;
 
-        private:
+            virtual void power_limit_enable_sustained_control(int domain, unsigned int domain_idx,
+                                                              int l0_domain, double setting) const = 0;
+
+            virtual void power_limit_sustained_control(int domain, unsigned int domain_idx,
+                                                       int l0_domain, double setting) const = 0;
+
+            virtual void power_limit_interval_sustained_control(int domain, unsigned int domain_idx,
+                                                                int l0_domain, double setting) const = 0;
     };
 
     const LevelZeroDevicePool &levelzero_device_pool();

--- a/service/src/LevelZeroDevicePoolImp.hpp
+++ b/service/src/LevelZeroDevicePoolImp.hpp
@@ -30,6 +30,8 @@ namespace geopm
                                  int l0_domain) const override;
             double frequency_max(int domain, unsigned int domain_idx,
                                  int l0_domain) const override;
+            uint32_t frequency_throttle_reasons(int domain, unsigned int domain_idx,
+                                                int l0_domain) const override;
             std::pair <double, double> frequency_range(int domain,
                                                        unsigned int domain_idx,
                                                        int l0_domain) const override;

--- a/service/src/LevelZeroDevicePoolImp.hpp
+++ b/service/src/LevelZeroDevicePoolImp.hpp
@@ -48,6 +48,14 @@ namespace geopm
                                     int l0_domain) const override;
             int32_t power_limit_max(int domain, unsigned int domain_idx,
                                     int l0_domain) const override;
+
+            int32_t power_limit_sustained(int domain, unsigned int domain_idx,
+                                          int l0_domain) const override;
+            bool power_limit_enabled_sustained(int domain, unsigned int domain_idx,
+                                               int l0_domain) const override;
+            int32_t power_limit_interval_sustained(int domain, unsigned int domain_idx,
+                                                   int l0_domain) const override;
+
             std::pair<uint64_t, uint64_t> energy_pair(int domain,
                                                       unsigned int domain_idx,
                                                       int l0_domain) const override;
@@ -58,6 +66,14 @@ namespace geopm
             void frequency_control(int domain, unsigned int domain_idx,
                                    int l0_domain, double range_min,
                                    double range_max) const override;
+
+            void power_limit_enable_sustained_control(int domain, unsigned int domain_idx,
+                                                      int l0_domain, double setting) const override;
+            void power_limit_sustained_control(int domain, unsigned int domain_idx,
+                                               int l0_domain, double setting) const override;
+            void power_limit_interval_sustained_control(int domain, unsigned int domain_idx,
+                                                        int l0_domain, double setting) const override;
+
 
         private:
             const LevelZero &m_levelzero;

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -118,7 +118,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_CORE_THROTTLE_REASONS", {
                                   "GPU Compute Hardware throttle reasons.  See oneAPI Level Zero Sysman Spec for decoding",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::bitwise_or,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_integer,
                                   {},

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -115,6 +115,22 @@ namespace geopm
                                   },
                                   1e6
                                   }},
+                              {M_NAME_PREFIX + "GPU_CORE_THROTTLE_REASONS", {
+                                  "GPU Compute Hardware throttle reasons.  See oneAPI Level Zero Sysman Spec for decoding",
+                                  GEOPM_DOMAIN_GPU_CHIP,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_integer,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_throttle_reasons(
+                                                   GEOPM_DOMAIN_GPU_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  1
+                                  }},
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
                                   "The minimum frequency request for the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,

--- a/service/src/LevelZeroIOGroup.hpp
+++ b/service/src/LevelZeroIOGroup.hpp
@@ -121,6 +121,9 @@ namespace geopm
 
             //GEOPM Domain indexed
             std::vector<std::pair<double,double> > m_frequency_range;
+            std::vector<bool> m_power_limit_sustained_enable;
+            std::vector<double> m_power_limit_sustained;
+            std::vector<double> m_power_limit_sustained_interval;
 
             std::shared_ptr<SaveControl> m_mock_save_ctl;
     };

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -33,6 +33,8 @@ namespace geopm
                                  int l0_domain_idx) const override;
             double frequency_max(unsigned int l0_device_idx, int l0_domain,
                                  int l0_domain_idx) const override;
+            uint32_t frequency_throttle_reasons(unsigned int l0_device_idx, int l0_domain,
+                                                int l0_domain_idx) const override;
             std::pair<double, double> frequency_range(unsigned int l0_device_idx,
                                                       int l0_domain,
                                                       int l0_domain_idx) const override;
@@ -63,7 +65,7 @@ namespace geopm
                 double tdp = 0;
                 double efficient = 0;
                 double actual = 0;
-                uint64_t throttle_reasons = 0;
+                uint32_t throttle_reasons = 0;
             };
             struct m_power_limit_s {
                 int32_t tdp = 0;

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -53,10 +53,17 @@ namespace geopm
             int32_t power_limit_tdp(unsigned int l0_device_idx) const override;
             int32_t power_limit_min(unsigned int l0_device_idx) const override;
             int32_t power_limit_max(unsigned int l0_device_idx) const override;
+            int32_t power_limit_sustained(unsigned int l0_device_idx) const override;
+            bool power_limit_enabled_sustained(unsigned int l0_device_idx) const override;
+            int32_t power_limit_interval_sustained(unsigned int l0_device_idx) const override;
 
             void frequency_control(unsigned int l0_device_idx, int l0_domain,
                                    int l0_domain_idx, double range_min,
                                    double range_max) const override;
+
+            virtual void power_limit_sustained_control(unsigned int l0_device_idx,
+                                                       bool enable, double limit,
+                                                       double interval) const override;
 
         private:
             struct m_frequency_s {
@@ -97,10 +104,13 @@ namespace geopm
                 mutable uint64_t cached_energy_timestamp;
             };
 
-
             void domain_cache(unsigned int l0_device_idx);
             void check_ze_result(ze_result_t ze_result, int error, std::string message,
                                  int line) const;
+
+            virtual std::tuple<zes_power_sustained_limit_t,
+                   zes_power_burst_limit_t,
+                   zes_power_peak_limit_t> power_limit(unsigned int l0_device_idx) const;
 
             std::pair<double, double> frequency_min_max(unsigned int l0_device_idx,
                                                         int l0_domain, int l0_domain_idx) const;

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -89,7 +89,7 @@ namespace geopm
                                   "GPU clock throttling reasons",
                                   {},
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::average,
+                                  Agg::bitwise_or,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double
                                   }},

--- a/service/src/geopm/Agg.hpp
+++ b/service/src/geopm/Agg.hpp
@@ -38,6 +38,10 @@ namespace geopm
             static double average(const std::vector<double> &operand);
             /// @brief Returns the median of the input operands.
             static double median(const std::vector<double> &operand);
+            /// @brief Returns the output of bitwise OR over all the
+            ///        operands where 0 is false and all positive numbers
+            ///        are true
+            static double bitwise_or(const std::vector<double> &operand);
             /// @brief Returns the output of logical AND over all the
             ///        operands where 0.0 is false and all other
             ///        values are true.

--- a/service/test/AggTest.cpp
+++ b/service/test/AggTest.cpp
@@ -43,13 +43,16 @@ TEST(AggTest, agg_function)
 
     EXPECT_EQ(1, Agg::bitwise_or({0.0, 0.0, 1.0, 0.0}));
     EXPECT_EQ(0, Agg::bitwise_or({0.0, 0.0}));
+    EXPECT_EQ(7, Agg::bitwise_or({5.0, 2.0}));
+    EXPECT_EQ(3, Agg::bitwise_or({3.0, 1.0}));
+    EXPECT_EQ(6, Agg::bitwise_or({4.0, 2.0}));
     EXPECT_EQ(0, Agg::bitwise_or({0.0, 0.0, NAN}));
     EXPECT_EQ(0, Agg::bitwise_or({0.1, 0}));
     EXPECT_EQ(0, Agg::bitwise_or({-1, 0}));
     EXPECT_EQ(1, Agg::bitwise_or({1, 0}));
     EXPECT_EQ(0, Agg::bitwise_or({NAN, 0.0}));
     EXPECT_EQ(1, Agg::bitwise_or({NAN, 1.0, NAN}));
-    EXPECT_EQ(0, Agg::bitwise_or({NAN, NAN}));
+    EXPECT_TRUE(std::isnan(Agg::bitwise_or({NAN, NAN})));
     EXPECT_EQ(1, Agg::bitwise_or({NAN, 1.0}));
 
     EXPECT_TRUE(std::isnan(Agg::region_hash({})));

--- a/service/test/AggTest.cpp
+++ b/service/test/AggTest.cpp
@@ -41,6 +41,17 @@ TEST(AggTest, agg_function)
     EXPECT_EQ(1.0, Agg::logical_or({1.0, 1.0, 0.0}));
     EXPECT_EQ(0.0, Agg::logical_or({0.0, 0.0}));
 
+    EXPECT_EQ(1, Agg::bitwise_or({0.0, 0.0, 1.0, 0.0}));
+    EXPECT_EQ(0, Agg::bitwise_or({0.0, 0.0}));
+    EXPECT_EQ(0, Agg::bitwise_or({0.0, 0.0, NAN}));
+    EXPECT_EQ(0, Agg::bitwise_or({0.1, 0}));
+    EXPECT_EQ(0, Agg::bitwise_or({-1, 0}));
+    EXPECT_EQ(1, Agg::bitwise_or({1, 0}));
+    EXPECT_EQ(0, Agg::bitwise_or({NAN, 0.0}));
+    EXPECT_EQ(1, Agg::bitwise_or({NAN, 1.0, NAN}));
+    EXPECT_EQ(0, Agg::bitwise_or({NAN, NAN}));
+    EXPECT_EQ(1, Agg::bitwise_or({NAN, 1.0}));
+
     EXPECT_TRUE(std::isnan(Agg::region_hash({})));
 
     EXPECT_TRUE(std::isnan(Agg::region_hash({NAN, NAN})));

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -216,6 +216,7 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     const int num_gpu_subdevice = m_platform_topo->num_domain(GEOPM_DOMAIN_GPU_CHIP);
 
     std::vector<double> mock_freq = {1530, 1630, 1320, 1420, 420, 520, 135, 235};
+    std::vector<double> mock_throttle = {0, 2, 4, 10, 1, 3, 9, 5};
     std::vector<double> mock_energy = {9000000, 11000000, 2300000, 5341000000};
     std::vector<int> batch_idx;
 
@@ -224,6 +225,11 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq.at(sub_idx)));
         batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+    }
+
+    for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_throttle.at(sub_idx)));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_CORE_THROTTLE_REASONS", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
 
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
@@ -236,25 +242,35 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         double frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         double frequency_batch = levelzero_io.sample(batch_idx.at(sub_idx));
-
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(sub_idx)*1e6);
         EXPECT_DOUBLE_EQ(frequency, frequency_batch);
+
+        double throttle = levelzero_io.read_signal("LEVELZERO::GPU_CORE_THROTTLE_REASONS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double throttle_batch = levelzero_io.sample(batch_idx.at(sub_idx + num_gpu_subdevice));
+        EXPECT_DOUBLE_EQ(throttle, mock_throttle.at(sub_idx));
+        EXPECT_DOUBLE_EQ(throttle, throttle_batch);
     }
 
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
         double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_GPU, gpu_idx);
-        double energy_batch = levelzero_io.sample(batch_idx.at(num_gpu_subdevice+gpu_idx));
-
+        double energy_batch = levelzero_io.sample(batch_idx.at(2*num_gpu_subdevice+gpu_idx));
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(gpu_idx)/1e6);
         EXPECT_DOUBLE_EQ(energy, energy_batch);
     }
 
     //second round of testing with a modified value
     mock_freq = {1730, 1830, 1520, 1620, 620, 720, 335, 435};
+    mock_throttle = {2, 6, 8, 4, 12, 16, 18, 22};
     mock_energy = {9320000, 12300000, 2360000, 3417000000};
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_throttle.at(sub_idx)));
     }
+
+    for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
+        EXPECT_CALL(*m_device_pool, frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_throttle.at(sub_idx)));
+    }
+
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(gpu_idx)));
     }
@@ -263,13 +279,17 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         double frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         double frequency_batch = levelzero_io.sample(batch_idx.at(sub_idx));
-
         EXPECT_DOUBLE_EQ(frequency, mock_freq.at(sub_idx)*1e6);
         EXPECT_DOUBLE_EQ(frequency, frequency_batch);
+
+        double throttle = levelzero_io.read_signal("LEVELZERO::GPU_CORE_THROTTLE_REASONS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double throttle_batch = levelzero_io.sample(batch_idx.at(sub_idx + num_gpu_subdevice));
+        EXPECT_DOUBLE_EQ(throttle, mock_throttle.at(sub_idx));
+        EXPECT_DOUBLE_EQ(throttle, throttle_batch);
     }
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
         double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_GPU, gpu_idx);
-        double energy_batch = levelzero_io.sample(batch_idx.at(num_gpu_subdevice+gpu_idx));
+        double energy_batch = levelzero_io.sample(batch_idx.at(2*num_gpu_subdevice+gpu_idx));
 
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(gpu_idx)/1e6);
         EXPECT_DOUBLE_EQ(energy, energy_batch);

--- a/service/test/MockLevelZero.hpp
+++ b/service/test/MockLevelZero.hpp
@@ -25,6 +25,8 @@ class MockLevelZero : public geopm::LevelZero
                     (const, override));
         MOCK_METHOD(double, frequency_max, (unsigned int, int, int),
                     (const, override));
+        MOCK_METHOD(uint32_t, frequency_throttle_reasons, (unsigned int, int, int),
+                    (const, override));
         MOCK_METHOD((std::pair<double, double>), frequency_range,
                     (unsigned int, int, int), (const, override));
 

--- a/service/test/MockLevelZeroDevicePool.hpp
+++ b/service/test/MockLevelZeroDevicePool.hpp
@@ -22,6 +22,8 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
                     (int, unsigned int, int), (const, override));
         MOCK_METHOD(double, frequency_max,
                     (int, unsigned int, int), (const, override));
+        MOCK_METHOD(uint32_t, frequency_throttle_reasons,
+                    (int, unsigned int, int), (const, override));
         MOCK_METHOD((std::pair<double, double>), frequency_range,
                     (int, unsigned int, int), (const, override));
 


### PR DESCRIPTION
- Relates to #2449 feature request from github issues
- Fixes #2449 change request from github issues.

This PR adds signals, controls, pruning, and save/restore logic for the sustained power limit interval, power, and enable defined in the sysman spec [here](https://spec.oneapi.io/level-zero/1.3.7/sysman/api.html#zespowergetlimits)

This support is based upon the 1.3.7 release and does not use the newer power limit extension ([here](https://spec.oneapi.io/level-zero/latest/sysman/api.html#zespowergetlimitsext)).  Until the new extensions can be tested with GEOPM this should provide basic power capping support 

Tasks keeping this in draft
- [ ] Further testing of enable/disable control and pruning on live systems
- [ ] Plan for supporting new vs old API interfaces in Level Zero or a roadmap of when the changes will be implemented for GEOPM.