### PR TITLE
Initial config for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,53 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-json
+    -   id: check-added-large-files
+-   repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.13.0
+    hooks:
+    # Following only exists on non-EOL Python versions
+    #-   id: check-metaschema
+    #    name: "Check MSR Definition Format"
+    #    files: json_schemas/[^/]+\.schema\.json$
+    -   id: check-jsonschema
+        name: "Check MSR Definition Format"
+        files: IGNOREFORNOW/msr_[^/]+\.json$
+        args: ["--schemafile", "service/json_schemas/msrs.schema.json"]
+-   repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+    -   id: rst-backticks
+    -   id: rst-directive-colons
+    -   id: rst-inline-touching-normal
+-   repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
+    hooks:
+    -   id: flake8
+        args: ["--max-line-length=120", "--extend-ignore=E261"]
+-   repo: https://github.com/pycqa/bandit
+    rev: '1.7.0'
+    hooks:
+    -   id: bandit
+        # Only gate high-severity issues
+        args: ["-lll"]
+-   repo: https://github.com/codespell-project/codespell
+    rev: 'v2.2.0'
+    hooks:
+    -   id: codespell
+        args: ["--ignore-words-list", "atleast,clos"]
+-   repo: local
+    hooks:
+    -   id: geopm-license
+        name: GEOPM License Checks
+        description: This hook checks whether files have the right license header.
+        pass_filenames: false
+        entry: ./check-precommit-license
+        language: script
+        types: [file]

--- a/check-precommit-license
+++ b/check-precommit-license
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# This pre-commit hook checks common, low-cost-to-test continuous-integration
+# or code review rejection reasons.
+#
+# To enable this hook, install as "${GEOPM_SOURCE}/.git/hook/pre-commit"
+skiplicensecheck=$(git config --type=bool hooks.geopm.skiplicensecheck)
+
+exec 1>&2
+
+TOPLEVEL="$(git rev-parse --show-toplevel)"
+TESTLICENSE="${TOPLEVEL}/copying_headers/test-license"
+
+if [ "$skiplicensecheck" != "true" ]
+then
+        # Ensure a manifest exists. This skips all of the extra checks in
+        # autogen.sh since this script already assumes we're in a git repo.
+        git ls-tree --full-tree -r HEAD | awk '{print $4}' | sort > "${TOPLEVEL}/MANIFEST"
+
+        # Ensure the `man` symlink is valid, even if we didn't already build
+        # documentation output.
+        manlink=$(readlink "${TOPLEVEL}/man")
+        manlink_rc=$?
+        if [ "$manlink_rc" -eq 0 ]
+        then
+                mkdir -p "${TOPLEVEL}/${manlink}"
+        else
+                # The symlink is a workaround for some other documentation
+                # build things. This warning is expected to be emitted if we
+                # move past this workaround at some point.
+                echo "Warning: unable to find 'man' in the repository"
+        fi
+
+        check_output=$("$TESTLICENSE" "$TOPLEVEL" 2>&1)
+        check_rc=$?
+        if [ "$check_rc" -ne 0 ]
+        then
+                cat <<\EOF
+Error: Failed the GEOPM license check. You can disable this check using:
+    git config hooks.geopm.skiplicensecheck true
+
+License check output:
+EOF
+                echo "$check_output"
+                exit 1
+        fi
+fi

--- a/service/docs/source/devel.rst
+++ b/service/docs/source/devel.rst
@@ -277,10 +277,22 @@ Avoid preprocessor macros as much as possible (use enum not #define).
 Preprocessor usage should be reserved for expressing configure time
 options.
 
+Pre-Commit Checks
+-----------------
+This repository includes a configuration for `pre-commit
+<https://pre-commit.com/>`_ that uses some of their standard hooks that are
+relevant to GEOPM, and adds a hook that performs the GEOPM license checks.
+
+To install the pre-commit infrastructure and our configuration::
+
+    pip install pre-commit
+    pre-commit install
+
+Now whenever you make a commit, it will automatically perform some of the less
+time-consuming tests we have available in this repository.
 
 License Headers
 ---------------
-
 Introducing a new file requires a license comment in its header with a
 corresponding copying_headers/header.\ * file.  The new file path must
 be listed in the corresponding copying_headers/MANIFEST.* file.  This


### PR DESCRIPTION
- Add an initial configuration for pre-commit.com checks to run on this repository
- Related to #2530

Some of these pre-commit tests fail on the current contents of the repo. Some pre-work exists to resolve those failures.

To run a single check on all files in the repo, use the `--all-files` option in `pre-commit run`. E.g., for the geopm license checks (that one succeeds for all files right now):

```
pre-commit run geopm-license --all-files
```

Or to find issues with rst file backtick usage:

```
pre-commit run rst-backticks --all-files
```