### PR TITLE
Added high level alias for GPU_UTILIZATION to LevelZeroIOGroup

### DIFF
--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -502,6 +502,7 @@ namespace geopm
                                M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL");
         register_control_alias("GPU_CORE_FREQUENCY_CONTROL",
                                M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL");
+        register_signal_alias("GPU_UTILIZATION", M_NAME_PREFIX + "GPU_UTILIZATION");
         register_signal_alias("GPU_CORE_ACTIVITY", M_NAME_PREFIX + "GPU_CORE_UTILIZATION");
         register_signal_alias("GPU_UNCORE_ACTIVITY", M_NAME_PREFIX + "GPU_UNCORE_UTILIZATION");
         register_control_alias("GPU_CORE_FREQUENCY_MIN_AVAIL",


### PR DESCRIPTION
- Relates to #2465 issue from github issues
- Fixes #2465 change request from github issues.

Update to LevelZero IO group to match high level documentation of GPU aliases (and NVML IO Group aliases).  

Tasks remaining before merge:
- [x] Live system testing