### PR TITLE
Make aggregation functions consistent across IOGroups

### DIFF
--- a/service/docs/source/geopm_pio_cnl.7.rst
+++ b/service/docs/source/geopm_pio_cnl.7.rst
@@ -22,7 +22,7 @@ All signals are available with board-level scope, on systems that expose the
     Returns the current board power consumption, in watts. This signal maps to
     ``/sys/cray/pm_counters/power``.
 
-    * **Aggregation**: average
+    * **Aggregation**: sum
     * **Domain**: board
     * **Format**: integer
     * **Unit**: watts
@@ -40,7 +40,7 @@ All signals are available with board-level scope, on systems that expose the
     Returns the current power consumption of memory components on the board, in
     watts. This signal maps to ``/sys/cray/pm_counters/memory_power``.
 
-    * **Aggregation**: average
+    * **Aggregation**: sum
     * **Domain**: board
     * **Format**: integer
     * **Unit**: watts
@@ -58,7 +58,7 @@ All signals are available with board-level scope, on systems that expose the
     Returns the current power consumption of CPU components on the board, in
     watts. This signal maps to ``/sys/cray/pm_counters/cpu_power``.
 
-    * **Aggregation**: average
+    * **Aggregation**: sum
     * **Domain**: board
     * **Format**: integer
     * **Unit**: watts

--- a/service/docs/source/geopm_pio_levelzero.7.rst
+++ b/service/docs/source/geopm_pio_levelzero.7.rst
@@ -26,7 +26,7 @@ Signals
 ``LEVELZERO::GPU_CORE_FREQUENCY_MAX_AVAIL``
     The maximum supported frequency of the GPU Compute Hardware.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: expect_same
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: hertz
@@ -34,7 +34,7 @@ Signals
 ``LEVELZERO::GPU_CORE_FREQUENCY_MIN_AVAIL``
     The minimum supported frequency of the GPU Compute Hardware.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: expect_same
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: hertz
@@ -50,7 +50,7 @@ Signals
 ``LEVELZERO::GPU_ENERGY_TIMESTAMP``
     Timestamp for the GPU energy read in seconds.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: sum
     *  **Domain**: gpu
     *  **Format**: double
     *  **Unit**: seconds
@@ -66,7 +66,7 @@ Signals
 ``LEVELZERO::GPU_UNCORE_FREQUENCY_MAX_AVAIL``
     The maximum supported frequency of the GPU Memory Hardware.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: expect_same
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: hertz
@@ -74,7 +74,7 @@ Signals
 ``LEVELZERO::GPU_UNCORE_FREQUENCY_MIN_AVAIL``
     The minimum supported frequency of the GPU Memory Hardware.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: expect_same
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: hertz
@@ -106,7 +106,7 @@ Signals
 ``LEVELZERO::GPU_ACTIVE_TIME``
     Time in seconds that this resource is actively running a workload.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: seconds
@@ -114,7 +114,7 @@ Signals
 ``LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP``
     The timestamp for the ``LEVELZERO::GPU_ACTIVE_TIME`` read in seconds.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: seconds
@@ -122,7 +122,7 @@ Signals
 ``LEVELZERO::GPU_CORE_ACTIVE_TIME``
     Time in seconds that the GPU compute engines (EUs) are actively running a workload.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: seconds
@@ -130,7 +130,7 @@ Signals
 ``LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP``
     The timestamp for the ``LEVELZERO::GPU_CORE_ACTIVE_TIME`` signal read in seconds.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: seconds
@@ -138,7 +138,7 @@ Signals
 ``LEVELZERO::GPU_UNCORE_ACTIVE_TIME``
     Time in seconds that the GPU copy engines are actively running a workload.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: seconds
@@ -146,7 +146,7 @@ Signals
 ``LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP``
     The timestamp for the ``LEVELZERO::GPU_UNCORE_ACTIVE_TIME`` signal read in seconds.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: seconds
@@ -190,7 +190,7 @@ Every control is exposed as a signal with the same name.  The relevant signal ag
 ``LEVELZERO::GPU_CORE_FREQUENCY_MIN_CONTROL``
     Sets the minimum frequency request for the GPU Compute Hardware.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: expect_same
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: hertz
@@ -198,7 +198,7 @@ Every control is exposed as a signal with the same name.  The relevant signal ag
 ``LEVELZERO::GPU_CORE_FREQUENCY_MAX_CONTROL``
     Sets the minimum frequency request for the GPU Compute Hardware.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: expect_same
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: hertz
@@ -206,7 +206,7 @@ Every control is exposed as a signal with the same name.  The relevant signal ag
 ``LEVELZERO::GPU_CORE_FREQUENCY_CONTROL``
     Sets both the minimum and maximum frequency request for the GPU Compute Hardware to a single user provided value (min=max).  Only valid as a signal after being written, NAN returned otherwise.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: expect_same
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: hertz

--- a/service/docs/source/geopm_pio_nvml.7.rst
+++ b/service/docs/source/geopm_pio_nvml.7.rst
@@ -106,7 +106,7 @@ Signals
 ``NVML::GPU_UNCORE_UTILIZATION``
     Fraction of time the GPU memory was accessed in the last set of driver samples.
 
-    *  **Aggregation**: max
+    *  **Aggregation**: average
     *  **Domain**: gpu
     *  **Format**: double
     *  **Unit**: n/a
@@ -143,7 +143,7 @@ Every control is exposed as a signal with the same name.  The relevant signal ag
 ``NVML::GPU_CORE_FREQUENCY_RESET_CONTROL``
     Resets Streaming Multiprocessor frequency min and max limits to default values.  Parameter provided is unused.
 
-    *  **Aggregation**: average
+    *  **Aggregation**: expect_same
     *  **Domain**: gpu
     *  **Format**: double
     *  **Unit**: n/a

--- a/service/docs/source/geopm_pio_sst.7.rst
+++ b/service/docs/source/geopm_pio_sst.7.rst
@@ -136,7 +136,7 @@ Configuration
     Returns the CPU's assigned CLOS.
 
     * **Aggregation**: select_first
-    * **Domain**: package
+    * **Domain**: core
     * **Format**: double
     * **Unit**: n/a
 
@@ -193,7 +193,7 @@ Controls
     Assign a core to a CLOS.
 
     * **Aggregation**: select_first
-    * **Domain**: package
+    * **Domain**: core
     * **Format**: double
     * **Unit**: n/a
 

--- a/service/docs/source/geopm_pio_sst.7.rst
+++ b/service/docs/source/geopm_pio_sst.7.rst
@@ -38,7 +38,7 @@ System Info
 ``SST::CONFIG_LEVEL``
     Returns the system's configuration level (SST-PP feature)
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -47,7 +47,7 @@ System Info
     Returns 1 if SST-CP feature is supported, 0 if
     unsupported.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: sum
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -60,7 +60,7 @@ System Info
     cores. Generally, if there are fewer high priority cores, the
     increase in turbo frequency limit is greater.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -69,7 +69,7 @@ System Info
     Returns the high priority turbo frequency for bucket
     *n* at the SSE license level.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -78,7 +78,7 @@ System Info
     Returns the high priority turbo frequency for bucket
     *n* at the AVX2 license level.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -87,7 +87,7 @@ System Info
     Returns the high priority turbo frequency for bucket
     n at the AVX512 license level.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -97,7 +97,7 @@ System Info
     specified license level. Note these frequencies do not change based
     on the number of high priority cores.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -106,7 +106,7 @@ System Info
     Returns 1 if SST-TF feature is supported, 0 if
     unsupported.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: sum
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -118,7 +118,7 @@ Configuration
     Returns 1 if SST-TF feature is enabled, 0 if
     disabled.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: sum
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -127,7 +127,7 @@ Configuration
     Returns 1 if SST-CP feature is enabled, 0 if
     disabled.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -135,7 +135,7 @@ Configuration
 ``SST::COREPRIORITY:ASSOCIATION``
     Returns the CPU's assigned CLOS.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: core
     * **Format**: double
     * **Unit**: n/a
@@ -145,7 +145,7 @@ Configuration
     value indicates a higher importance. Priority ranges from 0-1 and is
     used to distribute power amongst cores.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -155,7 +155,7 @@ Configuration
     sufficient power headroom, all cores will receive this minimum
     frequency before any remaining power is distributed.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -165,7 +165,7 @@ Configuration
     Returns the maximum frequency of CLOS *n*. Power will
     not be distributed to cores beyond this maximum frequency.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -176,7 +176,7 @@ Controls
 ``SST::TURBO_ENABLE``
     Enable SST-TF feature. Enabling SST-TF also causes SST-CP to be enabled.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: sum
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -184,7 +184,7 @@ Controls
 ``SST::COREPRIORITY_ENABLE``
     Enable SST-CP feature. Disabling SST-CP also causes SST-TF to be disabled.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: sum
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -192,7 +192,7 @@ Controls
 ``SST::COREPRIORITY:ASSOCIATION``
     Assign a core to a CLOS.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: core
     * **Format**: double
     * **Unit**: n/a
@@ -202,7 +202,7 @@ Controls
     indicates a higher importance. Weight ranges from 0-1 and is used to
     distribute power amongst cores.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -212,7 +212,7 @@ Controls
     sufficient power headroom, all cores will receive this minimum
     frequency before any remaining power is distributed.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a
@@ -221,7 +221,7 @@ Controls
     Set the maximum frequency of CLOS *n*. Power will not
     be distributed to cores beyond this maximum frequency.
 
-    * **Aggregation**: select_first
+    * **Aggregation**: expect_same
     * **Domain**: package
     * **Format**: double
     * **Unit**: n/a

--- a/service/src/CNLIOGroup.cpp
+++ b/service/src/CNLIOGroup.cpp
@@ -39,7 +39,7 @@ namespace geopm
     CNLIOGroup::CNLIOGroup(const std::string &cpu_info_path)
         : m_signal_available({{"CNL::BOARD_POWER", {
                                    "Point in time power",
-                                   Agg::average,
+                                   Agg::sum,
                                    string_format_integer,
                                    get_formatted_file_reader(cpu_info_path + "/power", "W"),
                                    false,
@@ -57,7 +57,7 @@ namespace geopm
                                    IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE}},
                               {"CNL::MEMORY_POWER", {
                                    "Point in time memory power",
-                                   Agg::average,
+                                   Agg::sum,
                                    string_format_integer,
                                    get_formatted_file_reader(cpu_info_path + "/memory_power", "W"),
                                    false,
@@ -75,7 +75,7 @@ namespace geopm
                                    IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE}},
                               {"CNL::BOARD_POWER_CPU", {
                                    "Point in time CPU power",
-                                   Agg::average,
+                                   Agg::sum,
                                    string_format_integer,
                                    get_formatted_file_reader(cpu_info_path + "/cpu_power", "W"),
                                    false,

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -70,7 +70,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL", {
                                   "The maximum supported frequency of the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::expect_same,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
@@ -86,7 +86,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_AVAIL", {
                                   "The minimum supported frequency of the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::expect_same,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
@@ -102,7 +102,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL", {
                                   "The maximum frequency request for the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::expect_same,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
@@ -134,7 +134,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
                                   "The minimum frequency request for the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::expect_same,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
@@ -167,7 +167,7 @@ namespace geopm
                                   "Timestamp for the GPU energy read in seconds."
                                   "\nValue is updated on LEVELZERO::GPU_ENERGY read.",
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
                                   string_format_double,
                                   {},
@@ -199,7 +199,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_UNCORE_FREQUENCY_MAX_AVAIL", {
                                   "The maximum supported frequency of the GPU Memory Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::expect_same,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
@@ -215,7 +215,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_UNCORE_FREQUENCY_MIN_AVAIL", {
                                   "The minimum supported frequency of the GPU Memory Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::expect_same,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
@@ -280,7 +280,7 @@ namespace geopm
                                   "Time in seconds that this resource is actively running a workload."
                                   "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
                                   string_format_double,
                                   {},
@@ -298,7 +298,7 @@ namespace geopm
                                   "\nValue is updated on LEVELZERO::GPU_ACTIVE_TIME read."
                                   "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
                                   string_format_double,
                                   {},
@@ -315,7 +315,7 @@ namespace geopm
                                   "Time in seconds that the GPU compute engines (EUs) are actively running a workload."
                                   "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
                                   string_format_double,
                                   {},
@@ -333,7 +333,7 @@ namespace geopm
                                   "\nValue is updated on LEVELZERO::GPU_CORE_ACTIVE_TIME read."
                                   "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
                                   string_format_double,
                                   {},
@@ -350,7 +350,7 @@ namespace geopm
                                   "Time in seconds that the GPU copy engines are actively running a workload."
                                   "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
                                   string_format_double,
                                   {},
@@ -368,7 +368,7 @@ namespace geopm
                                   "\nValue is updated on LEVELZERO::GPU_UNCORE_ACTIVE_TIME read."
                                   "\nSee the Intel oneAPI Level Zero Sysman documentation for more info.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::sum,
                                   IOGroup::M_SIGNAL_BEHAVIOR_MONOTONE,
                                   string_format_double,
                                   {},
@@ -387,7 +387,7 @@ namespace geopm
                                   "\nOnly valid as a signal after being written, NAN returned otherwise."
                                   "\nReadings are valid only after writing to this control",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::expect_same,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
@@ -407,14 +407,14 @@ namespace geopm
                                     "Sets the minimum frequency request for the GPU Compute Hardware.",
                                     {},
                                     GEOPM_DOMAIN_GPU_CHIP,
-                                    Agg::average,
+                                    Agg::expect_same,
                                     string_format_double
                                     }},
                                {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL", {
                                     "Sets the maximum frequency request for the GPU Compute Hardware.",
                                     {},
                                     GEOPM_DOMAIN_GPU_CHIP,
-                                    Agg::average,
+                                    Agg::expect_same,
                                     string_format_double
                                     }},
                                {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_CONTROL", {
@@ -423,7 +423,7 @@ namespace geopm
                                     "\nOnly valid as a signal after being written, NAN returned otherwise.",
                                     {},
                                     GEOPM_DOMAIN_GPU_CHIP,
-                                    Agg::average,
+                                    Agg::expect_same,
                                     string_format_double
                                     }}
                               })
@@ -438,6 +438,7 @@ namespace geopm
                      "  Derivative signal based on LEVELZERO::GPU_ENERGY.",
                      M_NAME_PREFIX + "GPU_ENERGY",
                      M_NAME_PREFIX + "GPU_ENERGY_TIMESTAMP",
+                     Agg::average,
                      IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
             {M_NAME_PREFIX + "GPU_UTILIZATION",
                     {"Utilization of all GPU engines. Level Zero logical engines may map to the same hardware,"
@@ -445,6 +446,7 @@ namespace geopm
                      "\nSee the LevelZero Sysman Engine documentation for more info.",
                      M_NAME_PREFIX + "GPU_ACTIVE_TIME",
                      M_NAME_PREFIX + "GPU_ACTIVE_TIME_TIMESTAMP",
+                     Agg::average,
                      IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
             {M_NAME_PREFIX + "GPU_CORE_UTILIZATION",
                     {"Utilization of the GPU Compute engines (EUs). Level Zero logical engines may map to the same hardware,"
@@ -452,6 +454,7 @@ namespace geopm
                      "\nSee the LevelZero Sysman Engine documentation for more info.",
                      M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME",
                      M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME_TIMESTAMP",
+                     Agg::average,
                      IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
             {M_NAME_PREFIX + "GPU_UNCORE_UTILIZATION",
                     {"Utilization of the GPU Copy engines. Level Zero logical engines may map to the same hardware,"
@@ -459,6 +462,7 @@ namespace geopm
                      "\nSee the LevelZero Sysman Engine documentation for more info.",
                      M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME",
                      M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME_TIMESTAMP",
+                     Agg::average,
                      IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
         })
         , m_mock_save_ctl(save_control_test)
@@ -602,7 +606,7 @@ namespace geopm
                 m_signal_available[ds.first] = {ds.second.m_description + "\n    alias_for: " +
                                                 ds.second.m_base_name + " rate of change",
                                                 domain,
-                                                agg_function(ds.second.m_base_name),
+                                                ds.second.m_agg_function,
                                                 ds.second.m_behavior,
                                                 format_function(ds.second.m_base_name),
                                                 result,

--- a/service/src/LevelZeroIOGroup.hpp
+++ b/service/src/LevelZeroIOGroup.hpp
@@ -102,6 +102,7 @@ namespace geopm
                 std::string m_description;
                 std::string m_base_name;
                 std::string m_time_name;
+                std::function<double(const std::vector<double> &)> m_agg_function;
                 int m_behavior;
             };
 

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -148,7 +148,7 @@ namespace geopm
                                   "Fraction of time the GPU memory was accessed in the last set of driver samples",
                                   {},
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::max,
+                                  Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double
                                   }},
@@ -180,7 +180,7 @@ namespace geopm
                                   "Resets streaming multiprocessor frequency min and max limits to default values.",
                                   {},
                                   GEOPM_DOMAIN_GPU,
-                                  Agg::average,
+                                  Agg::expect_same,
                                   IOGroup::M_SIGNAL_BEHAVIOR_CONSTANT,
                                   string_format_double
                                   }}

--- a/service/src/SSTIOGroup.hpp
+++ b/service/src/SSTIOGroup.hpp
@@ -10,7 +10,7 @@
 #include <functional>
 
 #include "geopm/IOGroup.hpp"
-
+#include "geopm/Agg.hpp"
 
 namespace geopm
 {
@@ -74,6 +74,23 @@ namespace geopm
                                            uint32_t end_bit, double multiplier,
                                            int units, const std::string &description,
                                            m_signal_behavior_e behavior)
+                    : sst_signal_mailbox_field_s(
+                        request_data,
+                        begin_bit,
+                        end_bit,
+                        multiplier,
+                        units,
+                        description,
+                        behavior,
+                        Agg::expect_same)
+                {
+                }
+
+                sst_signal_mailbox_field_s(uint32_t request_data, uint32_t begin_bit,
+                                           uint32_t end_bit, double multiplier,
+                                           int units, const std::string &description,
+                                           m_signal_behavior_e behavior,
+                                           std::function<double(const std::vector<double> &)> agg_function)
                     : request_data(request_data)
                     , begin_bit(begin_bit)
                     , end_bit(end_bit)
@@ -81,6 +98,7 @@ namespace geopm
                     , units(units)
                     , description(description)
                     , behavior(behavior)
+                    , agg_function(agg_function)
                 {
                 }
                 uint32_t request_data;
@@ -90,6 +108,7 @@ namespace geopm
                 int units;
                 std::string description;
                 m_signal_behavior_e behavior;
+                std::function<double(const std::vector<double> &)> agg_function;
             };
             struct sst_signal_mailbox_raw_s {
                 //! @param command Which type of mailbox command
@@ -111,11 +130,26 @@ namespace geopm
                 sst_control_mailbox_field_s(uint32_t write_data, uint32_t begin_bit,
                                             uint32_t end_bit, int units,
                                             const std::string &description)
+                    : sst_control_mailbox_field_s(
+                        write_data,
+                        begin_bit,
+                        end_bit,
+                        units,
+                        description,
+                        Agg::expect_same)
+                {
+                }
+
+                sst_control_mailbox_field_s(uint32_t write_data, uint32_t begin_bit,
+                                            uint32_t end_bit, int units,
+                                            const std::string &description,
+                                            std::function<double(const std::vector<double> &)> agg_function)
                     : write_data(write_data)
                     , begin_bit(begin_bit)
                     , end_bit(end_bit)
                     , units(units)
                     , description(description)
+                    , agg_function(agg_function)
                 {
                 }
                 uint32_t write_data;
@@ -123,6 +157,7 @@ namespace geopm
                 uint32_t end_bit;
                 int units;
                 std::string description;
+                std::function<double(const std::vector<double> &)> agg_function;
             };
             struct sst_control_mailbox_raw_s {
                 //! @param command Which type of mailbox command
@@ -152,11 +187,26 @@ namespace geopm
                 sst_control_mmio_field_s(uint32_t begin_bit, uint32_t end_bit,
                                          double multiplier, int units,
                                          const std::string &description)
+                    : sst_control_mmio_field_s(
+                        begin_bit,
+                        end_bit,
+                        multiplier,
+                        units,
+                        description,
+                        Agg::expect_same)
+                {
+                }
+                
+                sst_control_mmio_field_s(uint32_t begin_bit, uint32_t end_bit,
+                                         double multiplier, int units,
+                                         const std::string &description,
+                                         std::function<double(const std::vector<double> &)> agg_function)
                     : begin_bit(begin_bit)
                     , end_bit(end_bit)
                     , multiplier(multiplier)
                     , units(units)
                     , description(description)
+                    , agg_function(agg_function)
                 {
                 }
                 uint32_t begin_bit;
@@ -164,6 +214,7 @@ namespace geopm
                 double multiplier;
                 int units;
                 std::string description;
+                std::function<double(const std::vector<double> &)> agg_function;
             };
             struct sst_control_mmio_raw_s {
                 //! @param command Which type of mailbox command
@@ -186,6 +237,23 @@ namespace geopm
                                         uint32_t end_bit, double multiplier,
                                         int units, const std::string &description,
                                         m_signal_behavior_e behavior)
+                    : sst_signal_mmio_field_s(
+                        write_value,
+                        begin_bit,
+                        end_bit,
+                        multiplier,
+                        units,
+                        description,
+                        behavior,
+                        Agg::expect_same)
+                {
+                }
+
+                sst_signal_mmio_field_s(uint32_t write_value, uint32_t begin_bit,
+                                        uint32_t end_bit, double multiplier,
+                                        int units, const std::string &description,
+                                        m_signal_behavior_e behavior,
+                                        std::function<double(const std::vector<double> &)> agg_function)
                     : write_value(write_value)
                     , begin_bit(begin_bit)
                     , end_bit(end_bit)
@@ -193,6 +261,7 @@ namespace geopm
                     , units(units)
                     , description(description)
                     , behavior(behavior)
+                    , agg_function(agg_function)
                 {
                 }
                 uint32_t write_value;
@@ -202,6 +271,7 @@ namespace geopm
                 int units;
                 std::string description;
                 m_signal_behavior_e behavior;
+                std::function<double(const std::vector<double> &)> agg_function;
             };
 
             void add_mbox_signals(const std::string &raw_name,


### PR DESCRIPTION
Update aggregation functions in CNL, LevelZero, and NVML IOGroups to
match how aggregation functions were defined for MSRs (for consistency
across all IOGroups).

Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>

- Relates to #2505 
- Fixes #2546 