### PR TITLE
Retry SST operations when they fail due to a busy mailbox

### DIFF
--- a/service/src/SSTIO.cpp
+++ b/service/src/SSTIO.cpp
@@ -242,8 +242,10 @@ namespace geopm
                 m_mbox_read_interfaces);
 
             for (auto &batch : m_mbox_read_batch) {
+                errno = 0;
                 int err = m_ioctl->mbox(batch.get());
                 if (err == -1 && errno == EBUSY) {
+                    errno = 0;
                     err = m_ioctl->mbox(batch.get());
                 }
                 if (err == -1) {
@@ -300,8 +302,10 @@ namespace geopm
 
             for (auto &batch : m_mbox_write_batch) {
                 // Read existing value (TODO: only need if not whole mask write)
+                errno = 0;
                 int err = m_ioctl->mbox(batch.get());
                 if (err == -1 && errno == EBUSY) {
+                    errno = 0;
                     err = m_ioctl->mbox(batch.get());
                 }
                 if (err == -1) {
@@ -328,8 +332,10 @@ namespace geopm
 
             for (auto &batch : m_mbox_write_batch) {
                 // Write the adjusted value
+                errno = 0;
                 int err = m_ioctl->mbox(batch.get());
                 if (err == -1 && errno == EBUSY) {
+                    errno = 0;
                     err = m_ioctl->mbox(batch.get());
                 }
                 if (err == -1) {
@@ -392,6 +398,7 @@ namespace geopm
                               .subcommand = subcommand } }
         };
 
+        errno = 0;
         int err = m_ioctl->mbox(&read_batch);
         if (err == -1 && errno == EBUSY) {
             err = m_ioctl->mbox(&read_batch);
@@ -419,6 +426,7 @@ namespace geopm
                               .command = command,
                               .subcommand = read_subcommand } }
         };
+        errno = 0;
         int err = m_ioctl->mbox(&batch);
         if (err == -1 && errno == EBUSY) {
             err = m_ioctl->mbox(&batch);
@@ -434,6 +442,7 @@ namespace geopm
         batch.interfaces[0].read_value = 0;
         batch.interfaces[0].subcommand = subcommand;
 
+        errno = 0;
         err = m_ioctl->mbox(&batch);
         if (err == -1 && errno == EBUSY) {
             err = m_ioctl->mbox(&batch);

--- a/service/src/SSTIO.cpp
+++ b/service/src/SSTIO.cpp
@@ -243,6 +243,9 @@ namespace geopm
 
             for (auto &batch : m_mbox_read_batch) {
                 int err = m_ioctl->mbox(batch.get());
+                if (err == -1 && errno == EBUSY) {
+                    err = m_ioctl->mbox(batch.get());
+                }
                 if (err == -1) {
                     throw Exception("SSTIOImp::read_batch() mbox read failed",
                                     errno, __FILE__, __LINE__);
@@ -298,6 +301,9 @@ namespace geopm
             for (auto &batch : m_mbox_write_batch) {
                 // Read existing value (TODO: only need if not whole mask write)
                 int err = m_ioctl->mbox(batch.get());
+                if (err == -1 && errno == EBUSY) {
+                    err = m_ioctl->mbox(batch.get());
+                }
                 if (err == -1) {
                     throw Exception("sstioimp::write_batch() pre-write mbox read failed",
                                     errno, __FILE__, __LINE__);
@@ -323,6 +329,9 @@ namespace geopm
             for (auto &batch : m_mbox_write_batch) {
                 // Write the adjusted value
                 int err = m_ioctl->mbox(batch.get());
+                if (err == -1 && errno == EBUSY) {
+                    err = m_ioctl->mbox(batch.get());
+                }
                 if (err == -1) {
                     throw Exception("sstioimp::write_batch() mbox write failed",
                                     errno, __FILE__, __LINE__);
@@ -384,6 +393,9 @@ namespace geopm
         };
 
         int err = m_ioctl->mbox(&read_batch);
+        if (err == -1 && errno == EBUSY) {
+            err = m_ioctl->mbox(&read_batch);
+        }
         if (err == -1) {
             throw Exception("sstioimp::read_mbox_once() mbox read failed",
                             errno, __FILE__, __LINE__);
@@ -408,6 +420,9 @@ namespace geopm
                               .subcommand = read_subcommand } }
         };
         int err = m_ioctl->mbox(&batch);
+        if (err == -1 && errno == EBUSY) {
+            err = m_ioctl->mbox(&batch);
+        }
         if (err == -1) {
             throw Exception("sstioimp::write_mbox_once() pre-write mbox read failed",
                             errno, __FILE__, __LINE__);
@@ -420,6 +435,9 @@ namespace geopm
         batch.interfaces[0].subcommand = subcommand;
 
         err = m_ioctl->mbox(&batch);
+        if (err == -1 && errno == EBUSY) {
+            err = m_ioctl->mbox(&batch);
+        }
         if (err == -1) {
             throw Exception("sstioimp::write_mbox_once() mbox write failed",
                             errno, __FILE__, __LINE__);


### PR DESCRIPTION
- Retry mbox operations one time if EBUSY is returned from the operation. If a failure happens during the retry, then throw an exception.
- Resolves #2489