### PR TITLE
Address integration test that sporadically fails

### DIFF
--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,3 +1,4 @@
 matplotlib>=2.2.2
 numpy>=1.14.3
 pandas>=0.23.0
+flaky>=3.7.0

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,4 +1,2 @@
 matplotlib>=2.2.2
-numpy>=1.14.3
-pandas>=0.23.0
 flaky>=3.7.0

--- a/integration/test/test_scaling_region.py
+++ b/integration/test/test_scaling_region.py
@@ -14,6 +14,7 @@ import re
 import unittest
 import os
 import glob
+from flaky import flaky
 
 import geopmpy.io
 import geopmpy.agent
@@ -93,6 +94,7 @@ class TestIntegrationScalingRegion(unittest.TestCase):
             launcher.run(test_name)
 
 
+    @flaky(max_runs=3, min_passes=2)
     def test_monotone_performance(self):
         """Test that the reports generated show linear performance with
            respect to CPU frequency.


### PR DESCRIPTION
- Add flaky Python module to the requirements for integration/.
- This module will automatically try to re-run tests that fail based on parameters set in the test decorator.
- Remove redundant modules from various requirements.txt files.
- Resolves #2498, #2497.