### PR TITLE
Added support for GPU efficient frequency signal from LevelZero

### DIFF
--- a/service/docs/source/geopm_pio_levelzero.7.rst
+++ b/service/docs/source/geopm_pio_levelzero.7.rst
@@ -23,6 +23,14 @@ Signals
     *  **Format**: double
     *  **Unit**: hertz
 
+``LEVELZERO::GPU_CORE_FREQUENCY_EFFICIENT``
+    The efficient minimum frequency of the GPU Compute Hardware.
+
+    *  **Aggregation**: average
+    *  **Domain**: gpu_chip
+    *  **Format**: double
+    *  **Unit**: hertz
+
 ``LEVELZERO::GPU_CORE_FREQUENCY_MAX_AVAIL``
     The maximum supported frequency of the GPU Compute Hardware.
 

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -410,7 +410,6 @@ namespace geopm
         return frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).throttle_reasons;
     }
 
-
     LevelZeroImp::m_frequency_s LevelZeroImp::frequency_status_helper(unsigned int l0_device_idx,
                                                                       int l0_domain, int l0_domain_idx) const
     {

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -398,11 +398,18 @@ namespace geopm
         return frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).actual;
     }
 
+    double LevelZeroImp::frequency_efficient(unsigned int l0_device_idx,
+                                             int l0_domain, int l0_domain_idx) const
+    {
+        return frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).efficient;
+    }
+
     uint32_t LevelZeroImp::frequency_throttle_reasons(unsigned int l0_device_idx,
                                                       int l0_domain, int l0_domain_idx) const
     {
         return frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).throttle_reasons;
     }
+
 
     LevelZeroImp::m_frequency_s LevelZeroImp::frequency_status_helper(unsigned int l0_device_idx,
                                                                       int l0_domain, int l0_domain_idx) const

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -49,6 +49,15 @@ namespace geopm
             /// @return GPU device core clock rate in MHz.
             virtual double frequency_status(unsigned int l0_device_idx,
                                             int l0_domain, int l0_domain_idx) const = 0;
+            /// @brief Get the LevelZero device efficient frequency in MHz
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero GPU.
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @param [in] l0_domain_idx The LevelZero index indicating a particular
+            ///        domain of the GPU.
+            /// @return GPU device efficnet clock rate in MHz.
+            virtual double frequency_efficient(unsigned int l0_device_idx,
+                                               int l0_domain, int l0_domain_idx) const = 0;
             /// @brief Get the LevelZero device mininmum frequency in MHz
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero GPU.

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -55,7 +55,7 @@ namespace geopm
             /// @param [in] l0_domain The LevelZero domain type being targeted
             /// @param [in] l0_domain_idx The LevelZero index indicating a particular
             ///        domain of the GPU.
-            /// @return GPU device efficnet clock rate in MHz.
+            /// @return GPU device efficient clock rate in MHz.
             virtual double frequency_efficient(unsigned int l0_device_idx,
                                                int l0_domain, int l0_domain_idx) const = 0;
             /// @brief Get the LevelZero device mininmum frequency in MHz

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -106,6 +106,25 @@ namespace geopm
                                             dev_subdev_idx_pair.second);
     }
 
+    double LevelZeroDevicePoolImp::frequency_efficient(int domain, unsigned int domain_idx,
+                                                       int l0_domain) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for the frequency domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        check_domain_exists(m_levelzero.frequency_domain_count(dev_subdev_idx_pair.first,
+                                                               l0_domain),
+                                                               __func__, __LINE__);
+
+        return m_levelzero.frequency_efficient(dev_subdev_idx_pair.first, l0_domain,
+                                               dev_subdev_idx_pair.second);
+    }
+
     double LevelZeroDevicePoolImp::frequency_min(int domain, unsigned int domain_idx,
                                                  int l0_domain) const
     {

--- a/service/src/LevelZeroDevicePool.hpp
+++ b/service/src/LevelZeroDevicePool.hpp
@@ -34,6 +34,14 @@ namespace geopm
             /// @return GPU device core clock rate in MHz.
             virtual double frequency_status(int domain, unsigned int domain_idx,
                                             int l0_domain) const = 0;
+            /// @brief Get the LevelZero device efficient frequency in MHz
+            /// @param [in] domain The GEOPM domain type being targeted
+            /// @param [in] domain_idx The GEOPM domain index
+            ///             (i.e. GPU being targeted)
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return GPU device efficient clock rate in MHz.
+            virtual double frequency_efficient(int domain, unsigned int domain_idx,
+                                               int l0_domain) const = 0;
             /// @brief Get the LevelZero device mininmum frequency in MHz
             /// @param [in] domain The GEOPM domain type being targeted
             /// @param [in] domain_idx The GEOPM domain index

--- a/service/src/LevelZeroDevicePoolImp.hpp
+++ b/service/src/LevelZeroDevicePoolImp.hpp
@@ -26,6 +26,8 @@ namespace geopm
 
             double frequency_status(int domain, unsigned int domain_idx,
                                     int l0_domain) const override;
+            double frequency_efficient(int domain, unsigned int domain_idx,
+                                       int l0_domain) const override;
             double frequency_min(int domain, unsigned int domain_idx,
                                  int l0_domain) const override;
             double frequency_max(int domain, unsigned int domain_idx,

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -67,6 +67,22 @@ namespace geopm
                                   },
                                   1e6
                                   }},
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_EFFICIENT", {
+                                  "The efficient minimum frequency of the GPU Compute Hardware.",
+                                  GEOPM_DOMAIN_GPU_CHIP,
+                                  Agg::expect_same,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_efficient(
+                                                   GEOPM_DOMAIN_GPU_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  1e6
+                                  }},
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL", {
                                   "The maximum supported frequency of the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -70,7 +70,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_EFFICIENT", {
                                   "The efficient minimum frequency of the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::expect_same,
+                                  Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -28,6 +28,8 @@ namespace geopm
             int frequency_domain_count(unsigned int l0_device_idx,
                                        int domain) const override;
             double frequency_status(unsigned int l0_device_idx,
+                                    int l0_domain, int l0_domain_idx) const override;
+            double frequency_efficient(unsigned int l0_device_idx,
                                        int l0_domain, int l0_domain_idx) const override;
             double frequency_min(unsigned int l0_device_idx, int l0_domain,
                                  int l0_domain_idx) const override;

--- a/service/test/LevelZeroDevicePoolTest.cpp
+++ b/service/test/LevelZeroDevicePoolTest.cpp
@@ -71,11 +71,12 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
         EXPECT_CALL(*m_levelzero, engine_domain_count(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
         for (int sub_idx = 0; sub_idx < num_subdevice_per_device; ++sub_idx) {
             EXPECT_CALL(*m_levelzero, frequency_status(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset));
-            EXPECT_CALL(*m_levelzero, frequency_min(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*10));
-            EXPECT_CALL(*m_levelzero, frequency_max(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*20));
+            EXPECT_CALL(*m_levelzero, frequency_efficient(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*10));
+            EXPECT_CALL(*m_levelzero, frequency_min(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*20));
+            EXPECT_CALL(*m_levelzero, frequency_max(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*30));
 
-            EXPECT_CALL(*m_levelzero, active_time(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*30));
-            EXPECT_CALL(*m_levelzero, active_time_timestamp(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*40));
+            EXPECT_CALL(*m_levelzero, active_time(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*40));
+            EXPECT_CALL(*m_levelzero, active_time_timestamp(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value+offset+num_gpu_subdevice*50));
             ++offset;
         }
     }
@@ -83,11 +84,12 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
 
     for (int sub_idx = 0; sub_idx < num_gpu_subdevice; ++sub_idx) {
         EXPECT_EQ(value+sub_idx, m_device_pool.frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_EQ(value+sub_idx+num_gpu_subdevice*10, m_device_pool.frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_EQ(value+sub_idx+num_gpu_subdevice*20, m_device_pool.frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ(value+sub_idx+num_gpu_subdevice*10, m_device_pool.frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ(value+sub_idx+num_gpu_subdevice*20, m_device_pool.frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ(value+sub_idx+num_gpu_subdevice*30, m_device_pool.frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
 
-        EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*30), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*40), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*40), m_device_pool.active_time(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ((uint64_t)(value+sub_idx+num_gpu_subdevice*50), m_device_pool.active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
 
         EXPECT_NO_THROW(m_device_pool.frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, value, value));
     }
@@ -121,10 +123,12 @@ TEST_F(LevelZeroDevicePoolTest, domain_error)
 
     //Frequency
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_status(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "Not supported on this hardware");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "Not supported on this hardware");
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_min(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "Not supported on this hardware");
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_max(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_COMPUTE), GEOPM_ERROR_INVALID, "Not supported on this hardware");
 
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_status(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the frequency domain");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_efficient(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the frequency domain");
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_min(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the frequency domain");
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.frequency_max(GEOPM_DOMAIN_GPU, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain "+std::to_string(GEOPM_DOMAIN_GPU)+" is not supported for the frequency domain");
 

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -697,8 +697,8 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
                     frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         // EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_STATUS
         //             frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-         EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_EFFICIENT
-                     frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_EFFICIENT
+                    frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_CALL(*m_device_pool, // GPU_CORE_THROTTLE_REASONS
                     frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_CALL(*m_device_pool, // GPU_UNCORE_ACTIVE_TIME

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -159,7 +159,7 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
                     frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_STATUS
                     frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_STATUS
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_EFFICIENT
                     frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_CALL(*m_device_pool, // GPU_CORE_THROTTLE_REASONS
                     frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));

--- a/service/test/MockLevelZero.hpp
+++ b/service/test/MockLevelZero.hpp
@@ -21,6 +21,8 @@ class MockLevelZero : public geopm::LevelZero
                     (const, override));
         MOCK_METHOD(double, frequency_status, (unsigned int, int, int),
                     (const, override));
+        MOCK_METHOD(double, frequency_efficient, (unsigned int, int, int),
+                    (const, override));
         MOCK_METHOD(double, frequency_min, (unsigned int, int, int),
                     (const, override));
         MOCK_METHOD(double, frequency_max, (unsigned int, int, int),

--- a/service/test/MockLevelZeroDevicePool.hpp
+++ b/service/test/MockLevelZeroDevicePool.hpp
@@ -18,6 +18,8 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
 
         MOCK_METHOD(double, frequency_status,
                     (int, unsigned int, int), (const, override));
+        MOCK_METHOD(double, frequency_efficient,
+                    (int, unsigned int, int), (const, override));
         MOCK_METHOD(double, frequency_min,
                     (int, unsigned int, int), (const, override));
         MOCK_METHOD(double, frequency_max,


### PR DESCRIPTION
- Relates to #2661 feature request from github issues
- Fixes #2661 change request from github issues.

Provides the user with the LEVELZERO::GPU_FREQUENCY_EFFICIENT signal, which pulls the [zes_freq_state_t.efficient](https://spec.oneapi.io/level-zero/latest/sysman/api.html#_CPPv416zes_freq_state_t) value. 

This provides administrators & agents an idea of the efficient frequency of a GPU without having to characterize each individual GPU, though characterization may provide better overall information for a specific set of workloads. 

Before merge:
- [x] update documentation with information on new signal
- [x] Update unit tests