### PR TITLE
Update the GPU-CA to use the ConstConfigIOGroup

### DIFF
--- a/integration/experiment/energy_efficiency/gpu_activity.py
+++ b/integration/experiment/energy_efficiency/gpu_activity.py
@@ -19,12 +19,6 @@ from experiment import machine
 
 def setup_run_args(parser):
     common_args.setup_run_args(parser)
-    parser.add_argument('--gpu-frequency-efficient', dest='gpu_fe',
-                        action='store', default='nan',
-                        help='The efficient frequency of the gpu (a.k.a. Fe) for this experiment')
-    parser.add_argument('--gpu-frequency-max', dest='gpu_fmax',
-                        action='store', default='nan',
-                        help='The maximum frequency of the gpu (a.k.a. Fmax) for this experiment')
     parser.add_argument('--phi-list', nargs='+', help='A space separated list of phi values to use')
 
 def report_signals():
@@ -33,7 +27,7 @@ def report_signals():
 def trace_signals():
     return []
 
-def launch_configs(output_dir, app_conf, gpu_fe, gpu_fmax, phi_list):
+def launch_configs(output_dir, app_conf, phi_list):
     mach = machine.init_output_dir(output_dir)
     sys_min = mach.frequency_min()
     sys_max = mach.frequency_max()
@@ -45,9 +39,7 @@ def launch_configs(output_dir, app_conf, gpu_fe, gpu_fmax, phi_list):
     else:
         phi_values = [x/10 for x in list(range(0,11))]
 
-    config_list = [{"GPU_FREQ_MAX" : float(gpu_fmax),
-                    "GPU_FREQ_EFFICIENT": float(gpu_fe),
-                    "GPU_PHI" : float(phi)} for phi in phi_values]
+    config_list = [{"GPU_PHI" : float(phi)} for phi in phi_values]
     config_names = ['phi'+str(int(phi*100)) for phi in phi_values]
 
     targets = []
@@ -69,7 +61,7 @@ def launch(app_conf, args, experiment_cli_args):
                                                     trace_signals=trace_signals())
     extra_cli_args += experiment_cli_args
 
-    targets = launch_configs(output_dir, app_conf, args.gpu_fe, args.gpu_fmax, args.phi_list)
+    targets = launch_configs(output_dir, app_conf, args.phi_list)
 
     launch_util.launch_all_runs(targets=targets,
                                 num_nodes=args.node_count,

--- a/integration/experiment/gpu_frequency_sweep/gen_gpu_activity_constconfig_recommendation.py
+++ b/integration/experiment/gpu_frequency_sweep/gen_gpu_activity_constconfig_recommendation.py
@@ -70,7 +70,7 @@ def get_config_from_frequency_sweep(full_df):
                     "GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY" : {
                         "domain" : "board",
                         "description" : "Defines the efficient compute frequency to use for GPUs.  " +
-                                        "This value is based on a workload that scales strongly with the frequency domain",
+                                        "This value is based on a workload that scales strongly with the frequency domain.",
                         "units" : "hertz",
                         "aggregation" : "average",
                         "values" : [gpu_freq_efficient],

--- a/integration/experiment/uncore_frequency_sweep/gen_cpu_activity_constconfig_recommendation.py
+++ b/integration/experiment/uncore_frequency_sweep/gen_cpu_activity_constconfig_recommendation.py
@@ -143,7 +143,7 @@ def get_config_from_frequency_sweep(full_df, region_list):
                     "CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY": {
                         "domain" : "board",
                         "description" : "Defines the efficient uncore frequency to use for CPUs.  " +
-                                        "This value is based on a workload that scales strongly with the frequency domain",
+                                        "This value is based on a workload that scales strongly with the frequency domain.",
                         "units" : "hertz",
                         "aggregation" : "average",
                         "values" : [uncore_freq_recommendation],
@@ -153,7 +153,7 @@ def get_config_from_frequency_sweep(full_df, region_list):
     for idx, (k,v) in enumerate(mem_bw_characterization.items()):
         json_dict["CPU_UNCORE_FREQUENCY_" + str(idx)] = {"domain" : "board",
                                                         "description" : "CPU Uncore Frequency associated with " +
-                                                                        "CPU_UNCORE_MAX_MEMORY_BANDWIDTH_" + str(idx),
+                                                                        "CPU_UNCORE_MAX_MEMORY_BANDWIDTH_" + str(idx) + ".",
                                                         "units" : "hertz",
                                                         "aggregation" : "average",
                                                         "values" : [k]}
@@ -161,7 +161,7 @@ def get_config_from_frequency_sweep(full_df, region_list):
                                                                     "description" : "Maximum memory bandwidth in " +
                                                                                     "bytes perf second " +
                                                                                     "associated with " +
-                                                                                    "CPU_UNCORE_FREQUENCY_" + str(idx),
+                                                                                    "CPU_UNCORE_FREQUENCY_" + str(idx) + ".",
                                                                     "units" : "none",
                                                                     "aggregation" : "average",
                                                                     "values" : [v]}

--- a/integration/test/test_gpu_activity_agent.py
+++ b/integration/test/test_gpu_activity_agent.py
@@ -42,7 +42,7 @@ class TestIntegration_gpu_activity(unittest.TestCase):
         # Once the GPU Frequency sweep infrastructure is added a full
         # characterization integration test should be added that does
         # a GPU frequency sweep of parres dgemm, parses the frequency
-        # sweep using the gen_gpu_activity_policy_recommendation.py
+        # sweep using the gen_gpu_activity_constconfig_recommendation.py
         # script, and uses the output provided.
         #
         # This is a less time consuming version of that approach,
@@ -78,8 +78,6 @@ class TestIntegration_gpu_activity(unittest.TestCase):
             cool_off_time=3,
             enable_traces=False,
             enable_profile_traces=False,
-            gpu_fe=efficient_freq,
-            gpu_fmax=max_freq,
             phi_list=None,
         )
 

--- a/service/docs/source/geopm_agent_gpu_activity.7.rst
+++ b/service/docs/source/geopm_agent_gpu_activity.7.rst
@@ -17,8 +17,8 @@ based upon the compute activity of each GPU as provided by the
 ``GPU_CORE_ACTIVITY`` signal and modified by the ``GPU_UTILIZATION`` signal.
 
 The agent scales frequency in the range of ``Fe`` to ``Fmax``, where ``Fmax``
-is provided by the NVML or LevelZero IOGroup and ``Fe`` is provided by the
-ConstConfigIOGroup or the LevelZeroIOGroup.
+is provided by the NVMLIOGroup or LevelZeroIOGroup and ``Fe`` is provided by the
+ConstConfigIOGroup or LevelZeroIOGroup.
 
 Low activity regions (compute activity
 of 0.0) run at the ``Fe`` frequency, high activity regions (compute activity of 1.0)
@@ -91,7 +91,7 @@ An example ConstConfigIOGroup configuration file is provided below::
     {
         "GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY": {
             "domain": "board",
-            "description": "Defines the efficient compute frequency to use for GPUs.  This value is based on a workload that scales strongly with the frequency domain",
+            "description": "Defines the efficient compute frequency to use for GPUs.  This value is based on a workload that scales strongly with the frequency domain.",
             "units": "hertz",
             "aggregation": "average",
             "values": [982000000.0]

--- a/src/GPUActivityAgent.hpp
+++ b/src/GPUActivityAgent.hpp
@@ -78,8 +78,6 @@ namespace geopm
 
             // Policy indices; must match policy_names()
             enum m_policy_e {
-                M_POLICY_GPU_FREQ_MAX,
-                M_POLICY_GPU_FREQ_EFFICIENT,
                 M_POLICY_GPU_PHI,
                 M_NUM_POLICY
             };
@@ -93,8 +91,11 @@ namespace geopm
 
             double m_gpu_frequency_requests;
             double m_gpu_frequency_clipped;
-            double m_f_max;
-            double m_f_efficient;
+            double m_freq_gpu_min;
+            double m_freq_gpu_max;
+            double m_freq_gpu_efficient;
+            double m_resolved_f_gpu_max;
+            double m_resolved_f_gpu_efficient;
             double m_f_range;
             std::vector<double> m_gpu_active_region_start;
             std::vector<double> m_gpu_active_region_stop;

--- a/test/GPUActivityAgentTest.cpp
+++ b/test/GPUActivityAgentTest.cpp
@@ -191,6 +191,16 @@ TEST_F(GPUActivityAgentTest, validate_policy)
     EXPECT_CALL(*m_platform_io, signal_names()).WillRepeatedly(Return(empty_set));
     policy[PHI] = 0.1;
     EXPECT_NO_THROW(m_agent->validate_policy(policy));
+
+    //Policy Phi < 0 --> Error
+    policy[PHI] = -1;
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "POLICY_GPU_PHI value out of range");
+
+    //Policy Phi > 1.0 --> Error
+    policy[PHI] = 1.1;
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "POLICY_GPU_PHI value out of range");
 }
 
 void GPUActivityAgentTest::test_adjust_platform(std::vector<double> &policy,

--- a/test/GPUActivityAgentTest.cpp
+++ b/test/GPUActivityAgentTest.cpp
@@ -130,8 +130,8 @@ void GPUActivityAgentTest::SetUp()
     ASSERT_LT(M_FREQ_MIN, 0.2e9);
     ASSERT_LT(1.4e9, M_FREQ_MAX);
 
-    std::set<std::string> signal_name_set = {"GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY"};
-    ON_CALL(*m_platform_io, read_signal("GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
+    std::set<std::string> signal_name_set = {"CONST_CONFIG::GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY"};
+    ON_CALL(*m_platform_io, read_signal("CONST_CONFIG::GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
             .WillByDefault(Return(M_FREQ_EFFICIENT));
 
     ON_CALL(*m_platform_io, signal_names()).WillByDefault(Return(signal_name_set));
@@ -286,4 +286,19 @@ TEST_F(GPUActivityAgentTest, adjust_platform_signal_out_of_bounds_low)
     double mock_util = 1.0;
     test_adjust_platform(policy, mock_active, mock_util, M_FREQ_EFFICIENT);
 
+}
+
+TEST_F(GPUActivityAgentTest, invalid_fe)
+{
+    ON_CALL(*m_platform_io, read_signal("CONST_CONFIG::GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
+            .WillByDefault(Return(1e99));
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->init(0, {}, false), GEOPM_ERROR_INVALID,
+                                "(): GPU efficient frequency out of range: ");
+
+    ON_CALL(*m_platform_io, read_signal("CONST_CONFIG::GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
+            .WillByDefault(Return(-1));
+
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->init(0, {}, false), GEOPM_ERROR_INVALID,
+                                "(): GPU efficient frequency out of range: ");
 }

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -331,6 +331,7 @@ if ENABLE_BETA
                    test/gtest_links/GPUActivityAgentTest.adjust_platform_zero \
                    test/gtest_links/GPUActivityAgentTest.adjust_platform_signal_out_of_bounds_high \
                    test/gtest_links/GPUActivityAgentTest.adjust_platform_signal_out_of_bounds_low \
+                   test/gtest_links/GPUActivityAgentTest.invalid_fe \
                    test/gtest_links/PolicyStoreImpTest.self_consistent \
                    test/gtest_links/PolicyStoreImpTest.table_precedence \
                    test/gtest_links/PolicyStoreImpTest.update_policy \


### PR DESCRIPTION
- Relates to #2698 feature request from github issues
- Fixes #2708 change request from github issues.

Updates the GPU-CA to use the information in the ConstConfigIOGroup during runs, reduce the GPU-CA policy to only the phi value, and allows for per-node characterization runs.

This PR builds upon #2690 and #2692