### PR TITLE
Use control access list when generating signal access list

### DIFF
--- a/service/README.rst
+++ b/service/README.rst
@@ -127,7 +127,7 @@ Access Management
 -----------------
 
 Access to signals and controls through the GEOPM Service is configured
-by the system administrator.  The administrator controls a default
+by the system administrator.  The administrator maintains a default
 access list that applies to all users of the system.  This list
 may be augmented so that users who are members of particular Unix groups may
 have enhanced access.  The default lists are stored in:
@@ -153,6 +153,12 @@ non-root users through the GEOPM Service until a system administrator
 enables access through these allow lists.  It is recommended that all
 manipulation of these files should be done through the GEOPM Service
 with the ``geopmaccess`` command line tool.
+
+By convention, all control settings can be read by requesting the
+signal that shares the same name as the control.  Note that when
+adding a control name to the access list for writing, the
+administrator is implicitly providing read access to the control
+setting as well.
 
 
 Opening a Session

--- a/service/docs/source/geopmaccess.1.rst
+++ b/service/docs/source/geopmaccess.1.rst
@@ -90,6 +90,12 @@ be provided.  For example, when the ``-c`` option is provided without
 any other options, the list of controls that may be configured by the
 calling user is printed.
 
+By convention, all control settings can be read by requesting the
+signal that shares the same name as the control.  Note that when
+adding a control name to the access list for writing, the
+administrator is implicitly providing read access to the control
+setting as well.
+
 All users of the system will have access to the signals and controls
 determined by the "default access list."  The default access list may
 be read by specifying the ``-u`` / ``--user`` option.  These

--- a/service/geopmdpy/system_files.py
+++ b/service/geopmdpy/system_files.py
@@ -892,14 +892,18 @@ class AccessLists(object):
         group_dir = os.path.join(self._CONFIG_PATH, group)
         if os.path.isdir(group_dir):
             secure_make_dirs(group_dir)
-            path = os.path.join(group_dir, 'allowed_signals')
-            signals = self._read_allowed(path)
-            signals = self._filter_valid_signals(signals)
-            signals = sorted(signals)
+            # Read and filter control names
             path = os.path.join(group_dir, 'allowed_controls')
             controls = self._read_allowed(path)
             controls = self._filter_valid_controls(controls)
-            controls = sorted(controls)
+            controls = sorted(set(controls))
+            # Read and filter signal names
+            path = os.path.join(group_dir, 'allowed_signals')
+            signals = self._read_allowed(path)
+            # All controls that may be written may also be read
+            signals.extend(controls)
+            signals = self._filter_valid_signals(signals)
+            signals = sorted(set(signals))
         else:
             signals = []
             controls = []

--- a/service/geopmdpy_test/__main__.py
+++ b/service/geopmdpy_test/__main__.py
@@ -7,6 +7,7 @@
 import unittest
 
 from TestAccess import *
+from TestAccessLists import *
 from TestController import *
 from TestDBusXML import *
 from TestError import *


### PR DESCRIPTION
- Users with permission to write a control should always be allowed to read back the value.
- Fixes #2707


