### PR TITLE
Add a CLOS Governor

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -455,6 +455,9 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/SampleAggregatorImp.hpp \
                             src/Scheduler.cpp \
                             src/Scheduler.hpp \
+                            src/SSTClosGovernor.cpp \
+                            src/SSTClosGovernor.hpp \
+                            src/SSTClosGovernorImp.hpp \
                             src/Tracer.cpp \
                             src/Tracer.hpp \
                             src/TreeComm.cpp \

--- a/src/SSTClosGovernor.cpp
+++ b/src/SSTClosGovernor.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "SSTClosGovernor.hpp"
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include "SSTClosGovernorImp.hpp"
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm/PlatformIO.hpp"
+#include "geopm/PlatformTopo.hpp"
+
+#include "config.h"
+
+namespace geopm
+{
+    std::unique_ptr<SSTClosGovernor> SSTClosGovernor::make_unique(void)
+    {
+        return geopm::make_unique<SSTClosGovernorImp>();
+    }
+
+    std::shared_ptr<SSTClosGovernor> SSTClosGovernor::make_shared(void)
+    {
+        return std::make_shared<SSTClosGovernorImp>();
+    }
+
+    SSTClosGovernorImp::SSTClosGovernorImp()
+        : SSTClosGovernorImp(platform_io(), platform_topo())
+    {
+    }
+
+    SSTClosGovernorImp::SSTClosGovernorImp(PlatformIO &platform_io, const PlatformTopo &platform_topo)
+        : m_platform_io(platform_io)
+        , m_platform_topo(platform_topo)
+        , m_do_write_batch(false)
+        , m_is_enabled(true)
+        , m_clos_assoc_ctl_domain_type(m_platform_io.control_domain_type("SST::COREPRIORITY:ASSOCIATION"))
+        , m_num_clos_assoc_ctl_domain(m_platform_topo.num_domain(m_clos_assoc_ctl_domain_type))
+        , m_clos_config_ctl_domain_type(m_platform_io.control_domain_type("SST::COREPRIORITY:0:FREQUENCY_MIN"))
+        , m_num_clos_config_ctl_domain(m_platform_topo.num_domain(m_clos_config_ctl_domain_type))
+        , m_frequency_min(m_platform_io.read_signal("CPU_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD, 0))
+        , m_frequency_sticker(m_platform_io.read_signal("CPU_FREQUENCY_STICKER", GEOPM_DOMAIN_BOARD, 0))
+        , m_frequency_max(m_platform_io.read_signal("CPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD, 0))
+        , m_last_clos(m_num_clos_assoc_ctl_domain, HIGH_PRIORITY)
+    {
+    }
+
+    bool SSTClosGovernor::is_supported(PlatformIO &platform_io)
+    {
+        bool result = false;
+
+        try {
+            result = platform_io.read_signal("SST::COREPRIORITY_SUPPORT:CAPABILITIES",
+                                             GEOPM_DOMAIN_BOARD, 0) > 0;
+            result &= platform_io.read_signal("SST::TURBOFREQ_SUPPORT:SUPPORTED",
+                                              GEOPM_DOMAIN_BOARD, 0) > 0;
+        }
+        catch (...) {
+            result = false;
+        }
+
+        return result;
+    }
+
+    void SSTClosGovernorImp::init_platform_io(void)
+    {
+        for (size_t ctl_idx = 0; ctl_idx < m_num_clos_assoc_ctl_domain; ++ctl_idx) {
+            m_clos_control_idx.push_back(m_platform_io.push_control(
+                "SST::COREPRIORITY:ASSOCIATION",
+                m_clos_assoc_ctl_domain_type,
+                static_cast<int>(ctl_idx)));
+        }
+        // Increase the turbo ratio limits so we can take advantage of the
+        // increased range offered by SST-TF
+        m_platform_io.write_control("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0",
+                                    GEOPM_DOMAIN_BOARD, 0, 255e8);
+        m_platform_io.write_control("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_1",
+                                    GEOPM_DOMAIN_BOARD, 0, 255e8);
+        m_platform_io.write_control("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_2",
+                                    GEOPM_DOMAIN_BOARD, 0, 255e8);
+        m_platform_io.write_control("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_3",
+                                    GEOPM_DOMAIN_BOARD, 0, 255e8);
+        m_platform_io.write_control("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_4",
+                                    GEOPM_DOMAIN_BOARD, 0, 255e8);
+        m_platform_io.write_control("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_5",
+                                    GEOPM_DOMAIN_BOARD, 0, 255e8);
+        m_platform_io.write_control("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_6",
+                                    GEOPM_DOMAIN_BOARD, 0, 255e8);
+        m_platform_io.write_control("MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_7",
+                                    GEOPM_DOMAIN_BOARD, 0, 255e8);
+
+        // Start everything in the high-priority class of service.
+        m_platform_io.write_control("SST::COREPRIORITY:ASSOCIATION",
+                                    GEOPM_DOMAIN_BOARD, 0, HIGH_PRIORITY);
+
+        enable_sst_turbo_prioritization();
+
+        // Highest priority bucket. Start by distributing at the bottom of the
+        // turbo range, but give high priority to distribute up to max.
+        m_platform_io.write_control("SST::COREPRIORITY:0:PRIORITY",
+                                    GEOPM_DOMAIN_BOARD, 0, 0.0);
+        m_platform_io.write_control("SST::COREPRIORITY:0:FREQUENCY_MIN",
+                                    GEOPM_DOMAIN_BOARD, 0, m_frequency_sticker);
+        m_platform_io.write_control("SST::COREPRIORITY:0:FREQUENCY_MAX",
+                                    GEOPM_DOMAIN_BOARD, 0, m_frequency_max);
+
+        // Next-highest bucket. Apply the same ranges, but with less priority.
+        m_platform_io.write_control("SST::COREPRIORITY:1:PRIORITY",
+                                    GEOPM_DOMAIN_BOARD, 0, 0.34);
+        m_platform_io.write_control("SST::COREPRIORITY:1:FREQUENCY_MIN",
+                                    GEOPM_DOMAIN_BOARD, 0, m_frequency_sticker);
+        m_platform_io.write_control("SST::COREPRIORITY:1:FREQUENCY_MAX",
+                                    GEOPM_DOMAIN_BOARD, 0, m_frequency_max);
+
+        // First low-priority bucket. Initially just give it the bottom of the
+        // turbo range. Potentially go lower at run time.
+        m_platform_io.write_control("SST::COREPRIORITY:2:PRIORITY",
+                                    GEOPM_DOMAIN_BOARD, 0, 0.67);
+        m_platform_io.write_control("SST::COREPRIORITY:2:FREQUENCY_MIN",
+                                    GEOPM_DOMAIN_BOARD, 0, m_frequency_sticker);
+        m_platform_io.write_control("SST::COREPRIORITY:2:FREQUENCY_MAX",
+                                    GEOPM_DOMAIN_BOARD, 0, (m_frequency_sticker + m_frequency_max) / 2);
+
+        // Least prioritized bucket. Initially just give it the bottom of the
+        // turbo range. Potentially go lower at run time.
+        m_platform_io.write_control("SST::COREPRIORITY:3:PRIORITY",
+                                    GEOPM_DOMAIN_BOARD, 0, 1.0);
+        m_platform_io.write_control("SST::COREPRIORITY:3:FREQUENCY_MIN",
+                                    GEOPM_DOMAIN_BOARD, 0, m_frequency_sticker);
+        m_platform_io.write_control("SST::COREPRIORITY:3:FREQUENCY_MAX",
+                                    GEOPM_DOMAIN_BOARD, 0, m_frequency_sticker);
+    }
+
+    int SSTClosGovernorImp::clos_domain_type(void) const
+    {
+        return m_clos_assoc_ctl_domain_type;
+    }
+
+    void SSTClosGovernorImp::adjust_platform(
+        const std::vector<double> &clos_by_core)
+    {
+        if (clos_by_core.size() != m_num_clos_assoc_ctl_domain) {
+            throw Exception("SSTClosGovernorImp::" + std::string(__func__) +
+                                "(): size of request vector does not match size of control domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        m_do_write_batch = m_is_enabled && clos_by_core != m_last_clos;
+        if (m_is_enabled) {
+            for (size_t idx = 0; idx < m_num_clos_assoc_ctl_domain; ++idx) {
+                m_platform_io.adjust(m_clos_control_idx[idx], clos_by_core[idx]);
+            }
+            m_last_clos = clos_by_core;
+        }
+    }
+
+    bool SSTClosGovernorImp::do_write_batch(void) const
+    {
+        return m_do_write_batch;
+    }
+
+    void SSTClosGovernorImp::enable_sst_turbo_prioritization()
+    {
+        // Enable prioritized turbo by cores
+        m_platform_io.write_control("SST::COREPRIORITY_ENABLE:ENABLE",
+                                    GEOPM_DOMAIN_BOARD, 0, 1);
+
+        // Enable the ability to extend the turbo range of high priority cores
+        // by decreasing the turbo range of low priority cores
+        m_platform_io.write_control("SST::TURBO_ENABLE:ENABLE",
+                                    GEOPM_DOMAIN_BOARD, 0, 1);
+
+        m_is_enabled = true;
+    }
+
+    void SSTClosGovernorImp::disable_sst_turbo_prioritization()
+    {
+        m_is_enabled = false;
+
+        // Disable the ability to extend the turbo range of high priority cores
+        // by decreasing the turbo range of low priority cores
+        m_platform_io.write_control("SST::TURBO_ENABLE:ENABLE",
+                                    GEOPM_DOMAIN_BOARD, 0, 0);
+
+        // Disable prioritized turbo by cores
+        m_platform_io.write_control("SST::COREPRIORITY_ENABLE:ENABLE",
+                                    GEOPM_DOMAIN_BOARD, 0, 0);
+    }
+}

--- a/src/SSTClosGovernor.hpp
+++ b/src/SSTClosGovernor.hpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef SSTCLOSGOVERNOR_HPP_INCLUDE
+#define SSTCLOSGOVERNOR_HPP_INCLUDE
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace geopm
+{
+    class PlatformIO;
+    class PlatformTopo;
+
+    /// Govern class of service (CLOS) controls.
+    class SSTClosGovernor
+    {
+        public:
+            enum ClosLevel_e {
+                HIGH_PRIORITY = 0,
+                MEDIUM_HIGH_PRIORITY = 1,
+                MEDIUM_LOW_PRIORITY = 2,
+                LOW_PRIORITY = 3,
+            };
+
+            SSTClosGovernor() = default;
+            virtual ~SSTClosGovernor() = default;
+
+            /// @brief Registers signals and controls with PlatformIO using the
+            ///        default control domain.
+            virtual void init_platform_io(void) = 0;
+
+            /// @brief Get the domain type of CLOS control on the
+            ///        platform.  Users of the SSTClosGovernor can
+            ///        use this information to determine the size of
+            ///        the vector to pass to adjust_platform().
+            /// @return The domain with which CLOS will be governed.
+            virtual int clos_domain_type(void) const = 0;
+
+            /// @brief Write CLOS controls
+            /// @param [in] clos_by_core Desired per-core CLOS.
+            virtual void adjust_platform(const std::vector<double> &clos_by_core) = 0;
+
+            /// @brief Returns true if the last call to adjust_platform
+            ///        requires writing controls.
+            /// @return True if platform adjustments have been made, false otherwise.
+            virtual bool do_write_batch(void) const = 0;
+
+            /// Enable prioritized turbo frequency and core priority
+            /// features. This is a no-op if those features are not supported
+            /// on the platform.
+            virtual void enable_sst_turbo_prioritization() = 0;
+
+            /// Disable prioritized turbo frequency and core priority
+            /// features. This is a no-op if those features are not supported
+            /// on the platform.
+            virtual void disable_sst_turbo_prioritization() = 0;
+
+            /// Indicate whether this platform supports core priority and
+            /// prioritized turbo frequency limits.
+            static bool is_supported(PlatformIO &platform_io);
+
+            static std::unique_ptr<SSTClosGovernor> make_unique(void);
+            static std::shared_ptr<SSTClosGovernor> make_shared(void);
+    };
+}
+
+#endif // SSTCLOSGOVERNOR_HPP_INCLUDE

--- a/src/SSTClosGovernorImp.hpp
+++ b/src/SSTClosGovernorImp.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef SSTCLOSGOVERNORIMP_HPP_INCLUDE
+#define SSTCLOSGOVERNORIMP_HPP_INCLUDE
+
+#include "SSTClosGovernor.hpp"
+
+namespace geopm
+{
+    class SSTClosGovernorImp : public SSTClosGovernor
+    {
+        public:
+            SSTClosGovernorImp();
+            SSTClosGovernorImp(PlatformIO &platform_io, const PlatformTopo &platform_topo);
+            virtual ~SSTClosGovernorImp() = default;
+            void init_platform_io(void) override;
+            int clos_domain_type(void) const override;
+            void adjust_platform(const std::vector<double> &clos_by_core) override;
+            bool do_write_batch(void) const override;
+
+            // No-op if sst-tf is not supported. Mods both tf and cp
+            void enable_sst_turbo_prioritization() override;
+            void disable_sst_turbo_prioritization() override;
+
+        private:
+            PlatformIO &m_platform_io;
+            const PlatformTopo &m_platform_topo;
+            bool m_do_write_batch;
+            bool m_is_enabled;
+            int m_clos_assoc_ctl_domain_type;
+            size_t m_num_clos_assoc_ctl_domain;
+            int m_clos_config_ctl_domain_type;
+            size_t m_num_clos_config_ctl_domain;
+            double m_frequency_min;
+            double m_frequency_sticker;
+            double m_frequency_max;
+            std::vector<int> m_clos_control_idx;
+            std::vector<int> m_frequency_control_idx;
+            std::vector<double> m_last_clos;
+    };
+}
+
+#endif // SSTCLOSGOVERNORIMP_HPP_INCLUDE

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -272,6 +272,10 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/SchedTest.test_proc_cpuset_6 \
               test/gtest_links/SchedTest.test_proc_cpuset_7 \
               test/gtest_links/SchedTest.test_proc_cpuset_8 \
+              test/gtest_links/SSTClosGovernorTest.is_supported \
+              test/gtest_links/SSTClosGovernorTest.govern \
+              test/gtest_links/SSTClosGovernorTest.enable \
+              test/gtest_links/SSTClosGovernorTest.disable \
               test/gtest_links/SSTFrequencyLimitDetectorTest.returns_single_core_limit_by_default \
               test/gtest_links/SSTFrequencyLimitDetectorTest.returns_max_observed_frequency_when_sst_disabled \
               test/gtest_links/SSTFrequencyLimitDetectorTest.detects_nearest_license_level_limit_bucket_0 \
@@ -419,6 +423,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/MockReporter.hpp \
                           test/MockSampleAggregator.hpp \
                           test/MockSharedMemory.hpp \
+                          test/MockSSTClosGovernor.hpp \
                           test/MockTracer.hpp \
                           test/MockTreeComm.hpp \
                           test/MockTreeCommLevel.hpp \
@@ -440,6 +445,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/ReporterTest.cpp \
                           test/SampleAggregatorTest.cpp \
                           test/SchedTest.cpp \
+                          test/SSTClosGovernorTest.cpp \
                           test/SSTFrequencyLimitDetectorTest.cpp \
                           test/TracerTest.cpp \
                           test/TreeCommLevelTest.cpp \

--- a/test/MockSSTClosGovernor.hpp
+++ b/test/MockSSTClosGovernor.hpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOCKSSTCLOSGOVERNOR_HPP_INCLUDE
+#define MOCKSSTCLOSGOVERNOR_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "SSTClosGovernor.hpp"
+
+class MockSSTClosGovernor : public geopm::SSTClosGovernor
+{
+    public:
+        MOCK_METHOD(void, init_platform_io, (), (override));
+        MOCK_METHOD(int, clos_domain_type, (), (const, override));
+        MOCK_METHOD(void, adjust_platform,
+                    (const std::vector<double> &clos_by_core), (override));
+        MOCK_METHOD(bool, do_write_batch, (), (const, override));
+        MOCK_METHOD(void, enable_sst_turbo_prioritization, (), (override));
+        MOCK_METHOD(void, disable_sst_turbo_prioritization, (), (override));
+};
+
+#endif // MOCKSSTCLOSGOVERNOR_HPP_INCLUDE

--- a/test/SSTClosGovernorTest.cpp
+++ b/test/SSTClosGovernorTest.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "SSTClosGovernor.hpp"
+
+#include <memory>
+#include <stdexcept>
+
+#include "gmock/gmock-matchers.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "MockPlatformIO.hpp"
+#include "MockPlatformTopo.hpp"
+#include "SSTClosGovernorImp.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm_test.hpp"
+#include "geopm_topo.h"
+
+using geopm::SSTClosGovernor;
+using geopm::SSTClosGovernorImp;
+using ::testing::_;
+using ::testing::Expectation;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::Throw;
+
+const int CLOS_CONTROL_IDX = 100;
+
+const int CORE_COUNT = 4;
+const int PACKAGE_COUNT = 1;
+const double MIN_FREQ = 1e9;
+const double STICKER_FREQ = 2e9;
+const double MAX_FREQ = 3e9;
+
+class SSTClosGovernorTest : public ::testing::Test
+{
+    protected:
+        void SetUp(void);
+
+        MockPlatformIO m_platform_io;
+        MockPlatformTopo m_platform_topo;
+        const double M_PKG_POWER_MIN = 50;
+        const double M_PKG_POWER_MAX = 300;
+        const double M_PKG_POWER_WIN = 0.015;
+        std::vector<double> m_expected_power;
+        std::unique_ptr<SSTClosGovernor> m_governor;
+};
+
+void SSTClosGovernorTest::SetUp(void)
+{
+    ON_CALL(m_platform_io, control_domain_type("SST::COREPRIORITY:ASSOCIATION"))
+        .WillByDefault(Return(GEOPM_DOMAIN_CORE));
+    ON_CALL(m_platform_topo, num_domain(GEOPM_DOMAIN_CORE))
+        .WillByDefault(Return(CORE_COUNT));
+    ON_CALL(m_platform_io, control_domain_type("SST::COREPRIORITY:0:FREQUENCY_MIN"))
+        .WillByDefault(Return(GEOPM_DOMAIN_PACKAGE));
+    ON_CALL(m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .WillByDefault(Return(PACKAGE_COUNT));
+
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_MIN_AVAIL", _, _))
+        .WillByDefault(Return(MIN_FREQ));
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_STICKER", _, _))
+        .WillByDefault(Return(STICKER_FREQ));
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_MAX_AVAIL", _, _))
+        .WillByDefault(Return(MAX_FREQ));
+
+    ON_CALL(m_platform_io, push_control("SST::COREPRIORITY:ASSOCIATION", GEOPM_DOMAIN_CORE, _))
+        .WillByDefault(Invoke([](const std::string &, int, int core) { return CLOS_CONTROL_IDX + core; }));
+
+    m_governor = geopm::make_unique<SSTClosGovernorImp>(m_platform_io, m_platform_topo);
+    m_governor->init_platform_io();
+}
+
+TEST_F(SSTClosGovernorTest, is_supported)
+{
+    EXPECT_CALL(m_platform_io, read_signal("SST::COREPRIORITY_SUPPORT:CAPABILITIES", _, _))
+        .WillOnce(Return(1))
+        .WillOnce(Return(1))
+        .WillOnce(Throw(std::runtime_error("injected error")));
+    EXPECT_CALL(m_platform_io, read_signal("SST::TURBOFREQ_SUPPORT:SUPPORTED", _, _))
+        .WillOnce(Return(1))
+        .WillOnce(Return(0));
+
+    EXPECT_TRUE(SSTClosGovernor::is_supported(m_platform_io));
+    EXPECT_FALSE(SSTClosGovernor::is_supported(m_platform_io));
+    EXPECT_FALSE(SSTClosGovernor::is_supported(m_platform_io));
+}
+
+TEST_F(SSTClosGovernorTest, govern)
+{
+    EXPECT_FALSE(m_governor->do_write_batch());
+    EXPECT_CALL(m_platform_io, adjust(CLOS_CONTROL_IDX + 0, 3));
+    EXPECT_CALL(m_platform_io, adjust(CLOS_CONTROL_IDX + 1, 2));
+    EXPECT_CALL(m_platform_io, adjust(CLOS_CONTROL_IDX + 2, 1));
+    EXPECT_CALL(m_platform_io, adjust(CLOS_CONTROL_IDX + 3, 0));
+    m_governor->adjust_platform({3, 2, 1, 0});
+    EXPECT_TRUE(m_governor->do_write_batch());
+
+    // Wrong-sized inputs
+    EXPECT_THROW(m_governor->adjust_platform({1, 2, 3}), geopm::Exception);
+    EXPECT_THROW(m_governor->adjust_platform({1, 2, 3, 2, 1}), geopm::Exception);
+}
+
+TEST_F(SSTClosGovernorTest, enable)
+{
+
+    Expectation sst_cp_enable = EXPECT_CALL(m_platform_io, write_control("SST::COREPRIORITY_ENABLE:ENABLE", _, _, 1));
+    EXPECT_CALL(m_platform_io, write_control("SST::TURBO_ENABLE:ENABLE", _, _, 1))
+        .After(sst_cp_enable);
+    m_governor->enable_sst_turbo_prioritization();
+}
+
+TEST_F(SSTClosGovernorTest, disable)
+{
+    Expectation sst_tf_disable = EXPECT_CALL(m_platform_io, write_control("SST::TURBO_ENABLE:ENABLE", _, _, 0));
+    EXPECT_CALL(m_platform_io, write_control("SST::COREPRIORITY_ENABLE:ENABLE", _, _, 0))
+        .After(sst_tf_disable);
+    m_governor->disable_sst_turbo_prioritization();
+}


### PR DESCRIPTION
- Resolves #2665
- Offers a control abstraction similar to power and frequency governors, but interacts with class of service controls from SSTIOGroup.