### PR TITLE
Set signal and control access lists independenly

### DIFF
--- a/service/geopmdpy/access.py
+++ b/service/geopmdpy/access.py
@@ -66,10 +66,6 @@ class Access:
                           are not supported.
 
         """
-        try:
-            _, current_controls = self._geopm_proxy.PlatformGetGroupAccess(group)
-        except DBusError as ee:
-            raise RuntimeError('Failed to read group signal access list for specified group: {}'.format(group)) from ee
         if not is_force:
             signals_supported, _ = self._geopm_proxy.PlatformGetAllAccess()
             signals_requested = set(signals)
@@ -78,7 +74,7 @@ class Access:
                 raise RuntimeError(f'Requested access to signals that are not available: {missing}')
         if not is_dry_run:
             try:
-                self._geopm_proxy.PlatformSetGroupAccess(group, signals, current_controls)
+                self._geopm_proxy.PlatformSetGroupAccessSignals(group, signals)
             except DBusError as ee:
                 raise RuntimeError('Failed to set group signal access list, try with sudo or as "root" user (requires CAP_SYS_ADMIN)') from ee
 
@@ -108,10 +104,6 @@ class Access:
                           not supported.
 
         """
-        try:
-            current_signals, _ = self._geopm_proxy.PlatformGetGroupAccess(group)
-        except DBusError as ee:
-            raise RuntimeError('Failed to read group control access list for specified group: {}'.format(group)) from ee
         if not is_force:
             _, controls_supported = self._geopm_proxy.PlatformGetAllAccess()
             controls_requested = set(controls)
@@ -120,7 +112,7 @@ class Access:
                 raise RuntimeError(f'Requested access to controls that are not available: {missing}')
         if not is_dry_run:
             try:
-                self._geopm_proxy.PlatformSetGroupAccess(group, current_signals, controls)
+                self._geopm_proxy.PlatformSetGroupAccessControls(group, controls)
             except DBusError as ee:
                 raise RuntimeError('Failed to set group control access list, try with sudo or as "root" user (requires CAP_SYS_ADMIN)') from ee
 

--- a/service/geopmdpy/dbus_xml.py
+++ b/service/geopmdpy/dbus_xml.py
@@ -97,6 +97,50 @@ def geopm_dbus_xml(TopoService=None, PlatformService=None):
         </doc:description>
       </doc:doc>
     </method>
+    <method name="PlatformSetGroupAccessSignals">
+      <arg direction="in" name="group" type="s">
+        <doc:doc>
+          <doc:summary>{PlatformSetGroupAccessSignals_params0_description}
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <arg direction="in" name="allowed_signals" type="as">
+        <doc:doc>
+          <doc:summary>{PlatformSetGroupAccessSignals_params1_description}
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <doc:doc>
+        <doc:description>
+          <doc:summary>{PlatformSetGroupAccess_short_description}
+          </doc:summary>
+          <doc:para>{PlatformSetGroupAccess_long_description}
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </method>
+    <method name="PlatformSetGroupAccessControls">
+      <arg direction="in" name="group" type="s">
+        <doc:doc>
+          <doc:summary>{PlatformSetGroupAccessControls_params0_description}
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <arg direction="in" name="allowed_controls" type="as">
+        <doc:doc>
+          <doc:summary>{PlatformSetGroupAccessControls_params1_description}
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <doc:doc>
+        <doc:description>
+          <doc:summary>{PlatformSetGroupAccess_short_description}
+          </doc:summary>
+          <doc:para>{PlatformSetGroupAccess_long_description}
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </method>
     <method name="PlatformGetUserAccess">
       <arg direction="out" name="access_lists" type="(asas)">
         <doc:doc>
@@ -348,6 +392,8 @@ def geopm_dbus_xml(TopoService=None, PlatformService=None):
         TopoGetCache = google.parse(TopoService.get_cache.__doc__)
         PlatformGetGroupAccess = google.parse(PlatformService.get_group_access.__doc__)
         PlatformSetGroupAccess = google.parse(PlatformService.set_group_access.__doc__)
+        PlatformSetGroupAccessSignals = google.parse(PlatformService.set_group_access_signals.__doc__)
+        PlatformSetGroupAccessControls = google.parse(PlatformService.set_group_access_controls.__doc__)
         PlatformGetUserAccess = google.parse(PlatformService.get_user_access.__doc__)
         PlatformGetAllAccess = google.parse(PlatformService.get_all_access.__doc__)
         PlatformGetSignalInfo = google.parse(PlatformService.get_signal_info.__doc__)
@@ -373,8 +419,16 @@ def geopm_dbus_xml(TopoService=None, PlatformService=None):
             PlatformSetGroupAccess_params0_description=PlatformSetGroupAccess.params[0].description,
             PlatformSetGroupAccess_params1_description=PlatformSetGroupAccess.params[1].description,
             PlatformSetGroupAccess_params2_description=PlatformSetGroupAccess.params[2].description,
-            PlatformSetGroupAccess_short_description=PlatformGetGroupAccess.short_description,
-            PlatformSetGroupAccess_long_description=PlatformGetGroupAccess.long_description,
+            PlatformSetGroupAccess_short_description=PlatformSetGroupAccess.short_description,
+            PlatformSetGroupAccess_long_description=PlatformSetGroupAccess.long_description,
+            PlatformSetGroupAccessSignals_params0_description=PlatformSetGroupAccessSignals.params[0].description,
+            PlatformSetGroupAccessSignals_params1_description=PlatformSetGroupAccessSignals.params[1].description,
+            PlatformSetGroupAccessSignals_short_description=PlatformSetGroupAccessSignals.short_description,
+            PlatformSetGroupAccessSignals_long_description=PlatformSetGroupAccessSignals.long_description,
+            PlatformSetGroupAccessControls_params0_description=PlatformSetGroupAccessControls.params[0].description,
+            PlatformSetGroupAccessControls_params1_description=PlatformSetGroupAccessControls.params[1].description,
+            PlatformSetGroupAccessControls_short_description=PlatformSetGroupAccessControls.short_description,
+            PlatformSetGroupAccessControls_long_description=PlatformSetGroupAccessControls.long_description,
             PlatformGetUserAccess_returns_description=PlatformGetUserAccess.returns.description,
             PlatformGetUserAccess_short_description=PlatformGetUserAccess.short_description,
             PlatformGetUserAccess_long_description=PlatformGetUserAccess.long_description,

--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -108,6 +108,50 @@ class PlatformService(object):
         """
         self._access_lists.set_group_access(group, allowed_signals, allowed_controls)
 
+    def set_group_access_signals(self, group, allowed_signals):
+        """Set signals in the allowed lists
+
+        Write the list of allowed signals for the specified group.  If
+        the group is None or the empty string then the default lists
+        of allowed signal are updated.
+
+        The values are securely written atomically to files located in
+        /etc/geopm-service using the secure_make_dirs() and
+        secure_make_file() interfaces.
+
+        Args:
+            group (str): Name of group
+
+            allowed_signals (list(str)): Signal names that are allowed
+
+        Raises:
+            RuntimeError: The group name is not valid on the system.
+
+        """
+        self._access_lists.set_group_access_signals(group, allowed_signals)
+
+    def set_group_access_controls(self, group, allowed_controls):
+        """Set controls in the allowed lists
+
+        Write the list of allowed controls for the specified group.  If
+        the group is None or the empty string then the default lists
+        of allowed control are updated.
+
+        The values are securely written atomically to files located in
+        /etc/geopm-service using the secure_make_dirs() and
+        secure_make_file() interfaces.
+
+        Args:
+            group (str): Name of group
+
+            allowed_controls (list(str)): Control names that are allowed
+
+        Raises:
+            RuntimeError: The group name is not valid on the system.
+
+        """
+        self._access_lists.set_group_access_controls(group, allowed_controls)
+
     def get_user_access(self, user):
         """Get the list of all of the signals and controls that are
         accessible to the specified user.
@@ -753,6 +797,16 @@ class GEOPMService(object):
     def PlatformSetGroupAccess(self, group, allowed_signals, allowed_controls, **call_info):
         self._check_cap_sys_admin(call_info, "PlatformSetGroupAccess")
         self._platform.set_group_access(group, allowed_signals, allowed_controls)
+
+    @accepts_additional_arguments
+    def PlatformSetGroupAccessSignals(self, group, allowed_signals, **call_info):
+        self._check_cap_sys_admin(call_info, "PlatformSetGroupAccess")
+        self._platform.set_group_access_signals(group, allowed_signals)
+
+    @accepts_additional_arguments
+    def PlatformSetGroupAccessControls(self, group, allowed_controls, **call_info):
+        self._check_cap_sys_admin(call_info, "PlatformSetGroupAccess")
+        self._platform.set_group_access_controls(group, allowed_controls)
 
     @accepts_additional_arguments
     def PlatformGetUserAccess(self, **call_info):

--- a/service/geopmdpy/system_files.py
+++ b/service/geopmdpy/system_files.py
@@ -941,6 +941,60 @@ class AccessLists(object):
         path = os.path.join(group_dir, 'allowed_controls')
         self._write_allowed(path, allowed_controls)
 
+    def set_group_access_signals(self, group, allowed_signals):
+        """Set signals in the allowed lists
+
+        Write the list of allowed signals for the specified group.  If
+        the group is None or the empty string then the default lists
+        of allowed signals are updated.
+
+        The values are securely written atomically to files located in
+        /etc/geopm-service using the secure_make_dirs() and
+        secure_make_file() interfaces.
+
+        Args:
+            group (str): Name of group
+
+            allowed_signals (list(str)): Signal names that are allowed
+
+        Raises:
+            RuntimeError: The group name is not valid on the system.
+
+        """
+        group = self._validate_group(group)
+        group_dir = os.path.join(self._CONFIG_PATH, group)
+        secure_make_dirs(group_dir,
+                         perm_mode=GEOPM_SERVICE_CONFIG_PATH_PERM)
+        path = os.path.join(group_dir, 'allowed_signals')
+        self._write_allowed(path, allowed_signals)
+
+    def set_group_access_controls(self, group, allowed_controls):
+        """Set controls in the allowed lists
+
+        Write the list of allowed controls for the specified group.  If
+        the group is None or the empty string then the default lists
+        of allowed controls are updated.
+
+        The values are securely written atomically to files located in
+        /etc/geopm-service using the secure_make_dirs() and
+        secure_make_file() interfaces.
+
+        Args:
+            group (str): Name of group
+
+            allowed_controls (list(str)): Control names that are allowed
+
+        Raises:
+            RuntimeError: The group name is not valid on the system.
+
+        """
+        group = self._validate_group(group)
+        group_dir = os.path.join(self._CONFIG_PATH, group)
+        secure_make_dirs(group_dir,
+                         perm_mode=GEOPM_SERVICE_CONFIG_PATH_PERM)
+        path = os.path.join(group_dir, 'allowed_controls')
+        self._write_allowed(path, allowed_controls)
+
     def get_user_access(self, user):
         """Get the list of all of the signals and controls that are
         accessible to the specified user.

--- a/service/geopmdpy_test/TestAccess.py
+++ b/service/geopmdpy_test/TestAccess.py
@@ -142,14 +142,12 @@ class TestAccess(unittest.TestCase):
         """
         return_value = (self._signals_expect,
                         self._controls_expect)
-        self._geopm_proxy.PlatformSetGroupAccess = mock.Mock()
-        self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=return_value)
+        self._geopm_proxy.PlatformSetGroupAccessSignals = mock.Mock()
         self._geopm_proxy.PlatformGetAllAccess = mock.Mock(return_value=return_value)
         with mock.patch('sys.stdin.readlines', return_value=self._signals_expect):
             self._access.run(True, False, False, None, False, False, False, False, False)
-            self._geopm_proxy.PlatformGetGroupAccess.assert_called_once_with('')
-            self._geopm_proxy.PlatformSetGroupAccess.assert_called_once_with('',
-                self._signals_expect, self._controls_expect)
+            self._geopm_proxy.PlatformSetGroupAccessSignals.assert_called_once_with('',
+                self._signals_expect)
             self._geopm_proxy.PlatformGetAllAccess.assert_called_once()
 
     def test_write_default_controls(self):
@@ -160,14 +158,12 @@ class TestAccess(unittest.TestCase):
         """
         return_value = (self._signals_expect,
                         self._controls_expect)
-        self._geopm_proxy.PlatformSetGroupAccess = mock.Mock()
-        self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=return_value)
+        self._geopm_proxy.PlatformSetGroupAccessControls = mock.Mock()
         self._geopm_proxy.PlatformGetAllAccess = mock.Mock(return_value=return_value)
         with mock.patch('sys.stdin.readlines', return_value=self._controls_expect):
             self._access.run(True, False, True, None, False, False, False, False, False)
-            self._geopm_proxy.PlatformGetGroupAccess.assert_called_once_with('')
-            self._geopm_proxy.PlatformSetGroupAccess.assert_called_once_with('',
-                self._signals_expect, self._controls_expect)
+            self._geopm_proxy.PlatformSetGroupAccessControls.assert_called_once_with('',
+                self._controls_expect)
             self._geopm_proxy.PlatformGetAllAccess.assert_called_once()
 
     def test_write_invalid_signals(self):
@@ -178,13 +174,11 @@ class TestAccess(unittest.TestCase):
         """
         return_value = (self._signals_expect,
                         self._controls_expect)
-        self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=return_value)
         self._geopm_proxy.PlatformGetAllAccess = mock.Mock(return_value=([], []))
         err_msg = f'Requested access to signals that are not available: {", ".join(sorted(self._signals_expect))}'
         with mock.patch('sys.stdin.readlines', return_value=self._signals_expect):
             with self.assertRaisesRegex(RuntimeError, err_msg):
                 self._access.run(True, False, False, None, False, False, False, False, False)
-            self._geopm_proxy.PlatformGetGroupAccess.assert_called_once_with('')
             self._geopm_proxy.PlatformGetAllAccess.assert_called_once()
 
     def test_write_invalid_signals_force(self):
@@ -195,12 +189,10 @@ class TestAccess(unittest.TestCase):
         """
         empty_access = ([], [])
         self._geopm_proxy.PlatformSetGroupAccess = mock.Mock()
-        self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=empty_access)
         with mock.patch('sys.stdin.readlines', return_value=self._signals_expect):
             self._access.run(True, False, False, None, False, False, False, True, False)
-            self._geopm_proxy.PlatformGetGroupAccess.assert_called_once_with('')
-            self._geopm_proxy.PlatformSetGroupAccess.assert_called_once_with('',
-                self._signals_expect, [])
+            self._geopm_proxy.PlatformSetGroupAccessSignals.assert_called_once_with('',
+                self._signals_expect)
 
     def test_write_invalid_controls(self):
         """Test command to write invalid default control access list
@@ -210,13 +202,11 @@ class TestAccess(unittest.TestCase):
         """
         return_value = (self._signals_expect,
                         self._controls_expect)
-        self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=return_value)
         self._geopm_proxy.PlatformGetAllAccess = mock.Mock(return_value=([], []))
         err_msg = f'Requested access to controls that are not available: {", ".join(sorted(self._controls_expect))}'
         with mock.patch('sys.stdin.readlines', return_value=self._controls_expect):
             with self.assertRaisesRegex(RuntimeError, err_msg):
                 self._access.run(True, False, True, None, False, False, False, False, False)
-            self._geopm_proxy.PlatformGetGroupAccess.assert_called_once_with('')
             self._geopm_proxy.PlatformGetAllAccess.assert_called_once()
 
     def test_write_signals_dry_run(self):
@@ -227,11 +217,9 @@ class TestAccess(unittest.TestCase):
         """
         return_value = (self._signals_expect,
                         self._controls_expect)
-        self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=return_value)
         self._geopm_proxy.PlatformGetAllAccess = mock.Mock(return_value=return_value)
         with mock.patch('sys.stdin.readlines', return_value=self._signals_expect):
             self._access.run(True, False, False, None, False, False, True, False, False)
-            self._geopm_proxy.PlatformGetGroupAccess.assert_called_once_with('')
             self._geopm_proxy.PlatformGetAllAccess.assert_called_once()
 
     def test_write_invalid_signals_dry_run(self):
@@ -242,13 +230,11 @@ class TestAccess(unittest.TestCase):
         """
         return_value = (self._signals_expect,
                         self._controls_expect)
-        self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=return_value)
         self._geopm_proxy.PlatformGetAllAccess = mock.Mock(return_value=([], []))
         err_msg = f'Requested access to signals that are not available: {", ".join(sorted(self._signals_expect))}'
         with mock.patch('sys.stdin.readlines', return_value=self._signals_expect):
             with self.assertRaisesRegex(RuntimeError, err_msg):
                 self._access.run(True, False, False, None, False, False, True, False, False)
-            self._geopm_proxy.PlatformGetGroupAccess.assert_called_once_with('')
             self._geopm_proxy.PlatformGetAllAccess.assert_called_once()
 
     def test_write_group_signals(self):
@@ -260,13 +246,11 @@ class TestAccess(unittest.TestCase):
         return_value = (self._signals_expect,
                         self._controls_expect)
         self._geopm_proxy.PlatformSetGroupAccess = mock.Mock()
-        self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=return_value)
         self._geopm_proxy.PlatformGetAllAccess = mock.Mock(return_value=return_value)
         with mock.patch('sys.stdin.readlines', return_value=self._signals_expect):
             self._access.run(True, False, False, 'test', False, False, False, False, False)
-            self._geopm_proxy.PlatformGetGroupAccess.assert_called_once_with('test')
-            self._geopm_proxy.PlatformSetGroupAccess.assert_called_once_with('test',
-                self._signals_expect, self._controls_expect)
+            self._geopm_proxy.PlatformSetGroupAccessSignals.assert_called_once_with('test',
+                self._signals_expect)
             self._geopm_proxy.PlatformGetAllAccess.assert_called_once()
 
     def test_write_group_controls(self):
@@ -277,14 +261,12 @@ class TestAccess(unittest.TestCase):
         """
         return_value = (self._signals_expect,
                         self._controls_expect)
-        self._geopm_proxy.PlatformSetGroupAccess = mock.Mock()
-        self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=return_value)
+        self._geopm_proxy.PlatformSetGroupAccessControls = mock.Mock()
         self._geopm_proxy.PlatformGetAllAccess = mock.Mock(return_value=return_value)
         with mock.patch('sys.stdin.readlines', return_value=self._controls_expect):
             self._access.run(True, False, True, 'test', False, False, False, False, False)
-            self._geopm_proxy.PlatformGetGroupAccess.assert_called_once_with('test')
-            self._geopm_proxy.PlatformSetGroupAccess.assert_called_once_with('test',
-                self._signals_expect, self._controls_expect)
+            self._geopm_proxy.PlatformSetGroupAccessControls.assert_called_once_with('test',
+                self._controls_expect)
             self._geopm_proxy.PlatformGetAllAccess.assert_called_once()
 
     def test_edit_signals(self):
@@ -311,15 +293,15 @@ echo {self._signals_expect[0]} >> $1
                           self._controls_expect)
             start_return = (self._signals_expect[1:],
                             self._controls_expect)
-            self._geopm_proxy.PlatformSetGroupAccess = mock.Mock()
+            self._geopm_proxy.PlatformSetGroupAccessSignals = mock.Mock()
             self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=start_return)
             self._geopm_proxy.PlatformGetAllAccess = mock.Mock(return_value=all_return)
             self._access.run(True, False, False, None, False, False, False, False, True)
             self._geopm_proxy.PlatformGetGroupAccess.assert_called_with('')
             set_signals = self._signals_expect[1:]
             set_signals.append(self._signals_expect[0])
-            self._geopm_proxy.PlatformSetGroupAccess.assert_called_once_with('',
-                set_signals, self._controls_expect)
+            self._geopm_proxy.PlatformSetGroupAccessSignals.assert_called_once_with('',
+                set_signals)
             self._geopm_proxy.PlatformGetAllAccess.assert_called_once()
         finally:
             if orig_editor is None:
@@ -338,13 +320,11 @@ echo {self._signals_expect[0]} >> $1
         return_value = (self._signals_expect,
                         self._controls_expect)
         self._geopm_proxy.PlatformSetGroupAccess = mock.Mock()
-        self._geopm_proxy.PlatformGetGroupAccess = mock.Mock(return_value=return_value)
         self._geopm_proxy.PlatformGetAllAccess = mock.Mock(return_value=return_value)
         with mock.patch('sys.stdin.readlines', return_value=self._signals_expect):
             self._access.run(False, False, False, None, False, True, False, False, False)
-            self._geopm_proxy.PlatformGetGroupAccess.assert_called_once_with('')
-            self._geopm_proxy.PlatformSetGroupAccess.assert_called_once_with('',
-                [], self._controls_expect)
+            self._geopm_proxy.PlatformSetGroupAccessSignals.assert_called_once_with('',
+                [])
 
 
 

--- a/service/geopmdpy_test/TestAccessLists.py
+++ b/service/geopmdpy_test/TestAccessLists.py
@@ -111,13 +111,44 @@ default
                      mock.call(control_file, 'frequency\n')]
             mock_smf.assert_has_calls(calls)
 
+        with mock.patch('geopmdpy.pio.signal_names', return_value=all_signals), \
+             mock.patch('geopmdpy.system_files.secure_make_dirs') as mock_smd, \
+             mock.patch('geopmdpy.system_files.secure_make_file') as mock_smf:
+
+            self._access_lists.set_group_access_signals(group, ['power'])
+
+            test_dir = os.path.join(self._CONFIG_PATH.name,
+                                    '0.DEFAULT_ACCESS' if group == '' else group)
+
+            signal_file = os.path.join(test_dir, 'allowed_signals')
+
+            mock_smd.assert_called_once_with(test_dir, perm_mode=0o700)
+            calls = [mock.call(signal_file, 'power\n')]
+            mock_smf.assert_has_calls(calls)
+
+        with mock.patch('geopmdpy.pio.control_names', return_value=all_controls), \
+             mock.patch('geopmdpy.system_files.secure_make_dirs') as mock_smd, \
+             mock.patch('geopmdpy.system_files.secure_make_file') as mock_smf:
+
+            self._access_lists.set_group_access_controls(group, ['frequency'])
+
+            test_dir = os.path.join(self._CONFIG_PATH.name,
+                                    '0.DEFAULT_ACCESS' if group == '' else group)
+
+            control_file = os.path.join(test_dir, 'allowed_controls')
+
+            mock_smd.assert_called_once_with(test_dir, perm_mode=0o700)
+            calls = [mock.call(control_file, 'frequency\n')]
+            mock_smf.assert_has_calls(calls)
+
+
     def test_set_group_access_empty(self):
         self._set_group_access_test_helper('')
 
     def test_set_group_access_named(self):
         with mock.patch('grp.getgrnam', return_value='named') as mock_getgrnam:
             self._set_group_access_test_helper('named')
-            mock_getgrnam.assert_called_once_with('named')
+            mock_getgrnam.assert_called_with('named')
 
     def test_get_group_access_empty(self):
         signals, controls = self._access_lists.get_group_access('')

--- a/service/geopmdpy_test/__main__.py
+++ b/service/geopmdpy_test/__main__.py
@@ -8,18 +8,20 @@ import unittest
 
 from TestAccess import *
 from TestAccessLists import *
+from TestActiveSessions import *
 from TestController import *
 from TestDBusXML import *
 from TestError import *
+from TestMSRDataFiles import *
 from TestPIO import *
 from TestPlatformService import *
 from TestRequestQueue import *
+from TestSecureFiles import *
 from TestSession import *
 from TestTimedLoop import *
 from TestTopo import *
-from TestActiveSessions import *
-from TestSecureFiles import *
-from TestAccessLists import *
+from TestWriteLock import *
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/service/geopmdpy_test/__main__.py
+++ b/service/geopmdpy_test/__main__.py
@@ -19,6 +19,7 @@ from TestTimedLoop import *
 from TestTopo import *
 from TestActiveSessions import *
 from TestSecureFiles import *
+from TestAccessLists import *
 
 if __name__ == '__main__':
     unittest.main()

--- a/service/io.github.geopm.xml
+++ b/service/io.github.geopm.xml
@@ -42,7 +42,7 @@ with CPUs.
       </arg>
       <arg direction="out" name="access_lists" type="(asas)">
         <doc:doc>
-          <doc:summary>list(str), list(str): Signal and control allowed lists
+          <doc:summary>list(str), list(str): Signal and control allowed lists, both in sorted order.
           </doc:summary>
         </doc:doc>
       </arg>
@@ -85,18 +85,74 @@ empty lists are returned.
       </arg>
       <doc:doc>
         <doc:description>
-          <doc:summary>Get the signal and control access lists
+          <doc:summary>Set signals and controls in the allowed lists
           </doc:summary>
-          <doc:para>Read the list of allowed signals and controls for the
+          <doc:para>Write the list of allowed signals and controls for the
 specified group.  If the group is None or the empty string
 then the default lists of allowed signals and controls are
-returned.
+updated.
 
-The values are securely read from files located in
-/etc/geopm-service using the secure_read_file() interface.
+The values are securely written atomically to files located in
+/etc/geopm-service using the secure_make_dirs() and
+secure_make_file() interfaces.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </method>
+    <method name="PlatformSetGroupAccessSignals">
+      <arg direction="in" name="group" type="s">
+        <doc:doc>
+          <doc:summary>Name of group
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <arg direction="in" name="allowed_signals" type="as">
+        <doc:doc>
+          <doc:summary>Signal names that are allowed
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <doc:doc>
+        <doc:description>
+          <doc:summary>Set signals and controls in the allowed lists
+          </doc:summary>
+          <doc:para>Write the list of allowed signals and controls for the
+specified group.  If the group is None or the empty string
+then the default lists of allowed signals and controls are
+updated.
 
-If no secure file exist for the specified group, then two
-empty lists are returned.
+The values are securely written atomically to files located in
+/etc/geopm-service using the secure_make_dirs() and
+secure_make_file() interfaces.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </method>
+    <method name="PlatformSetGroupAccessControls">
+      <arg direction="in" name="group" type="s">
+        <doc:doc>
+          <doc:summary>Name of group
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <arg direction="in" name="allowed_controls" type="as">
+        <doc:doc>
+          <doc:summary>Control names that are allowed
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <doc:doc>
+        <doc:description>
+          <doc:summary>Set signals and controls in the allowed lists
+          </doc:summary>
+          <doc:para>Write the list of allowed signals and controls for the
+specified group.  If the group is None or the empty string
+then the default lists of allowed signals and controls are
+updated.
+
+The values are securely written atomically to files located in
+/etc/geopm-service using the secure_make_dirs() and
+secure_make_file() interfaces.
           </doc:para>
         </doc:description>
       </doc:doc>
@@ -104,7 +160,7 @@ empty lists are returned.
     <method name="PlatformGetUserAccess">
       <arg direction="out" name="access_lists" type="(asas)">
         <doc:doc>
-          <doc:summary>list(str), list(str): Signal and control allowed lists
+          <doc:summary>list(str), list(str): Signal and control allowed lists, both in sorted order.
           </doc:summary>
         </doc:doc>
       </arg>
@@ -133,7 +189,7 @@ lists are what this method returns.
     <method name="PlatformGetAllAccess">
       <arg direction="out" name="access_lists" type="(asas)">
         <doc:doc>
-          <doc:summary>list(str), list(str): All supported signals and controls
+          <doc:summary>list(str), list(str): All supported signals and controls, in sorted order.
           </doc:summary>
         </doc:doc>
       </arg>


### PR DESCRIPTION
- Add new DBus interface for signal or control access list write
- Use new control/signal interfaces in geopmaccess
- Fixes #2712
