### PR TITLE
Update ConstConfigIOGroup config file schema

### DIFF
--- a/service/json_schemas/const_config_io.schema.json
+++ b/service/json_schemas/const_config_io.schema.json
@@ -25,14 +25,14 @@
                     },
                     "minItems": 1
                 },
-                "default_value": {
+                "common_value": {
                     "type": "number"
                 }
             },
             "required": ["description", "units", "domain", "aggregation"],
             "oneOf": [
                 {"required": ["values"]},
-                {"required": ["default_value"]}
+                {"required": ["common_value"]}
             ],
             "additionalProperties": false
         }

--- a/service/json_schemas/const_config_io.schema.json
+++ b/service/json_schemas/const_config_io.schema.json
@@ -24,9 +24,16 @@
                         "type": "number"
                     },
                     "minItems": 1
+                },
+                "default_value": {
+                    "type": "number"
                 }
             },
-            "required": ["description", "units", "domain", "aggregation", "values"],
+            "required": ["description", "units", "domain", "aggregation"],
+            "oneOf": [
+                {"required": ["values"]},
+                {"required": ["default_value"]}
+            ],
             "additionalProperties": false
         }
     },

--- a/service/src/ConstConfigIOGroup.cpp
+++ b/service/src/ConstConfigIOGroup.cpp
@@ -335,7 +335,8 @@ namespace geopm
         auto signals = root.object_items();
         for (const auto &signal : signals) {
             check_json_signal(signal);
-            std::string name = M_SIGNAL_PREFIX + signal.first;
+            const std::string &NAME = signal.first;
+            const std::string FULL_NAME = M_SIGNAL_PREFIX + NAME;
 
             auto properties = signal.second.object_items();
             int units = IOGroup::string_to_units(
@@ -350,14 +351,16 @@ namespace geopm
             if (values_provided && default_value_provided) {
                 // Only one field is required
                 throw Exception("ConstConfigIOGroup::parse_config_json(): "
-                                "\"values\" and \"default_value\" provided for " +
-                                name, GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                                "\"values\" and \"default_value\" provided for "
+                                "signal \"" + NAME + "\"", GEOPM_ERROR_INVALID,
+                                 __FILE__, __LINE__);
             }
             else if (!values_provided && !default_value_provided) {
                 // One of the two fields is required
                 throw Exception("ConstConfigIOGroup::parse_config_json(): "
-                                "missing \"values\" or \"default_value\" for " +
-                                name, GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                                "missing \"values\" or \"default_value\" for "
+                                "signal \"" + NAME + "\"", GEOPM_ERROR_INVALID,
+                                 __FILE__, __LINE__);
             }
 
             std::vector<double> values;
@@ -365,21 +368,22 @@ namespace geopm
                 auto json_values = properties["values"].array_items();
                 if (json_values.empty()) {
                     throw Exception("ConstConfigIOGroup::parse_config_json(): "
-                                    "empty array of values provided for " + name,
-                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                                    "empty array of values provided for "
+                                    "signal \"" + NAME + "\"", GEOPM_ERROR_INVALID,
+                                    __FILE__, __LINE__);
                 }
                 if (static_cast<int>(json_values.size()) != m_platform_topo.num_domain(domain_type)) {
                     throw Exception("ConstConfigIOGroup::parse_config_json(): "
-                                    "number of values for " + name + " does not "
-                                    "match domain size", GEOPM_ERROR_INVALID,
-                                    __FILE__, __LINE__);
+                                    "number of values for signal \"" + NAME +
+                                    "\" does not match domain size",
+                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                 }
 
                 for (const auto &val : json_values) {
                     if (!val.is_number()) {
                         throw Exception("ConstConfigIOGroup::parse_config_json():"
-                                        " for signal " + name + ", incorrect type"
-                                        " for property: \"values\"",
+                                        " for signal \"" + NAME + "\", incorrect "
+                                        "type for property: \"values\"",
                                         GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                     }
                     values.push_back(val.number_value());
@@ -392,13 +396,14 @@ namespace geopm
             std::string description = properties["description"].string_value();
             if (description.empty()) {
                 throw Exception("ConstConfigIOGroup::parse_config_json(): "
-                                "empty description provided for " + name,
-                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                                "empty description provided for signal \"" +
+                                NAME + "\"", GEOPM_ERROR_INVALID,
+                                __FILE__, __LINE__);
             }
             // TODO: check for duplicate signals. At the moment, we're using
             // json11 to parse JSON strings, which handles duplicate entries
             // by taking the latest entry encountered.
-            m_signal_available[name] =
+            m_signal_available[FULL_NAME] =
                 std::make_shared<m_signal_info_s>(
                     m_signal_info_s {
                         .units = units,

--- a/service/src/ConstConfigIOGroup.cpp
+++ b/service/src/ConstConfigIOGroup.cpp
@@ -215,7 +215,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        double value = 0.0;
+        double value = NAN;
         if (it->second->common_value_provided) {
             value = it->second->values[0];
         }

--- a/service/src/ConstConfigIOGroup.cpp
+++ b/service/src/ConstConfigIOGroup.cpp
@@ -144,7 +144,7 @@ namespace geopm
             }
         }
 
-        if (it->second->common_value_provided) {
+        if (it->second->is_common_value_provided) {
             domain_idx = 0;
         }
 
@@ -216,7 +216,7 @@ namespace geopm
         }
 
         double value = NAN;
-        if (it->second->common_value_provided) {
+        if (it->second->is_common_value_provided) {
             value = it->second->values[0];
         }
         else {
@@ -348,15 +348,15 @@ namespace geopm
 
             std::vector<double> values;
             bool values_provided = properties.find("values") != properties.end();
-            bool common_value_provided = properties.find("common_value") != properties.end();
-            if (values_provided && common_value_provided) {
+            bool is_common_value_provided = properties.find("common_value") != properties.end();
+            if (values_provided && is_common_value_provided) {
                 // Only one field is required
                 throw Exception("ConstConfigIOGroup::parse_config_json(): "
                                 "\"values\" and \"common_value\" provided for "
                                 "signal \"" + NAME + "\"", GEOPM_ERROR_INVALID,
                                  __FILE__, __LINE__);
             }
-            else if (!values_provided && !common_value_provided) {
+            else if (!values_provided && !is_common_value_provided) {
                 // One of the two fields is required
                 throw Exception("ConstConfigIOGroup::parse_config_json(): "
                                 "missing \"values\" and \"common_value\" for "
@@ -410,7 +410,7 @@ namespace geopm
                         .domain = domain_type,
                         .agg_function = agg_func,
                         .description = description,
-                        .common_value_provided = common_value_provided,
+                        .is_common_value_provided = is_common_value_provided,
                         .values = values});
         }
     }

--- a/service/src/ConstConfigIOGroup.hpp
+++ b/service/src/ConstConfigIOGroup.hpp
@@ -88,7 +88,7 @@ namespace geopm
                 int domain;
                 std::function<double(const std::vector<double> &)> agg_function;
                 std::string description;
-                bool default_value;
+                bool common_value_provided;
                 std::vector<double> values;
             };
 

--- a/service/src/ConstConfigIOGroup.hpp
+++ b/service/src/ConstConfigIOGroup.hpp
@@ -88,6 +88,7 @@ namespace geopm
                 int domain;
                 std::function<double(const std::vector<double> &)> agg_function;
                 std::string description;
+                bool default_value;
                 std::vector<double> values;
             };
 
@@ -96,7 +97,7 @@ namespace geopm
                 int domain_idx;
             };
 
-            void parse_config_json(const PlatformTopo &topo, const std::string &config);
+            void parse_config_json(const std::string &config);
             static json11::Json construct_config_json_obj(const std::string &config);
             static void check_json_signal(const json11::Json::object::value_type &signal);
 
@@ -106,6 +107,7 @@ namespace geopm
             static const std::string M_CONFIG_PATH_ENV;
             static const std::string M_DEFAULT_CONFIG_FILE_PATH;
 
+            const PlatformTopo &m_platform_topo;
             std::map<std::string, std::shared_ptr<m_signal_info_s> > m_signal_available;
             std::vector<m_signal_ref_s> m_pushed_signals;
     };

--- a/service/src/ConstConfigIOGroup.hpp
+++ b/service/src/ConstConfigIOGroup.hpp
@@ -88,7 +88,7 @@ namespace geopm
                 int domain;
                 std::function<double(const std::vector<double> &)> agg_function;
                 std::string description;
-                bool common_value_provided;
+                bool is_common_value_provided;
                 std::vector<double> values;
             };
 

--- a/service/test/ConstConfigIOGroupTest.cpp
+++ b/service/test/ConstConfigIOGroupTest.cpp
@@ -178,7 +178,7 @@ TEST_F(ConstConfigIOGroupTest, input_missing_properties)
     );
 }
 
-TEST_F(ConstConfigIOGroupTest, input_values_and_default_value)
+TEST_F(ConstConfigIOGroupTest, input_values_and_common_value)
 {
     set_up_topo_expect_exactly({});
     std::string json_string = "{"
@@ -188,7 +188,7 @@ TEST_F(ConstConfigIOGroupTest, input_values_and_default_value)
     "        \"units\": \"hertz\","
     "        \"aggregation\": \"sum\","
     "        \"values\": [ 1500, 1600, 1700 ],"
-    "        \"default_value\": 1500"
+    "        \"common_value\": 1500"
     "    }"
     "}";
     create_config_file(json_string);
@@ -197,11 +197,11 @@ TEST_F(ConstConfigIOGroupTest, input_values_and_default_value)
         ConstConfigIOGroup iogroup(*m_default_topo, M_CONFIG_FILE_PATH, ""),
         GEOPM_ERROR_INVALID,
         "ConstConfigIOGroup::parse_config_json(): "
-        "\"values\" and \"default_value\" provided for signal \"GPU_CORE_FREQUENCY\""
+        "\"values\" and \"common_value\" provided for signal \"GPU_CORE_FREQUENCY\""
     );
 }
 
-TEST_F(ConstConfigIOGroupTest, missing_values_and_default_value)
+TEST_F(ConstConfigIOGroupTest, missing_values_and_common_value)
 {
     set_up_topo_expect_exactly({});
     std::string json_string = "{"
@@ -218,7 +218,7 @@ TEST_F(ConstConfigIOGroupTest, missing_values_and_default_value)
         ConstConfigIOGroup iogroup(*m_default_topo, M_CONFIG_FILE_PATH, ""),
         GEOPM_ERROR_INVALID,
         "ConstConfigIOGroup::parse_config_json(): "
-        "missing \"values\" and \"default_value\" for signal \"GPU_CORE_FREQUENCY\""
+        "missing \"values\" and \"common_value\" for signal \"GPU_CORE_FREQUENCY\""
     );
 }
 
@@ -240,8 +240,8 @@ TEST_F(ConstConfigIOGroupTest, input_unexpected_properties)
     GEOPM_EXPECT_THROW_MESSAGE(
         ConstConfigIOGroup iogroup(*m_default_topo, M_CONFIG_FILE_PATH, ""),
         GEOPM_ERROR_INVALID,
-        "ConstConfigIOGroup::parse_config_json():"
-        " unexpected property: \"" "magic" "\""
+        "ConstConfigIOGroup::parse_config_json(): "
+        "for signal \"GPU_CORE_FREQUENCY\", unexpected property: \"" "magic" "\""
     );
 }
 
@@ -262,8 +262,8 @@ TEST_F(ConstConfigIOGroupTest, input_capital_properties)
     GEOPM_EXPECT_THROW_MESSAGE(
         ConstConfigIOGroup iogroup(*m_default_topo, M_CONFIG_FILE_PATH, ""),
         GEOPM_ERROR_INVALID,
-        "ConstConfigIOGroup::parse_config_json():"
-        " unexpected property: \"" "DOMAIN" "\""
+        "ConstConfigIOGroup::parse_config_json(): "
+        "for signal \"GPU_CORE_FREQUENCY\", unexpected property: \"" "DOMAIN" "\""
     );
 }
 
@@ -459,8 +459,8 @@ TEST_F(ConstConfigIOGroupTest, input_incorrect_type)
     GEOPM_EXPECT_THROW_MESSAGE(
         ConstConfigIOGroup iogroup(*m_default_topo, M_CONFIG_FILE_PATH, ""),
         GEOPM_ERROR_INVALID,
-        "ConstConfigIOGroup::parse_config_json():"
-        " incorrect type for property: \"" "aggregation" "\""
+        "ConstConfigIOGroup::parse_config_json(): "
+        "for signal \"GPU_CORE_FREQUENCY\", incorrect type for property: \"" "aggregation" "\""
     );
 }
 
@@ -487,7 +487,7 @@ TEST_F(ConstConfigIOGroupTest, input_array_value_type)
     );
 }
 
-TEST_F(ConstConfigIOGroupTest, input_default_value_type)
+TEST_F(ConstConfigIOGroupTest, input_common_value_type)
 {
     set_up_topo_expect_at_most({GEOPM_DOMAIN_GPU});
     std::string json_string = "{"
@@ -496,7 +496,7 @@ TEST_F(ConstConfigIOGroupTest, input_default_value_type)
     "        \"description\": \"Provides GPU core frequency\","
     "        \"units\": \"hertz\","
     "        \"aggregation\": \"sum\","
-    "        \"default_value\": \"threehundred\""
+    "        \"common_value\": \"threehundred\""
     "    }"
     "}";
     create_config_file(json_string);
@@ -506,7 +506,7 @@ TEST_F(ConstConfigIOGroupTest, input_default_value_type)
         GEOPM_ERROR_INVALID,
         "ConstConfigIOGroup::parse_config_json(): "
         "for signal \"GPU_CORE_FREQUENCY\", "
-        "incorrect type for property: \"default_value\""
+        "incorrect type for property: \"common_value\""
     );
 }
 
@@ -642,21 +642,20 @@ TEST_F(ConstConfigIOGroupTest, valid_json_positive)
     EXPECT_EQ(iogroup.plugin_name(), "CONST_CONFIG");
 }
 
-TEST_F(ConstConfigIOGroupTest, valid_json_with_default_value_positive)
+TEST_F(ConstConfigIOGroupTest, valid_json_with_common_value_positive)
 {
-    set_up_topo_expect_exactly({GEOPM_DOMAIN_GPU, GEOPM_DOMAIN_CPU});
     std::string json_string = "{"
     "    \"GPU_CORE_FREQUENCY\": {"
     "        \"domain\": \"gpu\","
     "        \"description\": \"Provides GPU core frequency\","
     "        \"units\": \"hertz\","
     "        \"aggregation\": \"sum\","
-    "        \"default_value\": 1500"
+    "        \"common_value\": 1500"
     "    }"
     "}";
     create_config_file(json_string);
     ConstConfigIOGroup iogroup(*m_default_topo, M_CONFIG_FILE_PATH, "");
-    
+
     EXPECT_CALL(*m_default_topo, num_domain(GEOPM_DOMAIN_GPU))
         .Times(1)
         .RetiresOnSaturation();
@@ -841,21 +840,20 @@ TEST_F(ConstConfigIOGroupTest, valid_json_negative)
     );
 }
 
-TEST_F(ConstConfigIOGroupTest, valid_json_with_default_value_negative)
+TEST_F(ConstConfigIOGroupTest, valid_json_with_common_value_negative)
 {
-    set_up_topo_expect_exactly({GEOPM_DOMAIN_GPU, GEOPM_DOMAIN_CPU});
     std::string json_string = "{"
     "    \"GPU_CORE_FREQUENCY\": {"
     "        \"domain\": \"gpu\","
     "        \"description\": \"Provides GPU core frequency\","
     "        \"units\": \"hertz\","
     "        \"aggregation\": \"sum\","
-    "        \"default_value\": 1500"
+    "        \"common_value\": 1500"
     "    }"
     "}";
     create_config_file(json_string);
     ConstConfigIOGroup iogroup(*m_default_topo, M_CONFIG_FILE_PATH, "");
-    
+
     EXPECT_CALL(*m_default_topo, num_domain(GEOPM_DOMAIN_GPU))
         .Times(AtMost(1))
         .RetiresOnSaturation();

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -76,8 +76,13 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/ConstConfigIOGroupTest.input_array_value_type \
               test/gtest_links/ConstConfigIOGroupTest.input_array_value_num_domain \
               test/gtest_links/ConstConfigIOGroupTest.input_array_value_empty \
+              test/gtest_links/ConstConfigIOGroupTest.input_values_and_common_value \
+              test/gtest_links/ConstConfigIOGroupTest.missing_values_and_common_value \
+              test/gtest_links/ConstConfigIOGroupTest.input_common_value_type \
               test/gtest_links/ConstConfigIOGroupTest.valid_json_positive \
+              test/gtest_links/ConstConfigIOGroupTest.valid_json_with_common_value_positive \
               test/gtest_links/ConstConfigIOGroupTest.valid_json_negative \
+              test/gtest_links/ConstConfigIOGroupTest.valid_json_with_common_value_negative \
               test/gtest_links/ConstConfigIOGroupTest.loads_default_config \
               test/gtest_links/ConstConfigIOGroupTest.no_default_config \
               test/gtest_links/CpuinfoIOGroupTest.bad_min_max \


### PR DESCRIPTION
Update schema to allow specifying a default value for a signal. For each signal, either a default value or an array of values needs to be provided.

Signed-off-by: Alejandro Vilches <alejandro.vilches@intel.com>

- Relates to #2731 
- Fixes #2732 