### PR TITLE
Addition of GPU_CORE_FREQUENCY_STEP for NVIDIA GPUs

### DIFF
--- a/service/docs/source/geopm_pio.7.rst
+++ b/service/docs/source/geopm_pio.7.rst
@@ -171,13 +171,13 @@ Descriptions Of High Level Aliases
 ``GPU_CORE_ACTIVITY``
     GPU compute core activity expressed as a ratio of cycles.
 
-``GPU_CORE_FREQENCY_MAX_AVAIL``
+``GPU_CORE_FREQUENCY_MAX_AVAIL``
     Maximum supported GPU core frequency over the specified domain.
 
-``GPU_CORE_FREQENCY_MIN_AVAIL``
+``GPU_CORE_FREQUENCY_MIN_AVAIL``
     Minimum supported GPU core frequency over the specified domain.
 
-``GPU_CORE_FREQENCY_STEP``
+``GPU_CORE_FREQUENCY_STEP``
     Step size between GPU frequency settings.
 
 ``GPU_CORE_FREQUENCY_MAX_CONTROL``

--- a/service/docs/source/geopm_pio.7.rst
+++ b/service/docs/source/geopm_pio.7.rst
@@ -177,6 +177,9 @@ Descriptions Of High Level Aliases
 ``GPU_CORE_FREQENCY_MIN_AVAIL``
     Minimum supported GPU core frequency over the specified domain.
 
+``GPU_CORE_FREQENCY_STEP``
+    Step size between GPU frequency settings.
+
 ``GPU_CORE_FREQUENCY_MAX_CONTROL``
     Control that limits the maximum GPU core frequency.
 

--- a/service/docs/source/geopm_pio_nvml.7.rst
+++ b/service/docs/source/geopm_pio_nvml.7.rst
@@ -127,6 +127,13 @@ Signals
     *  **Format**: double
     *  **Unit**: hertz
 
+``NVML::GPU_CORE_FREQUENCY_STEP``
+    The Streaming Multiprocessor frequency step size in hertz.  If the step size is variable the average of all steps is provided.
+    *  **Aggregation**: expect_same
+    *  **Domain**: gpu
+    *  **Format**: double
+    *  **Unit**: hertz
+
 Controls
 --------
 
@@ -183,6 +190,9 @@ Signal Aliases
 
 ``GPU_CORE_FREQUENCY_MAX_AVAIL``
     Maps to ``NVML::GPU_CORE_FREQUENCY_MAX_AVAIL``.
+
+``GPU_CORE_FREQUENCY_STEP``
+    Maps to ``NVML::GPU_CORE_FREQUENCY_STEP``.
 
 ``GPU_ENERGY``
     Maps to ``NVML::GPU_ENERGY_CONSUMPTION_TOTAL``.

--- a/service/docs/source/geopm_pio_nvml.7.rst
+++ b/service/docs/source/geopm_pio_nvml.7.rst
@@ -128,7 +128,7 @@ Signals
     *  **Unit**: hertz
 
 ``NVML::GPU_CORE_FREQUENCY_STEP``
-    The Streaming Multiprocessor frequency step size in hertz.  If the step size is variable the average of all steps is provided.
+    The Streaming Multiprocessor frequency step size in hertz.  The average step size is provided in the case where the step size is variable.
     *  **Aggregation**: expect_same
     *  **Domain**: gpu
     *  **Format**: double

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -50,7 +50,7 @@ namespace geopm
         , m_frequency_min_control_request(m_platform_topo.num_domain(GEOPM_DOMAIN_GPU), NAN)
         , m_initial_power_limit(m_platform_topo.num_domain(GEOPM_DOMAIN_GPU), 0)
         , m_signal_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS", {
-                                  "Streaming multiprocessor frequency in hertz",
+                                  "Streaming Multiprocessor frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_GPU,
                                   Agg::average,
@@ -157,7 +157,7 @@ namespace geopm
                                   string_format_double
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL", {
-                                  "Streaming multiprocessor Maximum frequency in hertz",
+                                  "Streaming Multiprocessor Maximum frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_GPU,
                                   Agg::expect_same,
@@ -165,7 +165,7 @@ namespace geopm
                                   string_format_double
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_AVAIL", {
-                                  "Streaming multiprocessor Minimum frequency in hertz",
+                                  "Streaming Multiprocessor Minimum frequency in hertz",
                                   {},
                                   GEOPM_DOMAIN_GPU,
                                   Agg::expect_same,
@@ -173,7 +173,7 @@ namespace geopm
                                   string_format_double
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STEP", {
-                                  "The streaming multiprocessor frequency step size.\n"
+                                  "The Streaming Multiprocessor frequency step size in hertz.\n"
                                   "If the step size is variable the average of all steps is provided.",
                                   {},
                                   GEOPM_DOMAIN_GPU,
@@ -198,7 +198,7 @@ namespace geopm
                                   string_format_double
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL", {
-                                  "Resets streaming multiprocessor frequency min and max limits to default values.",
+                                  "Resets Streaming Multiprocessor frequency min and max limits to default values.",
                                   {},
                                   GEOPM_DOMAIN_GPU,
                                   Agg::expect_same,
@@ -207,21 +207,21 @@ namespace geopm
                                   }}
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL", {
-                                    "Sets streaming multiprocessor frequency max (in hertz)",
+                                    "Sets Streaming Multiprocessor frequency max (in hertz)",
                                     {},
                                     GEOPM_DOMAIN_GPU,
                                     Agg::expect_same,
                                     string_format_double
                                     }},
                                {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
-                                    "Sets streaming multiprocessor frequency min (in hertz)",
+                                    "Sets Streaming Multiprocessor frequency min (in hertz)",
                                     {},
                                     GEOPM_DOMAIN_GPU,
                                     Agg::expect_same,
                                     string_format_double
                                     }},
                                {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_RESET_CONTROL", {
-                                    "Resets streaming multiprocessor frequency min and max limits to default values."
+                                    "Resets Streaming Multiprocessor frequency min and max limits to default values."
                                     "\n  Parameter provided is unused.",
                                     {},
                                     GEOPM_DOMAIN_GPU,

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -269,13 +269,7 @@ namespace geopm
             m_frequency_max_control_request.at(domain_idx) = m_supported_freq.at(domain_idx).back() * 1e6;
             m_frequency_min_control_request.at(domain_idx) = m_supported_freq.at(domain_idx).front() * 1e6;
 
-
             if (m_supported_freq.at(domain_idx).size() >= 2) {
-                std::vector<unsigned int> diff_supported_frequency(supported_frequency.size());
-                std::adjacent_difference(supported_frequency.begin(), supported_frequency.end(),
-                                         diff_supported_frequency.begin());
-                diff_supported_frequency.erase(diff_supported_frequency.begin());
-
                 double step = (double) (supported_frequency.back() - supported_frequency.front())
                               / (supported_frequency.size() - 1);
 

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -173,7 +173,7 @@ namespace geopm
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STEP", {
                                   "The Streaming Multiprocessor frequency step size in hertz.\n"
-                                  "If the step size is variable the average of all steps is provided.",
+                                  "The average step size is provided in the case where the step size is variable.",
                                   {},
                                   GEOPM_DOMAIN_GPU,
                                   Agg::expect_same,

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -13,7 +13,6 @@
 #include <iostream>
 #include <sstream>
 #include <algorithm>
-#include <numeric>
 #include <string>
 #include <sched.h>
 #include <errno.h>
@@ -269,7 +268,8 @@ namespace geopm
             m_frequency_max_control_request.at(domain_idx) = m_supported_freq.at(domain_idx).back() * 1e6;
             m_frequency_min_control_request.at(domain_idx) = m_supported_freq.at(domain_idx).front() * 1e6;
 
-            if (m_supported_freq.at(domain_idx).size() >= 2) {
+            // Calculated step size if there are 2 or more supported frequencies
+            if (supported_frequency.size() >= 2) {
                 double step = (double) (supported_frequency.back() - supported_frequency.front())
                               / (supported_frequency.size() - 1);
 

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -269,14 +269,22 @@ namespace geopm
             m_frequency_max_control_request.at(domain_idx) = m_supported_freq.at(domain_idx).back() * 1e6;
             m_frequency_min_control_request.at(domain_idx) = m_supported_freq.at(domain_idx).front() * 1e6;
 
-            std::vector<unsigned int> diff_supported_frequency(supported_frequency.size());
-            std::adjacent_difference(supported_frequency.begin(), supported_frequency.end(),
-                                     diff_supported_frequency.begin());
-            diff_supported_frequency.erase(diff_supported_frequency.begin());
 
-            m_frequency_step.push_back((double) std::accumulate(diff_supported_frequency.begin(),
-                                                                diff_supported_frequency.end(), 0)
-                                                / diff_supported_frequency.size());
+            if (m_supported_freq.at(domain_idx).size() >= 2) {
+                std::vector<unsigned int> diff_supported_frequency(supported_frequency.size());
+                std::adjacent_difference(supported_frequency.begin(), supported_frequency.end(),
+                                         diff_supported_frequency.begin());
+                diff_supported_frequency.erase(diff_supported_frequency.begin());
+
+                double step = (double) (supported_frequency.back() - supported_frequency.front())
+                              / (supported_frequency.size() - 1);
+
+                m_frequency_step.push_back(step);
+            }
+            else {
+                m_frequency_step.push_back(NAN);
+            }
+
         }
 
         std::vector <std::string> unsupported_signal_names;
@@ -649,8 +657,8 @@ namespace geopm
             }
         }
         else if (signal_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STEP" || signal_name == "GPU_CORE_FREQUENCY_STEP") {
-            //  If supported freqs isn't populated we can't provide step size
-            if (m_supported_freq.at(domain_idx).size() != 0) {
+            //  If supported freqs doesn't provide at least two frequencies we won't have a step size
+            if (m_supported_freq.at(domain_idx).size() >= 2) {
                 result = 1e6 * m_frequency_step.at(domain_idx);
             }
         }

--- a/service/src/NVMLIOGroup.hpp
+++ b/service/src/NVMLIOGroup.hpp
@@ -70,6 +70,7 @@ namespace geopm
             std::vector<double> m_frequency_min_control_request;
             std::vector<double> m_initial_power_limit;
             std::vector<std::vector<unsigned int> > m_supported_freq;
+            std::vector<double> m_frequency_step;
 
             struct signal_s
             {

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -224,6 +224,7 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/NVMLIOGroupTest.push_control_adjust_write_batch \
               test/gtest_links/NVMLIOGroupTest.error_path \
               test/gtest_links/NVMLIOGroupTest.valid_signals \
+              test/gtest_links/NVMLIOGroupTest.single_freq_support \
               test/gtest_links/NVMLIOGroupTest.signal_and_control_trimming \
               test/gtest_links/PlatformIOTest.adjust \
               test/gtest_links/PlatformIOTest.adjust_agg \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -224,7 +224,7 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/NVMLIOGroupTest.push_control_adjust_write_batch \
               test/gtest_links/NVMLIOGroupTest.error_path \
               test/gtest_links/NVMLIOGroupTest.valid_signals \
-              test/gtest_links/NVMLIOGroupTest.single_freq_support \
+              test/gtest_links/NVMLIOGroupTest.single_supported_frequency \
               test/gtest_links/NVMLIOGroupTest.signal_and_control_trimming \
               test/gtest_links/PlatformIOTest.adjust \
               test/gtest_links/PlatformIOTest.adjust_agg \

--- a/service/test/NVMLIOGroupTest.cpp
+++ b/service/test/NVMLIOGroupTest.cpp
@@ -241,6 +241,7 @@ TEST_F(NVMLIOGroupTest, read_signal)
 
     std::vector<double> mock_freq = {1530, 1320, 420, 135};
     std::vector<unsigned int> mock_supported_freq = {135, 142, 407, 414, 760, 882, 1170, 1530};
+    double step_size = 199.285714;
     std::vector<double> mock_utilization_gpu = {100, 90, 50, 0};
     std::vector<double> mock_power = {153600, 70000, 300000, 50000};
     std::vector<double> mock_power_limit = {300000, 270000, 300000, 250000};
@@ -293,6 +294,11 @@ TEST_F(NVMLIOGroupTest, read_signal)
         double frequency_max_avail_alias = nvml_io.read_signal("GPU_CORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU, gpu_idx);
         EXPECT_DOUBLE_EQ(frequency_max_avail, mock_supported_freq.back() * 1e6);
         EXPECT_DOUBLE_EQ(frequency_max_avail, frequency_max_avail_alias);
+
+        double frequency_step = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STEP", GEOPM_DOMAIN_GPU, gpu_idx);
+        double frequency_step_alias = nvml_io.read_signal("GPU_CORE_FREQUENCY_STEP", GEOPM_DOMAIN_GPU, gpu_idx);
+        EXPECT_NEAR(frequency_step, step_size * 1e6, 1e4);
+        EXPECT_DOUBLE_EQ(frequency_step, frequency_step_alias);
 
         double utilization_gpu = nvml_io.read_signal(M_NAME_PREFIX + "GPU_UTILIZATION", GEOPM_DOMAIN_GPU, gpu_idx);
         double utilization_gpu_alias = nvml_io.read_signal("GPU_UTILIZATION", GEOPM_DOMAIN_GPU, gpu_idx);

--- a/service/test/NVMLIOGroupTest.cpp
+++ b/service/test/NVMLIOGroupTest.cpp
@@ -352,7 +352,7 @@ TEST_F(NVMLIOGroupTest, read_signal)
     }
 }
 
-TEST_F(NVMLIOGroupTest, single_freq_support)
+TEST_F(NVMLIOGroupTest, single_supported_frequency)
 {
 
     EXPECT_CALL(*m_device_pool, is_privileged_access()).WillRepeatedly(Return(false));

--- a/service/test/NVMLIOGroupTest.cpp
+++ b/service/test/NVMLIOGroupTest.cpp
@@ -352,6 +352,24 @@ TEST_F(NVMLIOGroupTest, read_signal)
     }
 }
 
+TEST_F(NVMLIOGroupTest, single_freq_support)
+{
+
+    EXPECT_CALL(*m_device_pool, is_privileged_access()).WillRepeatedly(Return(false));
+
+    // Corner case for only a single freq step being supported
+    std::vector<unsigned int> mock_supported_freq = {1170};
+
+    EXPECT_CALL(*m_device_pool, frequency_supported_sm(0)).WillRepeatedly(Return(mock_supported_freq));
+    NVMLIOGroup nvml_io(*m_platform_topo, *m_device_pool, nullptr);
+
+    double frequency_step = nvml_io.read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STEP", GEOPM_DOMAIN_GPU, 0);
+    double frequency_step_alias = nvml_io.read_signal("GPU_CORE_FREQUENCY_STEP", GEOPM_DOMAIN_GPU, 0);
+
+    EXPECT_TRUE(std::isnan(frequency_step));
+    EXPECT_TRUE(std::isnan(frequency_step_alias));
+}
+
 //Test case: Error path testing including:
 //              - Attempt to push a signal at an invalid domain level
 //              - Attempt to push an invalid signal


### PR DESCRIPTION
Signed-off-by: lowren.h.lawson@intel.com <lowren.h.lawson@intel.com>

- Relates to #2720 feature request from github issues
- Fixes #2723 change request from github issues.

Adds a GPU_CORE_FREQUENCY Step signal to NVMLIOGroup.

Example run using an NVIDIA V100:
```
geopmread GPU_CORE_FREQUENCY_STEP gpu 0
7500000
```