### PR TITLE
Add a spell-checking linter

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = googletest-release*,autom4te.cache,./service/docs/build,./service/contrib,libtool*,ltmain*,./integration/apps/*/*,./.git,./ChangeLog,*.patch,./test/ProfileTableTest.cpp,configure,config.*,depcomp,*.spec
+ignore-words-list = atleast,clos,fom,warmup,affinitize,affinitized,whis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  precheck:
+    name: "Pre-build checks"
+    # Run linters and other low-cost checks that do not depend on being in a
+    # particular configuration of the build matrix.
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: codespell-project/actions-codespell@v1.0
   build_and_test:
     name: "build_and_test: ${{ matrix.config.name }} ${{ matrix.debug-flag }}"
     runs-on: ubuntu-20.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/codespell-project/codespell
+    rev: 'v2.2.0'
+    hooks:
+    -   id: codespell

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -43,7 +43,7 @@ benefit from the feature and then describes the feature iteslf.
 Common roles include "user of the GEOPM runtime", "user of the GEOPM
 service", "developer of GEOPM", etc.  Please be as specific as
 possible when identifying the role, e.g. "user of the geopmsession
-command line tool" is prefered to "user of the GEOPM service".
+command line tool" is preferred to "user of the GEOPM service".
 
 When planning to implement a new feature as a contribution to the main
 repository, please start this collaboration by creating a feature

--- a/Makefile.am
+++ b/Makefile.am
@@ -150,6 +150,7 @@ dist_doc_DATA = COPYING \
                 # end
 
 EXTRA_DIST = $(TUTORIAL_DIST) \
+             .codespellrc \
              .github/include_guards.sh \
              .github/workflows/build.yml \
              .github/workflows/codeql-analysis.yml \

--- a/Makefile.am
+++ b/Makefile.am
@@ -177,6 +177,7 @@ EXTRA_DIST = $(TUTORIAL_DIST) \
              .github/ISSUE_TEMPLATE/change.md \
              .github/ISSUE_TEMPLATE/tech_debt.md \
              .gitignore \
+             .pre-commit-config.yaml \
              BLURB \
              CODE_OF_CONDUCT.md \
              CONTRIBUTING.rst \

--- a/README
+++ b/README
@@ -109,7 +109,7 @@ Guide for GEOPM Developers
 --------------------------
 
 GEOPM is an open development project and we use Github to plan, review
-and test our work.  The proccess we follow is documented here:
+and test our work.  The process we follow is documented here:
 
 https://geopm.github.io/devel.html
 
@@ -131,7 +131,7 @@ parallel applications, and support for the ``isst_interface`` driver.
 
 This software is production quality as of version 1.0.  We will be
 enforcing [semantic versioning](https://semver.org/) for all releases
-following version 1.0. Plese refer to the ChangeLog for a high level
+following version 1.0. Please refer to the ChangeLog for a high level
 history of changes in each release.  The test coverage report from
 gcov as reported by gcovr for the latest release are
 [posted to our web page](http://geopm.github.io/coverage/index.html).

--- a/autogen.sh
+++ b/autogen.sh
@@ -16,7 +16,7 @@ elif git describe --long > /dev/null 2>&1; then
     fi
     echo $version > VERSION
 elif [ ! -f VERSION ]; then
-    echo "WARNING:  VERSION file does not exist and git describe failed, setting verison to 0.0.0" 1>&2
+    echo "WARNING:  VERSION file does not exist and git describe failed, setting version to 0.0.0" 1>&2
     echo "0.0.0" > VERSION
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 geopm_abi_version=1:0:0
 AC_SUBST(geopm_abi_version)
-AC_DEFINE_UNQUOTED([GEOPM_ABI_VERSION], ["$geopm_abi_version"], [GEOPM shared object verion])
+AC_DEFINE_UNQUOTED([GEOPM_ABI_VERSION], ["$geopm_abi_version"], [GEOPM shared object version])
 
 LT_PREREQ([2.2.6])
 
@@ -432,7 +432,7 @@ AC_CHECK_LIB([geopmd], [geopm_pio_read_signal], [], [
     echo "missing libgeopmd: Install the geopm-service and use --with-geopmd or --with-geopmd-lib to specify location"
     exit -1])
 AC_CHECK_HEADER([geopm_pio.h], [], [
-    echo "missing geopm_pio.h: Intall the geopm-service and use --with-geopmd or --with-geopmd-include to specify location"
+    echo "missing geopm_pio.h: Install the geopm-service and use --with-geopmd or --with-geopmd-include to specify location"
     exit -1])
 
 AC_SEARCH_LIBS([elf_begin], [elf])

--- a/copying_headers/MANIFEST.EXEMPT
+++ b/copying_headers/MANIFEST.EXEMPT
@@ -70,6 +70,7 @@ integration/test/README.md
 json_schemas/geopmbench_config.schema.json
 json_schemas/geopmagent_policy.schema.json
 MANIFEST
+.pre-commit-config.yaml
 pull_request_template.md
 README
 README.md

--- a/copying_headers/MANIFEST.EXEMPT
+++ b/copying_headers/MANIFEST.EXEMPT
@@ -5,6 +5,7 @@ CONTRIBUTING.rst
 COPYING
 COPYING-TPP
 man
+.codespellrc
 copying_headers/header.BSD3-intel
 copying_headers/header.BSD3-llnl
 copying_headers/header.compile_flag

--- a/copying_headers/test-license
+++ b/copying_headers/test-license
@@ -245,7 +245,7 @@ class Repo(object):
 
     def check_license(self):
         """
-        Check all of the taged files for license headers.
+        Check all of the tagged files for license headers.
         """
         for tag in self.tag_list:
             header_path = os.path.join(self.copying, 'header.{0}'.format(tag))

--- a/integration/apps/README.md
+++ b/integration/apps/README.md
@@ -17,7 +17,7 @@ requirements for each application directory are provided.
   - [minife](minife)
   - [nekbone](nekbone)
 
-#### Network Bandwith Bound Applications
+#### Network Bandwidth Bound Applications
 
   - [nasft](nasft)
 
@@ -79,7 +79,7 @@ requirements for each application directory are provided.
   script may obtain the source by wget, svn, or git.  It may also be
   obtained from the local application source cache directory; the
   location of the application source cache defaults to
-  `$HOME/geopm_apps` and may be overriden in the user's environment or
+  `$HOME/geopm_apps` and may be overridden in the user's environment or
   ~/.geopmrc file as GEOPM_APPS_SRCDIR.
 
 #### Source patches

--- a/integration/experiment/README.md
+++ b/integration/experiment/README.md
@@ -8,7 +8,7 @@ parallel jobs, and analyzing the job output.
 
 There is some functionality that is shared between different
 expereiments and these features are captured in python modules
-at the base of the experiement directory.
+at the base of the experiment directory.
 
 #### `common_args.py`
 
@@ -29,7 +29,7 @@ enable run scripts to launch a sequence of job configurations.
 Used to generate a json file containing descriptive information about
 the compute nodes where jobs are running.  Each experiment creates one
 of these json files at run time.  The machine object may be used to
-configure an application and it is refered to by the "gen" analysis
+configure an application and it is referred to by the "gen" analysis
 scripts to understand the system where the jobs were run without
 requiring compute node access.
 
@@ -77,7 +77,7 @@ The general workflow is as follows:
    of nodes can be specified with `--nodes`; otherwise 1 node will be
    used.
 
-2. Generate the desired analysis targetting the resulting output with
+2. Generate the desired analysis targeting the resulting output with
    `--output-dir`; by default all reports/traces in the current
    working directory are used.  Some scripts support more verbose
    output with `--show-details`.

--- a/integration/experiment/energy_efficiency/cpu_activity.py
+++ b/integration/experiment/energy_efficiency/cpu_activity.py
@@ -32,7 +32,7 @@ def setup_run_args(parser):
                         action='store', default='nan',
                         help='The maximum frequency of the uncore (a.k.a. Fumax) for this experiment')
     parser.add_argument('--uncore-mbm-list', nargs='+', help='A list of uncore_freq & max_mem_bw values in the form uncore_freq_0 max_mem_bw_0 uncore_freq_1 ...')
-    parser.add_argument('--phi-list', nargs='+', help='A space seperated list of phi values (0 to 1.0) to use')
+    parser.add_argument('--phi-list', nargs='+', help='A space separated list of phi values (0 to 1.0) to use')
 
 def report_signals():
     return []

--- a/integration/experiment/energy_efficiency/gpu_activity.py
+++ b/integration/experiment/energy_efficiency/gpu_activity.py
@@ -25,7 +25,7 @@ def setup_run_args(parser):
     parser.add_argument('--gpu-frequency-max', dest='gpu_fmax',
                         action='store', default='nan',
                         help='The maximum frequency of the gpu (a.k.a. Fmax) for this experiment')
-    parser.add_argument('--phi-list', nargs='+', help='A space seperated list of phi values to use')
+    parser.add_argument('--phi-list', nargs='+', help='A space separated list of phi values to use')
 
 def report_signals():
     return []

--- a/integration/experiment/frequency_sweep/gen_region_summary.py
+++ b/integration/experiment/frequency_sweep/gen_region_summary.py
@@ -65,7 +65,7 @@ def region_summary(report_collection, output_dir, show_details):
     means_edf = edf.groupby(['freq_mhz'])[field_list].mean()
     means_adf = adf.groupby(['freq_mhz'])[adf_field_list].mean()
 
-    # Sort first by region alpha order, then decending by frequency
+    # Sort first by region alpha order, then descending by frequency
     means_df = means_df.sort_index(level=['region', 'freq_mhz'], ascending=[True, False])
     means_edf = means_edf.sort_index(level='freq_mhz', ascending=False)
     means_adf = means_adf.sort_index(level='freq_mhz', ascending=False)

--- a/integration/experiment/launch_util.py
+++ b/integration/experiment/launch_util.py
@@ -139,7 +139,7 @@ def launch_all_runs(targets, num_nodes, iterations, extra_cli_args, output_dir,
                     trial_complete = True
                 except subprocess.CalledProcessError as e:
                     # Hit if e.g. the app calls MPI_ABORT
-                    sys.stderr.write('Warning: <geopm> Execption encountered during run {}'.format(e))
+                    sys.stderr.write('Warning: <geopm> Exception encountered during run {}'.format(e))
                     sys.stderr.write('Retrying previous trial...')
                     # Without sleep, the failed run tries to start over and over again and becomes
                     # unresponsive to CTRL-C.

--- a/integration/experiment/plotting.py
+++ b/integration/experiment/plotting.py
@@ -6,7 +6,7 @@
 '''GEOPM Plotting
 
 Used to produce plots and other analysis files from report and/or
-trace files.  Also includes helpers for ploting scripts.
+trace files.  Also includes helpers for plotting scripts.
 
 
 
@@ -980,7 +980,7 @@ def generate_power_plot(trace_df, config):
         raise LookupError('No data remains after filtering.  Please check your datasets and filtering options.')
 
     # Do not include node_name, iteration or index in the groupby clause; The median iteration is extracted and used
-    # below for every node togther in a group.  The index must be preserved to ensure the DFs stay in order.
+    # below for every node together in a group.  The index must be preserved to ensure the DFs stay in order.
     if config.verbose:
         sys.stdout.write('Grouping data...\n')
         sys.stdout.flush()
@@ -1244,7 +1244,7 @@ def generate_epoch_plot(trace_df, config):
 def generate_freq_plot(trace_df, config):
     """Plots the per sample frequency per node per socket.
 
-    This function will plot the frequency of each socket on each node per sample.  It plots the sockets as seperate
+    This function will plot the frequency of each socket on each node per sample.  It plots the sockets as separate
     files denoted '...socket_0.svg', '...socket_1.svg', etc.  Specifying the 'analyze' option in the config object
     will also include a statistics print out of the data used in the plot.  Specifying the 'normalize' option will
     use uniform node names in the plot legend.  Setting the 'config.base_clock' parameter in the config object will

--- a/integration/experiment/power_sweep/gen_governor_balancer_comparison.py
+++ b/integration/experiment/power_sweep/gen_governor_balancer_comparison.py
@@ -44,7 +44,7 @@ def prepare(df):
     df = df.rename(rename_map)
     df.index = df.index.set_names('iteration', level='Profile')
 
-    # Sort decending by power limit, ascending by iteration
+    # Sort descending by power limit, ascending by iteration
     df = df.sort_index(level=['power_limit', 'iteration'], ascending=[False, True])
 
     return df

--- a/integration/experiment/trace_analysis/README.md
+++ b/integration/experiment/trace_analysis/README.md
@@ -1,6 +1,6 @@
 The scripts in this folder are used to analyze a single GEOPM trace
 file.  They can be used standalone by passing the path to the trace
-file as the last argumement on the command line, or by importing them
+file as the last argument on the command line, or by importing them
 into other scripts.
 
 A short summary of the available scripts is listed here.  Each script

--- a/integration/experiment/trace_analysis/gen_rate_hist.py
+++ b/integration/experiment/trace_analysis/gen_rate_hist.py
@@ -5,7 +5,7 @@
 #
 
 '''
-Displays a historgram of the control loop sample intervals
+Displays a histogram of the control loop sample intervals
 '''
 
 import pandas

--- a/integration/test/README.md
+++ b/integration/test/README.md
@@ -4,7 +4,7 @@ GEOPM Integration Tests
 This directory contains the integration tests for the GEOPM package.
 
 Please refer to the [README](../README.md) one directory up for
-information about how to define envirnment variables relevent to these
+information about how to define environment variables relevant to these
 scripts in your `.geopmrc` file and how to use the scripts in the
 [config](../config) directory.
 

--- a/integration/test/geopm_test_launcher.py
+++ b/integration/test/geopm_test_launcher.py
@@ -144,7 +144,7 @@ class TestLauncher(object):
             exec_wrapper = os.getenv('GEOPM_EXEC_WRAPPER', '')
             if exec_wrapper:
                 argv.extend(shlex.split(exec_wrapper))
-            # Use app config to get path and arguements
+            # Use app config to get path and arguments
             argv.append(self._app_conf.get_exec_path())
             argv.append('--verbose')
             argv.extend(self._app_conf.get_exec_args())
@@ -196,12 +196,12 @@ class TestLauncher(object):
                           line.find('Core(s) per socket:') == 0 or
                           line.find('Socket(s):') == 0]
         if self._performance == True:
-            # Mulitply num core per socket by num sockets, subtract 1, then multiply by threads per core.
+            # Multiply num core per socket by num sockets, subtract 1, then multiply by threads per core.
             # Remove one CPU for BSP to calculate number of CPU for application.
             # Use hyper-threads.
             self._num_cpu = ((cpu_thread_core_socket[2] * cpu_thread_core_socket[3]) - 1) * cpu_thread_core_socket[1]
         else:
-            # Mulitply num core per socket by num socket and remove one
+            # Multiply num core per socket by num socket and remove one
             # CPU for BSP to calculate number of CPU for application.
             # Don't use hyper-threads.
             self._num_cpu = cpu_thread_core_socket[2] * cpu_thread_core_socket[3] - 1

--- a/integration/test/test_omp_outer_loop.py
+++ b/integration/test/test_omp_outer_loop.py
@@ -5,7 +5,7 @@
 #
 
 """Test the detection of user defined regions in an application
-   configured such that the outer loop is an OMP paralell region.
+   configured such that the outer loop is an OMP parallel region.
 
 """
 
@@ -99,7 +99,7 @@ class TestIntegrationOMPOuterLoop(unittest.TestCase):
                     if observed_region['time-hint-network (s)'] != 0:
                         network_time_detected = True
             self.assertTrue(network_time_detected,
-                            msg="There should be some network time assiciated with an OMPT detected region.")
+                            msg="There should be some network time associated with an OMPT detected region.")
 
     def test_regions_present(self):
         """Test that the second run's report DOES contain the

--- a/integration/test_skipped/test_fmap_short_region_slop.py
+++ b/integration/test_skipped/test_fmap_short_region_slop.py
@@ -225,7 +225,7 @@ class TestIntegration_fmap_short_region_slop(unittest.TestCase):
 
 def create_report_df(report_path_fixed, report_path_dynamic, num_trial, num_duration):
     """Create pandas data frame that holds data from the reports that
-       relevent to the test
+       relevant to the test
 
     """
     result = pandas.DataFrame()

--- a/integration/test_skipped/test_levelzero_signals.py
+++ b/integration/test_skipped/test_levelzero_signals.py
@@ -31,7 +31,7 @@ class TestIntegrationLevelZeroSignals(unittest.TestCase):
         self._stdout = None
         self._stderr = None
 
-        #TODO: Add query for numnber of devices and subdevices
+        #TODO: Add query for number of devices and subdevices
         #TODO: Add check for ZES_SYSMAN_ENABLE=1
 
     def tearDown(self):

--- a/json_schemas/geopmbench_config.schema.json
+++ b/json_schemas/geopmbench_config.schema.json
@@ -23,7 +23,7 @@
         }
       },
       "hostname": {
-        "description": "Specify on which hosts to apply imbalance setttings",
+        "description": "Specify on which hosts to apply imbalance settings",
         "type": "array",
         "items": {
           "type": "string"

--- a/scripts/geopmpy/io.py
+++ b/scripts/geopmpy/io.py
@@ -522,7 +522,7 @@ class Trace(object):
             filtered_df['epoch_count'] = tmp_df['epoch_count']
         filtered_df = filtered_df.diff()
         # The following drops all 0's and the negative sample when traversing between 2 trace files.
-        # If the epoch_count column is included, this will also drop rows occuring mid-epoch.
+        # If the epoch_count column is included, this will also drop rows occurring mid-epoch.
         filtered_df = filtered_df.loc[(filtered_df > 0).all(axis=1)]
 
         # Reset 'index' to be 0 to the length of the unique trace files

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -844,7 +844,7 @@ Warning: <geopm> geopmpy.launcher: Incompatible CPU frequency governor
 
     def partition_option(self):
         """
-        Returns a list containing the command line options specifiying the
+        Returns a list containing the command line options specifying the
         compute node partition for the job to run on.
         """
         return []
@@ -886,7 +886,7 @@ Warning: <geopm> geopmpy.launcher: Incompatible CPU frequency governor
         """
         if self.is_slurm_enabled:
             # Use scontrol instead of sinfo -t alloc since sinfo will show all nodes currently allocated, not just
-            # the nodes associted with the current job context.
+            # the nodes associated with the current job context.
             return list(set(subprocess.check_output(['scontrol', 'show', 'hostname']).decode().splitlines()))
         else:
             raise NotImplementedError('<geopm> geopmpy.launcher: Allocated nodes feature requires SLURM')
@@ -1056,7 +1056,7 @@ class SrunLauncher(Launcher):
         """
         result = []
         if self.time_limit is not None:
-            # Time limit option exepcts minutes, covert from seconds
+            # Time limit option expects minutes, convert from seconds
             result = ['-t', str(int_ceil_div(self.time_limit, 60))]
         return result
 
@@ -1088,7 +1088,7 @@ class SrunLauncher(Launcher):
 
     def partition_option(self):
         """
-        Returns a list containing the command line options specifiying the
+        Returns a list containing the command line options specifying the
         compute node partition for the job to run on.
         """
         result = []
@@ -1230,7 +1230,7 @@ class OMPIExecLauncher(Launcher):
         result = super(OMPIExecLauncher, self).launcher_argv(is_geopmctl)
 
         if is_geopmctl:
-            # add not to warn on fork messge
+            # add not to warn on fork message
             result.extend(['--mca', 'mpi_warn_on_fork', '0'])
         return result
 
@@ -1618,7 +1618,7 @@ class AprunLauncher(Launcher):
         """
         result = []
         if self.time_limit is not None:
-            # Mulitply by Linux CPU per process due to aprun
+            # Multiply by Linux CPU per process due to aprun
             # definition of time limit.
             result = ['-t', str(self.time_limit * self.cpu_per_rank)]
         return result

--- a/service/README.rst
+++ b/service/README.rst
@@ -58,7 +58,7 @@ telemetry and configuration at a fine granularity.
 
 Clients use the GEOPM Service DBus interface to interact with the
 service.  The GEOPM Service package provides access to the DBus
-interfaces from the command line, or programatically with library
+interfaces from the command line, or programmatically with library
 interfaces for C, C++ and Python.
 
 The service supports many simultaneous client sessions that make

--- a/service/autogen.sh
+++ b/service/autogen.sh
@@ -16,7 +16,7 @@ elif git describe --long > /dev/null 2>&1; then
     fi
     echo $version > VERSION
 elif [ ! -f VERSION ]; then
-    echo "WARNING:  VERSION file does not exist and git describe failed, setting verison to 0.0.0" 1>&2
+    echo "WARNING:  VERSION file does not exist and git describe failed, setting version to 0.0.0" 1>&2
     echo "0.0.0" > VERSION
 fi
 

--- a/service/configure.ac
+++ b/service/configure.ac
@@ -19,7 +19,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 geopm_abi_version=1:0:0
 AC_SUBST(geopm_abi_version)
-AC_DEFINE_UNQUOTED([GEOPM_ABI_VERSION], ["$geopm_abi_version"], [GEOPM shared object verion])
+AC_DEFINE_UNQUOTED([GEOPM_ABI_VERSION], ["$geopm_abi_version"], [GEOPM shared object version])
 AC_DEFINE([GEOPM_SERVICE_BUILD], [], [Building objects used by geopm-service])
 
 LT_PREREQ([2.2.6])

--- a/service/docs/source/GEOPM_CXX_MAN_Comm.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_Comm.3.rst
@@ -169,7 +169,7 @@ Class Methods
   The **in** parameter *num_ranks* is the number of ranks that must fit in Cartesian grid.
   The **in, out** vector parameter *dimension* is the number of ranks per dimension.
   The size of this vector dictates the number of dimensions in the grid.
-  Fill indecies with 0 for API to fill with suitable value.
+  Fill indices with 0 for API to fill with suitable value.
 
 *
   ``free_mem()``:

--- a/service/docs/source/devel.rst
+++ b/service/docs/source/devel.rst
@@ -11,7 +11,7 @@ all files related to the GEOPM systemd service including the build
 system and all source code for the software components.  The base
 directory of the GEOPM git repository is populated with a build system
 that supports all software components not located in the ``service``
-directory.  The base build depends soley on components in the
+directory.  The base build depends solely on components in the
 ``service`` directory that are installed by the service build
 including: the ``libgeopmd.so`` library, the C and C++ public
 interface header files for that library, and the ``geopmdpy`` Python
@@ -36,7 +36,7 @@ repository:
     ./configure
     make
 
-    # Optionaly, build the GEOPM HPC runtime package
+    # Optionally, build the GEOPM HPC runtime package
     cd ..
     ./autogen.sh
     ./configure
@@ -114,7 +114,7 @@ There are many options that may be passed to each of the two configure
 scripts that are part of the GEOPM repository build system.  Two
 scripts called ``autogen.sh`` are provided, one in the base of the
 GEOPM repository and the other in the service directory.  Each of
-these scripts manage the GEOPM version that is imbedded in the build
+these scripts manage the GEOPM version that is embedded in the build
 artifacts, and create the two ``configure`` scripts using the
 autotools package.
 

--- a/service/docs/source/devel.rst
+++ b/service/docs/source/devel.rst
@@ -277,10 +277,22 @@ Avoid preprocessor macros as much as possible (use enum not #define).
 Preprocessor usage should be reserved for expressing configure time
 options.
 
+Pre-Commit Checks
+-----------------
+This repository includes a configuration for `pre-commit
+<https://pre-commit.com/>`_ that uses some of their standard hooks that are
+relevant to GEOPM, and adds a hook that performs the GEOPM license checks.
+
+To install the pre-commit infrastructure and our configuration::
+
+    pip install pre-commit
+    pre-commit install
+
+Now you will automatically run some checks whenever you make a commit, instead
+of waiting until you make a pull request to see all of them.
 
 License Headers
 ---------------
-
 Introducing a new file requires a license comment in its header with a
 corresponding copying_headers/header.\ * file.  The new file path must
 be listed in the corresponding copying_headers/MANIFEST.* file.  This

--- a/service/docs/source/geopm.7.rst
+++ b/service/docs/source/geopm.7.rst
@@ -36,7 +36,7 @@ Job Launch
 ----------
 The :doc:`geopmlaunch(1) <geopmlaunch.1>` script is the recommended method for
 launching the GEOPM HPC runtime. Unless modified by command-line arguments or
-environment variables, GEOPM will create a ``geopm.report`` file wiht a summary
+environment variables, GEOPM will create a ``geopm.report`` file with a summary
 of metrics from application execution. See :doc:`geopmreport(7)
 <geopm_report.7>`: for documentation about the output file format.
 
@@ -189,7 +189,7 @@ scenario, users launching GEOPM may not be required or allowed to
 specify the Agent or policy, if it has been set through the default
 environment as described in the ``ENVIRONMENT`` section below.  If not
 specified in the default environment, the location of the endpoint
-should be provided through ``--geopm-endpoint``\ ; this option supercedes
+should be provided through ``--geopm-endpoint``\ ; this option supersedes
 the use of ``--geopm-policy``.  When GEOPM receives the policy through
 the endpoint, the report will contain ``"DYNAMIC"`` for the value of the
 policy.  The specific values received over time can be viewed through

--- a/service/docs/source/geopm_agent_cpu_activity.7.rst
+++ b/service/docs/source/geopm_agent_cpu_activity.7.rst
@@ -39,7 +39,7 @@ the equation:
 
 ``Fureq = Fue + (Fumax - Fue) * CPU_UNCORE_ACTIVITY``
 
-The ``CPU_UNCORE_ACTIVITY`` is defined as a simple ratio of the current memory bandwdith
+The ``CPU_UNCORE_ACTIVITY`` is defined as a simple ratio of the current memory bandwidth
 divided by the maximum possible bandwidth at the current ``CPU_UNCORE_FREQUENCY_STATUS`` value.
 
 The ``Fe`` value for all domains is intended to be an energy efficient frequency
@@ -120,7 +120,7 @@ ConstConfigIOGroup Configuration File Generation
 
 Generating a ConstConfigIOGroup configuration file for the CPU Compute Activity agent requires
 system characterization using the GEOPM experiment infrastructure located in
-``$GEOPM_SOURCE/integration/experiment/`` and the aritmetic intensity
+``$GEOPM_SOURCE/integration/experiment/`` and the arithmetic intensity
 benchmark located in ``$GEOPM_SOURCE/integration/apps/arithmetic_intensity``.
 Prior to starting, the arithmetic intensity benchmark needs to be built (use
 the ``build.sh`` script provided in the benchmark's folder).

--- a/service/docs/source/geopm_pio.3.rst
+++ b/service/docs/source/geopm_pio.3.rst
@@ -196,7 +196,7 @@ Inspection Functions
   **out** *aggregation_type* One of the ``Agg::m_type_e`` enum values describing the way the signal is aggregated.
   **out** *format_type* One of the ``geopm::string_format_e`` enums defined in `Helper.hpp <https://github.com/geopm/geopm/blob/dev/service/src/geopm/Helper.hpp>`_\  that defines how to format
   the signal as a string.
-  **out** *behavior_type* One of the ``IOGroup::m_signal_behavior_e`` enum values that decribes
+  **out** *behavior_type* One of the ``IOGroup::m_signal_behavior_e`` enum values that describes
   the signals behavior over time.
   Returns zero on success, error value on failure.
 

--- a/service/docs/source/geopmadmin.1.rst
+++ b/service/docs/source/geopmadmin.1.rst
@@ -34,7 +34,7 @@ Options
                        controls the override values for the system.
 -a, --msr-allowlist    Print the minimum required allowlist for the ``msr-safe``
                        driver to enable all of the GEOPM features.
--c, --cpuid            Specify the ``cpuid`` in hexidecimal to select the
+-c, --cpuid            Specify the ``cpuid`` in hexadecimal to select the
                        architecture for the ``msr-safe`` allowlist generation. If
                        this option is not specified the architecture where the
                        application is running will be used.

--- a/service/docs/source/install.rst
+++ b/service/docs/source/install.rst
@@ -30,8 +30,8 @@ packages.  The ``geopm-service-devel`` package must be explicitly
 installed if it is required by the user.
 
 
-Level Zero Prequisite
----------------------
+Level Zero Prerequisite
+-----------------------
 
 Before installing the GEOPM Service packages, the ``level-zero``
 package must be installed.  This package enables GEOPM's support for

--- a/service/docs/source/security.rst
+++ b/service/docs/source/security.rst
@@ -33,7 +33,7 @@ more difficult to extend.
 Some features of existing device drivers may be enabled for
 end users by changing file permissions, however this does not allow
 for filtering of which driver features will be available, and is often
-insufficent due to Linux
+insufficient due to Linux
 `capabilities(7) <https://man7.org/linux/man-pages/man7/capabilities.7.html>`__
 requirements.
 

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -76,7 +76,7 @@ Requires: libgeopmd1 = %{version}
 %description devel
 
 Development package for the GEOPM Service.  This provides the
-programing interface to libgeopmd.so.  The package includes the C and
+programming interface to libgeopmd.so.  The package includes the C and
 C++ header files, maunuals for these interfaces and the unversioned
 libgeopmd.so shared object symbolic link.
 

--- a/service/geopmdpy/pio.py
+++ b/service/geopmdpy/pio.py
@@ -274,7 +274,7 @@ def push_signal(signal_name, domain_type, domain_idx):
     be pushed onto the stack prior to the fist call to read_batch()
     or adjust().  After calls to read_batch() or adjust() have been
     made, signals may be pushed again only after calling reset() and
-    before caling read_batch() or adjust() again.  Attempts to push a
+    before calling read_batch() or adjust() again.  Attempts to push a
     signal onto the stack after the first call to read_batch() or
     read_batch() (and without calling reset()) or attempts to push a
     signal_name that is not provided by signal_names() will result in

--- a/service/geopmdpy/system_files.py
+++ b/service/geopmdpy/system_files.py
@@ -187,7 +187,7 @@ def secure_read_file(path):
 
 
 def is_secure_path(path):
-    """Query if path may be openend safely
+    """Query if path may be opened safely
 
     Check if path exists, and refers to a regular file that is not a link.  A
     warning message is printed if the path is a link, a directory or is not a
@@ -1014,7 +1014,7 @@ class WriteLock(object):
     controlling process when the lock is held.  The class manages the advisory
     lock to serialize any attempts read or write the file.  Additionally the
     class checks that the lock file is a regular file with restricted
-    permissions.  Maniuplations of the control lock file should be done
+    permissions.  Manipulations of the control lock file should be done
     exclusively with the WriteLock object to insure that the advisory lock is
     effective.
 
@@ -1064,7 +1064,7 @@ class WriteLock(object):
         if self._fid == None:
             self._rpc_unlock()
             raise RuntimeError('Unable to open write lock securely after two tries')
-        # Advisory lock protects against simultanious multi-process
+        # Advisory lock protects against simultaneous multi-process
         # modifications to the file, although we expect only one geopmd
         # process using this class.
         fcntl.lockf(self._fid, fcntl.LOCK_EX)

--- a/service/geopmdpy/topo.py
+++ b/service/geopmdpy/topo.py
@@ -67,7 +67,7 @@ def num_domain(domain):
     """Get the number of domains available on the system of a specific
     domain type.  If the domain is valid, but there are no domains of
     that type on the system, the return value is zero.  Invalid domain
-    specificiation will result in a raised exception.
+    specification will result in a raised exception.
 
     Args:
         domain (int or str): The domain type from one of topo.DOMAIN_*

--- a/service/geopmdpy_test/TestActiveSessions.py
+++ b/service/geopmdpy_test/TestActiveSessions.py
@@ -423,7 +423,7 @@ class TestActiveSessions(unittest.TestCase):
         session_mock = mock.create_autospec(os.stat_result, spec_set=True)
         session_mock.st_ctime = 123
 
-        # There are 2 calls into is_pid_valid:  Ths first verifies the client PID
+        # There are 2 calls into is_pid_valid:  This first verifies the client PID
         # against the session PID.  The second verifies the batch PID against the session PID.
         # side_effect is used so that the first call returns True (the client PID is valid) and
         # the second call returns False (the batch PID is *not* valid).

--- a/service/geopmdpy_test/TestPlatformService.py
+++ b/service/geopmdpy_test/TestPlatformService.py
@@ -46,7 +46,7 @@ class TestPlatformService(unittest.TestCase):
         self._RUN_PATH.cleanup()
 
     def test_close_already_closed(self):
-        # We already have two independent componenets with the session.
+        # We already have two independent components with the session.
         client_pid = -999
         self.open_mock_session('user_name', client_pid, True, 2)  # 2
         self._platform_service.close_session(client_pid)              # 1
@@ -56,7 +56,7 @@ class TestPlatformService(unittest.TestCase):
             self._platform_service.close_session(client_pid) # error here
 
     def test_read_already_closed(self):
-        # We already have two independent componenets with the session.
+        # We already have two independent components with the session.
         client_pid = -999
         self.open_mock_session('user_name', client_pid, True, 2)  # 2
         self._platform_service.close_session(client_pid)              # 1

--- a/service/geopmdpy_test/TestTimedLoop.py
+++ b/service/geopmdpy_test/TestTimedLoop.py
@@ -40,7 +40,7 @@ class TestTimedLoop(unittest.TestCase):
     @unittest.skipIf(os.environ.get('GEOPM_TEST_EXTENDED') is None, "Requires accurate timing")
     def test_timed_loop_infinite(self):
         period = 0.01
-        tl = TimedLoop(period) # Infinte loop
+        tl = TimedLoop(period) # Infinite loop
 
         self.assertEqual(period, tl._period)
         self.assertIsNone(tl._num_loop)

--- a/service/integration/README.md
+++ b/service/integration/README.md
@@ -18,7 +18,7 @@ Test Setup
 
 The integration tests require a system-wide installation of the GEOPM
 service.  This is typically done by installing the GEOPM RPM packages.
-Runing the following commands will create the GEOPM Service RPM files
+Running the following commands will create the GEOPM Service RPM files
 from the GEOPM source code repository.
 
 ```bash

--- a/service/integration/test/check_write_session.sh
+++ b/service/integration/test/check_write_session.sh
@@ -16,7 +16,7 @@ if [[ $# -gt 0 ]] && [[ $1 == '--help' ]]; then
     a write session to set it to 2 GHz and reads the register again.
     The test then kills the write session with signal 9 and reads the
     control register a third time.  The test asserts that the control
-    value was changed by the write sesssion, and that this change was
+    value was changed by the write session, and that this change was
     reverted to the value it started with after the session is
     killed.
 "

--- a/service/integration/test/test_kill_geopmd_serial_run.sh
+++ b/service/integration/test/test_kill_geopmd_serial_run.sh
@@ -4,7 +4,7 @@
 #
 
 # test_kill_geopmd_serial_run.sh
-# Send signal 9 to geopmd while serial write has occured and client is sleeping,
+# Send signal 9 to geopmd while serial write has occurred and client is sleeping,
 # check that the client stays alive, no restore occurs,
 # and the client is able to write once the service is automatically restarted
 
@@ -13,7 +13,7 @@ if [[ $# -gt 0 ]] && [[ $1 == '--help' ]]; then
     Terminating geopmd process serial write
     ---------------------------------------
 
-    Send signal 9 to geopmd while serial write has occured and client is sleeping,
+    Send signal 9 to geopmd while serial write has occurred and client is sleeping,
     check that the client stays alive, no restore occurs,
     and the client is able to write once the service is automatically restarted
 
@@ -40,7 +40,7 @@ sleep 1
 check_control
 
 kill_geopmd
-# After we kill geopmd, client should stil be around, and the server was never there
+# After we kill geopmd, client should still be around, and the server was never there
 # because it is a serial run, not a batch (server) run.
 sleep 7
 

--- a/service/integration/test/test_su_give_access.sh
+++ b/service/integration/test/test_su_give_access.sh
@@ -13,7 +13,7 @@ if [[ $# -gt 0 ]] && [[ $1 == '--help' ]]; then
     which controls the maximum frequency of the core.  The test saves
     the existing settings so they can be restored at the end of the
     test.  Access to the control is removed from the list, and it is
-    shown that the test user cannot succesfully run the
+    shown that the test user cannot successfully run the
     check_write_session.sh script.  Access to the control is granted
     and it is shown that the test user can succefully change the
     value.

--- a/service/src/BatchServer.cpp
+++ b/service/src/BatchServer.cpp
@@ -189,7 +189,7 @@ namespace geopm
             in_message = m_batch_status->receive_message();
         }
         catch (const Exception &ex) {
-            // If we were not interupted by SIGTERM with correct errno value rethrow
+            // If we were not interrupted by SIGTERM with correct errno value rethrow
             if (ex.err_value() != EINTR ||
                 g_sigterm_count == 0) {
                 throw Exception("BatchServer::" + std::string(__func__) + " The client is unresponsive",
@@ -216,7 +216,7 @@ namespace geopm
             m_is_client_waiting = false;
         }
         catch (const Exception &ex) {
-            // If we were not interupted by SIGTERM with correct errno value rethrow
+            // If we were not interrupted by SIGTERM with correct errno value rethrow
             if (ex.err_value() != EINTR ||
                 g_sigterm_count == 0) {
                 throw Exception("BatchServer::" + std::string(__func__) + " The client is unresponsive",
@@ -276,7 +276,7 @@ namespace geopm
                                     std::to_string(in_message), GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
                     break;
             }
-            // If in_message came from client send respose
+            // If in_message came from client send response
             if (in_message != BatchStatus::M_MESSAGE_TERMINATE) {
                 write_message(out_message);
             }

--- a/service/src/BatchServer.hpp
+++ b/service/src/BatchServer.hpp
@@ -25,7 +25,7 @@ namespace geopm
     class BatchServer
     {
         public:
-            /// @brief Interace called by geopmd to create the server
+            /// @brief Interface called by geopmd to create the server
             ///        for batch commands.
             BatchServer() = default;
             virtual ~BatchServer() = default;

--- a/service/src/ConstConfigIOGroup.cpp
+++ b/service/src/ConstConfigIOGroup.cpp
@@ -398,7 +398,7 @@ namespace geopm
             auto it = M_SIGNAL_FIELDS.find(prop.first);
             if (it == M_SIGNAL_FIELDS.end()) {
                 throw Exception("ConstConfigIOGroup::parse_config_json():"
-                                " unexpected propety: \"" + prop.first +
+                                " unexpected property: \"" + prop.first +
                                 "\"", GEOPM_ERROR_INVALID, __FILE__,
                                 __LINE__);
             }

--- a/service/src/DCGMDevicePool.hpp
+++ b/service/src/DCGMDevicePool.hpp
@@ -10,7 +10,7 @@ namespace geopm
 {
     /// An interface for the NVIDIA Data Center GPU Manager (DCGM).
     /// This class is a wrapper around all calls to the DCGM library
-    /// and is intented to be called via the DCGMIOGroup.  Its primary
+    /// and is intended to be called via the DCGMIOGroup.  Its primary
     /// function is provided an abstracted interface to DCGM metrics
     /// of interest.
     class DCGMDevicePool
@@ -72,7 +72,7 @@ namespace geopm
             /// @brief Set maximum samples to store for for DCGM devices. This is
             ///       the maximum number of DCGM samples that will be kept.
             ///       0 indicates no limit
-            /// @param [in] max_samples maximun number of samples to store
+            /// @param [in] max_samples maximum number of samples to store
             virtual void max_samples(int max_samples) = 0;
 
             /// @brief Enable DCGM data polling through setting the watch fields

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -88,7 +88,7 @@ namespace geopm
                 if (num_subdevice == 0) {
                     std::cerr << "LevelZero::" << std::string(__func__)  <<
                                  ": GEOPM Requires at least one subdevice. "
-                                 "Please check ZE_AFFINITY_MASK enviroment variable "
+                                 "Please check ZE_AFFINITY_MASK environment variable "
                                  "setting.  Forcing device to act as sub-device" << std::endl;
                 }
 #endif
@@ -144,7 +144,7 @@ namespace geopm
                 throw Exception("LevelZero::" + std::string(__func__) +
                                 ": GEOPM Requires the number of subdevices to be" +
                                 " evenly divisible by the number of devices. " +
-                                " Please check ZE_AFFINITY_MASK enviroment variable settings",
+                                " Please check ZE_AFFINITY_MASK environment variable settings",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
 
@@ -155,7 +155,7 @@ namespace geopm
                     throw Exception("LevelZero::" + std::string(__func__) +
                                     ": GEOPM Requires the number of subdevices to be" +
                                     " the same on all devices. " +
-                                    " Please check ZE_AFFINITY_MASK enviroment variable settings",
+                                    " Please check ZE_AFFINITY_MASK environment variable settings",
                                     GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                 }
             }

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -85,7 +85,7 @@ namespace geopm
             /// @return Frequency throttle reasons
             virtual uint32_t frequency_throttle_reasons(unsigned int l0_device_idx, int l0_domain,
                                                         int l0_domain_idx) const = 0;
-            /// @brief Get the LevelZero device mininum and maximum frequency
+            /// @brief Get the LevelZero device minimum and maximum frequency
             ///        control range in MHz
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero GPU.

--- a/service/src/MSRIOGroup.cpp
+++ b/service/src/MSRIOGroup.cpp
@@ -500,13 +500,13 @@ namespace geopm
                 auto denom_it = signal_hidden.find("MSR::ACNT_RATE");
                 if (numer_it != signal_hidden.end() &&
                     denom_it != signal_hidden.end()){
-                    auto numers = numer_it->second.signals;
-                    auto numer = numers[domain_idx];
-                    auto denoms = denom_it->second.signals;
-                    auto denom = denoms[domain_idx];
+                    auto numerators = numer_it->second.signals;
+                    auto numerator = numerators[domain_idx];
+                    auto denominators = denom_it->second.signals;
+                    auto denominator = denominators[domain_idx];
 
                     result[domain_idx] =
-                        std::make_shared<RatioSignal>(numer, denom);
+                        std::make_shared<RatioSignal>(numerator, denominator);
                 }
             }
 

--- a/service/src/NVMLGPUTopo.cpp
+++ b/service/src/NVMLGPUTopo.cpp
@@ -43,7 +43,7 @@ namespace geopm
                 ideal_affinitization_mask_vec.push_back(m_nvml_device_pool.cpu_affinity_ideal_mask(gpu_idx));
             }
 
-            /// @todo: As an optimization this may be replacable with CPU_OR of all masks in ideal_affinitzation_mask_vec
+            /// @todo: As an optimization this may be replaceable with CPU_OR of all masks in ideal_affinitzation_mask_vec
             //       and CPU_COUNT of the output
             for (unsigned int gpu_idx = 0; gpu_idx <  num_gpu; ++gpu_idx) {
                 for (int cpu_idx = 0; cpu_idx < num_cpu; cpu_idx++) {

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -299,7 +299,7 @@ namespace geopm
             sv.second.controls = result;
         }
 
-        // Only a user with elevated priviledges will be able to control
+        // Only a user with elevated privileges will be able to control
         // frequency and power.  Prune the controls if we don't have access.
         if (!m_nvml_device_pool.is_privileged_access()) {
             m_control_available.erase(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL");

--- a/service/src/POSIXSignal.hpp
+++ b/service/src/POSIXSignal.hpp
@@ -118,7 +118,7 @@ namespace geopm
             ///
             /// @remark See documentation for sigsuspend(2) about
             ///         parameters and return value. Except that it
-            ///         doesn't return an error by defualt.
+            ///         doesn't return an error by default.
             virtual void sig_suspend(const sigset_t *mask) const = 0;
     };
 

--- a/service/src/RatioSignal.cpp
+++ b/service/src/RatioSignal.cpp
@@ -43,11 +43,11 @@ namespace geopm
         }
 
         double result = NAN;
-        double numer = m_numerator->sample();
-        double denom = m_denominator->sample();
+        double numerator = m_numerator->sample();
+        double denominator = m_denominator->sample();
 
-        if (denom != 0) {
-            result = numer / denom;
+        if (denominator != 0) {
+            result = numerator / denominator;
         }
         return result;
     }
@@ -55,11 +55,11 @@ namespace geopm
     double RatioSignal::read(void) const
     {
         double result = NAN;
-        double numer = m_numerator->read();
-        double denom = m_denominator->read();
+        double numerator = m_numerator->read();
+        double denominator = m_denominator->read();
 
-        if (denom != 0) {
-            result = numer / denom;
+        if (denominator != 0) {
+            result = numerator / denominator;
         }
         return result;
     }

--- a/service/src/SSTControl.hpp
+++ b/service/src/SSTControl.hpp
@@ -32,7 +32,7 @@ namespace geopm
             ///             write is being issued.
             /// @param [in] command Which SST interface command to issue.
             /// @param [in] subcommand Which SST interface subcommand to issue.
-            /// @param [in] interface_parameter Which SST mailbox paramter to use.
+            /// @param [in] interface_parameter Which SST mailbox parameter to use.
             /// @param [in] write_value The value to write to the interface.
             /// @param [in] begin_bit The first (least-significant) bit to
             ///             include in the write mask.

--- a/service/src/SSTIO.hpp
+++ b/service/src/SSTIO.hpp
@@ -132,7 +132,7 @@ namespace geopm
             /// @param [in] write_mask The mask to apply when writing this value
             virtual void adjust(int batch_idx, uint64_t write_value, uint64_t write_mask) = 0;
 
-            /// @brief Get the punit index assocaited with a CPU index
+            /// @brief Get the punit index associated with a CPU index
             /// @param [in] cpu_index Index of the CPU
             virtual uint32_t get_punit_from_cpu(uint32_t cpu_index) = 0;
 

--- a/service/src/SaveControl.cpp
+++ b/service/src/SaveControl.cpp
@@ -106,7 +106,7 @@ namespace geopm
                                                       "domain_idx",
                                                       "setting"};
             if (jss_map.size() != required_keys.size()) {
-                throw Exception("SaveControlImp::Settins(): JSON object representing m_setting_s must have four fields",
+                throw Exception("SaveControlImp::Settings(): JSON object representing m_setting_s must have four fields",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             for (const auto &rk : required_keys) {

--- a/service/src/geopm/IOGroup.hpp
+++ b/service/src/geopm/IOGroup.hpp
@@ -30,7 +30,7 @@ namespace geopm
 
             /// @brief Description of the runtime behavior of a signal
             enum m_signal_behavior_e {
-                /// signals that have a contant value
+                /// signals that have a constant value
                 M_SIGNAL_BEHAVIOR_CONSTANT,
                 /// signals that increase monotonically
                 M_SIGNAL_BEHAVIOR_MONOTONE,

--- a/service/src/geopm/PluginFactory.hpp
+++ b/service/src/geopm/PluginFactory.hpp
@@ -84,7 +84,7 @@ namespace geopm
             {
                 auto it = m_dictionary.find(plugin_name);
                 if (it == m_dictionary.end()) {
-                    throw Exception("PluginFactory::dictonary(): Plugin named \"" + plugin_name +
+                    throw Exception("PluginFactory::dictionary(): Plugin named \"" + plugin_name +
                                     "\" has not been registered with the factory.",
                                     GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                 }

--- a/service/src/geopm_pio.h
+++ b/service/src/geopm_pio.h
@@ -365,7 +365,7 @@ int geopm_pio_control_description(const char *control_name,
 ///        as a string.
 ///
 /// @param [out] behavior_type One of the IOGroup::m_signal_behavior_e
-///        enum values that decribes the signals behavior over time.
+///        enum values that describes the signals behavior over time.
 ///
 /// @return Zero on success, error value on failure.
 int geopm_pio_signal_info(const char *signal_name,

--- a/service/src/msr_data_skx.json
+++ b/service/src/msr_data_skx.json
@@ -669,7 +669,7 @@
                     "behavior":  "monotone",
                     "writeable": false,
                     "aggregation": "sum",
-                    "description": "A filtered counter of MSR::APERF:ACNT that only incrments for cycles the hardware expects are productive toward instruction execution. This counter cannot measure processor performance when the CPU is inactive."
+                    "description": "A filtered counter of MSR::APERF:ACNT that only increments for cycles the hardware expects are productive toward instruction execution. This counter cannot measure processor performance when the CPU is inactive."
                 }
             }
         },
@@ -1048,7 +1048,7 @@
                     "behavior":  "variable",
                     "aggregation": "sum",
                     "writeable": true,
-                    "description": "Log bit indicating if a GUARANTEED_PERFORMANCE change has occured.  Software responsible to clear via write to 0. When reading at a higher level domain than its native domain, it aggregates as the count of all such bits that have been set."
+                    "description": "Log bit indicating if a GUARANTEED_PERFORMANCE change has occurred.  Software responsible to clear via write to 0. When reading at a higher level domain than its native domain, it aggregates as the count of all such bits that have been set."
                 },
                 "EXCURSION_TO_MINIMUM": {
                     "begin_bit": 2,
@@ -1059,7 +1059,7 @@
                     "behavior":  "variable",
                     "aggregation": "sum",
                     "writeable": true,
-                    "description": "Log bit indicating if an excursion below the minimum requested performance has occured.  Software responsible to clear via write to 0. When reading at a higher level domain than its native domain, it aggregates as the count of all such bits that have been set."
+                    "description": "Log bit indicating if an excursion below the minimum requested performance has occurred.  Software responsible to clear via write to 0. When reading at a higher level domain than its native domain, it aggregates as the count of all such bits that have been set."
                 },
                 "HIGHEST_CHANGE": {
                     "begin_bit": 3,
@@ -1070,7 +1070,7 @@
                     "behavior":  "variable",
                     "aggregation": "sum",
                     "writeable": true,
-                    "description": "Log bit indicating if a HIGHEST_PEROFRMANCE change has occured.  Software responsible to clear via write to 0. When reading at a higher level domain than its native domain, it aggregates as the count of all such bits that have been set."
+                    "description": "Log bit indicating if a HIGHEST_PEROFRMANCE change has occurred.  Software responsible to clear via write to 0. When reading at a higher level domain than its native domain, it aggregates as the count of all such bits that have been set."
                 },
                 "PECI_OVERRIDE_ENTRY": {
                     "begin_bit": 4,

--- a/service/test/BatchServerTest.cpp
+++ b/service/test/BatchServerTest.cpp
@@ -237,10 +237,10 @@ TEST_F(BatchServerTest, stop_batch_exception)
 /**
  * @test Check BatchServerImp::run_batch() under normal operation, given a sequence of read requests.
  *       First the requests signals and controls are filled up.
- *       Second the server recieves a message to read the batch.
+ *       Second the server receives a message to read the batch.
  *       It then samples both signals, and writes the results into the shared memory buffer.
  *       The server sends a message for the client to continue.
- *       The server recieved a message from the client to quit.
+ *       The server received a message from the client to quit.
  */
 TEST_F(BatchServerTest, run_batch_read)
 {
@@ -303,10 +303,10 @@ TEST_F(BatchServerTest, run_batch_read)
 /**
  * @test Check BatchServerImp::run_batch() when there are no signals and you try to read.
  *       First the control requests are populated.
- *       Second the server recieves a message to read the batch.
+ *       Second the server receives a message to read the batch.
  *       However there are no signals, so it does nothing.
  *       The server sends a message for the client to continue.
- *       The server recieved a message from the client to quit.
+ *       The server received a message from the client to quit.
  */
 TEST_F(BatchServerTest, run_batch_read_empty)
 {
@@ -345,10 +345,10 @@ TEST_F(BatchServerTest, run_batch_read_empty)
 /**
  * @test Check BatchServerImp::run_batch() under normal operation, given a sequence of write requests.
  *       First the requests signals and controls are filled up.
- *       Second the server recieves a message to write the batch.
+ *       Second the server receives a message to write the batch.
  *       It then reads the values from the shared memory and writes all of the pushed controls to the platform.
  *       The server sends a message for the client to continue.
- *       The server recieved a message from the client to quit.
+ *       The server received a message from the client to quit.
  */
 TEST_F(BatchServerTest, run_batch_write)
 {
@@ -406,10 +406,10 @@ TEST_F(BatchServerTest, run_batch_write)
 /**
  * @test Check BatchServerImp::run_batch() when there are no controls and you try to write.
  *       First the requests only signals are filled up.
- *       Second the server recieves a message to write the batch.
+ *       Second the server receives a message to write the batch.
  *       However there are no controls, so it does nothing.
  *       The server sends a message for the client to continue.
- *       The server recieved a message from the client to quit.
+ *       The server received a message from the client to quit.
  */
 TEST_F(BatchServerTest, run_batch_write_empty)
 {

--- a/service/test/ConstConfigIOGroupTest.cpp
+++ b/service/test/ConstConfigIOGroupTest.cpp
@@ -149,7 +149,7 @@ TEST_F(ConstConfigIOGroupTest, input_unexpected_properties)
         ConstConfigIOGroup iogroup(M_CONFIG_FILE_PATH, ""),
         GEOPM_ERROR_INVALID,
         "ConstConfigIOGroup::parse_config_json():"
-        " unexpected propety: \"" "magic" "\""
+        " unexpected property: \"" "magic" "\""
     );
 }
 
@@ -170,7 +170,7 @@ TEST_F(ConstConfigIOGroupTest, input_capital_properties)
         ConstConfigIOGroup iogroup(M_CONFIG_FILE_PATH, ""),
         GEOPM_ERROR_INVALID,
         "ConstConfigIOGroup::parse_config_json():"
-        " unexpected propety: \"" "DOMAIN" "\""
+        " unexpected property: \"" "DOMAIN" "\""
     );
 }
 

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -849,7 +849,7 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
     for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
         EXPECT_CALL(*m_device_pool, frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, _, _)).
                     WillRepeatedly(Throw(geopm::Exception("Not Supported", GEOPM_ERROR_RUNTIME, __FILE__, __LINE__)));
-        // frequency_range is called a non-standard number of times due to the implemetation of the pruning code.
+        // frequency_range is called a non-standard number of times due to the implementation of the pruning code.
         // Only one chip is checked if there is a failure.
         EXPECT_CALL(*m_device_pool,
                     frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(AtLeast(3));

--- a/service/test/MSRFieldControlTest.cpp
+++ b/service/test/MSRFieldControlTest.cpp
@@ -147,7 +147,7 @@ TEST_F(MSRFieldControlTest, setup_batch)
 
 TEST_F(MSRFieldControlTest, errors)
 {
-    // cannot constuct with null msrio
+    // cannot construct with null msrio
     GEOPM_EXPECT_THROW_MESSAGE(MSRFieldControl(nullptr, m_cpu, m_offset,
                                                m_begin_bit, m_end_bit,
                                                geopm::MSR::M_FUNCTION_SCALE, 1.0),

--- a/service/test/MSRFieldSignalTest.cpp
+++ b/service/test/MSRFieldSignalTest.cpp
@@ -234,7 +234,7 @@ TEST_F(MSRFieldSignalTest, setup_batch)
 
 TEST_F(MSRFieldSignalTest, errors)
 {
-    // logic errors in contructor because this class is internal to MSRIOGroup.
+    // logic errors in constructor because this class is internal to MSRIOGroup.
     // @todo: consider whether Signal should be public to help writers of IOGroups
 #ifdef GEOPM_DEBUG
     // cannot construct with null underlying signal

--- a/service/test/POSIXSignalTest.cpp
+++ b/service/test/POSIXSignalTest.cpp
@@ -44,7 +44,7 @@ class POSIXSignalTest : public :: testing :: Test
  * @brief save the process's sigset before running the test fixture
  *
  * @details For testing the sigprocmask(), which modifies the process's sigset.
- * This proces is running multiple tests, and we do not want the tests to leave any residue.
+ * This process is running multiple tests, and we do not want the tests to leave any residue.
  * Usually variable scope would be sufficient to enforce, but we are modifying the state of the process
  * because we are testing the system calls API.
  */
@@ -317,7 +317,7 @@ TEST_F(POSIXSignalTest, sig_proc_mask_SIG_BLOCK)
     m_posix_sig->sig_proc_mask(SIG_SETMASK, &original_sigset, nullptr);
     // The set of blocked signals is the union of the original sigset and the additional sigset
     m_posix_sig->sig_proc_mask(SIG_BLOCK, &additional_sigset, nullptr);
-    // Recored the resulting value of the sigset
+    // Recorded the resulting value of the sigset
     sigset_t resulting_sigset;
     m_posix_sig->sig_proc_mask(SIG_SETMASK, nullptr, &resulting_sigset);
     // Convert resulting_sigset into std::set<int>
@@ -362,7 +362,7 @@ TEST_F(POSIXSignalTest, sig_proc_mask_SIG_UNBLOCK)
     // The signals in deleted_sigset are removed from the current set of blocked signals.
     // It is permissible to attempt to unblock a signal which is not blocked.
     m_posix_sig->sig_proc_mask(SIG_UNBLOCK, &deleted_sigset, nullptr);
-    // Recored the resulting value of the sigset
+    // Recorded the resulting value of the sigset
     sigset_t resulting_sigset;
     m_posix_sig->sig_proc_mask(SIG_SETMASK, nullptr, &resulting_sigset);
     // Convert resulting_sigset into std::set<int>

--- a/service/test/PlatformIOTest.cpp
+++ b/service/test/PlatformIOTest.cpp
@@ -165,7 +165,7 @@ void PlatformIOTest::SetUp()
         m_control_iogroup,
         m_override_iogroup
     };
-    // construct list of base pointers for contructor
+    // construct list of base pointers for constructor
     std::list<std::shared_ptr<IOGroup> > iogroup_list;
     for (auto ptr : m_iogroup_ptr) {
         iogroup_list.emplace_back(ptr);

--- a/specs/geopm-gcc-mvapich2-toss.spec
+++ b/specs/geopm-gcc-mvapich2-toss.spec
@@ -42,7 +42,7 @@ The Global Extensible Open Power Manager (GEOPM) is a framework for
 exploring power and energy optimizations targeting high performance
 computing.  The GEOPM package provides many built-in features.  A
 simple use case is reading hardware counters and setting hardware
-controls with platform independant syntax using a command line tool on
+controls with platform independent syntax using a command line tool on
 a particular compute node.  An advanced use case is dynamically
 coordinating hardware settings across all compute nodes used by an
 application in response to the application's behavior and requests

--- a/specs/geopm-intel-mvapich2-toss.spec
+++ b/specs/geopm-intel-mvapich2-toss.spec
@@ -40,7 +40,7 @@ The Global Extensible Open Power Manager (GEOPM) is a framework for
 exploring power and energy optimizations targeting high performance
 computing.  The GEOPM package provides many built-in features.  A
 simple use case is reading hardware counters and setting hardware
-controls with platform independant syntax using a command line tool on
+controls with platform independent syntax using a command line tool on
 a particular compute node.  An advanced use case is dynamically
 coordinating hardware settings across all compute nodes used by an
 application in response to the application's behavior and requests

--- a/src/Admin.cpp
+++ b/src/Admin.cpp
@@ -98,7 +98,7 @@ namespace geopm
         result.add_option("allowlist", 'a', "msr-allowlist", false,
                           "print the minimum msr-safe allowlist required by GEOPM");
         result.add_option("cpuid", 'c', "cpuid", "-1",
-                          "cpuid in hexidecimal for allowlist (default is current platform)");
+                          "cpuid in hexadecimal for allowlist (default is current platform)");
         result.add_example_usage("");
         result.add_example_usage("[--config-default|--config-override|--msr-allowlist] [--cpuid]");
         return result;

--- a/src/ApplicationSampler.hpp
+++ b/src/ApplicationSampler.hpp
@@ -30,7 +30,7 @@ namespace geopm
             static ApplicationSampler &application_sampler(void);
             /// @brief Returns set of region hashes associated with
             ///        application network functions.
-            /// @return Set of netowrk function region hashes.
+            /// @return Set of network function region hashes.
             static std::set<uint64_t> region_hash_network(void);
             /// @brief Returns the default shared memory key, which consists
             ///        of the prefix "/geopm-shm-" concatenated with the euid.

--- a/src/CPUActivityAgent.cpp
+++ b/src/CPUActivityAgent.cpp
@@ -359,7 +359,7 @@ namespace geopm
             // the uncore frequency in the efficient - performant range.
             // A more robust/future proof solution may be to directly query uncore
             // counters that indicate utilization (when/if available).
-            // For now only L3 bandwith metric is used.
+            // For now only L3 bandwidth metric is used.
             double uncore_req = m_resolved_f_uncore_efficient + f_uncore_range * scalability_uncore;
 
             // Clamp uncore request within policy limits

--- a/src/Comm.hpp
+++ b/src/Comm.hpp
@@ -62,7 +62,7 @@ namespace geopm
             /// @param [in] num_ranks Number of ranks that must fit in Cartesian grid.
             ///
             /// @param [in, out] dimension Number of ranks per dimension.  The size of this vector
-            ///        dictates the number of dimensions in the grid.  Fill indecies with 0 for API
+            ///        dictates the number of dimensions in the grid.  Fill indices with 0 for API
             ///        to fill with suitable value.
             virtual void dimension_create(int num_ranks, std::vector<int> &dimension) const = 0;
             /// @brief Free memory that was allocated for message passing and RMA

--- a/src/Controller.hpp
+++ b/src/Controller.hpp
@@ -33,7 +33,7 @@ namespace geopm
     {
         public:
             Controller();
-            /// @brief Standard contstructor for the Controller.
+            /// @brief Standard constructor for the Controller.
             ///
             /// @param [in] ppn1_comm The MPI communicator that supports
             ///        the control messages.

--- a/src/ELF.cpp
+++ b/src/ELF.cpp
@@ -37,7 +37,7 @@ namespace geopm
             ///         string if all symbols in section have been
             ///         iterated over.
             virtual std::string symbol_name(void) = 0;
-            /// @brief Get the offest of the current symbol.
+            /// @brief Get the offset of the current symbol.
             /// @return Current symbol offset.  Will return zero if
             ///         all symbols in section have been iterated
             ///         over.

--- a/src/EditDistEpochRecordFilter.hpp
+++ b/src/EditDistEpochRecordFilter.hpp
@@ -31,12 +31,12 @@ namespace geopm
             ///        potentially a period.  Suggested default is 3.
             ///
             /// @param [in] stable_period_hysteresis Factor that along
-            ///        with the period length that detemines when a
+            ///        with the period length that determines when a
             ///        stable period has been detected.  Suggested
             ///        default is 1.
             ///
             /// @param [in] unstable_period_hysteresis Factor that
-            ///        along with the period length that detemines
+            ///        along with the period length that determines
             ///        when the period has become unstable.  This
             ///        happens when the period changes from the
             ///        previously detected length.  Suggested default

--- a/src/EditDistPeriodicityDetector.hpp
+++ b/src/EditDistPeriodicityDetector.hpp
@@ -33,7 +33,7 @@ namespace geopm
             ///        period is determined, returns -1.
             int get_period(void) const;
             /// @brief Return the metric that will be maximized to
-            ///        detemine the period.  Until a stable period is
+            ///        determine the period.  Until a stable period is
             ///        determined, returns -1.
             int get_score(void) const;
             /// @brief Return the number of records that this object has

--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -181,7 +181,7 @@ namespace geopm
                     auto user_value = name_value_map[var_name];
                     std::cerr << "Warning: <geopm> User provided environment variable \"" << var_name
                               << "\" with value <"  << user_value << ">"
-                              << " has been overriden with value <"  << override_value << ">" << std::endl;
+                              << " has been overridden with value <"  << override_value << ">" << std::endl;
                 }
                 name_value_map[var_name] = override_value;
             }

--- a/src/FrequencyGovernor.hpp
+++ b/src/FrequencyGovernor.hpp
@@ -33,7 +33,7 @@ namespace geopm
             ///        init_platform_io().
             /// @throw Exception the requested domain does not contain the
             ///        frequency control's native domain.
-            /// @throw Exception The caller attemped to set the domain type
+            /// @throw Exception The caller attempted to set the domain type
             ///        after this governor initialized its PlatformIO controls.
             virtual void set_domain_type(int domain_type) = 0;
             /// @brief Write frequency control, may be clamped between
@@ -60,16 +60,16 @@ namespace geopm
             /// @brief Returns the frequency step for the platform.
             /// @return Step frequency.
             virtual double get_frequency_step() const = 0;
-            /// @brief Returns the number of clamping occurence count for the platform.
-            /// @return Clamp occurence counter
+            /// @brief Returns the number of clamping occurrence count for the platform.
+            /// @return Clamp occurrence counter
             virtual int get_clamp_count() const = 0;
             /// @brief Checks that the minimum and maximum frequency
             ///        are within range for the platform.  If not,
             ///        they will be clamped at the min and max for the
             ///        platform.
-            /// @param [inout] freq_min Minimum frequency to attempt
+            /// @param [in,out] freq_min Minimum frequency to attempt
             ///        to set, and resulting valid minimum.
-            /// @param [inout] freq_max Maximum frequency to attempt
+            /// @param [in,out] freq_max Maximum frequency to attempt
             ///        to set, and resulting valid maximum.
             virtual void validate_policy(double &freq_min, double &freq_max) const = 0;
             /// @brief Returns a unique_ptr to a concrete object

--- a/src/PowerBalancerAgent.hpp
+++ b/src/PowerBalancerAgent.hpp
@@ -30,7 +30,7 @@ namespace geopm
                 ///        first case this is the M_SEND_DOWN_LIMIT
                 ///        step at the beginning of the application
                 ///        run.  This value will also be non-zero in
-                ///        the case where the resource mananger has
+                ///        the case where the resource manager has
                 ///        requested a new budget for the application,
                 ///        and thus, the algorithm must be restarted
                 ///        at step M_SEND_DOWN_LIMIT.

--- a/src/PowerGovernor.hpp
+++ b/src/PowerGovernor.hpp
@@ -35,7 +35,7 @@ namespace geopm
             /// @param [in] min_pkg_power Minimum package power.
             /// @param [in] max_pkg_power Maximum package power.
             virtual void set_power_bounds(double min_pkg_power, double max_pkg_power) = 0;
-            /// @brief Get the time window for controling package power.
+            /// @brief Get the time window for controlling package power.
             /// @return Time window in units of seconds.
             virtual double power_package_time_window(void) const = 0;
             /// @brief Returns a unique_ptr to a concrete object

--- a/src/ProfileTracer.cpp
+++ b/src/ProfileTracer.cpp
@@ -24,7 +24,7 @@
 
 namespace geopm
 {
-    // defintion of the static data member
+    // definition of the static data member
     ApplicationSampler* ProfileTracerImp::m_application_sampler = nullptr;
 
     ProfileTracerImp::ProfileTracerImp(const std::string &start_time)

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -357,23 +357,23 @@ namespace geopm
         auto divide = [this](uint64_t hash, const std::vector<std::string> &sig) -> double
         {
             GEOPM_DEBUG_ASSERT(sig.size() == 2, "Wrong number of signals for divide()");
-            double numer = m_sample_agg->sample_region(m_sync_signal_idx[sig[0]], hash);
-            double denom = m_sample_agg->sample_region(m_sync_signal_idx[sig[1]], hash);
-            return denom == 0 ? 0.0 : numer / denom;
+            double numerator = m_sample_agg->sample_region(m_sync_signal_idx[sig[0]], hash);
+            double denominator = m_sample_agg->sample_region(m_sync_signal_idx[sig[1]], hash);
+            return denominator == 0 ? 0.0 : numerator / denominator;
         };
         auto divide_pct = [this](uint64_t hash, const std::vector<std::string> &sig) -> double
         {
             GEOPM_DEBUG_ASSERT(sig.size() == 2, "Wrong number of signals for divide_pct()");
-            double numer = m_sample_agg->sample_region(m_sync_signal_idx[sig[0]], hash);
-            double denom = m_sample_agg->sample_region(m_sync_signal_idx[sig[1]], hash);
-            return denom == 0 ? 0.0 : 100.0 * numer / denom;
+            double numerator = m_sample_agg->sample_region(m_sync_signal_idx[sig[0]], hash);
+            double denominator = m_sample_agg->sample_region(m_sync_signal_idx[sig[1]], hash);
+            return denominator == 0 ? 0.0 : 100.0 * numerator / denominator;
         };
         auto divide_sticker_scale = [this](uint64_t hash, const std::vector<std::string> &sig) -> double
         {
             GEOPM_DEBUG_ASSERT(sig.size() == 2, "Wrong number of signals for divide_sticker_scale()");
-            double numer = m_sample_agg->sample_region(m_sync_signal_idx[sig[0]], hash);
-            double denom = m_sample_agg->sample_region(m_sync_signal_idx[sig[1]], hash);
-            return denom == 0 ? 0.0 : m_sticker_freq * numer / denom;
+            double numerator = m_sample_agg->sample_region(m_sync_signal_idx[sig[0]], hash);
+            double denominator = m_sample_agg->sample_region(m_sync_signal_idx[sig[1]], hash);
+            return denominator == 0 ? 0.0 : m_sticker_freq * numerator / denominator;
         };
 
         m_sync_fields = {

--- a/src/geopm_agent.h
+++ b/src/geopm_agent.h
@@ -146,7 +146,7 @@ int geopm_agent_sample_name(const char *agent_name,
  *
  *  @param [out] num_agent The number of agents currently available.
  *
- *  @return Zero if no error occured.  Otherwise the error code will be returned.
+ *  @return Zero if no error occurred.  Otherwise the error code will be returned.
  */
 int geopm_agent_num_avail(int *num_agent);
 

--- a/src/geopm_endpoint.h
+++ b/src/geopm_endpoint.h
@@ -147,7 +147,7 @@ int geopm_endpoint_profile_name(struct geopm_endpoint_c *endpoint,
  *         geopm_endpoint_create() that has reported an attached
  *         agent.
  *
- *  @param [out] num_node Number of compute nodes controled by
+ *  @param [out] num_node Number of compute nodes controlled by
  *         attached agent.
  *
  *  @return Zero on success, error code on failure.
@@ -185,7 +185,7 @@ int geopm_endpoint_node_name(struct geopm_endpoint_c *endpoint,
  *         agent.
  *
  *  @param [in] policy_array Array of length returned by
- *         geopm_agent_num_policy() specifing the value of each policy
+ *         geopm_agent_num_policy() specifying the value of each policy
  *         parameter.
  *
  *  @return Zero on success, error code on failure

--- a/src/ompt_callback.cpp
+++ b/src/ompt_callback.cpp
@@ -38,7 +38,7 @@ extern "C"
                                    uint64_t count,
                                    const void *parallel_function)
     {
-        // Understanding based on inpection of the values passed by the
+        // Understanding based on inspection of the values passed by the
         // intel compiler implementation when running a test:
         //
         // - The omp team leader calls this function with the "count"

--- a/test/ApplicationStatusTest.cpp
+++ b/test/ApplicationStatusTest.cpp
@@ -261,7 +261,7 @@ TEST_F(ApplicationStatusTest, update_cache)
     EXPECT_EQ(-1, m_status->get_process(0));
 
     m_status->update_cache();
-    // set process initalizes hash for active CPUs
+    // set process initializes hash for active CPUs
     EXPECT_EQ(GEOPM_REGION_HASH_UNMARKED, m_status->get_hash(0));
     EXPECT_EQ(GEOPM_REGION_HASH_UNMARKED, m_status->get_hash(1));
     EXPECT_EQ(GEOPM_REGION_HASH_INVALID, m_status->get_hash(2));

--- a/test/CommMPIImpTest.cpp
+++ b/test/CommMPIImpTest.cpp
@@ -435,7 +435,7 @@ void CommMPIImpTest::check_params()
 TEST_F(CommMPIImpTest, mpi_comm_ops)
 {
     MPICommTestHelper tmp_comm;//no param constructor uses MPI_COMM_WORLD, others will dup causing failure
-    int test_rank = -1; // interally MPIComm.rank init's tmp var to -1 which is passed to [P]MPI_Comm_rank
+    int test_rank = -1; // internally MPIComm.rank init's tmp var to -1 which is passed to [P]MPI_Comm_rank
 
     // comm rank
     g_sizes.push_back(sizeof(MPI_Comm));

--- a/test/no_omp_cpu.c
+++ b/test/no_omp_cpu.c
@@ -26,7 +26,7 @@ void no_omp_cpu(int num_cpu, cpu_set_t *no_omp)
             assert(cpu_index < num_cpu);
             CPU_CLR(cpu_index, no_omp);
         } /* end pragma omp critical */
-    } /* end pragam omp parallel */
+    } /* end pragma omp parallel */
 }
 
 int main(int argc, char **argv)

--- a/test_hw/rapl_pkg_limit_test.c
+++ b/test_hw/rapl_pkg_limit_test.c
@@ -263,7 +263,7 @@ int rapl_pkg_limit_test(double power_limit, int num_rep)
         err = geopm_time(&end_time);
     }
     if (!err) {
-        /* Calcuate average power */
+        /* Calculate average power */
         total_time = geopm_time_diff(&begin_time, &end_time);
     }
     for (socket = 0; !err && socket < num_socket; ++socket) {
@@ -315,7 +315,7 @@ int rapl_pkg_limit_test(double power_limit, int num_rep)
                     socket, power_used[socket]);
         }
     }
-    /* Pipe error messages to standard error if they occured before
+    /* Pipe error messages to standard error if they occurred before
        the outfile was opened. */
     if (!outfile) {
         outfile = stderr;

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -37,7 +37,7 @@ To determine if tutorial_hosts is necessary, try the following:
   2. Issue the following: mpiexec.hydra -n 10 -ppn 10 hostname
     a. You should observe the same hostname is printed 10 times.
   3. Next issue: mpiexec.hydra -n 10 -ppn 5 hostname
-    a. You should observe 5 occurances of hostname A and 5 of B.
+    a. You should observe 5 occurrences of hostname A and 5 of B.
 If either 2.a or 3.a is not observed properly, you'll need to utilize
 the tutorial_hosts file.
 

--- a/tutorial/admin/07_setup_override_power_balancer.sh
+++ b/tutorial/admin/07_setup_override_power_balancer.sh
@@ -59,4 +59,4 @@ echo "{\"GEOPM_AGENT\": \"power_balancer\", \"GEOPM_POLICY\": \"$POLICY_FILE_PAT
 #   Agent: power_balancer
 #   Policy: {"CPU_POWER_LIMIT": 230}
 #   > grep Warning geopm_stdout
-#   Warning: <geopm> User provided environment variable "GEOPM_AGENT" with value <monitor> has been overriden with value <power_balancer>
+#   Warning: <geopm> User provided environment variable "GEOPM_AGENT" with value <monitor> has been overridden with value <power_balancer>

--- a/tutorial/agent/README.md
+++ b/tutorial/agent/README.md
@@ -19,7 +19,7 @@ from the previous tutorial found in $GEOPM_ROOT/tutorial/iogroup.  The
 ExampleAgent calculates the system utilization from the user, system,
 and idle time signals and prints the result to standard output or
 standard error.  The policies in this example are the bounds on the
-idle percentage that detemine whether standard out or standard error
+idle percentage that determine whether standard out or standard error
 is used.
 
 


### PR DESCRIPTION
- Fix spell-checking errors detected by codespell
- Add codespell to a new linter job in our GitHub Actions automation
- Add an initial pre-commit hook configuration that runs codespell

**Why both an action and a pre-commit hook?**
Actions can be used to gate PRs that are candidates to merge into dev, so every PR contribution goes through those checks. Pre-commit hooks do not run for anyone who chooses not to opt in to installing them. However, pre-commit hooks are are still valuable to contributors because they let the contributor see whether each individual commit introduces new issues, instead of only seeing those issues all at once when a PR is pushed.

Draft PR #2670 has some examples of other light-weight checks that might be useful as pre-commit and action linters.