### PR TITLE
No longer allow missing aggregation functions

### DIFF
--- a/service/docs/source/_ext/geopm_rst_extensions.py
+++ b/service/docs/source/_ext/geopm_rst_extensions.py
@@ -130,8 +130,15 @@ class GeopmMsrJson(SphinxDirective):
 
                 # The MSR description is followed by a list of properties.
                 msr_property_list = nodes.bullet_list()
+                try:
+                    aggregation_type = msr_field_data['aggregation']
+                except KeyError:
+                    aggregation_type = 'select_first'
+                    logger.error('Missing an aggregation function for %s in %s',
+                                 geopm_msr_name,
+                                 json_path)
                 description_items = [
-                    ('Aggregation', msr_field_data.get('aggregation', 'select_first')),
+                    ('Aggregation', aggregation_type),
                     ('Domain', msr_data['domain']),
                     ('Format', 'integer'),
                     ('Unit', msr_field_data['units'])

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -19,6 +19,7 @@ EXTRA_DIST += geopmdpy_test/__init__.py \
               geopmdpy_test/TestSecureFiles.py \
               geopmdpy_test/TestAccessLists.py \
               geopmdpy_test/TestWriteLock.py \
+              geopmdpy_test/TestMSRDataFiles.py \
               # end
 
 GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestAccessLists.test__read_allowed_invalid \
@@ -134,6 +135,7 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestAccessLists.test__read_allowed_i
                  geopmdpy_test/pytest_links/TestWriteLock.test_nested_creation \
                  geopmdpy_test/pytest_links/TestWriteLock.test_creation_bad_path \
                  geopmdpy_test/pytest_links/TestWriteLock.test_creation_bad_file \
+                 geopmdpy_test/pytest_links/TestMSRDataFiles.test_msr_data_files \
                  # end
 
 TESTS += $(GEOPMDPY_TESTS)

--- a/service/geopmdpy_test/TestMSRDataFiles.py
+++ b/service/geopmdpy_test/TestMSRDataFiles.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2015 - 2022, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+
+import unittest
+import os
+import glob
+import json
+import jsonschema
+
+
+class TestMSRDataFiles(unittest.TestCase):
+    def setUp(self):
+        msr_schema_file = os.path.dirname(os.path.abspath(__file__)) + \
+                          "/../json_schemas/msrs.schema.json"
+        with open(msr_schema_file, "r") as f:
+            self._MSR_SCHEMA = json.load(f)
+
+        msr_data_dir = os.path.dirname(os.path.abspath(__file__)) + "/../src"
+        self._MSR_DATA_FILES = glob.glob(msr_data_dir + "/msr_data_*.json")
+        self.assertTrue(self._MSR_DATA_FILES)
+
+    def test_msr_data_files(self):
+        for file_name in self._MSR_DATA_FILES:
+            with open(file_name, "r") as f:
+                msr_data = json.load(f)
+            jsonschema.validate(msr_data, schema=self._MSR_SCHEMA)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/service/json_schemas/msrs.schema.json
+++ b/service/json_schemas/msrs.schema.json
@@ -34,7 +34,7 @@
             "type": "string"
           }
         },
-        "required": ["begin_bit", "end_bit", "function", "scalar", "units", "writeable", "behavior"],
+        "required": ["begin_bit", "end_bit", "function", "scalar", "units", "writeable", "behavior", "aggregation"],
         "additionalProperties": false
       },
       "msrObject": {

--- a/service/src/MSRIOGroup.cpp
+++ b/service/src/MSRIOGroup.cpp
@@ -1456,10 +1456,10 @@ namespace geopm
             {"units", {Json::STRING, json_check_null_func, "must be a string"}},
             {"scalar", {Json::NUMBER, json_check_null_func, "must be a number"}},
             {"writeable", {Json::BOOL, json_check_null_func, "must be a bool"}},
-            {"behavior", {Json::STRING, json_check_null_func, "must be a valid behavior string"}}
+            {"behavior", {Json::STRING, json_check_null_func, "must be a valid behavior string"}},
+            {"aggregation", {Json::STRING, json_check_is_valid_aggregation, "must be a valid aggregation function name"}}
         };
         std::map<std::string, json_checker> optional_field_checker {
-            {"aggregation", {Json::STRING, json_check_is_valid_aggregation, "must be a valid aggregation function name"}},
             {"description", {Json::STRING, json_check_null_func, "must be a string"}}
         };
         check_expected_key_values(msr_field, field_checker, optional_field_checker,
@@ -1613,12 +1613,9 @@ namespace geopm
                 int units = IOGroup::string_to_units(field_data["units"].string_value());
                 bool is_control = field_data["writeable"].bool_value();
                 int behavior = IOGroup::string_to_behavior(field_data["behavior"].string_value());
+                std::string agg_function = field_data["aggregation"].string_value();
                 // optional fields
-                std::string agg_function = "select_first";
                 std::string description = M_DEFAULT_DESCRIPTION;
-                if (field_data.find("aggregation") != field_data.end()) {
-                    agg_function = field_data["aggregation"].string_value();
-                }
                 if (field_data.find("description") != field_data.end()) {
                     description = field_data["description"].string_value();
                 }

--- a/service/test/MSRIOGroupTest.cpp
+++ b/service/test/MSRIOGroupTest.cpp
@@ -1241,7 +1241,8 @@ TEST_F(MSRIOGroupTest, parse_json_msrs_error_fields)
         {"units", "hertz"},
         {"scalar", 2},
         {"writeable", false},
-        {"behavior", "variable"}
+        {"behavior", "variable"},
+        {"aggregation", "average"}
     };
     std::map<std::string, Json> fields, msr, input;
     // used to rebuild the Json object with the "fields" section updated
@@ -1260,7 +1261,7 @@ TEST_F(MSRIOGroupTest, parse_json_msrs_error_fields)
 
     // required keys
     std::vector<std::string> field_keys {"begin_bit", "end_bit", "function",
-                                         "units", "scalar", "writeable", "behavior"
+                                         "units", "scalar", "writeable", "behavior", "aggregation"
     };
     for (auto key : field_keys) {
         fields = complete;
@@ -1368,7 +1369,8 @@ TEST_F(MSRIOGroupTest, parse_json_msrs)
                        "units": "hertz",
                        "scalar": 2,
                        "behavior": "label",
-                       "writeable": true
+                       "writeable": true,
+                       "aggregation": "expect_same"
                    }
                }
            }
@@ -1391,6 +1393,7 @@ TEST_F(MSRIOGroupTest, parse_json_msrs)
               "    domain: package\n"
               "    iogroup: MSRIOGroup",
               m_msrio_group->signal_description("MSR::MSR_ONE:FIELD_RO"));
+    EXPECT_TRUE(is_agg_expect_same(m_msrio_group->agg_function("MSR::MSR_TWO:FIELD_RW")));
 }
 
 TEST_F(MSRIOGroupTest, batch_calls_no_push)


### PR DESCRIPTION
- MSRIOGroup no longer acepts missing aggregation functions
- MSR schema file makes the aggregation field required
- Added a test to validate MSR data/config files
- Added a check in the doc build for MSR documentation

Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>

- Fixes #2516 