### PR TITLE
Created a new integration `test_su_term_batch_write`

### DIFF
--- a/service/integration/Makefile.mk
+++ b/service/integration/Makefile.mk
@@ -16,6 +16,7 @@ EXTRA_DIST += integration/README.md \
               integration/test/test_su_term_batch.sh \
               integration/test/test_su_term_batch_helper.sh \
               integration/test/test_su_term_batch_write.sh \
+              integration/test/test_su_term_batch_write_helper.py \
               integration/test/test_su_term_batch_write_helper.sh \
               integration/test/do_write.sh \
               # end

--- a/service/integration/Makefile.mk
+++ b/service/integration/Makefile.mk
@@ -15,6 +15,8 @@ EXTRA_DIST += integration/README.md \
               integration/test/test_su_restart.sh \
               integration/test/test_su_term_batch.sh \
               integration/test/test_su_term_batch_helper.sh \
+              integration/test/test_su_term_batch_write.sh \
+              integration/test/test_su_term_batch_write_helper.sh \
               integration/test/do_write.sh \
               # end
 

--- a/service/integration/test/test_su_term_batch_write.sh
+++ b/service/integration/test/test_su_term_batch_write.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2022, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+if [[ $# -gt 0 ]] && [[ $1 == '--help' ]]; then
+    echo "
+    Terminating Batch Server
+    ------------------------
+
+    As a user, send term signal to a geopmsession process owned by the
+    test user, and make sure that server (owned by root) shuts down
+    cleanly.
+
+"
+    exit 0
+fi
+
+# PARAMETERS
+CONTROL=SERVICE::MSR::PERF_CTL:FREQ
+STICKER=CPU_FREQUENCY_STICKER
+DOMAIN=core
+DOMAIN_IDX=0
+REQUEST="${CONTROL} ${DOMAIN} ${DOMAIN_IDX}"
+REQUEST_STICKER="${STICKER} board ${DOMAIN_IDX}"
+
+test_error() {
+    echo "Error: $1" 1>&2
+    exit -1
+}
+
+TEST_DIR=$(dirname $(readlink -f $0))
+TEST_USER=test
+
+set -x
+
+# READ START VALUE OF CONTROL REGISTER
+START_VALUE=$(geopmread ${REQUEST}) ||
+    test_error "Call to read ${CONTROL} through geopmread failed"
+
+# READ START VALUE OF STICKER REGISTER
+REQUEST_VALUE=$(geopmread ${REQUEST_STICKER}) ||
+    test_error "Call to read ${STICKER} through geopmread failed"
+
+REQUEST_VALUE=$(( "$REQUEST_VALUE" - 100000000)) ||
+    test_error "Attempt to adjust ${REQUEST_VALUE} failed"
+
+# CHECK THAT IT IS DIFFERENT THAN THE TEST VALUE
+test ${REQUEST_VALUE} != ${START_VALUE} ||
+    test_error "Start value for the control is the same as the test value"
+
+# START A PYTHON SCRIPT THAT WRITES THE CONTROL VALUE
+TEST_SCRIPT="${TEST_DIR}/test_su_term_batch_write_helper.sh"
+if [[ $(whoami) == 'root' ]]; then
+    # sudo -u is used to change from the root user to the test user,
+    # who does not have elevated privileges.
+    export SESSION_PID=$(sudo -E -u ${TEST_USER} \
+        setsid python3 ${TEST_DIR}/test_su_term_batch_write_helper.py &  echo $!)
+else
+    setsid python3 ${TEST_DIR}/test_su_term_batch_write_helper.py &
+    export SESSION_PID=$!
+fi
+sleep 5
+
+# READ THE CONTROLLED REGISTER
+SESSION_VALUE=$(geopmread ${REQUEST})
+
+# CHECK THAT THE VALUE OF THE CONTROL REGISTER HAS BEEN CHANGED
+test ${SESSION_VALUE} == ${REQUEST_VALUE} ||
+    test_error "Writing the new value has failed"
+
+# TERMINATE THE CLIENT PROCESS, VERIFY THAT THE BATCH SERVER IS GONE TOO
+sleep 5
+# geopmaccess returns a JSON object containing the PID of the batch server
+BATCH_PID=$(sudo geopmaccess -s ${SESSION_PID} | \
+            python3 -c 'import sys,json; print(json.loads(sys.stdin.read())["batch_server"])')
+
+# BATCH_PID=$(sudo geopmaccess -s ${SESSION_PID} | \
+#             python3 -c 'import sys; print(sys.stdin.read())')
+
+kill -7 $SESSION_PID # Ok to send as test user
+sleep 5
+if ps --pid $BATCH_PID >& /dev/null; then
+    kill -9 $BATCH_PID
+    test_error "Batch server persists after client is terminated"
+fi
+
+# READ THE RESTORED REGISTER
+END_VALUE=$(geopmread ${REQUEST})
+
+# CHECK THAT SAVE/RESTORE WORKED
+test ${START_VALUE} == ${END_VALUE} ||
+    test_error "Control is not restored after the session"
+
+echo "SUCCESS"
+exit 0

--- a/service/integration/test/test_su_term_batch_write.sh
+++ b/service/integration/test/test_su_term_batch_write.sh
@@ -78,9 +78,6 @@ sleep 5
 BATCH_PID=$(sudo geopmaccess -s ${SESSION_PID} | \
             python3 -c 'import sys,json; print(json.loads(sys.stdin.read())["batch_server"])')
 
-# BATCH_PID=$(sudo geopmaccess -s ${SESSION_PID} | \
-#             python3 -c 'import sys; print(sys.stdin.read())')
-
 kill -7 $SESSION_PID # Ok to send as test user
 sleep 5
 if ps --pid $BATCH_PID >& /dev/null; then

--- a/service/integration/test/test_su_term_batch_write.sh
+++ b/service/integration/test/test_su_term_batch_write.sh
@@ -8,9 +8,9 @@ if [[ $# -gt 0 ]] && [[ $1 == '--help' ]]; then
     Terminating Batch Server
     ------------------------
 
-    As a user, send term signal to a geopmsession process owned by the
-    test user, and make sure that server (owned by root) shuts down
-    cleanly.
+    As a user, send a term signal to a running python script owned by
+    the test user that creates a writing batch server. Check that the
+    batch server (owned by root) shuts down cleanly.
 
 "
     exit 0

--- a/service/integration/test/test_su_term_batch_write.sh
+++ b/service/integration/test/test_su_term_batch_write.sh
@@ -17,7 +17,7 @@ if [[ $# -gt 0 ]] && [[ $1 == '--help' ]]; then
 fi
 
 # PARAMETERS
-CONTROL=SERVICE::MSR::PERF_CTL:FREQ
+CONTROL=MSR::PERF_CTL:FREQ
 STICKER=CPU_FREQUENCY_STICKER
 DOMAIN=core
 DOMAIN_IDX=0
@@ -54,8 +54,11 @@ TEST_SCRIPT="${TEST_DIR}/test_su_term_batch_write_helper.sh"
 if [[ $(whoami) == 'root' ]]; then
     # sudo -u is used to change from the root user to the test user,
     # who does not have elevated privileges.
-    export SESSION_PID=$(sudo -E -u ${TEST_USER} \
-        setsid python3 ${TEST_DIR}/test_su_term_batch_write_helper.py &  echo $!)
+    TEMP_FILE=$(mktemp --tmpdir test_su_term_batch_write_XXXXXXXX.tmp)
+    sudo -b -E -u ${TEST_USER} setsid ${TEST_SCRIPT} > ${TEMP_FILE}
+    sleep 2
+    export SESSION_PID=$(cat ${TEMP_FILE})
+    rm ${TEMP_FILE}
 else
     setsid python3 ${TEST_DIR}/test_su_term_batch_write_helper.py &
     export SESSION_PID=$!

--- a/service/integration/test/test_su_term_batch_write_helper.py
+++ b/service/integration/test/test_su_term_batch_write_helper.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2015 - 2022, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+from geopmdpy import pio
+from time import sleep
+from os import getpid
+
+def main():
+    index = pio.push_control("SERVICE::MSR::PERF_CTL:FREQ", "core", 0)
+    cpu_frequency_value = pio.read_signal("CPU_FREQUENCY_STICKER", "board", 0) - 100e6
+    pio.adjust(index, cpu_frequency_value)
+    pio.write_batch()
+    print(getpid())
+    sleep(1000)
+
+if __name__ == '__main__':
+    main()

--- a/service/integration/test/test_su_term_batch_write_helper.sh
+++ b/service/integration/test/test_su_term_batch_write_helper.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2022, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+TEST_DIR=$(dirname "$0")
+setsid python3 $TEST_DIR/test_su_term_batch_write_helper.py &
+echo $!

--- a/service/integration/test/test_su_term_batch_write_helper.sh
+++ b/service/integration/test/test_su_term_batch_write_helper.sh
@@ -4,5 +4,5 @@
 #
 
 TEST_DIR=$(dirname "$0")
-setsid python3 $TEST_DIR/test_su_term_batch_write_helper.py &
+python3 $TEST_DIR/test_su_term_batch_write_helper.py &
 echo $!


### PR DESCRIPTION
This test:
 - Prior to setting the control to a custom value,
   check that it is != to that custom value, and
   save the old value of the control.
 - Run a python script to overwrite the old value
   of the control with a custom value
 - Wait for the session to terminate.
 - Check that the control retains it's old value
   after the session has shut down (ie. the batch
   server restores the values of all signals and
   controls when it shuts down).

Signed-off-by: Konstantin Rebrov <konstantin.rebrov@intel.com>

- Relates to #2510
- Fixes #2510
