### PR TITLE
Make SST::*ENABLE controls trigger prerequisite controls

### DIFF
--- a/service/docs/source/geopm_pio_sst.7.rst
+++ b/service/docs/source/geopm_pio_sst.7.rst
@@ -174,7 +174,7 @@ Controls
 --------
 
 ``SST::TURBO_ENABLE``
-    Enable SST-TF feature.
+    Enable SST-TF feature. Enabling SST-TF also causes SST-CP to be enabled.
 
     * **Aggregation**: select_first
     * **Domain**: package
@@ -182,7 +182,7 @@ Controls
     * **Unit**: n/a
 
 ``SST::COREPRIORITY_ENABLE``
-    Enable SST-CP feature.
+    Enable SST-CP feature. Disabling SST-CP also causes SST-TF to be disabled.
 
     * **Aggregation**: select_first
     * **Domain**: package

--- a/service/src/SSTControl.hpp
+++ b/service/src/SSTControl.hpp
@@ -58,7 +58,7 @@ namespace geopm
             void write(double value) override;
             void save(void) override;
             void restore(void) override;
-            void set_write_dependency(uint64_t trigger_value, std::shared_ptr<geopm::Control> dependency, uint64_t dependency_write_value);
+            void set_write_dependency(uint64_t trigger_value, std::weak_ptr<geopm::Control> dependency, uint64_t dependency_write_value);
 
             private:
                 std::shared_ptr<SSTIO> m_sstio;
@@ -79,7 +79,7 @@ namespace geopm
                 uint32_t m_saved_value;
 
                 uint64_t m_trigger_write_value;
-                std::shared_ptr<geopm::Control> m_dependency;
+                std::weak_ptr<geopm::Control> m_dependency;
                 uint64_t m_dependency_write_value;
     };
 }

--- a/service/src/SSTControl.hpp
+++ b/service/src/SSTControl.hpp
@@ -58,6 +58,8 @@ namespace geopm
             void write(double value) override;
             void save(void) override;
             void restore(void) override;
+            void set_write_dependency(uint64_t trigger_value, std::shared_ptr<geopm::Control> dependency, uint64_t dependency_write_value);
+
             private:
                 std::shared_ptr<SSTIO> m_sstio;
                 const ControlType m_control_type;
@@ -75,6 +77,10 @@ namespace geopm
                 const uint32_t m_rmw_read_mask;
                 const double m_multiplier;
                 uint32_t m_saved_value;
+
+                uint64_t m_trigger_write_value;
+                std::shared_ptr<geopm::Control> m_dependency;
+                uint64_t m_dependency_write_value;
     };
 }
 

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -338,6 +338,10 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/SSTIOGroupTest.valid_signal_domains \
               test/gtest_links/SSTIOGroupTest.valid_signal_names \
               test/gtest_links/SSTIOGroupTest.save_restore_control \
+              test/gtest_links/SSTIOGroupTest.enable_sst_tf_implies_enable_sst_cp_write_once \
+              test/gtest_links/SSTIOGroupTest.disable_sst_cp_implies_disable_sst_tf_write_once \
+              test/gtest_links/SSTIOGroupTest.restored_controls_follow_ordered_dependencies_disabled \
+              test/gtest_links/SSTIOGroupTest.restored_controls_follow_ordered_dependencies_enabled \
               test/gtest_links/SSTSignalTest.mailbox_read_batch \
               test/gtest_links/SSTSignalTest.mmio_read_batch \
               test/gtest_links/SSTIOTest.mbox_batch_reads \


### PR DESCRIPTION
- `SST::TURBO_ENABLE:ENABLE` and `SST::COREPRIORITY_ENABLE:ENABLE` controls
  have cross-dependencies. If a user attempts to enable SST-TF while
  SST-CP is disabled, or to disable SST-CP while SST-TF is enabled, then
  the request will be rejected by the isst driver.
- This change makes turbo enable imply corepriority enable, and makes
  corepriority disable imply turbo disable for writes.
- This change removes batch write capabilities for SST::*ENABLE controls.
- Resolves #2451