### PR TITLE
Use pid.wait() in timed loop

### DIFF
--- a/integration/test/test_tutorial_python_agents.py
+++ b/integration/test/test_tutorial_python_agents.py
@@ -61,7 +61,7 @@ class TestIntegration_tutorial_python_agents(unittest.TestCase):
             self.assertAlmostEqual(
                 self._expected_stress_ng_timeout_seconds,
                 host_data['Application Totals']['runtime (s)'],
-                places=1)
+                places=0)
 
     def test_package_energy_report(self):
         with open(os.path.join(self._tutorial_dir, 'stress-package-energy.report')) as f:
@@ -71,7 +71,7 @@ class TestIntegration_tutorial_python_agents(unittest.TestCase):
             self.assertAlmostEqual(
                 self._expected_stress_ng_timeout_seconds,
                 host_data['Application Totals']['runtime (s)'],
-                places=1)
+                places=0)
             self.assertGreater(
                 host_data['Application Totals']['CPU_ENERGY@package-0'],
                 host_data['Application Totals']['CPU_ENERGY@package-1'])
@@ -88,7 +88,7 @@ class TestIntegration_tutorial_python_agents(unittest.TestCase):
             self.assertAlmostEqual(
                 self._expected_stress_ng_timeout_seconds,
                 host_data['Application Totals']['runtime (s)'],
-                places=1)
+                places=0)
             self.assertGreater(
                 host_data['Application Totals']['CPU_ENERGY@package-0'],
                 host_data['Application Totals']['CPU_ENERGY@package-1'])

--- a/service/geopmdpy/runtime.py
+++ b/service/geopmdpy/runtime.py
@@ -372,11 +372,11 @@ class Controller:
                 for control_idx, new_setting in zip(self._controls_idx, new_settings):
                     pio.adjust(control_idx, new_setting)
                 pio.write_batch()
+            self._agent.run_end()
         except:
             raise
         finally:
             pio.restore_control()
-            self._agent.run_end()
         self._returncode = pid.returncode
         sys.stderr.write(f'<geopmdpy> RUN END, return: {self._returncode}\n')
         return self._agent.get_report()

--- a/service/geopmdpy/runtime.py
+++ b/service/geopmdpy/runtime.py
@@ -109,6 +109,7 @@ class TimedLoop:
     def wait(self, timeout):
         """Pass-through to time.sleep()
 
+        Args:
             timeout (float): Target interval for the loop execution in
                              units of seconds.
         """

--- a/tutorial/python_agents/static_agent.py
+++ b/tutorial/python_agents/static_agent.py
@@ -33,16 +33,19 @@ class StaticAgent(geopmdpy.runtime.Agent):
         self._initial_controls = dict() if initial_controls is None else initial_controls
         geopmpy.reporter.init()
 
-    def run_begin(self, policy):
+    def run_begin(self, policy, profile):
         # The GEOPM runtime already saved controls by now. It will take care of
         # restoring the original values of these controls after our run finishes.
+        self._profile = profile
         for control_name, value in self._initial_controls.items():
             geopmdpy.pio.write_control(control_name, 'board', 0, value)
 
     def run_end(self):
         # Handle anything that should be managed after PlatformIO restores the
         # platform's pre-launch state.
-        pass
+        self._report = yaml.load(geopmpy.reporter.generate(self._profile, self.__class__.__name__),
+                                 Loader=yaml.SafeLoader)
+        self._report['Policy']['Initial Controls'] = self._initial_controls
 
     def get_signals(self):
         # This agent does not consume any PlatformIO signals.
@@ -71,14 +74,14 @@ class StaticAgent(geopmdpy.runtime.Agent):
     def get_period(self):
         return self._control_period
 
-    def get_report(self, profile):
-        report = yaml.load(geopmpy.reporter.generate(profile, self.__class__.__name__),
-                           Loader=yaml.SafeLoader)
-        report['Policy']['Initial Controls'] = self._initial_controls
+    def get_report(self):
         # Optionally add more agent-specific contents to the report here. For
         # example, if the agent makes any dynamic decisions at execution time,
         # it might report a summary of its decisions or algorithmic state.
-        return yaml.dump(report, default_flow_style=False, sort_keys=False)
+        result = None
+        if self._report is not None:
+            result = yaml.dump(self._report, default_flow_style=False, sort_keys=False)
+        return result
 
 
 def main():


### PR DESCRIPTION
- This enables the runtime to terminate when the process ends
- Using pid.wait() may incur a higher CPU overhead than time.sleep
- May consider a solution like #2567 to enable the direct use of time.sleep if this performance overhead is an issue.