### PR TITLE
Addition of GPU_CORE_FREQUENCY_STEP for Intel GPUs

### DIFF
--- a/service/docs/source/geopm_pio_levelzero.7.rst
+++ b/service/docs/source/geopm_pio_levelzero.7.rst
@@ -65,6 +65,13 @@ Signals
     *  **Format**: double
     *  **Unit**: celsius
 
+``LEVELZERO::GPU_CORE_FREQUENCY_STEP``
+    The GPU Compute Hardware frequency step size in hertz.  If the step size is variable the average of all steps is provided.
+    *  **Aggregation**: expect_same
+    *  **Domain**: gpu
+    *  **Format**: double
+    *  **Unit**: hertz
+
 ``LEVELZERO::GPU_ENERGY``
     GPU energy in joules.
 
@@ -282,8 +289,8 @@ Signal Aliases
 ``GPU_CORE_POWER``
     Maps to ``LEVELZERO::GPU_CORE_POWER``.
 
-``GPU_UTIIZATION``
-    Maps to ``LEVELZERO::GPU_UTIIZATION``.
+``GPU_UTILIZATION``
+    Maps to ``LEVELZERO::GPU_UTILIZATION``.
 
 ``GPU_CORE_ACTIVITY``
     Maps to ``LEVELZERO::GPU_CORE_UTILIZATION``.
@@ -305,6 +312,9 @@ Signal Aliases
 
 ``GPU_CORE_FREQUENCY_MAX_CONTROL``
     Maps to ``LEVELZERO::GPU_CORE_FREQUENCY_MAX_CONTROL``.
+
+``GPU_CORE_FREQUENCY_STEP``
+    Maps to ``LEVELZERO::GPU_CORE_FREQUENCY_STEP``.
 
 ``LEVELZERO::GPU_CORE_PERFORMANCE_FACTOR_CONTROL``
     Maps to ``LEVELZERO::GPU_CORE_PERFORMANCE_FACTOR``

--- a/service/docs/source/geopm_pio_levelzero.7.rst
+++ b/service/docs/source/geopm_pio_levelzero.7.rst
@@ -66,7 +66,7 @@ Signals
     *  **Unit**: celsius
 
 ``LEVELZERO::GPU_CORE_FREQUENCY_STEP``
-    The GPU Compute Hardware frequency step size in hertz.  If the step size is variable the average of all steps is provided.
+    The GPU Compute Hardware frequency step size in hertz.  The average step size is provided in the case where the step size is variable.
     *  **Aggregation**: expect_same
     *  **Domain**: gpu
     *  **Format**: double

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -652,6 +652,7 @@ namespace geopm
         return frequency_min_max(l0_device_idx, l0_domain, l0_domain_idx).second;
     }
 
+
     std::pair<double, double> LevelZeroImp::frequency_min_max(unsigned int l0_device_idx,
                                                               int l0_domain,
                                                               int l0_domain_idx) const
@@ -667,6 +668,30 @@ namespace geopm
 
         return {property.min, property.max};
     }
+
+    std::vector<double> LevelZeroImp::frequency_supported(unsigned int l0_device_idx,
+                                                          int l0_domain,
+                                                          int l0_domain_idx) const
+    {
+        ze_result_t ze_result;
+        zes_freq_handle_t handle = m_devices.at(l0_device_idx).subdevice.freq_domain.at(
+                                                               l0_domain).at(l0_domain_idx);
+        uint32_t num_freq = 0;
+
+        ze_result = zesFrequencyGetAvailableClocks(handle, &num_freq, nullptr);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZero::"
+                        + std::string(__func__) +
+                        ": Sysman failed to get supported frequency count.", __LINE__);
+
+        std::vector<double> result(num_freq);
+        ze_result = zesFrequencyGetAvailableClocks(handle, &num_freq, result.data());
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME, "LevelZero::"
+                        + std::string(__func__) +
+                        ": Sysman failed to get supported frequency list.", __LINE__);
+
+        return result;
+    }
+
 
     std::pair<double, double> LevelZeroImp::frequency_range(unsigned int l0_device_idx,
                                                             int l0_domain,

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -652,7 +652,6 @@ namespace geopm
         return frequency_min_max(l0_device_idx, l0_domain, l0_domain_idx).second;
     }
 
-
     std::pair<double, double> LevelZeroImp::frequency_min_max(unsigned int l0_device_idx,
                                                               int l0_domain,
                                                               int l0_domain_idx) const

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -76,6 +76,18 @@ namespace geopm
             /// @return GPU maximum frequency in MHz.
             virtual double frequency_max(unsigned int l0_device_idx, int l0_domain,
                                          int l0_domain_idx) const = 0;
+
+            /// @brief Get the LevelZero device supported frequencies in MHz
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero GPU.
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @param [in] l0_domain_idx The LevelZero index indicating a particular
+            ///        domain of the GPU.
+            /// @return GPU supported frequencies in MHz.
+            virtual std::vector<double> frequency_supported(unsigned int l0_device_idx,
+                                                            int l0_domain,
+                                                            int l0_domain_idx) const = 0;
+
             /// @brief Get the LevelZero device frequency throttle reasons
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero GPU.
@@ -85,6 +97,7 @@ namespace geopm
             /// @return Frequency throttle reasons
             virtual uint32_t frequency_throttle_reasons(unsigned int l0_device_idx, int l0_domain,
                                                         int l0_domain_idx) const = 0;
+
             /// @brief Get the LevelZero device minimum and maximum frequency
             ///        control range in MHz
             /// @param [in] l0_device_idx The index indicating a particular

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -97,7 +97,6 @@ namespace geopm
             /// @return Frequency throttle reasons
             virtual uint32_t frequency_throttle_reasons(unsigned int l0_device_idx, int l0_domain,
                                                         int l0_domain_idx) const = 0;
-
             /// @brief Get the LevelZero device minimum and maximum frequency
             ///        control range in MHz
             /// @param [in] l0_device_idx The index indicating a particular

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -168,7 +168,7 @@ namespace geopm
     double LevelZeroDevicePoolImp::frequency_step(int domain, unsigned int domain_idx,
                                                   int l0_domain) const
     {
-        double result = NAN;
+        double frequency_step_mhz = NAN;
         if (domain != GEOPM_DOMAIN_GPU_CHIP) {
             throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
                              ": domain " + std::to_string(domain) +
@@ -186,11 +186,12 @@ namespace geopm
                                                                                   dev_subdev_idx_pair.second);
         if (supported_frequency.size() >= 2) {
             std::sort(supported_frequency.begin(), supported_frequency.end());
-            result = (double) (supported_frequency.back() - supported_frequency.front())
-                              / (supported_frequency.size() - 1);
+            frequency_step_mhz = (double) (supported_frequency.back() -
+                                           supported_frequency.front()) /
+                                          (supported_frequency.size() - 1);
         }
 
-        return result;
+        return frequency_step_mhz;
     }
 
     uint32_t LevelZeroDevicePoolImp::frequency_throttle_reasons(int domain, unsigned int domain_idx,

--- a/service/src/LevelZeroDevicePool.hpp
+++ b/service/src/LevelZeroDevicePool.hpp
@@ -58,6 +58,14 @@ namespace geopm
             /// @return GPU maximum frequency in MHz.
             virtual double frequency_max(int domain, unsigned int domain_idx,
                                          int l0_domain) const = 0;
+            /// @brief Get the LevelZero device frequency step in MHz
+            /// @param [in] domain The GEOPM domain type being targeted
+            /// @param [in] domain_idx The GEOPM domain index
+            ///             (i.e. GPU being targeted)
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return GPU frequency step in MHz.
+            virtual double frequency_step(int domain, unsigned int domain_idx,
+                                          int l0_domain) const = 0;
             /// @brief Get the LevelZero device frequency throttle reasons
             /// @param [in] domain The GEOPM domain type being targeted
             /// @param [in] domain_idx The GEOPM domain index

--- a/service/src/LevelZeroDevicePoolImp.hpp
+++ b/service/src/LevelZeroDevicePoolImp.hpp
@@ -32,6 +32,8 @@ namespace geopm
                                  int l0_domain) const override;
             double frequency_max(int domain, unsigned int domain_idx,
                                  int l0_domain) const override;
+            double frequency_step(int domain, unsigned int domain_idx,
+                                  int l0_domain) const override;
             uint32_t frequency_throttle_reasons(int domain, unsigned int domain_idx,
                                                 int l0_domain) const override;
             std::pair <double, double> frequency_range(int domain,

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -115,6 +115,23 @@ namespace geopm
                                   },
                                   1e6
                                   }},
+                              {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STEP", {
+                                  "The compute domain frequency step size in hertz.\n"
+                                  "If the step size is variable the average of all steps is provided.",
+                                  GEOPM_DOMAIN_GPU_CHIP,
+                                  Agg::expect_same,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.frequency_step(
+                                                   GEOPM_DOMAIN_GPU_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  1e6
+                                  }},
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL", {
                                   "The maximum frequency request for the GPU Compute Hardware.",
                                   GEOPM_DOMAIN_GPU_CHIP,
@@ -593,6 +610,8 @@ namespace geopm
         register_signal_alias("GPU_UNCORE_ACTIVITY", M_NAME_PREFIX + "GPU_UNCORE_UTILIZATION");
         register_signal_alias("GPU_CORE_FREQUENCY_MIN_AVAIL",
                               M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_AVAIL");
+        register_signal_alias("GPU_CORE_FREQUENCY_STEP",
+                              M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STEP");
         register_signal_alias("GPU_CORE_FREQUENCY_MAX_AVAIL",
                               M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_AVAIL");
         register_signal_alias("GPU_CORE_FREQUENCY_MIN_CONTROL",

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -117,7 +117,7 @@ namespace geopm
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STEP", {
                                   "The compute domain frequency step size in hertz.\n"
-                                  "If the step size is variable the average of all steps is provided.",
+                                  "The average step size is provided in the case where the step size is variable.",
                                   GEOPM_DOMAIN_GPU_CHIP,
                                   Agg::expect_same,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -35,6 +35,9 @@ namespace geopm
                                  int l0_domain_idx) const override;
             double frequency_max(unsigned int l0_device_idx, int l0_domain,
                                  int l0_domain_idx) const override;
+            std::vector<double> frequency_supported(unsigned int l0_device_idx,
+                                                    int l0_domain,
+                                                    int l0_domain_idx) const override;
             uint32_t frequency_throttle_reasons(unsigned int l0_device_idx, int l0_domain,
                                                 int l0_domain_idx) const override;
             std::pair<double, double> frequency_range(unsigned int l0_device_idx,

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -157,6 +157,8 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
                     frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(7);
         EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MIN_AVAIL
                     frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MAX_AVAIL
+                    frequency_step(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_STATUS
                     frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_EFFICIENT
@@ -805,6 +807,8 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
         //             frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(7);
         EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MIN_AVAIL
                     frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MAX_AVAIL
+                    frequency_step(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         // EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_STATUS
         //             frequency_status(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_EFFICIENT

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -326,6 +326,7 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
 {
     SetUpDefaultExpectCalls();
     std::vector<double> mock_freq = {1530, 1630, 1320, 1420, 420, 520, 135, 235};
+    std::vector<double> mock_freq_supported = {130, 160, 190, 220, 240};
     std::vector<double> mock_freq_efficient = {700, 800, 600, 499, 300, 250, 99, 200};
     std::vector<double> mock_throttle = {0, 2, 4, 10, 1, 3, 9, 5};
     std::vector<double> mock_energy = {9000000, 11000000, 2300000, 5341000000};
@@ -599,6 +600,9 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
     //Temperature
     std::vector<double> mock_temperature_max_gpu = {10, 23, 84, 123, 133, 200, 1555, 169};
     std::vector<double> mock_temperature_max_mem = {10, 32, 89, 102, 130, 210, 1444, 168};
+
+    std::vector<double> mock_freq_step = {20, 30, 20, 30, 20, 30, 20, 30};
+
     //Active time
     std::vector<uint64_t> mock_active_time = {123, 970, 550, 20, 52, 567, 888, 923};
     std::vector<uint64_t> mock_active_time_compute = {1, 90, 50, 0, 123, 144, 521, 445};
@@ -621,6 +625,7 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
         EXPECT_CALL(*m_device_pool, frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq_max_gpu.at(sub_idx)));
         EXPECT_CALL(*m_device_pool, frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_freq_min_mem.at(sub_idx)));
         EXPECT_CALL(*m_device_pool, frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_freq_max_mem.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, frequency_step(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq_step.at(sub_idx)));
 
         //Temperature
         EXPECT_CALL(*m_device_pool, temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_temperature_max_mem.at(sub_idx)));
@@ -660,6 +665,10 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
         EXPECT_DOUBLE_EQ(frequency, mock_freq_min_mem.at(sub_idx)*1e6);
         frequency = levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_max_mem.at(sub_idx)*1e6);
+        frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STEP", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        frequency_alias = levelzero_io.read_signal("GPU_CORE_FREQUENCY_STEP", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(frequency, mock_freq_step.at(sub_idx)*1e6);
+        EXPECT_DOUBLE_EQ(frequency, frequency_alias);
 
         //Temperature
         double temperature = levelzero_io.read_signal("LEVELZERO::GPU_CORE_TEMPERATURE_MAXIMUM", GEOPM_DOMAIN_GPU_CHIP, sub_idx);

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -145,6 +145,8 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/LevelZeroDevicePoolTest.device_count \
               test/gtest_links/LevelZeroDevicePoolTest.subdevice_conversion_and_function \
               test/gtest_links/LevelZeroDevicePoolTest.subdevice_conversion_error \
+              test/gtest_links/LevelZeroDevicePoolTest.supported_frequency \
+              test/gtest_links/LevelZeroDevicePoolTest.single_supported_frequency \
               test/gtest_links/LevelZeroDevicePoolTest.domain_error \
               test/gtest_links/LevelZeroDevicePoolTest.subdevice_range_check \
               test/gtest_links/LevelZeroDevicePoolTest.device_range_check \

--- a/service/test/MockLevelZero.hpp
+++ b/service/test/MockLevelZero.hpp
@@ -31,6 +31,8 @@ class MockLevelZero : public geopm::LevelZero
                     (const, override));
         MOCK_METHOD((std::pair<double, double>), frequency_range,
                     (unsigned int, int, int), (const, override));
+        MOCK_METHOD((std::vector<double>), frequency_supported,
+                    (unsigned int, int, int), (const, override));
 
 
         MOCK_METHOD(double, temperature_max, (unsigned int, int, int),

--- a/service/test/MockLevelZeroDevicePool.hpp
+++ b/service/test/MockLevelZeroDevicePool.hpp
@@ -24,6 +24,8 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
                     (int, unsigned int, int), (const, override));
         MOCK_METHOD(double, frequency_max,
                     (int, unsigned int, int), (const, override));
+        MOCK_METHOD(double, frequency_step,
+                    (int, unsigned int, int), (const, override));
         MOCK_METHOD(uint32_t, frequency_throttle_reasons,
                     (int, unsigned int, int), (const, override));
         MOCK_METHOD((std::pair<double, double>), frequency_range,


### PR DESCRIPTION
- Relates to #2720 feature request from github issues
- Fixes #2722 change request from github issues.

Adds a GPU_CORE_FREQUENCY Step signal to LevelZeroIOGroup.