### PR TITLE
In ConstConfigIOGroup, check values against domain size

### DIFF
--- a/service/src/ConstConfigIOGroup.hpp
+++ b/service/src/ConstConfigIOGroup.hpp
@@ -16,11 +16,14 @@
 
 namespace geopm
 {
+    class PlatformTopo;
+
     class ConstConfigIOGroup : public IOGroup
     {
         public:
             ConstConfigIOGroup();
-            ConstConfigIOGroup(const std::string &user_file_path,
+            ConstConfigIOGroup(const PlatformTopo& topo,
+                               const std::string &user_file_path,
                                const std::string &default_file_path);
             std::set<std::string> signal_names(void) const override;
             /// @return empty set; this IOGroup does not provide any controls.
@@ -93,7 +96,7 @@ namespace geopm
                 int domain_idx;
             };
 
-            void parse_config_json(const std::string &config);
+            void parse_config_json(const PlatformTopo &topo, const std::string &config);
             static json11::Json construct_config_json_obj(const std::string &config);
             static void check_json_signal(const json11::Json::object::value_type &signal);
 

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -74,6 +74,7 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/ConstConfigIOGroupTest.input_invalid_aggregation \
               test/gtest_links/ConstConfigIOGroupTest.input_incorrect_type \
               test/gtest_links/ConstConfigIOGroupTest.input_array_value_type \
+              test/gtest_links/ConstConfigIOGroupTest.input_array_value_num_domain \
               test/gtest_links/ConstConfigIOGroupTest.input_array_value_empty \
               test/gtest_links/ConstConfigIOGroupTest.valid_json_positive \
               test/gtest_links/ConstConfigIOGroupTest.valid_json_negative \


### PR DESCRIPTION
- Check the number of values for each signal concurs with domain size reported by PlatformTopo
- Add unit test to validate domain sizes are checked properly

Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>

- Fixes #2710 