### PR TITLE
CPU-CA test updates for CPU-CA constconfig

### DIFF
--- a/src/CPUActivityAgent.cpp
+++ b/src/CPUActivityAgent.cpp
@@ -160,6 +160,22 @@ namespace geopm
             m_freq_uncore_efficient = m_freq_uncore_min;
         }
 
+        if (m_freq_core_efficient > m_freq_core_max ||
+            m_freq_core_efficient < m_freq_core_min ) {
+            throw Exception("CPUActivityAgent::" + std::string(__func__) +
+                            "(): Core efficient frequency out of range: " +
+                            std::to_string(m_freq_core_efficient) +
+                            ".", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (m_freq_uncore_efficient > m_freq_uncore_max ||
+            m_freq_uncore_efficient < m_freq_uncore_min ) {
+            throw Exception("CPUActivityAgent::" + std::string(__func__) +
+                            "(): Uncore efficient frequency out of range: " +
+                            std::to_string(m_freq_uncore_efficient) +
+                            ".", GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
         // Grab all (uncore frequency, max memory bandwidth) pairs
         for (unsigned int entry_idx = 0; entry_idx < ALL_NAMES.size(); ++entry_idx) {
             const std::string KEY_NAME = "CONST_CONFIG::CPU_UNCORE_FREQUENCY_" +

--- a/test/CPUActivityAgentTest.cpp
+++ b/test/CPUActivityAgentTest.cpp
@@ -543,33 +543,53 @@ TEST_F(CPUActivityAgentTest, no_mem_constconfig)
 
 }
 
-TEST_F(CPUActivityAgentTest, invalid_fe)
+
+TEST_F(CPUActivityAgentTest, invalid_fe_core_low)
 {
     setup_default_expect_calls();
-    EXPECT_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", _, _)).Times(4);
-    EXPECT_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY", _, _)).Times(4);
-    ON_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
-            .WillByDefault(Return(m_cpu_freq_max + 1));
-    GEOPM_EXPECT_THROW_MESSAGE(m_agent->init(0, {}, false), GEOPM_ERROR_INVALID,
-                                "(): Core efficient frequency out of range: ");
+    EXPECT_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", _, _)).Times(1);
+    EXPECT_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY", _, _)).Times(1);
 
-    setup_default_expect_calls();
     ON_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
             .WillByDefault(Return(m_cpu_freq_min - 1));
     GEOPM_EXPECT_THROW_MESSAGE(m_agent->init(0, {}, false), GEOPM_ERROR_INVALID,
                                 "(): Core efficient frequency out of range: ");
+}
 
+TEST_F(CPUActivityAgentTest, invalid_fe_core_high)
+{
     setup_default_expect_calls();
+    EXPECT_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", _, _)).Times(1);
+    EXPECT_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY", _, _)).Times(1);
+
+    ON_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
+            .WillByDefault(Return(m_cpu_freq_max + 1));
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->init(0, {}, false), GEOPM_ERROR_INVALID,
+                                "(): Core efficient frequency out of range: ");
+}
+
+TEST_F(CPUActivityAgentTest, invalid_fe_uncore_low)
+{
+    setup_default_expect_calls();
+    EXPECT_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", _, _)).Times(1);
+    EXPECT_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY", _, _)).Times(1);
+
+    ON_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
+            .WillByDefault(Return(m_cpu_uncore_freq_min - 1));
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->init(0, {}, false), GEOPM_ERROR_INVALID,
+                                "(): Uncore efficient frequency out of range: ");
+}
+
+TEST_F(CPUActivityAgentTest, invalid_fe_uncore_high)
+{
+    setup_default_expect_calls();
+    EXPECT_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", _, _)).Times(1);
+    EXPECT_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY", _, _)).Times(1);
+
     ON_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
             .WillByDefault(Return(m_cpu_freq_min));
     ON_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
             .WillByDefault(Return(m_cpu_uncore_freq_max + 1));
-    GEOPM_EXPECT_THROW_MESSAGE(m_agent->init(0, {}, false), GEOPM_ERROR_INVALID,
-                                "(): Uncore efficient frequency out of range: ");
-
-    setup_default_expect_calls();
-    ON_CALL(*m_platform_io, read_signal("CONST_CONFIG::CPU_UNCORE_FREQUENCY_EFFICIENT_HIGH_INTENSITY", GEOPM_DOMAIN_BOARD, 0))
-            .WillByDefault(Return(m_cpu_uncore_freq_min - 1));
     GEOPM_EXPECT_THROW_MESSAGE(m_agent->init(0, {}, false), GEOPM_ERROR_INVALID,
                                 "(): Uncore efficient frequency out of range: ");
 }

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -321,6 +321,7 @@ if ENABLE_BETA
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_lower_bound_check \
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_signal_out_of_bounds \
                    test/gtest_links/CPUActivityAgentTest.control_signal_granularity_check \
+                   test/gtest_links/CPUActivityAgentTest.invalid_fe \
                    test/gtest_links/DaemonTest.get_default_policy \
                    test/gtest_links/DaemonTest.get_profile_policy \
                    test/gtest_links/GPUActivityAgentTest.name \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -321,7 +321,10 @@ if ENABLE_BETA
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_lower_bound_check \
                    test/gtest_links/CPUActivityAgentTest.adjust_platform_signal_out_of_bounds \
                    test/gtest_links/CPUActivityAgentTest.control_signal_granularity_check \
-                   test/gtest_links/CPUActivityAgentTest.invalid_fe \
+                   test/gtest_links/CPUActivityAgentTest.invalid_fe_core_low \
+                   test/gtest_links/CPUActivityAgentTest.invalid_fe_core_high \
+                   test/gtest_links/CPUActivityAgentTest.invalid_fe_uncore_low \
+                   test/gtest_links/CPUActivityAgentTest.invalid_fe_uncore_high \
                    test/gtest_links/DaemonTest.get_default_policy \
                    test/gtest_links/DaemonTest.get_profile_policy \
                    test/gtest_links/GPUActivityAgentTest.name \


### PR DESCRIPTION
Signed-off-by: Lowren Lawson <lowren.h.lawson@intel.com>

- Relates to #2735 issue from github issues
- Fixes #2735 change request from github issues.

Update to CPU-CA to add explicit Fe checking, and update to test to handle Fe checking & add proper CONST_CONFIG::* signal names. 