### PR TITLE
Use CPUID for querying sticker frequency

### DIFF
--- a/service/src/CpuinfoIOGroup.cpp
+++ b/service/src/CpuinfoIOGroup.cpp
@@ -105,8 +105,7 @@ namespace geopm
                             result = unit_factor[unit_idx] * std::stod(value_str);
                         }
                         catch (const std::invalid_argument &ex) {
-                            throw Exception("Invalid frequency: " + std::string(ex.what()),
-                                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                            result = NAN;
                         }
                     }
                 }

--- a/service/src/CpuinfoIOGroup.cpp
+++ b/service/src/CpuinfoIOGroup.cpp
@@ -12,7 +12,9 @@
 #include <fstream>
 #include <algorithm>
 #include <iterator>
+#ifndef GEOPM_TEST
 #include <cpuid.h>
+#endif
 #include "geopm/Helper.hpp"
 #include "geopm/PlatformTopo.hpp"
 #include "geopm/Exception.hpp"
@@ -64,11 +66,7 @@ namespace geopm
     static double read_cpu_freq_sticker(void)
     {
         double result = read_cpuid_freq_sticker();
-        if (std::isnan(result)) {
-            throw Exception("Unable to determine sticker frequency",
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-        else if (result == 0) {
+        if (result == 0) {
             throw Exception("Sticker frequency not supported by CPUID",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }

--- a/service/src/CpuinfoIOGroup.cpp
+++ b/service/src/CpuinfoIOGroup.cpp
@@ -68,7 +68,7 @@ namespace geopm
         double result = read_cpuid_freq_sticker();
         if (result == 0) {
             throw Exception("Sticker frequency not supported by CPUID",
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                            GEOPM_ERROR_PLATFORM_UNSUPPORTED, __FILE__, __LINE__);
         }
         return result;
     }
@@ -106,17 +106,17 @@ namespace geopm
         if (read_signal("CPUINFO::FREQ_MAX", GEOPM_DOMAIN_BOARD, 0) <=
             read_signal("CPUINFO::FREQ_MIN", GEOPM_DOMAIN_BOARD, 0)) {
             throw Exception("CpuinfoIOGroup::CpuinfoIOGroup(): Max frequency less than min",
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                            GEOPM_ERROR_PLATFORM_UNSUPPORTED, __FILE__, __LINE__);
         }
         else if (read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0) <
                  read_signal("CPUINFO::FREQ_MIN", GEOPM_DOMAIN_BOARD, 0)) {
             throw Exception("CpuinfoIOGroup::CpuinfoIOGroup(): Sticker frequency less than min",
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                            GEOPM_ERROR_PLATFORM_UNSUPPORTED, __FILE__, __LINE__);
         }
         else if (read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0) >
                  read_signal("CPUINFO::FREQ_MAX", GEOPM_DOMAIN_BOARD, 0)) {
             throw Exception("CpuinfoIOGroup::CpuinfoIOGroup(): Sticker frequency greater than max",
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                            GEOPM_ERROR_PLATFORM_UNSUPPORTED, __FILE__, __LINE__);
         }
 
         register_signal_alias("CPU_FREQUENCY_MIN_AVAIL", "CPUINFO::FREQ_MIN");

--- a/service/src/CpuinfoIOGroup.cpp
+++ b/service/src/CpuinfoIOGroup.cpp
@@ -103,6 +103,22 @@ namespace geopm
                                    Agg::expect_same,
                                    "Step size between processor frequency settings"}}})
     {
+        if (read_signal("CPUINFO::FREQ_MAX", GEOPM_DOMAIN_BOARD, 0) <=
+            read_signal("CPUINFO::FREQ_MIN", GEOPM_DOMAIN_BOARD, 0)) {
+            throw Exception("CpuinfoIOGroup::CpuinfoIOGroup(): Max frequency less than min",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        else if (read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0) <
+                 read_signal("CPUINFO::FREQ_MIN", GEOPM_DOMAIN_BOARD, 0)) {
+            throw Exception("CpuinfoIOGroup::CpuinfoIOGroup(): Sticker frequency less than min",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        else if (read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0) >
+                 read_signal("CPUINFO::FREQ_MAX", GEOPM_DOMAIN_BOARD, 0)) {
+            throw Exception("CpuinfoIOGroup::CpuinfoIOGroup(): Sticker frequency greater than max",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
         register_signal_alias("CPU_FREQUENCY_MIN_AVAIL", "CPUINFO::FREQ_MIN");
         register_signal_alias("CPU_FREQUENCY_STICKER", "CPUINFO::FREQ_STICKER");
         register_signal_alias("CPU_FREQUENCY_STEP", "CPUINFO::FREQ_STEP");

--- a/service/src/CpuinfoIOGroup.hpp
+++ b/service/src/CpuinfoIOGroup.hpp
@@ -18,8 +18,7 @@ namespace geopm
     {
         public:
             CpuinfoIOGroup();
-            CpuinfoIOGroup(const std::string &cpu_info_path,
-                           const std::string &cpu_freq_min_path,
+            CpuinfoIOGroup(const std::string &cpu_freq_min_path,
                            const std::string &cpu_freq_max_path);
             virtual ~CpuinfoIOGroup() = default;
             /// @return the list of signal names provided by this IOGroup.

--- a/service/test/CpuinfoIOGroupTest.cpp
+++ b/service/test/CpuinfoIOGroupTest.cpp
@@ -263,9 +263,8 @@ TEST_F(CpuinfoIOGroupTest, parse_error_no_sticker)
     std::ofstream cpuinfo_stream(m_cpuinfo_path);
     cpuinfo_stream << cpuinfo_str;
     cpuinfo_stream.close();
-    GEOPM_EXPECT_THROW_MESSAGE(
-        CpuinfoIOGroup(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path),
-        GEOPM_ERROR_INVALID, "Invalid frequency");
+    EXPECT_NO_THROW(
+        CpuinfoIOGroup(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path));
 }
 
 TEST_F(CpuinfoIOGroupTest, parse_sticker_multiple_ghz)

--- a/service/test/CpuinfoIOGroupTest.cpp
+++ b/service/test/CpuinfoIOGroupTest.cpp
@@ -115,4 +115,26 @@ TEST_F(CpuinfoIOGroupTest, plugin)
     EXPECT_EQ("CPUINFO", CpuinfoIOGroup(m_cpufreq_min_path, m_cpufreq_max_path).plugin_name());
 }
 
+TEST_F(CpuinfoIOGroupTest, bad_min_max)
+{
+    std::ofstream cpufreq_min_stream(m_cpufreq_min_path);
+    cpufreq_min_stream << "2000000";
+    cpufreq_min_stream.close();
+    std::ofstream cpufreq_max_stream(m_cpufreq_max_path);
+    cpufreq_max_stream << "1000000";
+    cpufreq_max_stream.close();
+
+    GEOPM_EXPECT_THROW_MESSAGE(CpuinfoIOGroup (m_cpufreq_min_path, m_cpufreq_max_path),
+                               GEOPM_ERROR_INVALID, "Max frequency less than min");
+}
+
+TEST_F(CpuinfoIOGroupTest, bad_sticker)
+{
+    g_cpuid_sticker = 100;
+    GEOPM_EXPECT_THROW_MESSAGE(CpuinfoIOGroup (m_cpufreq_min_path, m_cpufreq_max_path),
+                               GEOPM_ERROR_INVALID, "Sticker frequency less than min");
+    g_cpuid_sticker = 2100;
+    GEOPM_EXPECT_THROW_MESSAGE(CpuinfoIOGroup (m_cpufreq_min_path, m_cpufreq_max_path),
+                               GEOPM_ERROR_INVALID, "Sticker frequency greater than max");
+}
 

--- a/service/test/CpuinfoIOGroupTest.cpp
+++ b/service/test/CpuinfoIOGroupTest.cpp
@@ -92,7 +92,7 @@ TEST_F(CpuinfoIOGroupTest, cpuid_sticker_not_supported)
 {
     g_cpuid_sticker = 0;
     GEOPM_EXPECT_THROW_MESSAGE(CpuinfoIOGroup (m_cpufreq_min_path, m_cpufreq_max_path),
-                               GEOPM_ERROR_INVALID, "not supported");
+                               GEOPM_ERROR_PLATFORM_UNSUPPORTED, "not supported");
 }
 
 TEST_F(CpuinfoIOGroupTest, push_signal)
@@ -125,16 +125,16 @@ TEST_F(CpuinfoIOGroupTest, bad_min_max)
     cpufreq_max_stream.close();
 
     GEOPM_EXPECT_THROW_MESSAGE(CpuinfoIOGroup (m_cpufreq_min_path, m_cpufreq_max_path),
-                               GEOPM_ERROR_INVALID, "Max frequency less than min");
+                               GEOPM_ERROR_PLATFORM_UNSUPPORTED, "Max frequency less than min");
 }
 
 TEST_F(CpuinfoIOGroupTest, bad_sticker)
 {
     g_cpuid_sticker = 100;
     GEOPM_EXPECT_THROW_MESSAGE(CpuinfoIOGroup (m_cpufreq_min_path, m_cpufreq_max_path),
-                               GEOPM_ERROR_INVALID, "Sticker frequency less than min");
+                               GEOPM_ERROR_PLATFORM_UNSUPPORTED, "Sticker frequency less than min");
     g_cpuid_sticker = 2100;
     GEOPM_EXPECT_THROW_MESSAGE(CpuinfoIOGroup (m_cpufreq_min_path, m_cpufreq_max_path),
-                               GEOPM_ERROR_INVALID, "Sticker frequency greater than max");
+                               GEOPM_ERROR_PLATFORM_UNSUPPORTED, "Sticker frequency greater than max");
 }
 

--- a/service/test/CpuinfoIOGroupTest.cpp
+++ b/service/test/CpuinfoIOGroupTest.cpp
@@ -10,13 +10,26 @@
 #include <memory>
 #include <cmath>
 
+extern "C"
+{
+    static int g_cpuid_sticker = 0;
+    static int mock_cpuid(unsigned int leaf, unsigned int *eax, unsigned int *ebx,
+                          unsigned int *ecx, unsigned int *edx)
+    {
+        *eax = g_cpuid_sticker;
+        return 0;
+    }
+#define __get_cpuid(p0, p1, p2, p3, p4) mock_cpuid(p0, p1, p2, p3, p4)
+}
+#define GEOPM_TEST
+#include "src/CpuinfoIOGroup.cpp"
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "geopm_hash.h"
 
 #include "geopm/Exception.hpp"
 #include "geopm/PluginFactory.hpp"
-#include "CpuinfoIOGroup.hpp"
 #include "geopm/PlatformTopo.hpp"
 #include "geopm_test.hpp"
 
@@ -30,42 +43,30 @@ class CpuinfoIOGroupTest: public :: testing :: Test
     protected:
         void SetUp();
         void TearDown();
-        const std::string m_cpuinfo_path =     "CpuinfoIOGroupTest_cpu_info";
         const std::string m_cpufreq_min_path = "CpuinfoIOGroupTest_cpu_freq_min";
         const std::string m_cpufreq_max_path = "CpuinfoIOGroupTest_cpu_freq_max";
 };
 
 void CpuinfoIOGroupTest::SetUp()
 {
+    g_cpuid_sticker = 1300;
     std::ofstream cpufreq_min_stream(m_cpufreq_min_path);
     cpufreq_min_stream << "1000000";
     cpufreq_min_stream.close();
     std::ofstream cpufreq_max_stream(m_cpufreq_max_path);
     cpufreq_max_stream << "2000000";
     cpufreq_max_stream.close();
-
 }
 
 void CpuinfoIOGroupTest::TearDown()
 {
     std::remove(m_cpufreq_min_path.c_str());
     std::remove(m_cpufreq_max_path.c_str());
-    std::remove(m_cpuinfo_path.c_str());
 }
 
 TEST_F(CpuinfoIOGroupTest, valid_signals)
 {
-    const std::string cpuinfo_str =
-        "processor       : 254\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 @ 1.30GHz\n"
-        "stepping        : 1\n";
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    CpuinfoIOGroup freq_limits(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path);
+    CpuinfoIOGroup freq_limits(m_cpufreq_min_path, m_cpufreq_max_path);
 
     // all provided signals are valid
     EXPECT_NE(0u, freq_limits.signal_names().size());
@@ -78,17 +79,7 @@ TEST_F(CpuinfoIOGroupTest, valid_signals)
 
 TEST_F(CpuinfoIOGroupTest, read_signal)
 {
-    const std::string cpuinfo_str =
-        "processor       : 254\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 @ 1.30GHz\n"
-        "stepping        : 1\n";
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    CpuinfoIOGroup freq_limits(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path);
+    CpuinfoIOGroup freq_limits(m_cpufreq_min_path, m_cpufreq_max_path);
     double freq = freq_limits.read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0);
     EXPECT_DOUBLE_EQ(1.3e9, freq);
 
@@ -97,19 +88,16 @@ TEST_F(CpuinfoIOGroupTest, read_signal)
                  Exception);
 }
 
+TEST_F(CpuinfoIOGroupTest, cpuid_sticker_not_supported)
+{
+    g_cpuid_sticker = 0;
+    GEOPM_EXPECT_THROW_MESSAGE(CpuinfoIOGroup (m_cpufreq_min_path, m_cpufreq_max_path),
+                               GEOPM_ERROR_INVALID, "not supported");
+}
+
 TEST_F(CpuinfoIOGroupTest, push_signal)
 {
-    const std::string cpuinfo_str =
-        "processor       : 254\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 @ 1.30GHz\n"
-        "stepping        : 1\n";
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    CpuinfoIOGroup freq_limits(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path);
+    CpuinfoIOGroup freq_limits(m_cpufreq_min_path, m_cpufreq_max_path);
 
     int idx = freq_limits.push_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0);
     EXPECT_GT(idx, 0);
@@ -122,308 +110,9 @@ TEST_F(CpuinfoIOGroupTest, push_signal)
                  Exception);
 }
 
-TEST_F(CpuinfoIOGroupTest, parse_sticker_with_at)
-{
-    const std::string cpuinfo_str =
-        "processor       : 254\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 @ 1.30GHz\n"
-        "stepping        : 1\n"
-        "microcode       : 0x1ac\n"
-        "cpu MHz         : 1036.394\n"
-        "cache size      : 1024 KB\n"
-        "physical id     : 0\n"
-        "siblings        : 256\n"
-        "core id         : 72\n"
-        "cpu cores       : 64\n"
-        "apicid          : 291\n"
-        "initial apicid  : 291\n"
-        "fpu             : yes\n"
-        "fpu_exception   : yes\n"
-        "cpuid level     : 13\n"
-        "wp              : yes\n"
-        "flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl est tm2 ssse3 fma cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch ida arat epb pln pts dtherm fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms avx512f rdseed adx avx512pf avx512er avx512cd xsaveopt\n"
-        "bogomips        : 2594.01\n"
-        "clflush size    : 64\n"
-        "cache_alignment : 64\n"
-        "address sizes   : 46 bits physical, 48 bits virtual\n"
-        "power management:\n\n";
-
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    CpuinfoIOGroup freq_limits(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path);
-    double freq = freq_limits.read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0);
-    EXPECT_DOUBLE_EQ(1.3e9, freq);
-}
-
-TEST_F(CpuinfoIOGroupTest, parse_sticker_without_at)
-{
-    const std::string cpuinfo_str =
-        "processor       : 255\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 1.20GHz\n"
-        "stepping        : 1\n"
-        "microcode       : 0x1ac\n"
-        "cpu MHz         : 1069.199\n"
-        "cache size      : 1024 KB\n"
-        "physical id     : 0\n"
-        "siblings        : 256\n"
-        "core id         : 73\n"
-        "cpu cores       : 64\n"
-        "apicid          : 295\n"
-        "initial apicid  : 295\n"
-        "fpu             : yes\n"
-        "fpu_exception   : yes\n"
-        "cpuid level     : 13\n"
-        "wp              : yes\n"
-        "flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl est tm2 ssse3 fma cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch ida arat epb pln pts dtherm fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms avx512f rdseed adx avx512pf avx512er avx512cd xsaveopt\n"
-        "bogomips        : 2594.01\n"
-        "clflush size    : 64\n"
-        "cache_alignment : 64\n"
-        "address sizes   : 46 bits physical, 48 bits virtual\n"
-        "power management:\n\n";
-
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    CpuinfoIOGroup freq_limits(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path);
-    double freq = freq_limits.read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0);
-    EXPECT_DOUBLE_EQ(1.2e9, freq);
-}
-
-TEST_F(CpuinfoIOGroupTest, parse_sticker_with_ghz_space)
-{
-    const std::string cpuinfo_str =
-        "processor       : 255\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 1.10 GHz\n"
-        "stepping        : 1\n"
-        "microcode       : 0x1ac\n"
-        "cpu MHz         : 1069.199\n"
-        "cache size      : 1024 KB\n"
-        "physical id     : 0\n"
-        "siblings        : 256\n"
-        "core id         : 73\n"
-        "cpu cores       : 64\n"
-        "apicid          : 295\n"
-        "initial apicid  : 295\n"
-        "fpu             : yes\n"
-        "fpu_exception   : yes\n"
-        "cpuid level     : 13\n"
-        "wp              : yes\n"
-        "flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl est tm2 ssse3 fma cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch ida arat epb pln pts dtherm fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms avx512f rdseed adx avx512pf avx512er avx512cd xsaveopt\n"
-        "bogomips        : 2594.01\n"
-        "clflush size    : 64\n"
-        "cache_alignment : 64\n"
-        "address sizes   : 46 bits physical, 48 bits virtual\n"
-        "power management:\n\n";
-
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    CpuinfoIOGroup freq_limits(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path);
-    double freq = freq_limits.read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0);
-    EXPECT_DOUBLE_EQ(1.1e9, freq);
-}
-
-TEST_F(CpuinfoIOGroupTest, parse_sticker_missing_newline)
-{
-    const std::string cpuinfo_str =
-        "processor       : 255\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 1.10GHz";
-
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    CpuinfoIOGroup freq_limits(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path);
-    double freq = freq_limits.read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0);
-    EXPECT_DOUBLE_EQ(1.1e9, freq);
-}
-
-TEST_F(CpuinfoIOGroupTest, parse_error_no_sticker)
-{
-    const std::string cpuinfo_str =
-        "processor       : 255\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU GHz\n"
-        "stepping        : 1";
-
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    EXPECT_NO_THROW(
-        CpuinfoIOGroup(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path));
-}
-
-TEST_F(CpuinfoIOGroupTest, parse_sticker_multiple_ghz)
-{
-    std::string cpuinfo_str =
-        "processor       : 255\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 8.7GHz\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 1.5GHz\n"
-        "stepping        : 1.0GHz\n";
-
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    CpuinfoIOGroup freq_limits(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path);
-    double freq = freq_limits.read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0);
-    EXPECT_DOUBLE_EQ(1.5e9, freq);
-}
-
-TEST_F(CpuinfoIOGroupTest, parse_sticker_multiple_model_name)
-{
-    const std::string cpuinfo_str =
-        "processor       : 254\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name X    : Intel(R) Genuine Intel(R) CPU 0000 @ 1.00GHz\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 @ 1.30GHz\n"
-        "stepping        : 1\n"
-        "microcode       : 0x1ac\n"
-        "cpu MHz         : 1036.394\n"
-        "cache size      : 1024 KB\n"
-        "physical id     : 0\n"
-        "siblings        : 256\n"
-        "core id         : 72\n"
-        "cpu cores       : 64\n"
-        "apicid          : 291\n"
-        "initial apicid  : 291\n"
-        "fpu             : yes\n"
-        "fpu_exception   : yes\n"
-        "cpuid level     : 13\n"
-        "wp              : yes\n"
-        "flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl est tm2 ssse3 fma cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch ida arat epb pln pts dtherm fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms avx512f rdseed adx avx512pf avx512er avx512cd xsaveopt\n"
-        "bogomips        : 2594.01\n"
-        "clflush size    : 64\n"
-        "cache_alignment : 64\n"
-        "address sizes   : 46 bits physical, 48 bits virtual\n"
-        "power management:\n\n";
-
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    CpuinfoIOGroup freq_limits(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path);
-    double freq = freq_limits.read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0);
-    EXPECT_DOUBLE_EQ(1.3e9, freq);
-}
-
-TEST_F(CpuinfoIOGroupTest, parse_cpu_freq)
-{
-    const std::string cpuinfo_str =
-        "processor       : 254\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name X    : Intel(R) Genuine Intel(R) CPU 0000 @ 1.00GHz\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 @ 1.30GHz\n"
-        "stepping        : 1\n"
-        "microcode       : 0x1ac\n"
-        "cpu MHz         : 1036.394\n"
-        "cache size      : 1024 KB\n"
-        "physical id     : 0\n"
-        "siblings        : 256\n"
-        "core id         : 72\n"
-        "cpu cores       : 64\n"
-        "apicid          : 291\n"
-        "initial apicid  : 291\n"
-        "fpu             : yes\n"
-        "fpu_exception   : yes\n"
-        "cpuid level     : 13\n"
-        "wp              : yes\n"
-        "flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl est tm2 ssse3 fma cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch ida arat epb pln pts dtherm fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms avx512f rdseed adx avx512pf avx512er avx512cd xsaveopt\n"
-        "bogomips        : 2594.01\n"
-        "clflush size    : 64\n"
-        "cache_alignment : 64\n"
-        "address sizes   : 46 bits physical, 48 bits virtual\n"
-        "power management:\n\n";
-
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    CpuinfoIOGroup freq_limits(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path);
-    double freq = freq_limits.read_signal("CPUINFO::FREQ_MIN", GEOPM_DOMAIN_BOARD, 0);
-    EXPECT_DOUBLE_EQ(1.0e9, freq);
-    freq = freq_limits.read_signal("CPUINFO::FREQ_MAX", GEOPM_DOMAIN_BOARD, 0);
-    EXPECT_DOUBLE_EQ(2.0e9, freq);
-
-    EXPECT_TRUE(freq_limits.is_valid_signal("CPU_FREQUENCY_MIN_AVAIL"));
-}
-
 TEST_F(CpuinfoIOGroupTest, plugin)
 {
-    const std::string cpuinfo_str =
-        "processor       : 254\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name X    : Intel(R) Genuine Intel(R) CPU 0000 @ 1.00GHz\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 @ 1.30GHz\n"
-        "stepping        : 1\n"
-        "microcode       : 0x1ac\n"
-        "cpu MHz         : 1036.394\n"
-        "cache size      : 1024 KB\n"
-        "physical id     : 0\n"
-        "siblings        : 256\n"
-        "core id         : 72\n"
-        "cpu cores       : 64\n"
-        "apicid          : 291\n"
-        "initial apicid  : 291\n"
-        "fpu             : yes\n"
-        "fpu_exception   : yes\n"
-        "cpuid level     : 13\n"
-        "wp              : yes\n"
-        "flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl est tm2 ssse3 fma cx16 xtpr pdcm sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch ida arat epb pln pts dtherm fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms avx512f rdseed adx avx512pf avx512er avx512cd xsaveopt\n"
-        "bogomips        : 2594.01\n"
-        "clflush size    : 64\n"
-        "cache_alignment : 64\n"
-        "address sizes   : 46 bits physical, 48 bits virtual\n"
-        "power management:\n\n";
-
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-    EXPECT_EQ("CPUINFO", CpuinfoIOGroup(m_cpuinfo_path, m_cpufreq_min_path, m_cpufreq_max_path).plugin_name());
+    EXPECT_EQ("CPUINFO", CpuinfoIOGroup(m_cpufreq_min_path, m_cpufreq_max_path).plugin_name());
 }
 
 
-TEST_F(CpuinfoIOGroupTest, parse_error_sticker_bad_path)
-{
-    const std::string cpuinfo_str =
-        "processor       : 255\n"
-        "vendor_id       : GenuineIntel\n"
-        "cpu family      : 6\n"
-        "model           : 87\n"
-        "model name      : Intel(R) Genuine Intel(R) CPU 0000 1.10GHz";
-
-    std::ofstream cpuinfo_stream(m_cpuinfo_path);
-    cpuinfo_stream << cpuinfo_str;
-    cpuinfo_stream.close();
-
-    GEOPM_EXPECT_THROW_MESSAGE(
-        CpuinfoIOGroup("/bad/path", m_cpufreq_min_path, m_cpufreq_max_path),
-        GEOPM_ERROR_RUNTIME, "Failed to open");
-
-    GEOPM_EXPECT_THROW_MESSAGE(
-        CpuinfoIOGroup(m_cpuinfo_path, "/bad/path", m_cpufreq_max_path),
-        GEOPM_ERROR_RUNTIME, "Failed to open");
-
-    GEOPM_EXPECT_THROW_MESSAGE(
-        CpuinfoIOGroup(m_cpuinfo_path, m_cpufreq_min_path, "/bad/path"),
-        GEOPM_ERROR_RUNTIME, "Failed to open");
-}

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -56,15 +56,9 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/CNLIOGroupTest.parse_power \
               test/gtest_links/CombinedSignalTest.sample_max \
               test/gtest_links/CombinedSignalTest.sample_sum \
-              test/gtest_links/CpuinfoIOGroupTest.parse_cpu_freq \
-              test/gtest_links/CpuinfoIOGroupTest.parse_error_no_sticker \
-              test/gtest_links/CpuinfoIOGroupTest.parse_error_sticker_bad_path \
-              test/gtest_links/CpuinfoIOGroupTest.parse_sticker_missing_newline \
-              test/gtest_links/CpuinfoIOGroupTest.parse_sticker_multiple_ghz \
-              test/gtest_links/CpuinfoIOGroupTest.parse_sticker_multiple_model_name \
-              test/gtest_links/CpuinfoIOGroupTest.parse_sticker_with_at \
-              test/gtest_links/CpuinfoIOGroupTest.parse_sticker_with_ghz_space \
-              test/gtest_links/CpuinfoIOGroupTest.parse_sticker_without_at \
+              test/gtest_links/CpuinfoIOGroupTest.bad_min_max \
+              test/gtest_links/CpuinfoIOGroupTest.bad_sticker \
+              test/gtest_links/CpuinfoIOGroupTest.cpuid_sticker_not_supported \
               test/gtest_links/CpuinfoIOGroupTest.plugin \
               test/gtest_links/CpuinfoIOGroupTest.push_signal \
               test/gtest_links/CpuinfoIOGroupTest.read_signal \


### PR DESCRIPTION
Signed-off-by: Lowren Lawson <lowren.h.lawson@intel.com>

- Relates to #2336 bug report from github issues
- Fixes #2336 change request from github issues.

Removes throw on lscpu parsing error in favor of falling back to cpuid calls and parsing.  
It may be preferable to have the entire function throw if the end result is NAN (not implemented in this PR)