### PR TITLE
Explain errors in the include guard checker

### DIFF
--- a/.github/include_guards.sh
+++ b/.github/include_guards.sh
@@ -11,6 +11,7 @@ for file in $(find $DIR -name "*.h" -o -name "*.hpp"); do
     guard=$(basename $file | sed "s|\.|_|g" | tr 'a-z' 'A-Z')_INCLUDE
     if [ $(grep -c $guard $file) -lt 2 ]; then
         echo "$file has missing or incorrect include guard"
+        echo "Expected: $guard"
         ret=1
     fi
 done


### PR DESCRIPTION
Print the expected include guard when the include-guard check fails