### PR TITLE
Make sure that the lists of clients, signals, and controls are in sorted order.

### DIFF
--- a/service/geopmdpy/access.py
+++ b/service/geopmdpy/access.py
@@ -129,66 +129,66 @@ class Access:
 
         Returns a human readable list of all signals available on the
         platform.  The returned string has one signal name on each
-        line.  The PlatformGetAllAccess D-Bus API of the
-        io.github.geopm interface is used.
+        line, and is in sorted order.  The PlatformGetAllAccess D-Bus API
+        of the io.github.geopm interface is used.
 
         Returns:
-            str: All available signals, one on each line
+            str: All available signals, one on each line, in sorted order
 
         """
         all_signals, _ = self._geopm_proxy.PlatformGetAllAccess()
-        return '\n'.join(all_signals)
+        return '\n'.join(sorted(all_signals))
 
     def get_all_controls(self):
         """Call GEOPM D-Bus API and return all supported control names
 
         Returns a human readable list of all controls available on the
         system.  The returned string has one control name on each
-        line.  The PlatformGetAllAccess D-Bus API of the
-        io.github.geopm interface is used.
+        line, and is in sorted order.  The PlatformGetAllAccess D-Bus API
+        of the io.github.geopm interface is used.
 
         Returns:
-            str: All available controls, one on each line
+            str: All available controls, one on each line, in sorted order
 
         """
         _, all_controls = self._geopm_proxy.PlatformGetAllAccess()
-        return '\n'.join(all_controls)
+        return '\n'.join(sorted(all_controls))
 
     def get_user_signals(self):
         """Call GEOPM D-Bus API and return user allowed signal names
 
         Returns a human readable list of user allowed signal names on
         the platform.  The returned string has one signal name on each
-        line.  The PlatformGetUserAccess D-Bus API of the
-        io.github.geopm interface is used.
+        line, and is in sorted order.  The PlatformGetAllAccess D-Bus API
+        of the io.github.geopm interface is used.
 
         Returns:
-            str: User allowed signals, one on each line
+            str: User allowed signals, one on each line, in sorted order
 
         """
         user_signals, _ = self._geopm_proxy.PlatformGetUserAccess()
-        return '\n'.join(user_signals)
+        return '\n'.join(sorted(user_signals))
 
     def get_user_controls(self):
         """Call GEOPM D-Bus API and return user allowed control names
 
         Returns a human readable list of user allowed controls on the
         platform.  The returned string has one control name on each
-        line.  The PlatformGetAllAccess D-Bus API of the
-        io.github.geopm interface is used.
+        line, and is in sorted order.  The PlatformGetAllAccess D-Bus API
+        of the io.github.geopm interface is used.
 
         Returns:
-            str: User allowed controls, one on each line
+            str: User allowed controls, one on each line, in sorted order
 
         """
         _, user_controls = self._geopm_proxy.PlatformGetUserAccess()
-        return '\n'.join(user_controls)
+        return '\n'.join(sorted(user_controls))
 
     def get_group_signals(self, group):
         """Call GEOPM D-Bus API and return the group's signal access list
 
         Returns a human readable list of the signals that are enabled.
-        The returned string has one signal name on each line.
+        The returned string has one signal name on each line, and is in sorted order.
 
         The default signal access list is returned if the group
         provided is the empty string.  If the group provided is not
@@ -210,19 +210,19 @@ class Access:
                          provided is '': the empty string.
 
         Returns:
-            str: Access list of signals, one on each line
+            str: Access list of signals, one on each line, in sorted order.
 
         """
 
         all_signals, _ = self._geopm_proxy.PlatformGetGroupAccess(group)
-        return '\n'.join(all_signals)
+        return '\n'.join(sorted(all_signals))
 
     def get_group_controls(self, group):
         """Call GEOPM D-Bus API and return the group's control access list
 
         Returns a human readable list of the controls that are
         enabled.  The returned string has one control name on each
-        line.
+        line, and is in sorted order.
 
         The default control access list is returned if the group
         provided is the empty string.  If the group provided is not
@@ -244,11 +244,11 @@ class Access:
                          provided is '': the empty string.
 
         Returns:
-            str: Access list of controls, one on each line
+            str: Access list of controls, one on each line, in sorted order.
 
         """
         _, all_controls = self._geopm_proxy.PlatformGetGroupAccess(group)
-        return '\n'.join(all_controls)
+        return '\n'.join(sorted(all_controls))
 
     def _edited_names_helper(self, initial_names):
         default_editor = '/usr/bin/vi'

--- a/service/geopmdpy/pio.py
+++ b/service/geopmdpy/pio.py
@@ -116,7 +116,7 @@ def signal_names():
     signal_name as input.
 
     Returns:
-        list(str): All available signal names.
+        list(str): All available signal names in sorted order.
 
     """
     global _dl
@@ -132,7 +132,7 @@ def signal_names():
         if err < 0:
             raise RuntimeError('geopm_pio_signal_name() failed: {}'.format(error.message(err)))
         result.append(gffi.gffi.string(signal_name_cstr).decode())
-    return result
+    return sorted(result)
 
 def control_names():
     """Get all available controls.
@@ -142,7 +142,7 @@ def control_names():
     control_name as input.
 
     Returns:
-        list(str): All available control names.
+        list(str): All available control names in sorted order.
 
     """
     global _dl
@@ -157,7 +157,7 @@ def control_names():
         if err < 0:
             raise RuntimeError('geopm_pio_control_name() failed: {}'.format(error.message(err)))
         result.append(gffi.gffi.string(control_name_cstr).decode())
-    return result
+    return sorted(result)
 
 def signal_domain_type(signal_name):
     """Get the domain type that is native for a signal.

--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -75,7 +75,7 @@ class PlatformService(object):
             group (str): Name of group
 
         Returns:
-            list(str), list(str): Signal and control allowed lists
+            list(str), list(str): Signal and control allowed lists, both in sorted order.
 
         Raises:
             RuntimeError: The group name is not valid on the system.
@@ -131,7 +131,7 @@ class PlatformService(object):
                         is returned.
 
         Returns:
-            list(str), list(str): Signal and control allowed lists
+            list(str), list(str): Signal and control allowed lists, both in sorted order.
 
         Raises:
             RuntimeError: The user does not exist.
@@ -148,7 +148,7 @@ class PlatformService(object):
         to calling get_user_access('root').
 
         Returns:
-            list(str), list(str): All supported signals and controls
+            list(str), list(str): All supported signals and controls, in sorted order.
 
         """
         return self._access_lists.get_all_access()

--- a/service/geopmdpy/system_files.py
+++ b/service/geopmdpy/system_files.py
@@ -467,10 +467,10 @@ class ActiveSessions(object):
         Creates a list of the PID values for all active session clients.
 
         Returns:
-            list(int): The Linux PID values for all active clients
+            list(int): The Linux PID values for all active clients in sorted order.
 
         """
-        return list(self._sessions.keys())
+        return sorted(list(self._sessions.keys()))
 
     def get_signals(self, client_pid):
         """Query all signal names that are available
@@ -482,14 +482,14 @@ class ActiveSessions(object):
             client_pid (int): Linux PID that opened the session
 
         Returns:
-            list(str): Signal name access list for the session
+            list(str): Signal name access list in sorted order for the session
 
         Raises:
             RuntimeError: Client does not have an open session
 
         """
         self.check_client_active(client_pid, 'get_signals')
-        return list(self._sessions[client_pid]['signals'])
+        return sorted(list(self._sessions[client_pid]['signals']))
 
     def get_controls(self, client_pid):
         """Query all control names that are available
@@ -501,14 +501,14 @@ class ActiveSessions(object):
             client_pid (int): Linux PID that opened the session
 
         Returns:
-            list(str): Control name access list for the session
+            list(str): Control name access list in sorted order for the session
 
         Raises:
             RuntimeError: Client does not have an open session
 
         """
         self.check_client_active(client_pid, 'get_controls')
-        return list(self._sessions[client_pid]['controls'])
+        return sorted(list(self._sessions[client_pid]['controls']))
 
     def get_watch_id(self, client_pid):
         """Query for the GLib watch ID for tracking the session lifetime
@@ -882,7 +882,7 @@ class AccessLists(object):
             group (str): Name of group
 
         Returns:
-            list(str)), list(str): Signal and control allowed lists
+            list(str)), list(str): Signal and control allowed lists, in sorted order.
 
         Raises:
             RuntimeError: The group name is not valid on the system.
@@ -895,9 +895,11 @@ class AccessLists(object):
             path = os.path.join(group_dir, 'allowed_signals')
             signals = self._read_allowed(path)
             signals = self._filter_valid_signals(signals)
+            signals = sorted(signals)
             path = os.path.join(group_dir, 'allowed_controls')
             controls = self._read_allowed(path)
             controls = self._filter_valid_controls(controls)
+            controls = sorted(controls)
         else:
             signals = []
             controls = []
@@ -958,7 +960,7 @@ class AccessLists(object):
                         is returned.
 
         Returns:
-            list(str), list(str): Signal and control allowed lists
+            list(str), list(str): Signal and control allowed lists, in sorted order.
 
         Raises:
             RuntimeError: The user does not exist.
@@ -993,7 +995,7 @@ class AccessLists(object):
         to calling get_user_access('root').
 
         Returns:
-            list(str), list(str): All supported signals and controls
+            list(str), list(str): All supported signals and controls, in sorted order.
 
         """
         return self._pio.signal_names(), self._pio.control_names()

--- a/service/geopmdpy_test/TestAccess.py
+++ b/service/geopmdpy_test/TestAccess.py
@@ -15,12 +15,12 @@ class TestAccess(unittest.TestCase):
     def setUp(self):
         self._geopm_proxy = mock.MagicMock()
         self._access = Access(self._geopm_proxy)
-        self._signals_expect = ['TIME',
-                                'ALL_ACCESS',
-                                'SIGNAL']
-        self._controls_expect = ['MAX_LIMIT',
-                                 'WRITABLE',
-                                 'CONTROL']
+        self._signals_expect = ['ALL_ACCESS',
+                                'SIGNAL',
+                                'TIME']
+        self._controls_expect = ['CONTROL',
+                                 'MAX_LIMIT',
+                                 'WRITABLE']
 
     def test_signals_query(self):
         """Test user signal access list query

--- a/service/geopmdpy_test/TestAccessLists.py
+++ b/service/geopmdpy_test/TestAccessLists.py
@@ -47,8 +47,8 @@ class TestAccessLists(unittest.TestCase):
         Tests that the parsing of the config files is resilient to
         comments and spacing oddities.
         '''
-        signals_expect = ['geopm', 'signals', 'default', 'energy']
-        controls_expect = ['geopm', 'controls', 'default', 'power']
+        signals_expect = ['default', 'energy', 'geopm', 'signals']
+        controls_expect = ['controls', 'default', 'geopm', 'power']
         default_dir = os.path.join(self._CONFIG_PATH.name, '0.DEFAULT_ACCESS')
         signal_file = os.path.join(default_dir, 'allowed_signals')
         signal_lines = """# Comment about the file contents
@@ -136,8 +136,8 @@ default
         signal_file = os.path.join(default_dir, 'allowed_signals')
         control_file = os.path.join(default_dir, 'allowed_controls')
 
-        signals_expect = ['geopm', 'signals', 'default', 'energy']
-        controls_expect = ['geopm', 'controls', 'default', 'power']
+        signals_expect = ['default', 'energy', 'geopm', 'signals']
+        controls_expect = ['controls', 'default', 'geopm', 'power']
         signal_lines, control_lines = \
             self._write_group_files_helper('', signals_expect, controls_expect)
         with mock.patch('geopmdpy.pio.signal_names', return_value=signals_expect), \
@@ -156,8 +156,8 @@ default
         signal_file = os.path.join(named_dir, 'allowed_signals')
         control_file = os.path.join(named_dir, 'allowed_controls')
 
-        signals_expect = ['geopm', 'signals', 'default', 'energy']
-        controls_expect = ['geopm', 'controls', 'named', 'power']
+        signals_expect = ['default', 'energy', 'geopm', 'signals']
+        controls_expect = ['controls', 'geopm', 'named', 'power']
         signal_lines, control_lines = self._write_group_files_helper('named', [], controls_expect)
 
         with mock.patch('geopmdpy.pio.signal_names', return_value=signals_expect), \
@@ -209,8 +209,8 @@ default
         signal_file = os.path.join(default_dir, 'allowed_signals')
         control_file = os.path.join(default_dir, 'allowed_controls')
 
-        signals_default = ['frequency', 'energy']
-        controls_default = ['geopm', 'controls', 'named', 'power']
+        signals_default = ['energy', 'frequency']
+        controls_default = ['controls','geopm', 'named', 'power']
         signal_lines, control_lines = \
             self._write_group_files_helper('', signals_default, controls_default)
 
@@ -237,20 +237,20 @@ default
         default_signal_file = os.path.join(default_dir, 'allowed_signals')
         default_control_file = os.path.join(default_dir, 'allowed_controls')
 
-        signals_default = ['frequency', 'energy', 'power']
+        signals_default = ['energy', 'frequency', 'power']
         controls_default = ['frequency', 'power']
         default_signal_lines, default_control_lines = \
             self._write_group_files_helper('', signals_default, controls_default)
 
-        signals_named = ['power', 'temperature', 'not-available-anymore']
-        controls_named = ['frequency_uncore', 'power_uncore', 'not-available-anymore-either']
+        signals_named = ['not-available-anymore', 'power', 'temperature']
+        controls_named = ['frequency_uncore', 'not-available-anymore-either', 'power_uncore']
         named_signal_lines, named_control_lines = \
             self._write_group_files_helper('named', signals_named, controls_named)
 
-        signals_avail = ['frequency', 'energy', 'power', 'temperature', 'extra_power',
-                         'extra_temperature']
-        controls_avail = ['frequency', 'power', 'frequency_uncore', 'power_uncore',
-                          'extra_frequency_uncore', 'extra_power_uncore']
+        signals_avail = ['energy', 'extra_power', 'extra_temperature', 'frequency',
+                         'power', 'temperature']
+        controls_avail = ['extra_frequency_uncore', 'extra_power_uncore', 'frequency', 'frequency_uncore',
+                          'power', 'power_uncore']
 
         all_signals = set(signals_named).union(set(signals_default))
         signals_expect = all_signals.intersection(signals_avail)
@@ -280,7 +280,7 @@ default
         self.assertEqual(set(controls_expect), set(controls))
 
     def test_get_user_access_root(self):
-        signals_default = ['frequency', 'energy', 'power']
+        signals_default = ['energy', 'frequency', 'power']
         controls_default = ['frequency', 'power']
         self._write_group_files_helper('', signals_default, controls_default)
 

--- a/service/geopmdpy_test/TestActiveSessions.py
+++ b/service/geopmdpy_test/TestActiveSessions.py
@@ -23,14 +23,14 @@ class TestActiveSessions(unittest.TestCase):
     json_good_example = {
         "client_pid" : 750,
         "reference_count" : 1,
-        "signals" : ["DRAM_ENERGY", "CPU_FREQUENCY_MAX_AVAIL", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
+        "signals" : ["CPU_FREQUENCY_MAX_AVAIL", "DRAM_ENERGY", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
         "controls" : ["CPU_FREQUENCY_CONTROL", "MSR::IA32_PERFEVTSEL0:CMASK"],
         "watch_id" : 754
     }
     json_good_example_2 = {
         "client_pid" : 450,
         "reference_count" : 1,
-        "signals" : ["DRAM_ENERGY", "CPU_FREQUENCY_MAX_AVAIL", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
+        "signals" : ["CPU_FREQUENCY_MAX_AVAIL", "DRAM_ENERGY", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
         "controls" : ["CPU_FREQUENCY_CONTROL", "MSR::IA32_PERFEVTSEL0:CMASK"],
         "watch_id" : 550
     }
@@ -44,28 +44,28 @@ class TestActiveSessions(unittest.TestCase):
     json_negative_reference_count = {
         "client_pid" : 750,
         "reference_count" : -2,
-        "signals" : ["DRAM_ENERGY", "CPU_FREQUENCY_MAX_AVAIL", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
+        "signals" : ["CPU_FREQUENCY_MAX_AVAIL", "DRAM_ENERGY", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
         "controls" : ["CPU_FREQUENCY_CONTROL", "MSR::IA32_PERFEVTSEL0:CMASK"],
         "watch_id" : 754
     }
     json_float_reference_count = {
         "client_pid" : 750,
         "reference_count" : 2.5,
-        "signals" : ["DRAM_ENERGY", "CPU_FREQUENCY_MAX_AVAIL", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
+        "signals" : ["CPU_FREQUENCY_MAX_AVAIL", "DRAM_ENERGY", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
         "controls" : ["CPU_FREQUENCY_CONTROL", "MSR::IA32_PERFEVTSEL0:CMASK"],
         "watch_id" : 754
     }
     json_wrong_data_types = {
         "client_pid" : "450",
         "reference_count" : 1,
-        "signals" : ["DRAM_ENERGY", "CPU_FREQUENCY_MAX_AVAIL", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
+        "signals" : ["CPU_FREQUENCY_MAX_AVAIL", "DRAM_ENERGY", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
         "controls" : ["CPU_FREQUENCY_CONTROL", "MSR::IA32_PERFEVTSEL0:CMASK"],
         "watch_id" : "550"
     }
     json_additional_properties = {
         "client_pid" : 450,
         "reference_count" : 1,
-        "signals" : ["DRAM_ENERGY", "CPU_FREQUENCY_MAX_AVAIL", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
+        "signals" : ["CPU_FREQUENCY_MAX_AVAIL", "DRAM_ENERGY", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
         "controls" : ["CPU_FREQUENCY_CONTROL", "MSR::IA32_PERFEVTSEL0:CMASK"],
         "actuators" : ["DRAM_ENERGY", "FREQUENCY_MIN", "MSR::IA32_PERFEVTSEL0:CMASK"],
         "watch_id" : 550,
@@ -76,7 +76,7 @@ class TestActiveSessions(unittest.TestCase):
     string_empty_file = ""
     string_typos_json = """{
         "client_pid" : 450,
-        "signals",  ["DRAM_ENERGY", "CPU_FREQUENCY_MAX_AVAIL", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
+        "signals",  ["CPU_FREQUENCY_MAX_AVAIL", "DRAM_ENERGY", "MSR::DRAM_ENERGY_STATUS:ENERGY"],
         "controls" : ["CPU_FREQUENCY_CONTROL", "MSR::IA32_PERFEVTSEL0:CMASK"],
         "watch_id" 550,
     }


### PR DESCRIPTION
- Relates to #2201
- Fixes #2201

Make sure that the lists of clients, signals, and controls are in sorted order.
Update the tests to reflect the new changes.