### PR TITLE
Disable syntax highlighting when reading rst files in integration tests

### DIFF
--- a/integration/test/util.py
+++ b/integration/test/util.py
@@ -309,8 +309,13 @@ def get_scripts_from_readme(rst_readme_path):
     """
     script_bodies = list()
     with open(rst_readme_path) as f:
-        doctree = publish_doctree(f.read())
-        for code_block in doctree.traverse(literal_block):
+        # Syntax highlighting is enabled by default. If the syntax highlighter
+        # (Pygments) is not installed, the tree-walk will skip over code blocks
+        # and this function will return an empty list. Explicitly disable
+        # highlighting so we can run this test regardless of whether Pygments
+        # is installed.
+        doctree = publish_doctree(f.read(), settings_overrides={'syntax_highlight': 'none'})
+        for code_block in doctree.findall(literal_block):
             if 'sh' in code_block['classes']:
                 script_bodies.append(code_block.astext())
     return script_bodies


### PR DESCRIPTION
- Related to PR #2155
- docutils fails to extract code blocks from a rst file if syntax
  highlighting is enabled and Pygments is not present. Syntax
  highlighting is enabled in docutils by default, and Pygments is not a
  package-level dependency of docutils.
- This change disables syntax highlighting when walking a doctree for
  integration tests.
- This change also resolves a deprecation warning emitted in the
  integration testing environment. Specifically, doctree traverse() is
  being replaced with findall().