### PR TITLE
Skip tests that require bare metal or OS features

### DIFF
--- a/service/geopmdpy_test/TestTimedLoop.py
+++ b/service/geopmdpy_test/TestTimedLoop.py
@@ -5,6 +5,7 @@
 #
 
 import unittest
+import os
 from unittest import mock
 from time import time
 
@@ -36,6 +37,7 @@ class TestTimedLoop(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, err_msg):
             TimedLoop('asd', 'dsa')
 
+    @unittest.skipIf(os.environ.get('GEOPM_TEST_EXTENDED') is None, "Requires accurate timing")
     def test_timed_loop_infinite(self):
         period = 0.01
         tl = TimedLoop(period) # Infinte loop
@@ -52,6 +54,7 @@ class TestTimedLoop(unittest.TestCase):
             if index == 50: # Break after 50 iterations
                 break
 
+    @unittest.skipIf(os.environ.get('GEOPM_TEST_EXTENDED') is None, "Requires accurate timing")
     def test_timed_loop_fixed(self):
         period = 0.01
         num_period = 10

--- a/service/test/BatchServerTest.cpp
+++ b/service/test/BatchServerTest.cpp
@@ -698,6 +698,8 @@ TEST_F(BatchServerTest, create_shmem)
  */
 TEST_F(BatchServerTest, fork_with_setup)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
+
     size_t *counter_mem = (size_t*) mmap(
         NULL,                        // void *addr
         sizeof(size_t),              // size_t length
@@ -740,6 +742,8 @@ TEST_F(BatchServerTest, fork_with_setup)
  */
 TEST_F(BatchServerTest, fork_with_setup_exception)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
+
     std::function<char(void)> setup = [](void)
     {
         return BatchStatus::M_MESSAGE_QUIT;
@@ -983,6 +987,8 @@ int BatchServerTest::fork_other(std::function<void(int, int)> child_process_func
  */
 TEST_F(BatchServerTest, fork_and_terminate_child)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
+
     /// This function contains the child process, which is the server.
     /// It takes the write_pipe_fd and the PID of the parent process, which is the client.
     std::function<void(int, int)> child_process_func =
@@ -1086,6 +1092,8 @@ TEST_F(BatchServerTest, fork_and_terminate_child)
  */
 TEST_F(BatchServerTest, fork_and_terminate_parent)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
+
     /// This function contains the child process, which is the client.
     /// It takes the read_pipe_fd and the PID of the parent process, which is the server.
     std::function<void(int, int)> child_process_func =
@@ -1185,8 +1193,11 @@ TEST_F(BatchServerTest, fork_and_terminate_parent)
  * @test Enables coverage for the path of the SIGCHLD handler upon normal operation,
  *       when a forked child process terminates, and sends a SIGCHLD to the server.
  */
+
 TEST_F(BatchServerTest, action_sigchld)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
+
     /// This function contains the child process, which is the client.
     /// It takes the read_pipe_fd and the PID of the parent process, which is the server.
     std::function<void(int, int)> child_process_func =
@@ -1255,6 +1266,7 @@ TEST_F(BatchServerTest, action_sigchld)
  */
 TEST_F(BatchServerTest, action_sigchld_error)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
     /// This function contains the child process, which is the server.
     /// It takes the write_pipe_fd and the PID of the parent process, which is the client.
     std::function<void(int, int)> child_process_func =

--- a/service/test/MSRIOGroupTest.cpp
+++ b/service/test/MSRIOGroupTest.cpp
@@ -667,6 +667,8 @@ TEST_F(MSRIOGroupTest, read_signal_power)
 
 TEST_F(MSRIOGroupTest, read_signal_scalability)
 {
+    GEOPM_TEST_EXTENDED("Requires accurate timing");
+
     uint64_t pcnt_offset = 0x64e;
     uint64_t acnt_offset = 0xe8;
     double result;

--- a/service/test/geopm_test.hpp
+++ b/service/test/geopm_test.hpp
@@ -32,6 +32,21 @@ bool is_agg_stddev(std::function<double(const std::vector<double> &)> func);
 bool is_agg_select_first(std::function<double(const std::vector<double> &)> func);
 bool is_agg_expect_same(std::function<double(const std::vector<double> &)> func);
 
+/// @brief Skip decorator for gtest test fixtures
+///
+/// Add to the top of any test fixture which has requirement that may not be
+/// met in typical CI situations, like single CPU VMs that are frequently
+/// interrupted.  This should be applied to tests that require more than one
+/// active thread.  Tests that are sensative to delays in execution due to
+/// timing requirements should also be decorated.  To enable these tests,
+/// export GEOPM_TEST_EXTENDED in the environment.
+///
+/// @param [IN] reason The requirement that may not be met in all test cases
+#define GEOPM_TEST_EXTENDED(reason) \
+if (getenv("GEOPM_TEST_EXTENDED") == nullptr) \
+GTEST_SKIP() << reason \
+             << ", export GEOPM_TEST_EXTENDED=1 to enable\n";
+
 /// Checks that the given statement throws a geopm::Exception with the
 /// right error code and message.  The message must be a substring of
 /// the thrown Exception's what() string.  Additional details may be

--- a/service/test/geopm_test.hpp
+++ b/service/test/geopm_test.hpp
@@ -34,14 +34,14 @@ bool is_agg_expect_same(std::function<double(const std::vector<double> &)> func)
 
 /// @brief Skip decorator for gtest test fixtures
 ///
-/// Add to the top of any test fixture which has requirement that may not be
+/// Add to the top of any test fixture which has a requirement that may not be
 /// met in typical CI situations, like single CPU VMs that are frequently
 /// interrupted.  This should be applied to tests that require more than one
-/// active thread.  Tests that are sensative to delays in execution due to
+/// active thread.  Tests that are sensitive to delays in execution due to
 /// timing requirements should also be decorated.  To enable these tests,
 /// export GEOPM_TEST_EXTENDED in the environment.
 ///
-/// @param [IN] reason The requirement that may not be met in all test cases
+/// @param [in] reason The requirement that may not be met in all test cases
 #define GEOPM_TEST_EXTENDED(reason) \
 if (getenv("GEOPM_TEST_EXTENDED") == nullptr) \
 GTEST_SKIP() << reason \

--- a/test/EndpointTest.cpp
+++ b/test/EndpointTest.cpp
@@ -226,6 +226,7 @@ TEST_F(EndpointTest, get_hostnames)
 
 TEST_F(EndpointTest, stop_wait_loop)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
     std::shared_ptr<Endpoint> mio = std::make_shared<EndpointImp>(m_shm_path, m_policy_shmem, m_sample_shmem, 0, 0);
     mio->open();
     mio->reset_wait_loop();
@@ -243,6 +244,8 @@ TEST_F(EndpointTest, stop_wait_loop)
 
 TEST_F(EndpointTest, attach_wait_loop_timeout_throws)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
+
     std::shared_ptr<Endpoint> mio = std::make_shared<EndpointImp>(m_shm_path, m_policy_shmem, m_sample_shmem, 0, 0);
     mio->open();
 
@@ -268,6 +271,8 @@ TEST_F(EndpointTest, attach_wait_loop_timeout_throws)
 
 TEST_F(EndpointTest, detach_wait_loop_timeout_throws)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
+
     struct geopm_endpoint_sample_shmem_s *data = (struct geopm_endpoint_sample_shmem_s *) m_sample_shmem->pointer();
     std::shared_ptr<Endpoint> mio = std::make_shared<EndpointImp>(m_shm_path, m_policy_shmem, m_sample_shmem, 0, 0);
     mio->open();
@@ -296,6 +301,8 @@ TEST_F(EndpointTest, detach_wait_loop_timeout_throws)
 
 TEST_F(EndpointTest, wait_stops_when_agent_attaches)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
+
     struct geopm_endpoint_sample_shmem_s *data = (struct geopm_endpoint_sample_shmem_s *) m_sample_shmem->pointer();
     std::shared_ptr<Endpoint> mio = std::make_shared<EndpointImp>(m_shm_path, m_policy_shmem, m_sample_shmem, 0, 0);
     mio->open();
@@ -335,6 +342,8 @@ TEST_F(EndpointTest, wait_attach_timeout_0)
 
 TEST_F(EndpointTest, wait_stops_when_agent_detaches)
 {
+    GEOPM_TEST_EXTENDED("Requires multiple threads");
+
     struct geopm_endpoint_sample_shmem_s *data = (struct geopm_endpoint_sample_shmem_s *) m_sample_shmem->pointer();
     std::shared_ptr<Endpoint> mio = std::make_shared<EndpointImp>(m_shm_path, m_policy_shmem, m_sample_shmem, 0, 0);
     mio->open();


### PR DESCRIPTION
- Add decorator for skipping test fixtures
- Tests that muliple threads
- Tests that require interupt free operation (time based tests)
- Can be inabled if GEOPM_TEST_EXTENDED is defined in environment
- Relates to #2444