### PR TITLE
Fix the overflow in `CircularBuffer::set_capacity`

### DIFF
--- a/service/docs/source/GEOPM_CXX_MAN_CircularBuffer.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_CircularBuffer.3.rst
@@ -31,7 +31,7 @@ Synopsis
 
        void CircularBuffer::insert(const T value);
 
-       const T& CircularBuffer::value(const unsigned int index) const;
+       const T& CircularBuffer::value(const int index) const;
 
        vector<T> CircularBuffer::make_vector(void) const;
 
@@ -47,43 +47,52 @@ Class Methods
 -------------
 
 
-*
-  ``set_capacity()``:
-  Resets the capacity of the circular buffer to *size* without
-  modifying its current contents.
+``set_capacity()``
+  Grows or shrinks the capacity of the circular buffer.
+  If the new capacity is greater than the size, then the current
+  contents will not be modified.
+  If the new capacity is smaller than the size, then only the newest
+  elements of the difference will be retained.
 
-*
-  ``clear()``:
+``clear()``
   Clears all entries from the buffer.  The size becomes ``0``, but the
   capacity is unchanged.
 
-*
-  ``size()``:
+``size()``
   Returns the number of items in the buffer.  This value will be less
   than or equal to the current capacity of the buffer.
 
-*
-  ``capacity()``:
+``capacity()``
   Returns the current size of the circular buffer at the time of the
   call.
 
-*
-  ``insert()``:
+``insert()``
   Inserts *value* into the buffer.  If the buffer is not full, the new
   value is simply added to the buffer. It the buffer is at capacity,
   The head of the buffer is **dropped** and moved to the next oldest entry
   and the new value is then inserted at the end of the buffer.
 
-*
-  ``value()``:
-  Accesses the contents of the circular buffer at *index*. Valid
-  indices range from ``0`` to ``[size-1]``, where *size* is the number of valid
-  entries in the buffer.  An attempt to retrieve a value for an out of
-  bound index will throw a :doc:`geopm::Exception(3) <GEOPM_CXX_MAN_Exception.3>` with an
-  ``error_value()`` of ``GEOPM_ERROR_INVALID``.
+``value()``
+  Returns a constant reference to the value from the buffer.
+  Accesses the contents of the circular buffer
+  at a particular *index*.
+  There are two kinds of valid indices: positive and negative ones.
 
-*
-  ``make_vector()``:
+  * Valid positive indices range from ``0`` to ``size-1``.
+
+  * Valid negative indices range from ``-1`` to ``-size``.
+    Negative indices work just like **python** indices,
+    to represent nth-most-recent insertions. For example,
+    ``-1`` is the last element, ``-2`` is the second to last element, and so on.
+
+  Where ``size`` is the number of valid entries in the buffer.
+
+  * An out of bounds *index* is ``> [size-1]`` **OR** ``< [-size]``.
+    An attempt to retrieve a value for an out of
+    bound index will throw a :doc:`geopm::Exception(3) <GEOPM_CXX_MAN_Exception.3>` with an
+    ``error_value()`` of ``GEOPM_ERROR_INVALID``.
+
+``make_vector()``
   Create a vector from the entire circular buffer contents.
   Or create a vector slice from the circular buffer contents,
   delimited by the *Start* index **(inclusive)** and *End* index **(exclusive)**

--- a/service/docs/source/GEOPM_CXX_MAN_CircularBuffer.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_CircularBuffer.3.rst
@@ -76,7 +76,6 @@ Class Methods
   Returns a constant reference to the value from the buffer.
   Accesses the contents of the circular buffer
   at a particular *index*.
-  There are two kinds of valid indices: positive and negative ones.
 
   * Valid positive indices range from ``0`` to ``size-1``.
 

--- a/service/src/geopm/CircularBuffer.hpp
+++ b/service/src/geopm/CircularBuffer.hpp
@@ -176,11 +176,11 @@ namespace geopm
             throw Exception("CircularBuffer::insert(): Cannot insert into a buffer of 0 size", GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
         }
         if (m_count < m_max_size) {
-            m_buffer[m_count] = value;
+            m_buffer.at(m_count) = value;
             m_count++;
         }
         else {
-            m_buffer[m_head] = value;
+            m_buffer.at(m_head) = value;
             m_head = ((m_head + 1) % m_max_size);
         }
     }
@@ -191,7 +191,7 @@ namespace geopm
         if (index >= m_count) {
             throw Exception("CircularBuffer::value(): index is out of bounds", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        return m_buffer[(m_head + index) % m_max_size];
+        return m_buffer.at((m_head + index) % m_max_size);
     }
 
     template <class type>

--- a/service/src/geopm/CircularBuffer.hpp
+++ b/service/src/geopm/CircularBuffer.hpp
@@ -73,7 +73,6 @@ namespace geopm
             ///
             /// Accesses the contents of the circular buffer
             /// at a particular index.
-            /// There are two kinds of valid indices: positive and negative ones.
             /// Valid positive indices range from 0 to [size-1].
             /// Valid negative indices range from -1 to -size.
             /// Negative indices work just like python indices,
@@ -197,9 +196,9 @@ namespace geopm
     template <class type>
     const type& CircularBuffer<type>::value(const int index) const
     {
-        if (index >= 0 && index >= m_count ||
-            index <  0 && index < -m_count) {
-            throw Exception("CircularBuffer::value(): index is out of bounds", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        if (index >= static_cast<int>(m_count) || index < -static_cast<int>(m_count)) {
+            throw Exception(std::string("CircularBuffer::value(): index [") + std::to_string(index) + "] is out of bounds",
+                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         if (index < 0) {
             const int new_index = m_count + index;

--- a/service/src/geopm/CircularBuffer.hpp
+++ b/service/src/geopm/CircularBuffer.hpp
@@ -32,10 +32,13 @@ namespace geopm
             virtual ~CircularBuffer();
             /// @brief Re-size the circular buffer.
             ///
-            /// Resets the capacity of the circular buffer without
-            /// modifying its current contents.
+            /// Grows or shrinks the capacity of the circular buffer.
+            /// If the new capacity is greater than the size, then the current contents
+            /// will not be modified.
+            /// If the new capacity is smaller than the size, then only the newest elements
+            /// of the difference will be retained.
             ///
-            /// @param [in] size Requested capacity for the buffer.
+            /// @param [in] size Requested new capacity for the buffer.
             void set_capacity(const unsigned int size);
             /// @brief Clears all entries from the buffer.
             ///
@@ -69,17 +72,23 @@ namespace geopm
             /// @brief Returns a constant reference to the value from the buffer.
             ///
             /// Accesses the contents of the circular buffer
-            /// at a particular index. Valid indices range
-            /// from 0 to [size-1]. Where size is the number
-            /// of valid entries in the buffer. An attempt to
-            /// retrieve a value for an out of bound index
+            /// at a particular index.
+            /// There are two kinds of valid indices: positive and negative ones.
+            /// Valid positive indices range from 0 to [size-1].
+            /// Valid negative indices range from -1 to -size.
+            /// Negative indices work just like python indices,
+            /// to represent nth-most-recent insertions. For example,
+            /// -1 is the last element, -2 is the second to last element, and so on.
+            /// Where size is the number of valid entries in the buffer.
+            /// An out of bounds index is > [size-1] OR < [-size].
+            /// An attempt to retrieve a value for an out of bound index
             /// will throw a geopm::Exception with an
             /// error_value() of GEOPM_ERROR_INVALID.
             ///
             /// @param [in] index Buffer index to retrieve.
             ///
             /// @return Value from the specified buffer index.
-            const type& value(const unsigned int index) const;
+            const type& value(const int index) const;
             /// @brief Create a vector from the entire circular buffer contents.
             ///
             /// @return Vector containing the circular buffer contents.
@@ -150,6 +159,7 @@ namespace geopm
     template <class type>
     void CircularBuffer<type>::set_capacity(const unsigned int size)
     {
+        // If the requested new capacity is less than the size.
         if (size < m_count && m_max_size > 0) {
             int size_diff = m_count - size;
             std::vector<type> temp;
@@ -185,12 +195,18 @@ namespace geopm
     }
 
     template <class type>
-    const type& CircularBuffer<type>::value(const unsigned int index) const
+    const type& CircularBuffer<type>::value(const int index) const
     {
-        if (index >= m_count) {
+        if (index >= 0 && index >= m_count ||
+            index <  0 && index < -m_count) {
             throw Exception("CircularBuffer::value(): index is out of bounds", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        return m_buffer.at((m_head + index) % m_max_size);
+        if (index < 0) {
+            const int new_index = m_count + index;
+            return m_buffer.at((m_head + new_index) % m_max_size);
+        } else {
+            return m_buffer.at((m_head + index) % m_max_size);
+        }
     }
 
     template <class type>

--- a/service/src/geopm/CircularBuffer.hpp
+++ b/service/src/geopm/CircularBuffer.hpp
@@ -153,9 +153,8 @@ namespace geopm
         if (size < m_count && m_max_size > 0) {
             int size_diff = m_count - size;
             std::vector<type> temp;
-            //Copy newest data into temporary vector
-            for (unsigned int i = m_head + size_diff; i != ((m_head + m_count) % m_max_size); i = ((i + 1) % m_max_size)) {
-                temp.push_back(m_buffer[i]);
+            for (size_t idx = size_diff; idx < m_count; ++idx) {
+                temp.push_back(value(idx));
             }
             //now re-size and swap out with tmp vector data
             m_buffer.resize(size);

--- a/service/test/CircularBufferTest.cpp
+++ b/service/test/CircularBufferTest.cpp
@@ -43,6 +43,7 @@ TEST_F(CircularBufferTest, buffer_values)
     EXPECT_DOUBLE_EQ(3.0, m_buffer->value(2));
     m_buffer->insert(4.0);
     m_buffer->insert(5.0);
+    // this one overflows the capacity, discards the oldest value 1.0
     m_buffer->insert(6.0);
     EXPECT_DOUBLE_EQ(2.0, m_buffer->value(0));
     EXPECT_DOUBLE_EQ(3.0, m_buffer->value(1));
@@ -63,6 +64,48 @@ TEST_F(CircularBufferTest, buffer_values)
     EXPECT_DOUBLE_EQ(6.0, m_buffer->value(2));
     EXPECT_DOUBLE_EQ(7.0, m_buffer->value(3));
     EXPECT_DOUBLE_EQ(8.0, m_buffer->value(4));
+}
+
+TEST_F(CircularBufferTest, buffer_values_negative_indices)
+{
+    m_buffer->insert(4.0);
+    m_buffer->insert(5.0);
+    EXPECT_DOUBLE_EQ(1.0, m_buffer->value(0));
+    EXPECT_DOUBLE_EQ(2.0, m_buffer->value(1));
+    EXPECT_DOUBLE_EQ(3.0, m_buffer->value(2));
+    EXPECT_DOUBLE_EQ(4.0, m_buffer->value(3));
+    EXPECT_DOUBLE_EQ(5.0, m_buffer->value(4));
+    //
+    EXPECT_DOUBLE_EQ(5.0, m_buffer->value(-1));
+    EXPECT_DOUBLE_EQ(4.0, m_buffer->value(-2));
+    EXPECT_DOUBLE_EQ(3.0, m_buffer->value(-3));
+    EXPECT_DOUBLE_EQ(2.0, m_buffer->value(-4));
+    EXPECT_DOUBLE_EQ(1.0, m_buffer->value(-5));
+    // overflows the capacity, writes over the oldest values
+    // shifts the rest of the values to the m_head
+    m_buffer->insert(10.0);
+    m_buffer->insert(11.0);
+    m_buffer->insert(12.0);
+    EXPECT_DOUBLE_EQ(4.0, m_buffer->value(0));
+    EXPECT_DOUBLE_EQ(5.0, m_buffer->value(1));
+    EXPECT_DOUBLE_EQ(10.0, m_buffer->value(2));
+    EXPECT_DOUBLE_EQ(11.0, m_buffer->value(3));
+    EXPECT_DOUBLE_EQ(12.0, m_buffer->value(4));
+    //
+    EXPECT_DOUBLE_EQ(12.0, m_buffer->value(-1));
+    EXPECT_DOUBLE_EQ(11.0, m_buffer->value(-2));
+    EXPECT_DOUBLE_EQ(10.0, m_buffer->value(-3));
+    EXPECT_DOUBLE_EQ(5.0, m_buffer->value(-4));
+    EXPECT_DOUBLE_EQ(4.0, m_buffer->value(-5));
+    // test invalid indices
+    ASSERT_EQ(5, m_buffer->capacity());
+    EXPECT_THROW(m_buffer->value(5), geopm::Exception);
+    EXPECT_THROW(m_buffer->value(6), geopm::Exception);
+    EXPECT_THROW(m_buffer->value(7), geopm::Exception);
+    //
+    EXPECT_THROW(m_buffer->value(-6), geopm::Exception);
+    EXPECT_THROW(m_buffer->value(-7), geopm::Exception);
+    EXPECT_THROW(m_buffer->value(-8), geopm::Exception);
 }
 
 TEST_F(CircularBufferTest, buffer_capacity)

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -48,6 +48,7 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/CircularBufferTest.buffer_capacity \
               test/gtest_links/CircularBufferTest.buffer_size \
               test/gtest_links/CircularBufferTest.buffer_values \
+              test/gtest_links/CircularBufferTest.buffer_values_negative_indices \
               test/gtest_links/CircularBufferTest.make_vector_slice \
               test/gtest_links/CNLIOGroupTest.valid_signals \
               test/gtest_links/CNLIOGroupTest.read_signal \


### PR DESCRIPTION
- Relates to #2507 
- Fixes #2507 

 - Previously the loop that used to copy the newest elements had a wrong offset.
 - It didn't correctly take into account looping over the `m_head` in the modulo.
 - I refactored the code to have a simplified loop using a proven class method.
