### PR TITLE
Disable msr-safe kernel driver

### DIFF
--- a/service/configure.ac
+++ b/service/configure.ac
@@ -140,6 +140,11 @@ if test "x$enable_debug" = "x1" ; then
 fi
 AC_SUBST([enable_debug])
 
+if test "x$enable_msr_safe" = "x1" ; then
+  AC_DEFINE([GEOPM_ENABLE_MSR_SAFE], [ ], [Enables usr of the msr-safe driver interfaces])
+fi
+AC_SUBST([enable_msr_safe])
+
 if test "x$enable_coverage" = "x1" ; then
   AC_DEFINE([GEOPM_COVERAGE], [ ], [Enables test coverage reporting])
   EXTRA_CFLAGS="$EXTRA_CFLAGS --coverage"

--- a/service/src/MSRPath.cpp
+++ b/service/src/MSRPath.cpp
@@ -19,7 +19,11 @@ namespace geopm
         path_ss << "/dev/cpu/" << cpu_idx;
         switch (fallback_idx) {
             case M_FALLBACK_MSRSAFE:
+#ifdef GEOPM_ENABLE_MSR_SAFE
                 path_ss << "/msr_safe";
+#else
+                path_ss << "/msr";
+#endif
                 break;
             case M_FALLBACK_MSR:
                 path_ss << "/msr";
@@ -34,7 +38,11 @@ namespace geopm
 
     std::string MSRPath::msr_batch_path(void)
     {
-        return "/dev/cpu/msr_batch";
+        std::string result;
+#ifdef GEOPM_ENABLE_MSR_SAFE
+        result = "/dev/cpu/msr_batch";
+#endif
+        return result;
     }
 }
 


### PR DESCRIPTION
- All access will go through the standard Linux msr driver unless expressly enabled with configure --enable-msr-safe.
- All GEOPM service features remain fuctional
- Some loss of performance is expected when msr-safe is not enabled due to the lack of the ioctl batch interface.