### PR TITLE
Make FrequencyGovernor accept desired domain

### DIFF
--- a/src/FrequencyGovernor.hpp
+++ b/src/FrequencyGovernor.hpp
@@ -28,6 +28,14 @@ namespace geopm
             ///        the vector to pass to adjust_platform().
             /// @return The domain with which frequency will be governed.
             virtual int frequency_domain_type(void) const = 0;
+            /// @brief Set the domain type of frequency control that will
+            ///        be used in adjust_platform(). Must be called before
+            ///        init_platform_io().
+            /// @throw Exception the requested domain does not contain the
+            ///        frequency control's native domain.
+            /// @throw Exception The caller attemped to set the domain type
+            ///        after this governor initialized its PlatformIO controls.
+            virtual void set_domain_type(int domain_type) = 0;
             /// @brief Write frequency control, may be clamped between
             ///        min and max frequency if request cannot be
             ///        satisfied.

--- a/src/FrequencyGovernorImp.hpp
+++ b/src/FrequencyGovernorImp.hpp
@@ -22,6 +22,7 @@ namespace geopm
             virtual ~FrequencyGovernorImp();
             void init_platform_io(void) override;
             int frequency_domain_type(void) const override;
+            void set_domain_type(int domain_type) override;
             void adjust_platform(const std::vector<double> &frequency_request) override;
             bool do_write_batch(void) const override;
             bool set_frequency_bounds(double freq_min, double freq_max) override;
@@ -42,6 +43,7 @@ namespace geopm
             int m_freq_ctl_domain_type;
             std::vector<int> m_control_idx;
             std::vector<double> m_last_freq;
+            bool m_is_platform_io_initialized;
     };
 }
 

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -173,6 +173,7 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/FrequencyGovernorTest.frequency_bounds_in_range \
               test/gtest_links/FrequencyGovernorTest.frequency_bounds_invalid \
               test/gtest_links/FrequencyGovernorTest.validate_policy \
+              test/gtest_links/FrequencyGovernorTest.set_domain_type \
               test/gtest_links/FrequencyMapAgentTest.adjust_platform_map \
               test/gtest_links/FrequencyMapAgentTest.adjust_platform_uncore \
               test/gtest_links/FrequencyMapAgentTest.name \

--- a/test/MockFrequencyGovernor.hpp
+++ b/test/MockFrequencyGovernor.hpp
@@ -15,6 +15,7 @@ class MockFrequencyGovernor : public geopm::FrequencyGovernor
     public:
         MOCK_METHOD(void, init_platform_io, (), (override));
         MOCK_METHOD(int, frequency_domain_type, (), (const, override));
+        MOCK_METHOD(void, set_domain_type, (int domain_type), (override));
         MOCK_METHOD(void, adjust_platform,
                     (const std::vector<double> &frequency_request), (override));
         MOCK_METHOD(bool, do_write_batch, (), (const, override));


### PR DESCRIPTION
- Add a FrequencyGovernor function that sets a new control domain to use in the governor.
- Users are allowed to specify the native domain or a more coarse domain.
- Requests to use a more fine-grained domain result in an exception.
- Resolves #2642