### PR TITLE
Fixed typo in LevelZero property assignment

### DIFF
--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -579,7 +579,7 @@ namespace geopm
                                          double range_max) const
     {
         ze_result_t ze_result;
-        zes_freq_properties_t property {};
+        zes_freq_properties_t property = {};
         zes_freq_range_t range;
         range.min = range_min;
         range.max = range_max;


### PR DESCRIPTION
Signed-off-by: Lowren Lawson <lowren.h.lawson@intel.com>

- Relates to #2565 bug report from github issues
- Fixes #2565  change request from github issues.

Simple fix for a missing assignment of default property values in frequency control