### PR TITLE
Update the CPU-CA to use the ConstConfigIOGroup

### DIFF
--- a/integration/experiment/energy_efficiency/cpu_activity.py
+++ b/integration/experiment/energy_efficiency/cpu_activity.py
@@ -19,20 +19,7 @@ from experiment import machine
 
 def setup_run_args(parser):
     common_args.setup_run_args(parser)
-    parser.add_argument('--cpu-frequency-efficient', dest='cpu_fe',
-                        action='store', default='nan',
-                        help='The efficient frequency of the cpu (a.k.a. Fce) for this experiment')
-    parser.add_argument('--cpu-frequency-max', dest='cpu_fmax',
-                        action='store', default='nan',
-                        help='The maximum frequency of the cpu (a.k.a. Fcmax) for this experiment')
-    parser.add_argument('--uncore-frequency-efficient', dest='uncore_fe',
-                        action='store', default='nan',
-                        help='The efficient frequency of the uncore (a.k.a. Fue) for this experiment')
-    parser.add_argument('--uncore-frequency-max', dest='uncore_fmax',
-                        action='store', default='nan',
-                        help='The maximum frequency of the uncore (a.k.a. Fumax) for this experiment')
-    parser.add_argument('--uncore-mbm-list', nargs='+', help='A list of uncore_freq & max_mem_bw values in the form uncore_freq_0 max_mem_bw_0 uncore_freq_1 ...')
-    parser.add_argument('--phi-list', nargs='+', help='A space separated list of phi values (0 to 1.0) to use')
+    parser.add_argument('--phi-list', nargs='+', help='A space seperated list of phi values (0 to 1.0) to use')
 
 def report_signals():
     return []
@@ -40,21 +27,7 @@ def report_signals():
 def trace_signals():
     return []
 
-def launch_configs(output_dir, app_conf, cpu_fe, cpu_fmax, uncore_fe,
-                    uncore_fmax, uncore_mbm_list, phi_list):
-
-    mach = machine.init_output_dir(output_dir)
-    sys_min = mach.frequency_min()
-    sys_max = mach.frequency_max()
-    sys_sticker = mach.frequency_sticker()
-
-    uncore_mbm_policy = {}
-    if uncore_mbm_list is not None:
-        for idx,val in enumerate(uncore_mbm_list):
-            if (idx % 2) == 0:
-                uncore_mbm_policy["CPU_UNCORE_FREQ_{}".format(int(idx / 2))] = float(val)
-            else:
-                uncore_mbm_policy["MAX_MEMORY_BANDWIDTH_{}".format(int((idx - 1) / 2))] = float(val)
+def launch_configs(output_dir, app_conf, phi_list):
 
     phi_values = []
     if phi_list is not None:
@@ -62,13 +35,8 @@ def launch_configs(output_dir, app_conf, cpu_fe, cpu_fmax, uncore_fe,
     else:
         phi_values = [x/10 for x in list(range(0,11))]
 
-    config_list = [{"CPU_FREQ_MAX" : float(cpu_fmax), "CPU_FREQ_EFFICIENT": float(cpu_fe),
-                    "CPU_UNCORE_FREQ_MAX" : float(uncore_fmax), "CPU_UNCORE_FREQ_EFFICIENT" : float(uncore_fe),
-                    "CPU_PHI" : float(phi)} for phi in phi_values]
+    config_list = [{"CPU_PHI" : float(phi)} for phi in phi_values]
     config_names = ['phi'+str(int(phi*100)) for phi in phi_values]
-
-    for config in config_list:
-        config.update(uncore_mbm_policy)
 
     targets = []
 
@@ -89,8 +57,7 @@ def launch(app_conf, args, experiment_cli_args):
                                                     trace_signals=trace_signals())
     extra_cli_args += experiment_cli_args
 
-    targets = launch_configs(output_dir, app_conf, args.cpu_fe, args.cpu_fmax, args.uncore_fe,
-                                args.uncore_fmax, args.uncore_mbm_list, args.phi_list)
+    targets = launch_configs(output_dir, app_conf, args.phi_list)
 
     launch_util.launch_all_runs(targets=targets,
                                 num_nodes=args.node_count,

--- a/integration/experiment/energy_efficiency/cpu_activity.py
+++ b/integration/experiment/energy_efficiency/cpu_activity.py
@@ -19,7 +19,7 @@ from experiment import machine
 
 def setup_run_args(parser):
     common_args.setup_run_args(parser)
-    parser.add_argument('--phi-list', nargs='+', help='A space seperated list of phi values (0 to 1.0) to use')
+    parser.add_argument('--phi-list', nargs='+', help='A space separated list of phi values (0 to 1.0) to use')
 
 def report_signals():
     return []

--- a/integration/test/test_cpu_activity_agent.py
+++ b/integration/test/test_cpu_activity_agent.py
@@ -171,7 +171,9 @@ class TestIntegration_cpu_activity(unittest.TestCase):
         json_config = json.dumps(uncore_config, indent=4)
         with open("const_config_io-ca.json", "w") as outfile:
             outfile.write(json_config)
-        os.environ["GEOPM_CONST_CONFIG_PATH"] = "const_config_io-ca.json"
+
+        const_path = Path('const_config_io-ca.json').resolve()
+        os.environ["GEOPM_CONST_CONFIG_PATH"] = str(const_path)
 
         ################################
         # CPU Activity Agent phi sweep #

--- a/service/docs/source/geopm_agent_cpu_activity.7.rst
+++ b/service/docs/source/geopm_agent_cpu_activity.7.rst
@@ -16,8 +16,7 @@ based upon the compute activity of each CPU as provided by the
 CPU_COMPUTE_ACTIVITY signal and modified by the CPU_UTILIZATION signal.
 
 The agent scales the core frequency in the range of ``Fce`` to ``Fcmax``, where
-``Fcmax`` is provided via the policy as ``CPU_FREQ_MAX`` and ``Fce`` is provided via
-the policy as ``CPU_FREQ_EFFICIENT``.
+``Fcmax`` and ``Fce`` are provided via the ConstConfigIOGroup.
 
 Low compute activity regions (compute activity of 0.0) run at the ``Fce`` frequency,
 high activity regions (compute activity of 1.0) run at the ``Fcmax`` frequency,
@@ -29,8 +28,7 @@ The ``CPU_COMPUTE_ACTIVITY`` is defined as a derivative signal based on the MSR:
 scalability metric.
 
 The agent also scales the uncore frequency in the range of ``Fue`` to
-``Fumax``, where ``Fumax`` is provided via the policy as ``CPU_UNCORE_FREQ_MAX``
-and ``Fue`` is provided via the policy as ``CPU_UNCORE_FREQ_EFFICIENT``.
+``Fumax``, where ``Fumax`` and ``Fue`` are povided via the ConstConfigIOGroup
 
 Low uncore activity regions (uncore activity of 0.0) run at the ``Fue`` frequency,
 high activity regions (uncore activity of 1.0) run at the ``Fumax`` frequency,
@@ -56,10 +54,10 @@ upon user/admin preference.
 The agent provides an optional input of ``phi`` that allows for biasing the
 frequency range for both domains used by the agent.  The default ``phi`` value of 0.5 provides frequency
 selection in the full range from ``Fe`` to ``Fmax``.  A ``phi`` value less than 0.5 biases the
-agent towards higher frequencies by increasing the ``Fe`` value provided by the policy.
+agent towards higher frequencies by increasing the ``Fe`` value.
 In the extreme case (``phi`` of 0) ``Fe`` will be raised to ``Fmax``.  A ``phi`` value greater than
-0.5 biases the agent towards lower frequencies by reducing the ``Fmax`` value provided
-by the policy.  In the extreme case (``phi`` of 1.0) ``Fmax`` will be lowered to ``Fe``.
+0.5 biases the agent towards lower frequencies by reducing the ``Fmax`` value.
+In the extreme case (``phi`` of 1.0) ``Fmax`` will be lowered to ``Fe``.
 
 Agent Name
 ----------
@@ -74,46 +72,11 @@ name (see :doc:`geopm(7) <geopm.7>`\ ).  This name can also be passed to the
 Policy Parameters
 -----------------
 
-The ``Fe`` & ``Fmax`` for each domain and the ``phi`` input
-are policy values.
-Setting ``Fe`` & ``Fmax`` for a domain to the same value can
-be used to force the entire application to run at a fixed frequency.
-
-  ``CPU_FREQ_MAX``\ :
-      The maximum cpu frequency in hertz that the algorithm is
-      allowed to choose.  If NAN is passed, it will use the
-      maximum available frequency by default.
-
-  ``CPU_FREQ_EFFICIENT``\ :
-      The minimum cpu frequency in hertz that the algorithm is
-      allowed to choose.  If NAN is passed, it will use the system
-      minimum frequency by default.
-
-  ``CPU_UNCORE_FREQ_MAX``\ :
-      The maximum cpu uncore frequency in hertz that the algorithm is
-      allowed to choose.  If NAN is passed, it will use the
-      maximum available frequency by default.
-
-  ``CPU_UNCORE_FREQ_EFFICIENT``\ :
-      The minimum cpu uncore frequency in hertz that the algorithm is
-      allowed to choose.  If NAN is passed, it will use the system
-      minimum frequency by default.
+The ``Phi`` input is the only policy value.
 
   ``CPU_PHI``\ :
       The performance bias knob.  The value must be between
       0.0 and 1.0. If NAN is passed, it will use 0.5 by default.
-
-  ``CPU_UNCORE_FREQ_#``\ :
-      The uncore frequency associated with the same numbered
-      maximum memory bandwidth.
-      Used to build a mapping of uncore frequencies to maximum
-      memory bandwidths for frequency steering.
-
-  ``MAX_MEMORY_BANDWIDTH_#``\ :
-      The maximum possible memory bandwidth associated with the
-      same numbered uncore frequency.
-      Used to build a mapping of uncore frequencies to maximum
-      memory bandwidths for frequency steering.
 
 ConstConfigIOGroup Configuration File Generation
 ------------------------------------------------
@@ -182,50 +145,101 @@ CPU compute activity agent ConstConfigIOGroup configuration file can then be gen
 
     integration/experiment/uncore_frequency_sweep/gen_cpu_activity_constconfig_recommendation.py --path <UNCORE_SWEEP_DIR> --region-list "intensity_1","intensity_16"
 
+An example ConstConfigIOGroup configuration file is provided below::
+
+    {
+        "CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY": {
+            "domain": "board",
+            "description": "Defines the efficient core frequency to use for CPUs.  Based on a workload that scales strongly with the frequency domain",
+            "units": "hertz",
+            "aggregation": "average",
+            "values": [2000000000.0]
+        },
+        "CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY": {
+            "domain": "board",
+            "description": "Defines the efficient uncore frequency to use for CPUs.  Based on a workload that scales strongly with the frequency domain",
+            "units": "hertz",
+            "aggregation": "average",
+            "values": [2000000000.0]
+        },
+        "CPU_UNCORE_FREQUENCY_0": {
+            "domain": "board",
+            "description": "CPU Uncore Frequency associated with CPU_UNCORE_MAX_MEMORY_BANDWIDTH_0",
+            "units": "hertz",
+            "aggregation": "average",
+            "values": [1200000000.0]
+        },
+        "CPU_UNCORE_MAX_MEMORY_BANDWIDTH_0": {
+            "domain": "board",
+            "description": "Maximum memory bandwidth in bytes perf second associated with CPU_UNCORE_FREQUENCY_0",
+            "units": "none",
+            "aggregation": "average",
+            "values": [45639800000.0]
+        },
+        "CPU_UNCORE_FREQUENCY_1": {
+            "domain": "board",
+            "description": "CPU Uncore Frequency associated with CPU_UNCORE_MAX_MEMORY_BANDWIDTH_1",
+            "units": "hertz",
+            "aggregation": "average",
+            "values": [1400000000.0]
+        },
+        "CPU_UNCORE_MAX_MEMORY_BANDWIDTH_1": {
+            "domain": "board",
+            "description": "Maximum memory bandwidth in bytes perf second associated with CPU_UNCORE_FREQUENCY_1",
+            "units": "none",
+            "aggregation": "average",
+            "values": [73881616666.66667]
+        },
+        "CPU_UNCORE_FREQUENCY_2": {
+            "domain": "board",
+            "description": "CPU Uncore Frequency associated with CPU_UNCORE_MAX_MEMORY_BANDWIDTH_2",
+            "units": "hertz",
+            "aggregation": "average",
+            "values": [1600000000.0]
+        },
+        "CPU_UNCORE_MAX_MEMORY_BANDWIDTH_2": {
+            "domain": "board",
+            "description": "Maximum memory bandwidth in bytes perf second associated with CPU_UNCORE_FREQUENCY_2",
+            "units": "none",
+            "aggregation": "average",
+            "values": [85787733333.33333]
+        },
+        "CPU_UNCORE_FREQUENCY_3": {
+            "domain": "board",
+            "description": "CPU Uncore Frequency associated with CPU_UNCORE_MAX_MEMORY_BANDWIDTH_3",
+            "units": "hertz",
+            "aggregation": "average",
+            "values": [1800000000.0]
+        },
+        "CPU_UNCORE_MAX_MEMORY_BANDWIDTH_3": {
+            "domain": "board",
+            "description": "Maximum memory bandwidth in bytes perf second associated with CPU_UNCORE_FREQUENCY_3",
+            "units": "none",
+            "aggregation": "average",
+            "values": [97272166666.66667]
+        },
+        "CPU_UNCORE_FREQUENCY_4": {
+            "domain": "board",
+            "description": "CPU Uncore Frequency associated with CPU_UNCORE_MAX_MEMORY_BANDWIDTH_4",
+            "units": "hertz",
+            "aggregation": "average",
+            "values": [2000000000.0]
+        },
+        "CPU_UNCORE_MAX_MEMORY_BANDWIDTH_4": {
+            "domain": "board",
+            "description": "Maximum memory bandwidth in bytes perf second associated with CPU_UNCORE_FREQUENCY_4",
+            "units": "none",
+            "aggregation": "average",
+            "values": [106515333333.33333]
+        }
+    }
+
 Example Policy
 --------------
 
-An example policy generated using a pair of workloads, one core bound
-and one uncore bound, is provided below.  Repeated NAN entries are
-skipped for space::
+An example policy is provided below::
 
-    {"CPU_FREQ_MAX": 3700000000,
-     "CPU_FREQ_EFFICIENT": "NAN",
-     "CPU_UNCORE_FREQ_MAX": 2400000000,
-     "CPU_UNCORE_FREQ_EFFICIENT": "NAN",
-     "CPU_PHI": 0.5,
-     "SAMPLE_PERIOD": 0.01,
-     "CPU_UNCORE_FREQ_0": 1200000000,
-     "MAX_MEMORY_BANDWIDTH_0": 45414967307.69231,
-     "CPU_UNCORE_FREQ_1": 1300000000,
-     "MAX_MEMORY_BANDWIDTH_1": 64326515384.61539,
-     "CPU_UNCORE_FREQ_2": 1400000000,
-     "MAX_MEMORY_BANDWIDTH_2": 72956528846.15384,
-     "CPU_UNCORE_FREQ_3": 1500000000,
-     "MAX_MEMORY_BANDWIDTH_3": 77349315384.61539,
-     "CPU_UNCORE_FREQ_4": 1600000000,
-     "MAX_MEMORY_BANDWIDTH_4": 82345998076.92308,
-     "CPU_UNCORE_FREQ_5": 1700000000,
-     "MAX_MEMORY_BANDWIDTH_5": 87738286538.46153,
-     "CPU_UNCORE_FREQ_6": 1800000000,
-     "MAX_MEMORY_BANDWIDTH_6": 91966364814.81482,
-     "CPU_UNCORE_FREQ_7": 1900000000,
-     "MAX_MEMORY_BANDWIDTH_7": 96728174074.07408,
-     "CPU_UNCORE_FREQ_8": 2000000000,
-     "MAX_MEMORY_BANDWIDTH_8": 100648379629.6296,
-     "CPU_UNCORE_FREQ_9": 2100000000,
-     "MAX_MEMORY_BANDWIDTH_9": 102409246296.2963,
-     "CPU_UNCORE_FREQ_10": 2200000000,
-     "MAX_MEMORY_BANDWIDTH_10": 103624103703.7037,
-     "CPU_UNCORE_FREQ_11": 2300000000,
-     "MAX_MEMORY_BANDWIDTH_11": 104268944444.4444,
-     "CPU_UNCORE_FREQ_12": 2400000000,
-     "MAX_MEMORY_BANDWIDTH_12": 104748888888.8889,
-     "CPU_UNCORE_FREQ_13": "NAN",
-     "MAX_MEMORY_BANDWIDTH_13": "NAN",
-     ...
-     "CPU_UNCORE_FREQ_28": "NAN",
-     "MAX_MEMORY_BANDWIDTH_28": "NAN"}
+    {"CPU_PHI": 0.5}
 
 Report Extensions
 -----------------

--- a/service/docs/source/geopm_agent_cpu_activity.7.rst
+++ b/service/docs/source/geopm_agent_cpu_activity.7.rst
@@ -16,7 +16,7 @@ based upon the compute activity of each CPU as provided by the
 CPU_COMPUTE_ACTIVITY signal and modified by the CPU_UTILIZATION signal.
 
 The agent scales the core frequency in the range of ``Fce`` to ``Fcmax``, where
-``Fcmax`` and ``Fce`` are provided via the ConstConfigIOGroup.
+``Fcmax`` and ``Fce`` are provided via the MSRIOGroup and ConstConfigIOGroup respectively.
 
 Low compute activity regions (compute activity of 0.0) run at the ``Fce`` frequency,
 high activity regions (compute activity of 1.0) run at the ``Fcmax`` frequency,
@@ -28,7 +28,8 @@ The ``CPU_COMPUTE_ACTIVITY`` is defined as a derivative signal based on the MSR:
 scalability metric.
 
 The agent also scales the uncore frequency in the range of ``Fue`` to
-``Fumax``, where ``Fumax`` and ``Fue`` are povided via the ConstConfigIOGroup
+``Fumax``, where ``Fumax`` and ``Fue`` are povided by the
+MSRIOGroup and ConstConfigIOGroup respectively.
 
 Low uncore activity regions (uncore activity of 0.0) run at the ``Fue`` frequency,
 high activity regions (uncore activity of 1.0) run at the ``Fumax`` frequency,

--- a/src/CPUActivityAgent.cpp
+++ b/src/CPUActivityAgent.cpp
@@ -179,7 +179,7 @@ namespace geopm
 
         if (m_qm_max_rate.empty()) {
             throw Exception("CPUActivityAgent::" + std::string(__func__) +
-                            "(): ConstConfigIO file did not contain" +
+                            "(): ConstConfigIOGroup configuration file does not contain" +
                             " memory bandwidth information.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }

--- a/src/CPUActivityAgent.cpp
+++ b/src/CPUActivityAgent.cpp
@@ -161,13 +161,13 @@ namespace geopm
         }
 
         // Grab all (uncore frequency, max memory bandwidth) pairs
-        for (int entry_idx = 0; entry_idx < (int)ALL_NAMES.size(); ++entry_idx) {
+        for (unsigned int entry_idx = 0; entry_idx < ALL_NAMES.size(); ++entry_idx) {
             const std::string KEY_NAME = "CONST_CONFIG::CPU_UNCORE_FREQUENCY_" +
                                           std::to_string(entry_idx);
             const std::string VAL_NAME = "CONST_CONFIG::CPU_UNCORE_MAX_MEMORY_BANDWIDTH_" +
                                           std::to_string(entry_idx);
-            if (ALL_NAMES.find(KEY_NAME) != ALL_NAMES.end() &&
-                ALL_NAMES.find(VAL_NAME) != ALL_NAMES.end()) {
+            if (ALL_NAMES.count(KEY_NAME) != 0 &&
+                ALL_NAMES.count(VAL_NAME) != 0) {
                 double uncore_freq = m_platform_io.read_signal(KEY_NAME, GEOPM_DOMAIN_BOARD, 0);
                 double max_mem_bw = m_platform_io.read_signal(VAL_NAME, GEOPM_DOMAIN_BOARD, 0);
                 if (!std::isnan(uncore_freq) && !std::isnan(max_mem_bw) &&

--- a/src/CPUActivityAgent.cpp
+++ b/src/CPUActivityAgent.cpp
@@ -141,11 +141,11 @@ namespace geopm
     void CPUActivityAgent::init_constconfig_io()
     {
         m_qm_max_rate = {};
-        const auto all_names = m_platform_io.signal_names();
+        const auto ALL_NAMES = m_platform_io.signal_names();
 
         // F efficient values
         std::string fe_constconfig = "CONST_CONFIG::CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY";
-        if (all_names.count(fe_constconfig) != 0) {
+        if (ALL_NAMES.count(fe_constconfig) != 0) {
             m_freq_core_efficient = m_platform_io.read_signal(fe_constconfig, GEOPM_DOMAIN_BOARD, 0);
         }
         else {
@@ -153,7 +153,7 @@ namespace geopm
         }
 
         fe_constconfig = "CONST_CONFIG::CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY";
-        if (all_names.count(fe_constconfig) != 0) {
+        if (ALL_NAMES.count(fe_constconfig) != 0) {
             m_freq_uncore_efficient = m_platform_io.read_signal(fe_constconfig, GEOPM_DOMAIN_BOARD, 0);
         }
         else {
@@ -161,15 +161,15 @@ namespace geopm
         }
 
         // Grab all (uncore frequency, max memory bandwidth) pairs
-        for (int entry_idx = 0; entry_idx < (int)all_names.size(); ++entry_idx) {
-            std::string key_name = "CONST_CONFIG::CPU_UNCORE_FREQUENCY_" +
-                                   std::to_string(entry_idx);
-            std::string val_name = "CONST_CONFIG::CPU_UNCORE_MAX_MEMORY_BANDWIDTH_" +
-                                   std::to_string(entry_idx);
-            if (all_names.find(key_name) != all_names.end() &&
-                all_names.find(val_name) != all_names.end()) {
-                double uncore_freq = m_platform_io.read_signal(key_name, GEOPM_DOMAIN_BOARD, 0);
-                double max_mem_bw = m_platform_io.read_signal(val_name, GEOPM_DOMAIN_BOARD, 0);
+        for (int entry_idx = 0; entry_idx < (int)ALL_NAMES.size(); ++entry_idx) {
+            const std::string KEY_NAME = "CONST_CONFIG::CPU_UNCORE_FREQUENCY_" +
+                                          std::to_string(entry_idx);
+            const std::string VAL_NAME = "CONST_CONFIG::CPU_UNCORE_MAX_MEMORY_BANDWIDTH_" +
+                                          std::to_string(entry_idx);
+            if (ALL_NAMES.find(KEY_NAME) != ALL_NAMES.end() &&
+                ALL_NAMES.find(VAL_NAME) != ALL_NAMES.end()) {
+                double uncore_freq = m_platform_io.read_signal(KEY_NAME, GEOPM_DOMAIN_BOARD, 0);
+                double max_mem_bw = m_platform_io.read_signal(VAL_NAME, GEOPM_DOMAIN_BOARD, 0);
                 if (!std::isnan(uncore_freq) && !std::isnan(max_mem_bw) &&
                     uncore_freq != 0 && max_mem_bw != 0) {
                     m_qm_max_rate[uncore_freq] = max_mem_bw;

--- a/src/CPUActivityAgent.cpp
+++ b/src/CPUActivityAgent.cpp
@@ -103,9 +103,6 @@ namespace geopm
         m_freq_core_min = m_freq_governor->get_frequency_min();
         m_freq_core_max = m_freq_governor->get_frequency_max();
 
-        // init to system max
-        m_resolved_f_core_max = m_freq_core_max;
-
         for (int domain_idx = 0; domain_idx < m_num_freq_ctl_domain; ++domain_idx) {
             m_core_scal.push_back({m_platform_io.push_signal("MSR::CPU_SCALABILITY_RATIO",
                                                              m_freq_ctl_domain_type,
@@ -163,8 +160,6 @@ namespace geopm
             m_freq_uncore_efficient = m_freq_uncore_min;
         }
 
-        m_resolved_f_uncore_efficient = m_freq_uncore_efficient;
-
         // Grab all (uncore frequency, max memory bandwidth) pairs
         for (int entry_idx = 0; entry_idx < (int)all_names.size(); ++entry_idx) {
             std::string key_name = "CONST_CONFIG::CPU_UNCORE_FREQUENCY_" +
@@ -188,9 +183,6 @@ namespace geopm
                             " memory bandwidth information.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-
-        // init resolved freq
-        m_resolved_f_core_efficient = m_freq_core_efficient;
     }
 
     // Validate incoming policy and configure default policy requests.
@@ -254,6 +246,14 @@ namespace geopm
         double f_uncore_range = m_freq_uncore_max - m_freq_uncore_efficient;
 
         double phi = in_policy[M_POLICY_CPU_PHI];
+
+        // Default phi = 0.5 case is full fe to fmax range
+        // Core
+        m_resolved_f_core_max = m_freq_core_max;
+        m_resolved_f_core_efficient = m_freq_core_efficient;
+        // Uncore
+        m_resolved_f_uncore_max = m_freq_uncore_max;
+        m_resolved_f_uncore_efficient = m_freq_uncore_efficient;
 
         // If phi is not 0.5 we move into the energy or performance biased behavior
         if (phi > 0.5) {

--- a/src/CPUActivityAgent.hpp
+++ b/src/CPUActivityAgent.hpp
@@ -71,8 +71,10 @@ namespace geopm
             double m_resolved_f_core_max;
             double m_freq_uncore_min;
             double m_freq_uncore_max;
+            double m_freq_uncore_efficient;
             double m_freq_core_min;
             double m_freq_core_max;
+            double m_freq_core_efficient;
 
             struct signal
             {
@@ -88,16 +90,8 @@ namespace geopm
 
             // Policy indices; must match policy_names()
             enum m_policy_e {
-                M_POLICY_CPU_FREQ_MAX,
-                M_POLICY_CPU_FREQ_EFFICIENT,
-                M_POLICY_UNCORE_FREQ_MAX,
-                M_POLICY_UNCORE_FREQ_EFFICIENT,
                 M_POLICY_CPU_PHI,
-                M_POLICY_FIRST_UNCORE_FREQ,
-                M_POLICY_FIRST_MAX_MEM_BW,
-                // The remainder of policy values can be additional pairs of
-                // (uncore freq, max memory bandwidth)
-                M_NUM_POLICY = 63,
+                M_NUM_POLICY,
             };
 
             // Sample indices; must match sample_names()
@@ -119,6 +113,7 @@ namespace geopm
             std::vector<control> m_uncore_freq_max_control;
 
             void init_platform_io(void);
+            void init_constconfig_io(void);
     };
 }
 #endif

--- a/test/CPUActivityAgentTest.cpp
+++ b/test/CPUActivityAgentTest.cpp
@@ -535,6 +535,6 @@ TEST_F(CPUActivityAgentTest, no_mem_constconfig)
     ON_CALL(*m_platform_io, signal_names()).WillByDefault(Return(signal_name_set));
     // leaf agent
     GEOPM_EXPECT_THROW_MESSAGE(m_agent->init(0, {}, false), GEOPM_ERROR_INVALID,
-                                "ConstConfigIO file did not contain memory bandwidth information");
+                                "ConstConfigIOGroup configuration file does not contain memory bandwidth information");
 
 }

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -313,7 +313,7 @@ if ENABLE_BETA
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_medium \
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_low \
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_zero \
-                   test/gtest_links/CPUActivityAgentTest.adjust_platform_nan \
+                   test/gtest_links/CPUActivityAgentTest.no_mem_constconfig \
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_lower_bound_check \
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_signal_out_of_bounds \
                    test/gtest_links/CPUActivityAgentTest.control_signal_granularity_check \


### PR DESCRIPTION
- Relates to #2698 feature request from github issues
- Fixes #2436  change request from github issues.

Updates the CPU-CA to use the information in the ConstConfigIOGroup during runs, reduce the CPU-CA policy to only the phi value, and allows for per-node characterization runs.