### PR TITLE
Update CPU-CA to use Frequency Governor

### DIFF
--- a/src/CPUActivityAgent.cpp
+++ b/src/CPUActivityAgent.cpp
@@ -48,7 +48,7 @@ namespace geopm
         , m_num_freq_ctl_domain(m_platform_topo.num_domain(m_freq_ctl_domain_type))
         , m_core_batch_writes(0)
         , m_uncore_frequency_requests(0)
-        , m_uncore_frequency_clipped(0)
+        , m_uncore_frequency_clamped(0)
         , m_resolved_f_uncore_efficient(0)
         , m_resolved_f_uncore_max(0)
         , m_resolved_f_core_efficient(0)
@@ -362,9 +362,9 @@ namespace geopm
             // For now only L3 bandwith metric is used.
             double uncore_req = m_resolved_f_uncore_efficient + f_uncore_range * scalability_uncore;
 
-            // Clip uncore request within policy limits
+            // Clamp uncore request within policy limits
             if (uncore_req > m_resolved_f_uncore_max || uncore_req < m_resolved_f_uncore_efficient) {
-                ++m_uncore_frequency_clipped;
+                ++m_uncore_frequency_clamped;
             }
             uncore_req = std::max(m_resolved_f_uncore_efficient, uncore_req);
             uncore_req = std::min(m_resolved_f_uncore_max, uncore_req);
@@ -477,12 +477,12 @@ namespace geopm
 
         result.push_back({"Core Batch Writes",
                           std::to_string(m_core_batch_writes)});
-        result.push_back({"Core Frequency Requests Clipped",
+        result.push_back({"Core Frequency Requests Clamped",
                           std::to_string(m_freq_governor->get_clamp_count())});
         result.push_back({"Uncore Frequency Requests",
                           std::to_string(m_uncore_frequency_requests)});
-        result.push_back({"Uncore Frequency Requests Clipped",
-                          std::to_string(m_uncore_frequency_clipped)});
+        result.push_back({"Uncore Frequency Requests Clamped",
+                          std::to_string(m_uncore_frequency_clamped)});
         result.push_back({"Resolved Maximum Core Frequency",
                           std::to_string(m_resolved_f_core_max)});
         result.push_back({"Resolved Efficient Core Frequency",

--- a/src/CPUActivityAgent.hpp
+++ b/src/CPUActivityAgent.hpp
@@ -62,9 +62,8 @@ namespace geopm
             std::shared_ptr<FrequencyGovernor> m_freq_governor;
             int m_freq_ctl_domain_type;
             int m_num_freq_ctl_domain;
-            double m_core_frequency_requests;
+            double m_core_batch_writes;
             double m_uncore_frequency_requests;
-            double m_core_frequency_clipped;
             double m_uncore_frequency_clipped;
             double m_resolved_f_uncore_efficient;
             double m_resolved_f_uncore_max;

--- a/src/CPUActivityAgent.hpp
+++ b/src/CPUActivityAgent.hpp
@@ -15,13 +15,16 @@ namespace geopm
 {
     class PlatformTopo;
     class PlatformIO;
+    class FrequencyGovernor;
 
     /// @brief Agent
     class CPUActivityAgent : public Agent
     {
         public:
             CPUActivityAgent();
-            CPUActivityAgent(PlatformIO &plat_io, const PlatformTopo &topo);
+            CPUActivityAgent(PlatformIO &plat_io,
+                             const PlatformTopo &topo,
+                             std::shared_ptr<FrequencyGovernor> gov);
             virtual ~CPUActivityAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
             void validate_policy(std::vector<double> &in_policy) const override;
@@ -54,9 +57,11 @@ namespace geopm
             double M_WAIT_SEC;
             const double M_POLICY_PHI_DEFAULT;
             const int M_NUM_PACKAGE;
-            const int M_NUM_CORE;
             bool m_do_write_batch;
             bool m_do_send_policy;
+            std::shared_ptr<FrequencyGovernor> m_freq_governor;
+            int m_freq_ctl_domain_type;
+            int m_num_freq_ctl_domain;
             double m_core_frequency_requests;
             double m_uncore_frequency_requests;
             double m_core_frequency_clipped;

--- a/src/CPUActivityAgent.hpp
+++ b/src/CPUActivityAgent.hpp
@@ -64,7 +64,7 @@ namespace geopm
             int m_num_freq_ctl_domain;
             double m_core_batch_writes;
             double m_uncore_frequency_requests;
-            double m_uncore_frequency_clipped;
+            double m_uncore_frequency_clamped;
             double m_resolved_f_uncore_efficient;
             double m_resolved_f_uncore_max;
             double m_resolved_f_core_efficient;

--- a/src/FrequencyGovernor.cpp
+++ b/src/FrequencyGovernor.cpp
@@ -43,6 +43,7 @@ namespace geopm
         , M_PLAT_FREQ_MAX(get_limit("CPU_FREQUENCY_MAX_AVAIL"))
         , m_freq_min(M_PLAT_FREQ_MIN)
         , m_freq_max(M_PLAT_FREQ_MAX)
+        , m_clamp_count(0)
         , m_do_write_batch(false)
         , m_freq_ctl_domain_type(m_platform_io.control_domain_type("CPU_FREQUENCY_MAX_CONTROL"))
         , m_is_platform_io_initialized(false)
@@ -132,9 +133,11 @@ namespace geopm
             double clamp_freq = NAN;
             if (frequency_request[idx] > m_freq_max) {
                 clamp_freq = m_freq_max;
+                ++m_clamp_count;
             }
             else if (frequency_request[idx] < m_freq_min) {
                 clamp_freq = m_freq_min;
+                ++m_clamp_count;
             }
             else {
                 clamp_freq = frequency_request[idx];
@@ -181,6 +184,11 @@ namespace geopm
     double FrequencyGovernorImp::get_frequency_step()  const
     {
         return M_FREQ_STEP;
+    }
+
+    int FrequencyGovernorImp::get_clamp_count()  const
+    {
+        return m_clamp_count;
     }
 
     void FrequencyGovernorImp::validate_policy(double &freq_min, double &freq_max) const

--- a/src/FrequencyGovernor.cpp
+++ b/src/FrequencyGovernor.cpp
@@ -39,7 +39,7 @@ namespace geopm
         : m_platform_io(platform_io)
         , m_platform_topo(platform_topo)
         , M_FREQ_STEP(get_limit("CPUINFO::FREQ_STEP"))
-        , M_PLAT_FREQ_MIN(get_limit("CPUINFO::FREQ_MIN"))
+        , M_PLAT_FREQ_MIN(get_limit("CPU_FREQUENCY_MIN_AVAIL"))
         , M_PLAT_FREQ_MAX(get_limit("CPU_FREQUENCY_MAX_AVAIL"))
         , m_freq_min(M_PLAT_FREQ_MIN)
         , m_freq_max(M_PLAT_FREQ_MAX)
@@ -59,7 +59,7 @@ namespace geopm
     {
         const int domain_type = m_platform_io.signal_domain_type(sig_name);
         double result = NAN;
-        if (sig_name == "CPUINFO::FREQ_MIN") {
+        if (sig_name == "CPU_FREQUENCY_MIN_AVAIL") {
             result = m_platform_io.read_signal(sig_name, domain_type, 0);
         }
         else if (sig_name == "CPUINFO::FREQ_STICKER") {
@@ -185,7 +185,7 @@ namespace geopm
 
     void FrequencyGovernorImp::validate_policy(double &freq_min, double &freq_max) const
     {
-        double target_freq_min = std::isnan(freq_min) ? get_limit("CPUINFO::FREQ_MIN") : freq_min;
+        double target_freq_min = std::isnan(freq_min) ? get_limit("CPU_FREQUENCY_MIN_AVAIL") : freq_min;
         double target_freq_max = std::isnan(freq_max) ? get_limit("CPUINFO::FREQ_STICKER") : freq_max;
         freq_min = target_freq_min;
         freq_max = target_freq_max;

--- a/src/FrequencyGovernor.hpp
+++ b/src/FrequencyGovernor.hpp
@@ -60,6 +60,9 @@ namespace geopm
             /// @brief Returns the frequency step for the platform.
             /// @return Step frequency.
             virtual double get_frequency_step() const = 0;
+            /// @brief Returns the number of clamping occurence count for the platform.
+            /// @return Clamp occurence counter
+            virtual int get_clamp_count() const = 0;
             /// @brief Checks that the minimum and maximum frequency
             ///        are within range for the platform.  If not,
             ///        they will be clamped at the min and max for the

--- a/src/FrequencyGovernorImp.hpp
+++ b/src/FrequencyGovernorImp.hpp
@@ -29,6 +29,7 @@ namespace geopm
             double get_frequency_min() const override;
             double get_frequency_max() const override;
             double get_frequency_step() const override;
+            int get_clamp_count() const override;
             void validate_policy(double &freq_min, double &freq_max) const override;
         private:
             double get_limit(const std::string &sig_name) const;
@@ -39,6 +40,7 @@ namespace geopm
             const double M_PLAT_FREQ_MAX;
             double m_freq_min;
             double m_freq_max;
+            int m_clamp_count;
             bool m_do_write_batch;
             int m_freq_ctl_domain_type;
             std::vector<int> m_control_idx;

--- a/test/CPUActivityAgentTest.cpp
+++ b/test/CPUActivityAgentTest.cpp
@@ -564,7 +564,7 @@ TEST_F(CPUActivityAgentTest, adjust_platform_signal_out_of_bounds)
 
     //Adjust
     //Check call was made.  It's the frequency governor responsibility to handle
-    //clipping.
+    //clamping.
     EXPECT_CALL(*m_gov, adjust_platform(_)).Times(1);
     //Check frequency
     EXPECT_CALL(*m_platform_io, adjust(CPU_UNCORE_MIN_CONTROL_IDX, m_cpu_uncore_freq_max)).Times(M_NUM_PACKAGE);
@@ -585,7 +585,7 @@ TEST_F(CPUActivityAgentTest, adjust_platform_signal_out_of_bounds)
 
     //Adjust
     //Check call was made.  It's the frequency governor responsibility to handle
-    //clipping.
+    //clamping.
     EXPECT_CALL(*m_gov, adjust_platform(_)).Times(1);
     //Check frequency
     EXPECT_CALL(*m_platform_io, adjust(CPU_UNCORE_MIN_CONTROL_IDX, m_cpu_uncore_freq_min)).Times(M_NUM_PACKAGE);

--- a/test/CPUActivityAgentTest.cpp
+++ b/test/CPUActivityAgentTest.cpp
@@ -46,7 +46,6 @@ class CPUActivityAgentTest : public ::testing::Test
             QM_CTR_SCALED_RATE_IDX,
             CPU_SCALABILITY_IDX,
             CPU_UNCORE_FREQUENCY_IDX,
-            CPU_FREQUENCY_CONTROL_IDX,
             CPU_UNCORE_MIN_CONTROL_IDX,
             CPU_UNCORE_MAX_CONTROL_IDX
         };
@@ -119,8 +118,6 @@ void CPUActivityAgentTest::SetUp()
     EXPECT_CALL(*m_platform_io, push_signal("CPU_UNCORE_FREQUENCY_STATUS", _, _)).Times(M_NUM_PACKAGE);
 
     // Controls
-    ON_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MAX_CONTROL", _, _))
-        .WillByDefault(Return(CPU_FREQUENCY_CONTROL_IDX));
     ON_CALL(*m_platform_io, push_control("CPU_UNCORE_FREQUENCY_MIN_CONTROL", _, _))
         .WillByDefault(Return(CPU_UNCORE_MIN_CONTROL_IDX));
     ON_CALL(*m_platform_io, push_control("CPU_UNCORE_FREQUENCY_MAX_CONTROL", _, _))
@@ -128,7 +125,6 @@ void CPUActivityAgentTest::SetUp()
     ON_CALL(*m_platform_io, agg_function(_))
         .WillByDefault(Return(geopm::Agg::average));
 
-    EXPECT_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MAX_CONTROL", _, _)).Times(M_NUM_CORE);
     EXPECT_CALL(*m_platform_io, push_control("CPU_UNCORE_FREQUENCY_MIN_CONTROL", _, _)).Times(M_NUM_PACKAGE);
     EXPECT_CALL(*m_platform_io, push_control("CPU_UNCORE_FREQUENCY_MAX_CONTROL", _, _)).Times(M_NUM_PACKAGE);
 

--- a/test/FrequencyGovernorTest.cpp
+++ b/test/FrequencyGovernorTest.cpp
@@ -89,6 +89,7 @@ TEST_F(FrequencyGovernorTest, adjust_platform)
     m_gov->adjust_platform(request);
     bool result = m_gov->do_write_batch();
     EXPECT_TRUE(result);
+    EXPECT_EQ(m_gov->get_clamp_count(), 0);
 }
 
 TEST_F(FrequencyGovernorTest, adjust_platform_clamping)
@@ -108,8 +109,7 @@ TEST_F(FrequencyGovernorTest, adjust_platform_clamping)
     m_gov->adjust_platform(request);
     bool result = m_gov->do_write_batch();
     EXPECT_TRUE(result);
-    int clamp = m_gov->get_clamp_count();
-    EXPECT_EQ(clamp, 2);
+    EXPECT_EQ(m_gov->get_clamp_count(), 2);
 }
 
 TEST_F(FrequencyGovernorTest, adjust_platform_error)
@@ -141,8 +141,7 @@ TEST_F(FrequencyGovernorTest, frequency_bounds_in_range)
     EXPECT_DOUBLE_EQ(new_min, m_gov->get_frequency_min());
     EXPECT_DOUBLE_EQ(new_max, m_gov->get_frequency_max());
 
-    int clamp = m_gov->get_clamp_count();
-    EXPECT_EQ(result, 0);
+    EXPECT_EQ(m_gov->get_clamp_count(), 0);
 }
 
 TEST_F(FrequencyGovernorTest, frequency_bounds_invalid)

--- a/test/FrequencyGovernorTest.cpp
+++ b/test/FrequencyGovernorTest.cpp
@@ -47,7 +47,7 @@ void FrequencyGovernorTest::SetUp(void)
     ON_CALL(m_topo, num_domain(M_CTL_DOMAIN)).WillByDefault(Return(M_NUM_CORE));
     ON_CALL(m_topo, num_domain(GEOPM_DOMAIN_CPU)).WillByDefault(Return(2*M_NUM_CORE));
     ON_CALL(m_platio, read_signal("CPUINFO::FREQ_STEP", _, _)).WillByDefault(Return(M_PLAT_STEP_FREQ));
-    ON_CALL(m_platio, read_signal("CPUINFO::FREQ_MIN", _, _)).WillByDefault(Return(M_PLAT_MIN_FREQ));
+    ON_CALL(m_platio, read_signal("CPU_FREQUENCY_MIN_AVAIL", _, _)).WillByDefault(Return(M_PLAT_MIN_FREQ));
     ON_CALL(m_platio, read_signal("CPUINFO::FREQ_STICKER", _, _)).WillByDefault(Return(M_PLAT_STICKER_FREQ));
     ON_CALL(m_platio, read_signal("CPU_FREQUENCY_MAX_AVAIL", _, _)).WillByDefault(Return(M_PLAT_MAX_FREQ));
 

--- a/test/FrequencyGovernorTest.cpp
+++ b/test/FrequencyGovernorTest.cpp
@@ -108,6 +108,8 @@ TEST_F(FrequencyGovernorTest, adjust_platform_clamping)
     m_gov->adjust_platform(request);
     bool result = m_gov->do_write_batch();
     EXPECT_TRUE(result);
+    int clamp = m_gov->get_clamp_count();
+    EXPECT_EQ(clamp, 2);
 }
 
 TEST_F(FrequencyGovernorTest, adjust_platform_error)
@@ -138,6 +140,9 @@ TEST_F(FrequencyGovernorTest, frequency_bounds_in_range)
     EXPECT_FALSE(result);
     EXPECT_DOUBLE_EQ(new_min, m_gov->get_frequency_min());
     EXPECT_DOUBLE_EQ(new_max, m_gov->get_frequency_max());
+
+    int clamp = m_gov->get_clamp_count();
+    EXPECT_EQ(result, 0);
 }
 
 TEST_F(FrequencyGovernorTest, frequency_bounds_invalid)

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -316,6 +316,7 @@ if ENABLE_BETA
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_nan \
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_lower_bound_check \
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_signal_out_of_bounds \
+                   test/gtest_links/CPUActivityAgentTest.control_signal_granularity_check \
                    test/gtest_links/DaemonTest.get_default_policy \
                    test/gtest_links/DaemonTest.get_profile_policy \
                    test/gtest_links/PolicyStoreImpTest.self_consistent \

--- a/test/MockFrequencyGovernor.hpp
+++ b/test/MockFrequencyGovernor.hpp
@@ -24,6 +24,7 @@ class MockFrequencyGovernor : public geopm::FrequencyGovernor
         MOCK_METHOD(double, get_frequency_min, (), (const, override));
         MOCK_METHOD(double, get_frequency_max, (), (const, override));
         MOCK_METHOD(double, get_frequency_step, (), (const, override));
+        MOCK_METHOD(int, get_clamp_count, (), (const, override));
         MOCK_METHOD(void, validate_policy, (double &freq_min, double &freq_max),
                     (const, override));
 };


### PR DESCRIPTION
- Relates to #2645 feature change from github issues
- Fixes #2645 change request from github issues.

Update to the CPU-CA v1 to use the frequency governor for CPU frequency controls.
Uses #2658 