### PR TITLE
Add missing geopm_pio.7 documentation

### DIFF
--- a/service/docs/source/geopm_pio.7.rst
+++ b/service/docs/source/geopm_pio.7.rst
@@ -105,8 +105,11 @@ Descriptions Of High Level Aliases
     Target maximum operating frequency of the CPU based on the control
     register.
 
+``CPU_FREQUENCY_MIN_AVAIL``
+    Minimum achievable processor frequency on the system.
+
 ``CPU_FREQUENCY_MAX_AVAIL``
-    Maximum processor frequency.
+    Maximum achievable processor frequency on the system.
 
 ``CPU_FREQUENCY_MIN_CONTROL``
     Target minimum operating frequency of the CPU based on the control
@@ -114,6 +117,12 @@ Descriptions Of High Level Aliases
 
 ``CPU_FREQUENCY_STATUS``
     The current operating frequency of the CPU.
+
+``CPU_FREQUENCY_STEP``
+    Step size between process frequency settings.
+
+``CPU_FREQUENCY_STICKER``
+    Processor base frequency.
 
 ``CPU_INSTRUCTIONS_RETIRED``
     The count of the number of instructions executed.
@@ -146,6 +155,12 @@ Descriptions Of High Level Aliases
 
 ``CPU_UNCORE_FREQUENCY_STATUS``
     Target operating frequency of the uncore.
+
+``CPU_UNCORE_FREQUENCY_MAX_CONTROL``
+    Control that limits the maximum frequency of the uncore.
+
+``CPU_UNCORE_FREQUENCY_MIN_CONTROL``
+    Control that limits the minimum frequency of the uncore.
 
 ``DRAM_ENERGY``
     An increasing meter of energy consumed by the DRAM over time. It will reset

--- a/service/docs/source/geopm_pio.7.rst
+++ b/service/docs/source/geopm_pio.7.rst
@@ -119,7 +119,7 @@ Descriptions Of High Level Aliases
     The current operating frequency of the CPU.
 
 ``CPU_FREQUENCY_STEP``
-    Step size between process frequency settings.
+    Step size between processor frequency settings.
 
 ``CPU_FREQUENCY_STICKER``
     Processor base frequency.

--- a/service/docs/source/geopm_pio_cpuinfo.7.rst
+++ b/service/docs/source/geopm_pio_cpuinfo.7.rst
@@ -41,7 +41,7 @@ Signals
     * **Unit**: hertz
 
 ``CPUINFO::FREQ_STEP``
-    Returns the step size between process frequency settings.
+    Returns the step size between processor frequency settings.
 
     * **Aggregation**: expect_same
     * **Domain**: cpu

--- a/service/src/CpuinfoIOGroup.cpp
+++ b/service/src/CpuinfoIOGroup.cpp
@@ -155,7 +155,7 @@ namespace geopm
                                    100e6,
                                    M_UNITS_HERTZ,
                                    Agg::expect_same,
-                                   "Step size between process frequency settings"}}})
+                                   "Step size between processor frequency settings"}}})
     {
         register_signal_alias("CPU_FREQUENCY_MIN_AVAIL", "CPUINFO::FREQ_MIN");
         register_signal_alias("CPU_FREQUENCY_STICKER", "CPUINFO::FREQ_STICKER");


### PR DESCRIPTION
- Missing high level signals provided by CpuinfoIOGroup
- Missing uncore frequency controls
- Fixes #2542
