### PR TITLE
Deprecate default implementation of Agent::enforce_policy

### DIFF
--- a/service/docs/source/GEOPM_CXX_MAN_Agent.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_Agent.3.rst
@@ -64,7 +64,7 @@ Link with ``-lgeopm``
 
        virtual void Agent::trace_values(vector<double> &values) = 0;
 
-       virtual void Agent::enforce_policy(const vector<double> &policy) const;
+       virtual void Agent::enforce_policy(const vector<double> &policy) const = 0;
 
        static int Agent::num_policy(const map<string, string> &dictionary);
 

--- a/src/Agent.hpp
+++ b/src/Agent.hpp
@@ -102,7 +102,7 @@ namespace geopm
             /// @brief Enforce the policy one time with
             ///        PlatformIO::write_control().  Called to enforce
             ///        static policies in the absence of a Controller.
-            virtual void enforce_policy(const std::vector<double> &policy) const {}
+            virtual void enforce_policy(const std::vector<double> &policy) const = 0;
             /// @brief Used to look up the number of values in the
             ///        policy vector sent down the tree for a specific
             ///        Agent.  This should be called with the

--- a/test/MockAgent.hpp
+++ b/test/MockAgent.hpp
@@ -45,6 +45,7 @@ class MockAgent : public geopm::Agent
         MOCK_METHOD((std::vector<std::function<std::string(double)> >), trace_formats, (),
                     (const, override));
         MOCK_METHOD(void, trace_values, (std::vector<double> & values), (override));
+        MOCK_METHOD(void, enforce_policy, (const std::vector<double> &policy), (const, override));
 };
 
 #endif


### PR DESCRIPTION
Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>

- Fixes #1333 