### PR TITLE
Removed unused variable in Option parser

### DIFF
--- a/src/OptionParser.cpp
+++ b/src/OptionParser.cpp
@@ -77,13 +77,11 @@ namespace geopm
         std::vector<struct option> long_options;
         std::string short_options;
 
-        int idx = 0;
         for (const auto &conf : m_bool_opts) {
             std::string name = conf.first;
             const struct m_opt_parse_s<bool> &opt = conf.second;
             short_options += opt.short_form;
             long_options.push_back({opt.long_form.c_str(), no_argument, NULL, opt.short_form});
-            ++idx;
         }
         for (const auto &conf : m_str_opts) {
             std::string name = conf.first;


### PR DESCRIPTION
Signed-off-by: lowren.h.lawson@intel.com <lowren.h.lawson@intel.com>

- Relates to #2684 bug report from github issues
- Fixes #2684 2684 change request from github issues.

Simple clean-up of unused variable.