### PR TITLE
Fix integration failure from wrong CPU frequency control name

### DIFF
--- a/integration/test/test_tutorial_python_agents.py
+++ b/integration/test/test_tutorial_python_agents.py
@@ -44,14 +44,14 @@ class TestIntegration_tutorial_python_agents(unittest.TestCase):
         script_bodies = util.get_scripts_from_readme(cls._readme_path)
 
         cls._initial_frequency_control = geopm_test_launcher.geopmread(
-            'CPU_FREQUENCY_CONTROL board 0')
+            'CPU_FREQUENCY_MAX_CONTROL board 0')
 
         for script_body in script_bodies:
             print('Executing:', script_body)
             subprocess.check_call(script_body, shell=True, cwd=cls._tutorial_dir)
 
         cls._final_frequency_control = geopm_test_launcher.geopmread(
-            'CPU_FREQUENCY_CONTROL board 0')
+            'CPU_FREQUENCY_MAX_CONTROL board 0')
 
     def test_monitor_report(self):
         with open(os.path.join(self._tutorial_dir, 'stress-monitor.report')) as f:
@@ -81,7 +81,7 @@ class TestIntegration_tutorial_python_agents(unittest.TestCase):
             report = yaml.load(f, Loader=yaml.SafeLoader)
             self.assertAlmostEqual(
                 self._expected_frequency_limit,
-                report['Policy']['Initial Controls']['CPU_FREQUENCY_CONTROL'],
+                report['Policy']['Initial Controls']['CPU_FREQUENCY_MAX_CONTROL'],
                 places=0)
             host_data = next(iter(report['Hosts'].values()))
 

--- a/tutorial/python_agents/README.rst
+++ b/tutorial/python_agents/README.rst
@@ -112,13 +112,13 @@ frequency control value. We'll refer back to this value later.
 
 .. code-block:: sh
 
-    geopmread CPU_FREQUENCY_CONTROL board 0
+    geopmread CPU_FREQUENCY_MAX_CONTROL board 0
 
 .. code-block:: sh
 
     ./static_agent.py --geopm-report stress-frequency-limit.report \
        --geopm-report-signals CPU_ENERGY@package \
-       --geopm-initialize-control CPU_FREQUENCY_CONTROL=1.5e9 -- \
+       --geopm-initialize-control CPU_FREQUENCY_MAX_CONTROL=1.5e9 -- \
        stress-ng --cpu 20 --taskset 0-19 --timeout 5
 
 Notice a few changes in the report. First, we can see that the Policy section
@@ -147,7 +147,7 @@ actually done).
     Agent: StaticAgent
     Policy:
       Initial Controls:
-        CPU_FREQUENCY_CONTROL: 1500000000.0
+        CPU_FREQUENCY_MAX_CONTROL: 1500000000.0
     Hosts:
       tutorial-hostname:
         Application Totals:

--- a/tutorial/python_agents/static_agent.py
+++ b/tutorial/python_agents/static_agent.py
@@ -99,7 +99,7 @@ def main():
                         action='append',
                         help='Initialize a control to a given value, separated by an "=" '
                              'symbol. e.g., to run at a cpu frequency of 2 GHz: '
-                             '--initialize-control CPU_FREQUENCY_CONTROL=2e9')
+                             '--initialize-control CPU_FREQUENCY_MAX_CONTROL=2e9')
     parser.add_argument('--geopm-profile',
                         help='Override the report profile name. Default: the launched command')
 


### PR DESCRIPTION
- Pull requests #2155 and #2152 were merged at the same time. One change
  adds a new user of CPU frequency control. The other change modifies th
  name of the frequency control.
- This change updates the user of the frequency control to refer to the
  new control name.