### PR TITLE
Add SST-TF and TRL frequency limit estimators

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -396,6 +396,12 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/FrequencyGovernor.cpp \
                             src/FrequencyGovernor.hpp \
                             src/FrequencyGovernorImp.hpp \
+                            src/FrequencyLimitDetector.cpp \
+                            src/FrequencyLimitDetector.hpp \
+                            src/SSTFrequencyLimitDetector.cpp \
+                            src/SSTFrequencyLimitDetector.hpp \
+                            src/TRLFrequencyLimitDetector.cpp \
+                            src/TRLFrequencyLimitDetector.hpp \
                             src/FrequencyMapAgent.cpp \
                             src/FrequencyMapAgent.hpp \
                             src/Imbalancer.cpp \

--- a/src/FrequencyLimitDetector.cpp
+++ b/src/FrequencyLimitDetector.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "config.h"
+
+#include "FrequencyLimitDetector.hpp"
+#include "SSTFrequencyLimitDetector.hpp"
+#include "TRLFrequencyLimitDetector.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm/PlatformIO.hpp"
+#include "geopm/PlatformTopo.hpp"
+
+namespace geopm
+{
+    static bool use_sst_tf_signals(PlatformIO &platform_io)
+    {
+        bool do_use_signals = false;
+        try {
+            do_use_signals = platform_io.read_signal(
+                "SST::TURBOFREQ_SUPPORT:SUPPORTED", GEOPM_DOMAIN_BOARD, 0);
+        }
+        catch (const geopm::Exception &) {
+            // Either we don't know if SST-TF is supported, or it definitely is
+            // not supported. So do not use SST-TF signals.
+        }
+        return do_use_signals;
+    }
+
+    std::unique_ptr<FrequencyLimitDetector> FrequencyLimitDetector::make_unique(
+        PlatformIO &platform_io, const PlatformTopo &platform_topo)
+    {
+
+        if (use_sst_tf_signals(platform_io)) {
+            return geopm::make_unique<SSTFrequencyLimitDetector>(platform_io, platform_topo);
+        }
+        else {
+            return geopm::make_unique<TRLFrequencyLimitDetector>(platform_io, platform_topo);
+        }
+    }
+
+    std::shared_ptr<FrequencyLimitDetector> FrequencyLimitDetector::make_shared(
+        PlatformIO &platform_io, const PlatformTopo &platform_topo)
+    {
+
+        if (use_sst_tf_signals(platform_io)) {
+            return std::make_shared<SSTFrequencyLimitDetector>(platform_io, platform_topo);
+        }
+        else {
+            return std::make_shared<TRLFrequencyLimitDetector>(platform_io, platform_topo);
+        }
+    }
+}

--- a/src/FrequencyLimitDetector.hpp
+++ b/src/FrequencyLimitDetector.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FREQUENCYLIMITDETECTOR_HPP_INCLUDE
+#define FREQUENCYLIMITDETECTOR_HPP_INCLUDE
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace geopm
+{
+    class PlatformIO;
+    class PlatformTopo;
+
+    /// @brief Detect maximum achievable frequency limits of CPU cores.
+    /// @details Estimates the maximum freuqency that each core can achieve if
+    /// it is given a sufficiently high frequency cap. Estimates are based on
+    /// recent behavior of the target core and other cores in the same CPU
+    /// package.
+    class FrequencyLimitDetector
+    {
+        public:
+            FrequencyLimitDetector() = default;
+            virtual ~FrequencyLimitDetector() = default;
+
+            /// @brief Update the estimates for maximum achievable core frequencies.
+            /// @details Caches the estimates to be queried by other functions
+            /// in this interface.
+            /// @param observed_core_frequencies The measured frequency for
+            /// each core across a region of interest (e.g., epoch to epoch,
+            /// across GEOPM regions, etc).
+            virtual void update_max_frequency_estimates(
+                const std::vector<double> &observed_core_frequencies) = 0;
+
+            /// @brief Estimate the maximum achievable frequencies of a given core.
+            /// @param [in] core_idx GEOPM topology index of the core to query.
+            /// @return A vector of alternative frequency configurations. Each
+            /// vector element is a pair of a count of high-priority cores in
+            /// the package, and this core's achievable frequency if that count
+            /// is not exceeded.
+            virtual std::vector<std::pair<unsigned int, double> > get_core_frequency_limits(
+                unsigned int core_idx) const = 0;
+
+            /// @brief Estimate the low priority frequency of a given core.
+            virtual double get_core_low_priority_frequency(
+                unsigned int core_idx) const = 0;
+
+            static std::unique_ptr<FrequencyLimitDetector> make_unique(
+                PlatformIO &platform_io, const PlatformTopo &platform_topo);
+
+            static std::shared_ptr<FrequencyLimitDetector> make_shared(
+                PlatformIO &platform_io, const PlatformTopo &platform_topo);
+    };
+}
+
+#endif

--- a/src/SSTFrequencyLimitDetector.cpp
+++ b/src/SSTFrequencyLimitDetector.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "config.h"
+
+#include "SSTFrequencyLimitDetector.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm/PlatformIO.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm_debug.hpp"
+
+namespace geopm
+{
+    enum Priorities_e {
+        HIGH_PRIORITY = 0,
+        MEDIUM_HIGH_PRIORITY = 1,
+        MEDIUM_LOW_PRIORITY = 2,
+        LOW_PRIORITY = 3,
+    };
+
+    SSTFrequencyLimitDetector::SSTFrequencyLimitDetector(
+        PlatformIO &platform_io,
+        const PlatformTopo &platform_topo)
+        : m_platform_io(platform_io)
+        , m_package_count(platform_topo.num_domain(GEOPM_DOMAIN_PACKAGE))
+        , m_core_count(platform_topo.num_domain(GEOPM_DOMAIN_CORE))
+        , m_clos_association_signals()
+        , m_frequency_limit_signals()
+        , m_sst_tf_enable_signals()
+        , M_CPU_FREQUENCY_MAX(m_platform_io.read_signal(
+              "CPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD, 0))
+        , M_CPU_FREQUENCY_STICKER(m_platform_io.read_signal(
+              "CPU_FREQUENCY_STICKER", GEOPM_DOMAIN_BOARD, 0))
+        , M_CPU_FREQUENCY_STEP(m_platform_io.read_signal(
+              "CPU_FREQUENCY_STEP", GEOPM_DOMAIN_BOARD, 0))
+        , M_ALL_CORE_TURBO_FREQUENCY(m_platform_io.read_signal(
+              "MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_7", GEOPM_DOMAIN_BOARD, 0))
+        , m_bucket_hp_cores{
+              static_cast<unsigned int>(m_platform_io.read_signal(
+                  "SST::HIGHPRIORITY_NCORES:0", GEOPM_DOMAIN_BOARD, 0)),
+              static_cast<unsigned int>(m_platform_io.read_signal(
+                  "SST::HIGHPRIORITY_NCORES:1", GEOPM_DOMAIN_BOARD, 0)),
+              static_cast<unsigned int>(m_platform_io.read_signal(
+                  "SST::HIGHPRIORITY_NCORES:2", GEOPM_DOMAIN_BOARD, 0))}
+        , M_LOW_PRIORITY_SSE_FREQUENCY(m_platform_io.read_signal(
+                    "SST::LOWPRIORITY_FREQUENCY:SSE", GEOPM_DOMAIN_BOARD, 0))
+        , M_LOW_PRIORITY_AVX2_FREQUENCY(m_platform_io.read_signal(
+                    "SST::LOWPRIORITY_FREQUENCY:AVX2", GEOPM_DOMAIN_BOARD, 0))
+        , M_LOW_PRIORITY_AVX512_FREQUENCY(m_platform_io.read_signal(
+                    "SST::LOWPRIORITY_FREQUENCY:AVX512", GEOPM_DOMAIN_BOARD, 0))
+        , m_bucket_sse_frequency{
+            m_platform_io.read_signal(
+                    "SST::HIGHPRIORITY_FREQUENCY_SSE:0", GEOPM_DOMAIN_BOARD, 0),
+            m_platform_io.read_signal(
+                    "SST::HIGHPRIORITY_FREQUENCY_SSE:1", GEOPM_DOMAIN_BOARD, 0),
+            m_platform_io.read_signal(
+                    "SST::HIGHPRIORITY_FREQUENCY_SSE:2", GEOPM_DOMAIN_BOARD, 0)}
+        , m_bucket_avx2_frequency{
+            m_platform_io.read_signal(
+                    "SST::HIGHPRIORITY_FREQUENCY_AVX2:0", GEOPM_DOMAIN_BOARD, 0),
+            m_platform_io.read_signal(
+                    "SST::HIGHPRIORITY_FREQUENCY_AVX2:1", GEOPM_DOMAIN_BOARD, 0),
+            m_platform_io.read_signal(
+                    "SST::HIGHPRIORITY_FREQUENCY_AVX2:2", GEOPM_DOMAIN_BOARD, 0)}
+        , m_bucket_avx512_frequency{
+            m_platform_io.read_signal(
+                    "SST::HIGHPRIORITY_FREQUENCY_AVX512:0", GEOPM_DOMAIN_BOARD, 0),
+            m_platform_io.read_signal(
+                    "SST::HIGHPRIORITY_FREQUENCY_AVX512:1", GEOPM_DOMAIN_BOARD, 0),
+            m_platform_io.read_signal(
+                    "SST::HIGHPRIORITY_FREQUENCY_AVX512:2", GEOPM_DOMAIN_BOARD, 0)}
+        , m_sse_hp_tradeoffs()
+        , m_avx2_hp_tradeoffs()
+        , m_avx512_hp_tradeoffs()
+        , m_cores_in_packages()
+        , m_core_frequency_limits(m_core_count, {{m_core_count / m_package_count, M_CPU_FREQUENCY_MAX}})
+        , m_core_lp_frequencies(m_core_count, M_CPU_FREQUENCY_STICKER)
+    {
+        for (size_t i = 0; i < m_core_count; ++i) {
+            m_clos_association_signals.push_back(m_platform_io.push_signal(
+                "SST::COREPRIORITY:ASSOCIATION", GEOPM_DOMAIN_CORE, i));
+            m_frequency_limit_signals.push_back(m_platform_io.push_signal(
+                "CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_CORE, i));
+        }
+
+        for (unsigned int i = 0; i < m_package_count; ++i) {
+            m_sst_tf_enable_signals.push_back(m_platform_io.push_signal(
+                "SST::TURBO_ENABLE:ENABLE", GEOPM_DOMAIN_PACKAGE, i));
+            const auto nested_ctls = platform_topo.domain_nested(
+                GEOPM_DOMAIN_CORE, GEOPM_DOMAIN_PACKAGE, i);
+            m_cores_in_packages.push_back(
+                std::vector<int>(nested_ctls.begin(), nested_ctls.end()));
+        }
+
+        for (size_t bucket = 0; bucket < m_bucket_hp_cores.size(); ++bucket) {
+            m_sse_hp_tradeoffs.emplace_back(
+                m_bucket_hp_cores[bucket], m_bucket_sse_frequency[bucket]);
+            m_avx2_hp_tradeoffs.emplace_back(
+                m_bucket_hp_cores[bucket], m_bucket_avx2_frequency[bucket]);
+            m_avx512_hp_tradeoffs.emplace_back(
+                m_bucket_hp_cores[bucket], m_bucket_avx512_frequency[bucket]);
+        }
+    }
+
+    void SSTFrequencyLimitDetector::update_max_frequency_estimates(
+        const std::vector<double> &observed_core_frequencies)
+    {
+        for (size_t package_idx = 0; package_idx < m_package_count; ++package_idx) {
+            const auto &cores_in_package = m_cores_in_packages[package_idx];
+            if (m_platform_io.sample(m_sst_tf_enable_signals[package_idx])) {
+                auto hp_core_count = std::count_if(
+                    cores_in_package.begin(), cores_in_package.end(),
+                    [this](int idx) {
+                        return m_platform_io.sample(m_clos_association_signals[idx]) <= MEDIUM_HIGH_PRIORITY;
+                    });
+
+                double sse_freq, avx2_freq, avx512_freq;
+
+                // Buckets are ordered from smallest to largest. Find the smallest
+                // bucket that contains the configured HP core count.
+                const auto bucket_it = std::find_if(
+                    m_bucket_hp_cores.begin(), m_bucket_hp_cores.end(),
+                    [hp_core_count](unsigned int bucket_core_count) {
+                        return hp_core_count <= bucket_core_count;
+                    });
+                if (bucket_it == m_bucket_hp_cores.end()) {
+                    sse_freq = M_ALL_CORE_TURBO_FREQUENCY;
+                    // AVX2 and AVX512 limits may or may not be different. Those
+                    // cannot be queried from the CPU, and are typically
+                    // empirically measured if they are actually needed. Let's just
+                    // approximate them for now.
+                    avx2_freq = M_ALL_CORE_TURBO_FREQUENCY;
+                    avx512_freq = M_ALL_CORE_TURBO_FREQUENCY;
+                }
+                else {
+                    auto bucket_idx = std::distance(m_bucket_hp_cores.begin(), bucket_it);
+                    sse_freq = m_bucket_sse_frequency[bucket_idx];
+                    avx2_freq = m_bucket_avx2_frequency[bucket_idx];
+                    avx512_freq = m_bucket_avx512_frequency[bucket_idx];
+                }
+
+                for (const auto core_idx : cores_in_package) {
+                    auto core_frequency_limit = m_platform_io.sample(m_frequency_limit_signals[core_idx]);
+
+                    // Two neighboring bins in the SST-TF table might or might
+                    // not be equal, so check both.
+                    if (observed_core_frequencies[core_idx] > avx2_freq ||
+                        observed_core_frequencies[core_idx] >= sse_freq ||
+                        (core_frequency_limit <= avx2_freq &&
+                         is_frequency_near_limit(observed_core_frequencies[core_idx], core_frequency_limit))) {
+                        m_core_frequency_limits[core_idx] = m_sse_hp_tradeoffs;
+                        m_core_lp_frequencies[core_idx] = M_LOW_PRIORITY_SSE_FREQUENCY;
+                    }
+                    else if (observed_core_frequencies[core_idx] > avx512_freq ||
+                             observed_core_frequencies[core_idx] >= avx2_freq ||
+                             (core_frequency_limit <= avx512_freq &&
+                              is_frequency_near_limit(observed_core_frequencies[core_idx], core_frequency_limit))) {
+                        m_core_frequency_limits[core_idx] = m_avx2_hp_tradeoffs;
+                        m_core_lp_frequencies[core_idx] = M_LOW_PRIORITY_AVX2_FREQUENCY;
+                    }
+                    else {
+                        m_core_frequency_limits[core_idx] = m_avx512_hp_tradeoffs;
+                        m_core_lp_frequencies[core_idx] = M_LOW_PRIORITY_AVX512_FREQUENCY;
+                    }
+                }
+            }
+            else {
+                // SST-TF is available, but disabled. Assume any core can reach
+                // the current max observed frequency across cores.
+                const auto core_with_max_frequency = *std::max_element(
+                    cores_in_package.begin(), cores_in_package.end(),
+                    [&observed_core_frequencies](int lhs, int rhs) {
+                        return observed_core_frequencies[lhs] < observed_core_frequencies[rhs];
+                    });
+                const auto max_frequency = observed_core_frequencies[core_with_max_frequency];
+                for (const auto core_idx : cores_in_package) {
+                    m_core_frequency_limits[core_idx] = {
+                        // Single-element vector because this is the only
+                        // tradeoff presented without SST-TF enabled.
+                        {cores_in_package.size(), max_frequency}};
+                    m_core_lp_frequencies[core_idx] = M_CPU_FREQUENCY_STICKER;
+                }
+            }
+        }
+    }
+
+    std::vector<std::pair<unsigned int, double> >
+        SSTFrequencyLimitDetector::get_core_frequency_limits(unsigned int core_idx) const
+    {
+        return m_core_frequency_limits.at(core_idx);
+    }
+
+    double SSTFrequencyLimitDetector::get_core_low_priority_frequency(
+        unsigned int core_idx) const
+    {
+        return m_core_lp_frequencies.at(core_idx);
+    }
+
+    bool SSTFrequencyLimitDetector::is_frequency_near_limit(
+        double frequency, double limit)
+    {
+        return frequency > (limit - M_CPU_FREQUENCY_STEP);
+    }
+}

--- a/src/SSTFrequencyLimitDetector.hpp
+++ b/src/SSTFrequencyLimitDetector.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef SSTFREQUENCYLIMITDETECTOR_HPP_INCLUDE
+#define SSTFREQUENCYLIMITDETECTOR_HPP_INCLUDE
+
+#include <FrequencyLimitDetector.hpp>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace geopm
+{
+    class SSTFrequencyLimitDetector : public FrequencyLimitDetector
+    {
+        public:
+            SSTFrequencyLimitDetector(
+                PlatformIO &platform_io,
+                const PlatformTopo &platform_topo);
+            void update_max_frequency_estimates(
+                const std::vector<double> &observed_core_frequencies) override;
+            std::vector<std::pair<unsigned int, double> > get_core_frequency_limits(
+                unsigned int core_idx) const override;
+            double get_core_low_priority_frequency(unsigned int core_idx) const override;
+
+        private:
+            // Return true if the given frequency is limited or almost limited
+            // by the given limit.
+            bool is_frequency_near_limit(double frequency, double limit);
+
+            PlatformIO &m_platform_io;
+            unsigned int m_package_count;
+            size_t m_core_count;
+            std::vector<int> m_clos_association_signals;
+            std::vector<int> m_frequency_limit_signals;
+            std::vector<int> m_sst_tf_enable_signals;
+            const double M_CPU_FREQUENCY_MAX;
+            const double M_CPU_FREQUENCY_STICKER;
+            const double M_CPU_FREQUENCY_STEP;
+            const double M_ALL_CORE_TURBO_FREQUENCY;
+            std::vector<unsigned int> m_bucket_hp_cores;
+            const double M_LOW_PRIORITY_SSE_FREQUENCY;
+            const double M_LOW_PRIORITY_AVX2_FREQUENCY;
+            const double M_LOW_PRIORITY_AVX512_FREQUENCY;
+
+            // Vectors of license level frequency limits by bucket number
+            std::vector<double> m_bucket_sse_frequency;
+            std::vector<double> m_bucket_avx2_frequency;
+            std::vector<double> m_bucket_avx512_frequency;
+            std::vector<std::pair<unsigned int, double> > m_sse_hp_tradeoffs;
+            std::vector<std::pair<unsigned int, double> > m_avx2_hp_tradeoffs;
+            std::vector<std::pair<unsigned int, double> > m_avx512_hp_tradeoffs;
+            std::vector<std::vector<int> > m_cores_in_packages;
+            std::vector<std::vector<std::pair<unsigned int, double> > > m_core_frequency_limits;
+            std::vector<double> m_core_lp_frequencies;
+    };
+}
+
+#endif

--- a/src/TRLFrequencyLimitDetector.cpp
+++ b/src/TRLFrequencyLimitDetector.cpp
@@ -1,0 +1,74 @@
+/*
+ *
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "config.h"
+
+#include "TRLFrequencyLimitDetector.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm/PlatformIO.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm_debug.hpp"
+
+namespace geopm
+{
+    TRLFrequencyLimitDetector::TRLFrequencyLimitDetector(
+        PlatformIO &platform_io,
+        const PlatformTopo &platform_topo)
+        : m_package_count(platform_topo.num_domain(GEOPM_DOMAIN_PACKAGE))
+        , m_core_count(platform_topo.num_domain(GEOPM_DOMAIN_CORE))
+        , M_CPU_FREQUENCY_MAX(platform_io.read_signal("CPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD, 0))
+        , M_CPU_FREQUENCY_STICKER(platform_io.read_signal("CPU_FREQUENCY_STICKER", GEOPM_DOMAIN_BOARD, 0))
+        , m_cores_in_packages()
+        // Initially assume we can reach single-core turbo limits
+        , m_core_frequency_limits(m_core_count, {{m_core_count / m_package_count, M_CPU_FREQUENCY_MAX}})
+        , m_core_lp_frequencies(m_core_count, M_CPU_FREQUENCY_STICKER)
+    {
+        for (unsigned int i = 0; i < m_package_count; ++i) {
+            const auto nested_ctls = platform_topo.domain_nested(
+                GEOPM_DOMAIN_CORE, GEOPM_DOMAIN_PACKAGE, i);
+            m_cores_in_packages.push_back(
+                std::vector<int>(nested_ctls.begin(), nested_ctls.end()));
+        }
+    }
+
+    void TRLFrequencyLimitDetector::update_max_frequency_estimates(
+        const std::vector<double> &observed_core_frequencies)
+    {
+        for (size_t package_idx = 0; package_idx < m_package_count; ++package_idx) {
+            // SST-TF is not being considered. Assume any core can reach the
+            // current max observed frequency across cores.
+            const auto &cores_in_package = m_cores_in_packages[package_idx];
+            const auto core_with_max_frequency = *std::max_element(
+                cores_in_package.begin(), cores_in_package.end(),
+                [&observed_core_frequencies](int lhs, int rhs) {
+                    return observed_core_frequencies[lhs] < observed_core_frequencies[rhs];
+                });
+            const auto max_frequency = observed_core_frequencies[core_with_max_frequency];
+            for (const auto core_idx : cores_in_package) {
+                m_core_frequency_limits[core_idx] = {
+                    {cores_in_package.size(), max_frequency}};
+                m_core_lp_frequencies[core_idx] = max_frequency;
+            }
+        }
+    }
+
+    std::vector<std::pair<unsigned int, double> >
+        TRLFrequencyLimitDetector::get_core_frequency_limits(unsigned int core_idx) const
+    {
+        return m_core_frequency_limits.at(core_idx);
+    }
+
+    double TRLFrequencyLimitDetector::get_core_low_priority_frequency(
+        unsigned int core_idx) const
+    {
+        return m_core_lp_frequencies.at(core_idx);
+    }
+}

--- a/src/TRLFrequencyLimitDetector.hpp
+++ b/src/TRLFrequencyLimitDetector.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TRLFREQUENCYLIMITDETECTOR_HPP_INCLUDE
+#define TRLFREQUENCYLIMITDETECTOR_HPP_INCLUDE
+
+#include <FrequencyLimitDetector.hpp>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace geopm
+{
+    // A frequency limit detector that depends on CPU package turbo ratio limits
+    class TRLFrequencyLimitDetector : public FrequencyLimitDetector
+    {
+        public:
+            TRLFrequencyLimitDetector(
+                PlatformIO &platform_io,
+                const PlatformTopo &);
+
+            void update_max_frequency_estimates(
+                const std::vector<double> &observed_core_frequencies) override;
+            std::vector<std::pair<unsigned int, double> > get_core_frequency_limits(
+                unsigned int core_idx) const override;
+            double get_core_low_priority_frequency(unsigned int core_idx) const override;
+
+        private:
+            unsigned int m_package_count;
+            size_t m_core_count;
+            const double M_CPU_FREQUENCY_MAX;
+            const double M_CPU_FREQUENCY_STICKER;
+            std::vector<std::vector<int> > m_cores_in_packages;
+            std::vector<std::vector<std::pair<unsigned int, double> > > m_core_frequency_limits;
+            std::vector<double> m_core_lp_frequencies;
+    };
+}
+
+#endif

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -271,6 +271,11 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/SchedTest.test_proc_cpuset_6 \
               test/gtest_links/SchedTest.test_proc_cpuset_7 \
               test/gtest_links/SchedTest.test_proc_cpuset_8 \
+              test/gtest_links/SSTFrequencyLimitDetectorTest.returns_single_core_limit_by_default \
+              test/gtest_links/SSTFrequencyLimitDetectorTest.returns_max_observed_frequency_when_sst_disabled \
+              test/gtest_links/SSTFrequencyLimitDetectorTest.detects_nearest_license_level_limit_bucket_0 \
+              test/gtest_links/SSTFrequencyLimitDetectorTest.detects_nearest_license_level_limit_bucket_1 \
+              test/gtest_links/SSTFrequencyLimitDetectorTest.limits_license_level_search_if_frequency_capped \
               test/gtest_links/TracerTest.columns \
               test/gtest_links/TracerTest.region_entry_exit \
               test/gtest_links/TracerTest.update_samples \
@@ -286,6 +291,8 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/TreeCommTest.geometry_nonroot \
               test/gtest_links/TreeCommTest.overhead_send \
               test/gtest_links/TreeCommTest.send_receive \
+              test/gtest_links/TRLFrequencyLimitDetectorTest.returns_single_core_limit_by_default \
+              test/gtest_links/TRLFrequencyLimitDetectorTest.returns_max_observed_frequency_after_update \
               test/gtest_links/ValidateRecordTest.valid_stream \
               test/gtest_links/ValidateRecordTest.process_change \
               test/gtest_links/ValidateRecordTest.entry_exit_paired \
@@ -377,6 +384,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/MockEndpoint.hpp \
                           test/MockEndpointPolicyTracer.hpp \
                           test/MockEndpointUser.hpp \
+                          test/MockFrequencyLimitDetector.hpp \
                           test/MockFrequencyGovernor.hpp \
                           test/MockIOGroup.hpp \
                           test/MockPlatformTopo.cpp \
@@ -413,9 +421,11 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/ReporterTest.cpp \
                           test/SampleAggregatorTest.cpp \
                           test/SchedTest.cpp \
+                          test/SSTFrequencyLimitDetectorTest.cpp \
                           test/TracerTest.cpp \
                           test/TreeCommLevelTest.cpp \
                           test/TreeCommTest.cpp \
+                          test/TRLFrequencyLimitDetectorTest.cpp \
                           test/ValidateRecordTest.cpp \
                           test/geopm_test.cpp \
                           test/geopm_test_helper.cpp \

--- a/test/MockFrequencyLimitDetector.hpp
+++ b/test/MockFrequencyLimitDetector.hpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOCKFREQUENCYLIMITDETECTOR_HPP_INCLUDE
+#define MOCKFREQUENCYLIMITDETECTOR_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "FrequencyLimitDetector.hpp"
+
+class MockFrequencyLimitDetector : public geopm::FrequencyLimitDetector
+{
+    public:
+        MOCK_METHOD(void, update_max_frequency_estimates,
+                    (const std::vector<double> &observed_core_frequencies),
+                    (override));
+        MOCK_METHOD((std::vector<std::pair<unsigned int, double> >),
+                    get_core_frequency_limits,
+                    (unsigned int core_idx),
+                    (const, override));
+        MOCK_METHOD(double, get_core_low_priority_frequency,
+                    (unsigned int core_idx),
+                    (const, override));
+};
+
+#endif

--- a/test/SSTFrequencyLimitDetectorTest.cpp
+++ b/test/SSTFrequencyLimitDetectorTest.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "MockPlatformIO.hpp"
+#include "MockPlatformTopo.hpp"
+#include "SSTFrequencyLimitDetector.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm/PlatformIO.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm_test.hpp"
+
+using ::testing::_;
+using testing::AllOf;
+using testing::ElementsAre;
+using testing::Ge;
+using ::testing::Invoke;
+using testing::Lt;
+using testing::Pair;
+using ::testing::Return;
+
+using geopm::SSTFrequencyLimitDetector;
+
+class SSTFrequencyLimitDetectorTest : public ::testing::Test
+{
+    public:
+        static const double CPU_FREQUENCY_MAX;
+        static const double ALL_CORE_TURBO_LIMIT;
+        static const double CPU_FREQUENCY_STICKER;
+        static const double CPU_FREQUENCY_STEP;
+        static const double LP_FREQ_SSE;
+        static const double LP_FREQ_AVX2;
+        static const double LP_FREQ_AVX512;
+
+        static const int CORE_COUNT;
+        static const std::vector<double> HP_CORES;
+        static const std::vector<double> HP_FREQS_SSE;
+        static const std::vector<double> HP_FREQS_AVX2;
+        static const std::vector<double> HP_FREQS_AVX512;
+
+        static const int CLOS_SIGNAL_INDEX_OFFSET;
+        static const int SST_ENABLE_SIGNAL_INDEX_OFFSET;
+        static const int FREQUENCY_CONTROL_SIGNAL_INDEX_OFFSET;
+    protected:
+        MockPlatformIO m_platform_io;
+        MockPlatformTopo m_platform_topo;
+
+        void SetUp();
+};
+
+const double SSTFrequencyLimitDetectorTest::CPU_FREQUENCY_MAX = 3.7e9;
+const double SSTFrequencyLimitDetectorTest::ALL_CORE_TURBO_LIMIT = 2.7e9;
+const double SSTFrequencyLimitDetectorTest::CPU_FREQUENCY_STICKER = 2.1e9;
+const double SSTFrequencyLimitDetectorTest::CPU_FREQUENCY_STEP = 1e8;
+const double SSTFrequencyLimitDetectorTest::LP_FREQ_SSE = 2.4e9;
+const double SSTFrequencyLimitDetectorTest::LP_FREQ_AVX2 = 2.1e9;
+const double SSTFrequencyLimitDetectorTest::LP_FREQ_AVX512 = 1.7e9;
+
+const int SSTFrequencyLimitDetectorTest::CORE_COUNT = 4;
+const std::vector<double> SSTFrequencyLimitDetectorTest::HP_CORES = {2, 3, 4};
+const std::vector<double> SSTFrequencyLimitDetectorTest::HP_FREQS_SSE = {3.6e9, 3.3e9, 3.0e9};
+const std::vector<double> SSTFrequencyLimitDetectorTest::HP_FREQS_AVX2 = {3.5e9, 3.2e9, 2.9e9};
+const std::vector<double> SSTFrequencyLimitDetectorTest::HP_FREQS_AVX512 = {3.4e9, 3.1e9, 2.8e9};
+
+const int SSTFrequencyLimitDetectorTest::CLOS_SIGNAL_INDEX_OFFSET = 100;
+const int SSTFrequencyLimitDetectorTest::SST_ENABLE_SIGNAL_INDEX_OFFSET = 1000;
+const int SSTFrequencyLimitDetectorTest::FREQUENCY_CONTROL_SIGNAL_INDEX_OFFSET = 2000;
+
+void SSTFrequencyLimitDetectorTest::SetUp()
+{
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_MAX_AVAIL", _, _))
+        .WillByDefault(Return(CPU_FREQUENCY_MAX));
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_STICKER", _, _))
+        .WillByDefault(Return(CPU_FREQUENCY_STICKER));
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_STEP", _, _))
+        .WillByDefault(Return(CPU_FREQUENCY_STEP));
+    ON_CALL(m_platform_io, read_signal("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_7", _, _))
+        .WillByDefault(Return(ALL_CORE_TURBO_LIMIT));
+    for (size_t i = 0; i < HP_CORES.size(); ++i) {
+        ON_CALL(m_platform_io, read_signal("SST::HIGHPRIORITY_NCORES:" + std::to_string(i), _, _))
+            .WillByDefault(Return(HP_CORES[i]));
+        ON_CALL(m_platform_io, read_signal("SST::HIGHPRIORITY_FREQUENCY_SSE:" + std::to_string(i), _, _))
+            .WillByDefault(Return(HP_FREQS_SSE[i]));
+        ON_CALL(m_platform_io, read_signal("SST::HIGHPRIORITY_FREQUENCY_AVX2:" + std::to_string(i), _, _))
+            .WillByDefault(Return(HP_FREQS_AVX2[i]));
+        ON_CALL(m_platform_io, read_signal("SST::HIGHPRIORITY_FREQUENCY_AVX512:" + std::to_string(i), _, _))
+            .WillByDefault(Return(HP_FREQS_AVX512[i]));
+    }
+    ON_CALL(m_platform_io, read_signal("SST::LOWPRIORITY_FREQUENCY:SSE", _, _))
+        .WillByDefault(Return(LP_FREQ_SSE));
+    ON_CALL(m_platform_io, read_signal("SST::LOWPRIORITY_FREQUENCY:AVX2", _, _))
+        .WillByDefault(Return(LP_FREQ_AVX2));
+    ON_CALL(m_platform_io, read_signal("SST::LOWPRIORITY_FREQUENCY:AVX512", _, _))
+        .WillByDefault(Return(LP_FREQ_AVX512));
+
+    ON_CALL(m_platform_io, push_signal("SST::COREPRIORITY:ASSOCIATION", GEOPM_DOMAIN_CORE, _))
+        .WillByDefault(Invoke(
+            [](const std::string &, int, int core_idx) {
+                return CLOS_SIGNAL_INDEX_OFFSET + core_idx;
+            }));
+    ON_CALL(m_platform_io, push_signal("SST::TURBO_ENABLE:ENABLE", GEOPM_DOMAIN_PACKAGE, _))
+        .WillByDefault(Invoke(
+            [](const std::string &, int, int package_idx) {
+                return SST_ENABLE_SIGNAL_INDEX_OFFSET + package_idx;
+            }));
+    ON_CALL(m_platform_io, push_signal("CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_CORE, _))
+        .WillByDefault(Invoke(
+            [](const std::string &, int, int core_idx) {
+                return FREQUENCY_CONTROL_SIGNAL_INDEX_OFFSET + core_idx;
+            }));
+
+    ON_CALL(m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .WillByDefault(Return(1));
+    ON_CALL(m_platform_topo, num_domain(GEOPM_DOMAIN_CORE))
+        .WillByDefault(Return(CORE_COUNT));
+    std::set<int> cores_in_package;
+    for (int i = 0; i < CORE_COUNT; ++i) {
+        cores_in_package.insert(i);
+    }
+    ON_CALL(m_platform_topo, domain_nested(GEOPM_DOMAIN_CORE, GEOPM_DOMAIN_PACKAGE, _))
+        .WillByDefault(Return(cores_in_package));
+}
+
+TEST_F(SSTFrequencyLimitDetectorTest, returns_single_core_limit_by_default)
+{
+    SSTFrequencyLimitDetector sst_frequency_limit_detector(m_platform_io, m_platform_topo);
+
+    for (size_t core_idx = 0; core_idx < CORE_COUNT; ++core_idx) {
+        EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(core_idx),
+                    ElementsAre(Pair(CORE_COUNT, CPU_FREQUENCY_MAX)));
+
+        EXPECT_EQ(CPU_FREQUENCY_STICKER,
+                  sst_frequency_limit_detector.get_core_low_priority_frequency(core_idx));
+    }
+}
+
+TEST_F(SSTFrequencyLimitDetectorTest, returns_max_observed_frequency_when_sst_disabled)
+{
+    SSTFrequencyLimitDetector sst_frequency_limit_detector(m_platform_io, m_platform_topo);
+
+    EXPECT_CALL(m_platform_io, sample(SST_ENABLE_SIGNAL_INDEX_OFFSET)).WillOnce(Return(0));
+
+    sst_frequency_limit_detector.update_max_frequency_estimates({1e9, 3e9, 2e9, 2.5e9});
+
+    for (size_t core_idx = 0; core_idx < CORE_COUNT; ++core_idx) {
+        EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(core_idx),
+                    ElementsAre(Pair(CORE_COUNT, 3e9)));
+
+        EXPECT_EQ(CPU_FREQUENCY_STICKER,
+                  sst_frequency_limit_detector.get_core_low_priority_frequency(core_idx));
+    }
+}
+
+TEST_F(SSTFrequencyLimitDetectorTest, detects_nearest_license_level_limit_bucket_0)
+{
+    SSTFrequencyLimitDetector sst_frequency_limit_detector(m_platform_io, m_platform_topo);
+
+    EXPECT_CALL(m_platform_io, sample(SST_ENABLE_SIGNAL_INDEX_OFFSET)).WillOnce(Return(1));
+    EXPECT_CALL(m_platform_io,
+                sample(AllOf(
+                    Ge(FREQUENCY_CONTROL_SIGNAL_INDEX_OFFSET),
+                    Lt(FREQUENCY_CONTROL_SIGNAL_INDEX_OFFSET + CORE_COUNT))))
+        .WillRepeatedly(Return(CPU_FREQUENCY_MAX));
+
+    // The first two cores are currently configured as high priority.
+    const int hp_core_count = 2;
+    EXPECT_CALL(m_platform_io,
+                sample(AllOf(Ge(CLOS_SIGNAL_INDEX_OFFSET), Lt(CLOS_SIGNAL_INDEX_OFFSET + hp_core_count))))
+        .Times(hp_core_count)
+        .WillRepeatedly(Return(0));
+    // Other cores are low priority
+    EXPECT_CALL(m_platform_io,
+                sample(AllOf(Ge(CLOS_SIGNAL_INDEX_OFFSET + hp_core_count), Lt(CLOS_SIGNAL_INDEX_OFFSET + CORE_COUNT))))
+        .WillRepeatedly(Return(3));
+
+    EXPECT_GE(HP_CORES[0], hp_core_count)
+        << "Self-consistency check on the test configuration. This test case "
+           "expects to be in SST-TF bucket 0.";
+    sst_frequency_limit_detector.update_max_frequency_estimates({
+        HP_FREQS_SSE[0] - 5e7,    // Just under the SSE limit, but not quite reaching AVX2
+        HP_FREQS_AVX512[0] - 2e8, // Far under the AVX512 limit
+        1e9, 1e9                  // Don't care about these cores for this test
+    });
+
+    EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(0),
+                ElementsAre(Pair(HP_CORES[0], HP_FREQS_SSE[0]),
+                            Pair(HP_CORES[1], HP_FREQS_SSE[1]),
+                            Pair(HP_CORES[2], HP_FREQS_SSE[2])));
+    EXPECT_EQ(LP_FREQ_SSE,
+              sst_frequency_limit_detector.get_core_low_priority_frequency(0));
+
+    EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(1),
+                ElementsAre(Pair(HP_CORES[0], HP_FREQS_AVX512[0]),
+                            Pair(HP_CORES[1], HP_FREQS_AVX512[1]),
+                            Pair(HP_CORES[2], HP_FREQS_AVX512[2])));
+    EXPECT_EQ(LP_FREQ_AVX512,
+              sst_frequency_limit_detector.get_core_low_priority_frequency(1));
+}
+
+TEST_F(SSTFrequencyLimitDetectorTest, detects_nearest_license_level_limit_bucket_1)
+{
+    SSTFrequencyLimitDetector sst_frequency_limit_detector(m_platform_io, m_platform_topo);
+
+    EXPECT_CALL(m_platform_io, sample(SST_ENABLE_SIGNAL_INDEX_OFFSET)).WillOnce(Return(1));
+    EXPECT_CALL(m_platform_io,
+                sample(AllOf(
+                    Ge(FREQUENCY_CONTROL_SIGNAL_INDEX_OFFSET),
+                    Lt(FREQUENCY_CONTROL_SIGNAL_INDEX_OFFSET + CORE_COUNT))))
+        .WillRepeatedly(Return(CPU_FREQUENCY_MAX));
+
+    // The first three cores are currently configured as high priority.
+    const int hp_core_count = 3;
+    EXPECT_CALL(m_platform_io,
+                sample(AllOf(Ge(CLOS_SIGNAL_INDEX_OFFSET), Lt(CLOS_SIGNAL_INDEX_OFFSET + hp_core_count))))
+        .Times(hp_core_count)
+        .WillRepeatedly(Return(0));
+    // Other cores are low priority
+    EXPECT_CALL(m_platform_io,
+                sample(AllOf(Ge(CLOS_SIGNAL_INDEX_OFFSET + hp_core_count), Lt(CLOS_SIGNAL_INDEX_OFFSET + CORE_COUNT))))
+        .WillRepeatedly(Return(3));
+
+    EXPECT_GE(HP_CORES[1], hp_core_count)
+        << "Self-consistency check on the test configuration. This test case "
+           "expects to be in SST-TF bucket 1.";
+    sst_frequency_limit_detector.update_max_frequency_estimates({
+        HP_FREQS_SSE[1] - 5e7,    // Just under the SSE limit, but not quite reaching AVX2
+        HP_FREQS_AVX2[1],         // Equal to the AVX2 limit -- Assume our limit is AVX2
+        HP_FREQS_AVX512[1] - 2e8, // Far under the AVX512 limit
+        1e9                       // Don't care about this core for this test
+    });
+
+    EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(0),
+                ElementsAre(Pair(HP_CORES[0], HP_FREQS_SSE[0]),
+                            Pair(HP_CORES[1], HP_FREQS_SSE[1]),
+                            Pair(HP_CORES[2], HP_FREQS_SSE[2])));
+    EXPECT_EQ(LP_FREQ_SSE,
+              sst_frequency_limit_detector.get_core_low_priority_frequency(0));
+
+    EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(1),
+                ElementsAre(Pair(HP_CORES[0], HP_FREQS_AVX2[0]),
+                            Pair(HP_CORES[1], HP_FREQS_AVX2[1]),
+                            Pair(HP_CORES[2], HP_FREQS_AVX2[2])));
+    EXPECT_EQ(LP_FREQ_AVX2,
+              sst_frequency_limit_detector.get_core_low_priority_frequency(1));
+
+    EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(2),
+                ElementsAre(Pair(HP_CORES[0], HP_FREQS_AVX512[0]),
+                            Pair(HP_CORES[1], HP_FREQS_AVX512[1]),
+                            Pair(HP_CORES[2], HP_FREQS_AVX512[2])));
+    EXPECT_EQ(LP_FREQ_AVX512,
+              sst_frequency_limit_detector.get_core_low_priority_frequency(2));
+}
+
+TEST_F(SSTFrequencyLimitDetectorTest, limits_license_level_search_if_frequency_capped)
+{
+    SSTFrequencyLimitDetector sst_frequency_limit_detector(m_platform_io, m_platform_topo);
+
+    EXPECT_CALL(m_platform_io, sample(SST_ENABLE_SIGNAL_INDEX_OFFSET)).WillOnce(Return(1));
+    static const double AVX2_FREQUENCY_CAP = HP_FREQS_AVX2[0];
+    EXPECT_CALL(m_platform_io,
+                sample(AllOf(
+                    Ge(FREQUENCY_CONTROL_SIGNAL_INDEX_OFFSET),
+                    Lt(FREQUENCY_CONTROL_SIGNAL_INDEX_OFFSET + CORE_COUNT))))
+        // Act like there's a CPU frequency cap at the AVX2 ceiling.
+        .WillRepeatedly(Return(AVX2_FREQUENCY_CAP));
+
+    // The first two cores are currently configured as high priority.
+    const int hp_core_count = 2;
+    EXPECT_CALL(m_platform_io,
+                sample(AllOf(Ge(CLOS_SIGNAL_INDEX_OFFSET), Lt(CLOS_SIGNAL_INDEX_OFFSET + hp_core_count))))
+        .Times(hp_core_count)
+        .WillRepeatedly(Return(0));
+    // Other cores are low priority
+    EXPECT_CALL(m_platform_io,
+                sample(AllOf(Ge(CLOS_SIGNAL_INDEX_OFFSET + hp_core_count), Lt(CLOS_SIGNAL_INDEX_OFFSET + CORE_COUNT))))
+        .WillRepeatedly(Return(3));
+
+    EXPECT_GE(HP_CORES[0], hp_core_count)
+        << "Self-consistency check on the test configuration. This test case "
+           "expects to be in SST-TF bucket 0.";
+    sst_frequency_limit_detector.update_max_frequency_estimates({
+        HP_FREQS_AVX2[0],   // Achieved everything we gave this core
+        HP_FREQS_AVX512[0], // Not quite able to achieve the frequency cap
+        1e9, 1e9            // Don't care about these cores for this test
+    });
+
+    // Core 0 exactly achieved the AVX2 ceiling, but that was also our cap.
+    // Assume that it could potentially go faster if we relaxed the cap.
+    EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(0),
+                ElementsAre(Pair(HP_CORES[0], HP_FREQS_SSE[0]),
+                            Pair(HP_CORES[1], HP_FREQS_SSE[1]),
+                            Pair(HP_CORES[2], HP_FREQS_SSE[2])));
+    EXPECT_EQ(LP_FREQ_SSE,
+              sst_frequency_limit_detector.get_core_low_priority_frequency(0));
+
+    // Core 1 achieved less than our cap. So assume the nearest SST-TF limit is
+    // the limiting factor.
+    EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(1),
+                ElementsAre(Pair(HP_CORES[0], HP_FREQS_AVX512[0]),
+                            Pair(HP_CORES[1], HP_FREQS_AVX512[1]),
+                            Pair(HP_CORES[2], HP_FREQS_AVX512[2])));
+    EXPECT_EQ(LP_FREQ_AVX512,
+              sst_frequency_limit_detector.get_core_low_priority_frequency(1));
+}
+

--- a/test/TRLFrequencyLimitDetectorTest.cpp
+++ b/test/TRLFrequencyLimitDetectorTest.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "MockPlatformIO.hpp"
+#include "MockPlatformTopo.hpp"
+#include "TRLFrequencyLimitDetector.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm/PlatformIO.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm_test.hpp"
+
+using ::testing::_;
+using testing::AllOf;
+using testing::ElementsAre;
+using testing::Ge;
+using ::testing::Invoke;
+using testing::Lt;
+using testing::Pair;
+using ::testing::Return;
+
+using geopm::TRLFrequencyLimitDetector;
+
+static const double CPU_FREQUENCY_MAX = 3.7e9;
+static const double ALL_CORE_TURBO_LIMIT = 2.7e9;
+static const double CPU_FREQUENCY_STICKER = 2.1e9;
+static const double CPU_FREQUENCY_STEP = 1e8;
+
+static const int CORE_COUNT = 4;
+
+class TRLFrequencyLimitDetectorTest : public ::testing::Test
+{
+    protected:
+        MockPlatformIO m_platform_io;
+        MockPlatformTopo m_platform_topo;
+
+        void SetUp();
+};
+
+void TRLFrequencyLimitDetectorTest::SetUp()
+{
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_MAX_AVAIL", _, _))
+        .WillByDefault(Return(CPU_FREQUENCY_MAX));
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_STICKER", _, _))
+        .WillByDefault(Return(CPU_FREQUENCY_STICKER));
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_STEP", _, _))
+        .WillByDefault(Return(CPU_FREQUENCY_STEP));
+    ON_CALL(m_platform_io, read_signal("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_7", _, _))
+        .WillByDefault(Return(ALL_CORE_TURBO_LIMIT));
+
+    ON_CALL(m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .WillByDefault(Return(1));
+    ON_CALL(m_platform_topo, num_domain(GEOPM_DOMAIN_CORE))
+        .WillByDefault(Return(CORE_COUNT));
+    std::set<int> cores_in_package;
+    for (int i = 0; i < CORE_COUNT; ++i) {
+        cores_in_package.insert(i);
+    }
+    ON_CALL(m_platform_topo, domain_nested(GEOPM_DOMAIN_CORE, GEOPM_DOMAIN_PACKAGE, _))
+        .WillByDefault(Return(cores_in_package));
+}
+
+TEST_F(TRLFrequencyLimitDetectorTest, returns_single_core_limit_by_default)
+{
+    TRLFrequencyLimitDetector sst_frequency_limit_detector(m_platform_io, m_platform_topo);
+
+    for (size_t core_idx = 0; core_idx < CORE_COUNT; ++core_idx) {
+        EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(core_idx),
+                    ElementsAre(Pair(CORE_COUNT, CPU_FREQUENCY_MAX)));
+
+        EXPECT_EQ(CPU_FREQUENCY_STICKER,
+                  sst_frequency_limit_detector.get_core_low_priority_frequency(core_idx));
+    }
+}
+
+TEST_F(TRLFrequencyLimitDetectorTest, returns_max_observed_frequency_after_update)
+{
+    TRLFrequencyLimitDetector sst_frequency_limit_detector(m_platform_io, m_platform_topo);
+
+    sst_frequency_limit_detector.update_max_frequency_estimates({1e9, 3e9, 2e9, 2.5e9});
+
+    for (size_t core_idx = 0; core_idx < CORE_COUNT; ++core_idx) {
+        EXPECT_THAT(sst_frequency_limit_detector.get_core_frequency_limits(core_idx),
+                    ElementsAre(Pair(CORE_COUNT, 3e9)));
+
+        EXPECT_EQ(3e9,
+                  sst_frequency_limit_detector.get_core_low_priority_frequency(core_idx));
+    }
+}


### PR DESCRIPTION
- Classes estimate the peak achievable CPU core frequency based on current
  achieved frequencies and SST or TRL configuration state.
- Resolves #2580