### PR TITLE
Support for LevelZero GPU CHIP temperatures

### DIFF
--- a/service/docs/source/geopm_pio_levelzero.7.rst
+++ b/service/docs/source/geopm_pio_levelzero.7.rst
@@ -49,6 +49,22 @@ Signals
     *  **Format**: double
     *  **Unit**: hertz
 
+``LEVELZERO::GPU_CORE_TEMPERATURE_MAXIMUM``
+    The maximum measured temperature across all sensors in the GPU accelerator."
+
+    *  **Aggregation**: expect_same
+    *  **Domain**: gpu_chip
+    *  **Format**: double
+    *  **Unit**: celsius
+
+``LEVELZERO::GPU_MEMORY_TEMPERATURE_MAXIMUM``
+    The maximum measured temperature across all sensors in the GPU memory."
+
+    *  **Aggregation**: expect_same
+    *  **Domain**: gpu_chip
+    *  **Format**: double
+    *  **Unit**: celsius
+
 ``LEVELZERO::GPU_ENERGY``
     GPU energy in joules.
 

--- a/service/docs/source/geopm_pio_levelzero.7.rst
+++ b/service/docs/source/geopm_pio_levelzero.7.rst
@@ -52,7 +52,7 @@ Signals
 ``LEVELZERO::GPU_CORE_TEMPERATURE_MAXIMUM``
     The maximum measured temperature across all sensors in the GPU accelerator."
 
-    *  **Aggregation**: expect_same
+    *  **Aggregation**: max
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: celsius
@@ -60,7 +60,7 @@ Signals
 ``LEVELZERO::GPU_MEMORY_TEMPERATURE_MAXIMUM``
     The maximum measured temperature across all sensors in the GPU memory."
 
-    *  **Aggregation**: expect_same
+    *  **Aggregation**: max
     *  **Domain**: gpu_chip
     *  **Format**: double
     *  **Unit**: celsius

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -76,6 +76,7 @@ namespace geopm
             /// @return GPU maximum frequency in MHz.
             virtual double frequency_max(unsigned int l0_device_idx, int l0_domain,
                                          int l0_domain_idx) const = 0;
+
             /// @brief Get the LevelZero device frequency throttle reasons
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero GPU.
@@ -96,6 +97,22 @@ namespace geopm
             virtual std::pair<double, double> frequency_range(unsigned int l0_device_idx,
                                                               int l0_domain,
                                                               int l0_domain_idx) const = 0;
+
+            /// @brief Get the number of LevelZero temperature domains
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return GPU temperature domain count.
+            virtual int temperature_domain_count(unsigned int l0_device_idx, int l0_domain) const = 0;
+            /// @brief Get the LevelZero device maximum temperature in Celsius
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero GPU.
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @param [in] l0_domain_idx The LevelZero index indicating a particular
+            ///        domain of the GPU.
+            /// @return Domain maximum temperature in Celsius.
+            virtual double temperature_max(unsigned int l0_device_idx, int l0_domain,
+                                           int l0_domain_idx) const = 0;
+
+
 
             /// @brief Get the number of LevelZero engine domains
             /// @param [in] l0_domain The LevelZero domain type being targeted

--- a/service/src/LevelZero.hpp
+++ b/service/src/LevelZero.hpp
@@ -76,7 +76,6 @@ namespace geopm
             /// @return GPU maximum frequency in MHz.
             virtual double frequency_max(unsigned int l0_device_idx, int l0_domain,
                                          int l0_domain_idx) const = 0;
-
             /// @brief Get the LevelZero device frequency throttle reasons
             /// @param [in] l0_device_idx The index indicating a particular
             ///        Level Zero GPU.
@@ -99,6 +98,8 @@ namespace geopm
                                                               int l0_domain_idx) const = 0;
 
             /// @brief Get the number of LevelZero temperature domains
+            /// @param [in] l0_device_idx The index indicating a particular
+            ///        Level Zero GPU.
             /// @param [in] l0_domain The LevelZero domain type being targeted
             /// @return GPU temperature domain count.
             virtual int temperature_domain_count(unsigned int l0_device_idx, int l0_domain) const = 0;
@@ -111,9 +112,6 @@ namespace geopm
             /// @return Domain maximum temperature in Celsius.
             virtual double temperature_max(unsigned int l0_device_idx, int l0_domain,
                                            int l0_domain_idx) const = 0;
-
-
-
             /// @brief Get the number of LevelZero engine domains
             /// @param [in] l0_domain The LevelZero domain type being targeted
             /// @return GPU engine domain count.

--- a/service/src/LevelZeroDevicePool.cpp
+++ b/service/src/LevelZeroDevicePool.cpp
@@ -184,7 +184,6 @@ namespace geopm
                                                       dev_subdev_idx_pair.second);
     }
 
-
     std::pair<double, double> LevelZeroDevicePoolImp::frequency_range(int domain,
                                                                       unsigned int domain_idx,
                                                                       int l0_domain) const
@@ -204,6 +203,26 @@ namespace geopm
                                            dev_subdev_idx_pair.second);
 
     }
+
+    double LevelZeroDevicePoolImp::temperature_max(int domain, unsigned int domain_idx,
+                                                   int l0_domain) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                             ": domain " + std::to_string(domain) +
+                            " is not supported for the temperature domain.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        check_domain_exists(m_levelzero.temperature_domain_count(dev_subdev_idx_pair.first,
+                                                                 l0_domain), __func__,
+                                                                 __LINE__);
+
+        return m_levelzero.temperature_max(dev_subdev_idx_pair.first, l0_domain,
+                                           dev_subdev_idx_pair.second);
+    }
+
 
     std::pair<uint64_t, uint64_t> LevelZeroDevicePoolImp::active_time_pair(int domain,
                                                                            unsigned int domain_idx,

--- a/service/src/LevelZeroDevicePool.hpp
+++ b/service/src/LevelZeroDevicePool.hpp
@@ -58,7 +58,6 @@ namespace geopm
             /// @return GPU maximum frequency in MHz.
             virtual double frequency_max(int domain, unsigned int domain_idx,
                                          int l0_domain) const = 0;
-
             /// @brief Get the LevelZero device frequency throttle reasons
             /// @param [in] domain The GEOPM domain type being targeted
             /// @param [in] domain_idx The GEOPM domain index

--- a/service/src/LevelZeroDevicePool.hpp
+++ b/service/src/LevelZeroDevicePool.hpp
@@ -58,6 +58,7 @@ namespace geopm
             /// @return GPU maximum frequency in MHz.
             virtual double frequency_max(int domain, unsigned int domain_idx,
                                          int l0_domain) const = 0;
+
             /// @brief Get the LevelZero device frequency throttle reasons
             /// @param [in] domain The GEOPM domain type being targeted
             /// @param [in] domain_idx The GEOPM domain index
@@ -69,6 +70,15 @@ namespace geopm
             virtual std::pair<double, double> frequency_range(int domain,
                                                               unsigned int domain_idx,
                                                               int l0_domain) const = 0;
+
+            /// @brief Get the LevelZero domain maximum temperature in Celsius
+            /// @param [in] domain The GEOPM domain type being targeted
+            /// @param [in] domain_idx The GEOPM domain index
+            ///             (i.e. GPU being targeted)
+            /// @param [in] l0_domain The LevelZero domain type being targeted
+            /// @return GPU domain maximum temperature in Celsius.
+            virtual double temperature_max(int domain, unsigned int domain_idx,
+                                           int l0_domain) const = 0;
 
             // UTILIZATION SIGNAL FUNCTIONS
             /// @brief Get the LevelZero device active time and timestamp in microseconds

--- a/service/src/LevelZeroDevicePoolImp.hpp
+++ b/service/src/LevelZeroDevicePoolImp.hpp
@@ -37,6 +37,10 @@ namespace geopm
             std::pair <double, double> frequency_range(int domain,
                                                        unsigned int domain_idx,
                                                        int l0_domain) const override;
+
+            double temperature_max(int domain, unsigned int domain_idx,
+                                   int l0_domain) const override;
+
             std::pair<uint64_t, uint64_t> active_time_pair(int domain,
                                                            unsigned int device_idx,
                                                            int l0_domain) const override;

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -450,7 +450,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_CORE_TEMPERATURE_MAXIMUM", {
                                   "The maximum measured temperature across all sensors in the GPU accelerator.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::max,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},
@@ -466,7 +466,7 @@ namespace geopm
                               {M_NAME_PREFIX + "GPU_MEMORY_TEMPERATURE_MAXIMUM", {
                                   "The maximum measured temperature across all sensors in the GPU memory.",
                                   GEOPM_DOMAIN_GPU_CHIP,
-                                  Agg::average,
+                                  Agg::max,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
                                   {},

--- a/service/src/LevelZeroIOGroup.cpp
+++ b/service/src/LevelZeroIOGroup.cpp
@@ -447,6 +447,38 @@ namespace geopm
                                   },
                                   .01
                                   }},
+                              {M_NAME_PREFIX + "GPU_CORE_TEMPERATURE_MAXIMUM", {
+                                  "The maximum measured temperature across all sensors in the GPU accelerator.",
+                                  GEOPM_DOMAIN_GPU_CHIP,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.temperature_max(
+                                                   GEOPM_DOMAIN_GPU_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE);
+                                  },
+                                  1
+                                  }},
+                              {M_NAME_PREFIX + "GPU_MEMORY_TEMPERATURE_MAXIMUM", {
+                                  "The maximum measured temperature across all sensors in the GPU memory.",
+                                  GEOPM_DOMAIN_GPU_CHIP,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.temperature_max(
+                                                   GEOPM_DOMAIN_GPU_CHIP,
+                                                   domain_idx,
+                                                   geopm::LevelZero::M_DOMAIN_MEMORY);
+                                  },
+                                  1
+                                  }},
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
                                     "Sets the minimum frequency request for the GPU Compute Hardware.",

--- a/service/src/LevelZeroImp.hpp
+++ b/service/src/LevelZeroImp.hpp
@@ -41,6 +41,11 @@ namespace geopm
                                                       int l0_domain,
                                                       int l0_domain_idx) const override;
 
+            int temperature_domain_count(unsigned int l0_device_idx,
+                                         int l0_domain) const override;
+            double temperature_max(unsigned int l0_device_idx, int l0_domain,
+                                   int l0_domain_idx) const override;
+
             int engine_domain_count(unsigned int l0_device_idx, int domain) const override;
             std::pair<uint64_t, uint64_t> active_time_pair(unsigned int l0_device_idx,
                                                            int l0_domain, int l0_domain_idx) const override;
@@ -95,6 +100,7 @@ namespace geopm
             struct m_subdevice_s {
                 // These are enum geopm_levelzero_domain_e indexed, then subdevice indexed
                 std::vector<std::vector<zes_freq_handle_t> > freq_domain;
+                std::vector<std::vector<zes_temp_handle_t> > temp_domain_max;
                 std::vector<std::vector<zes_engine_handle_t> > engine_domain;
                 mutable std::vector<std::vector<uint64_t> > cached_timestamp;
 
@@ -130,6 +136,7 @@ namespace geopm
             void power_domain_cache(unsigned int l0_device_idx);
             void perf_domain_cache(unsigned int l0_device_idx);
             void engine_domain_cache(unsigned int l0_device_idx);
+            void temperature_domain_cache(unsigned int l0_device_idx);
             void check_ze_result(ze_result_t ze_result, int error, std::string message,
                                  int line) const;
 

--- a/service/test/LevelZeroDevicePoolTest.cpp
+++ b/service/test/LevelZeroDevicePoolTest.cpp
@@ -66,6 +66,10 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
     int value = 1500;
     std::vector<double> perf_value_chip_compute = {0.50, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57};
     std::vector<double> perf_value_chip_mem = {0.40, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47};
+
+    std::vector<double> temp_value_chip_compute = {99, 12, 25, 356, 58, 79, 76, 21};
+    std::vector<double> temp_value_chip_mem = {42, 59, 66, 78, 92, 88, 1, 16};
+
     int offset = 0;
     int domain_count = 1; //any non-zero number to ensure we don't throw
     for (int dev_idx = 0; dev_idx < num_gpu; ++dev_idx) {
@@ -74,6 +78,9 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
 
         EXPECT_CALL(*m_levelzero, performance_domain_count(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
         EXPECT_CALL(*m_levelzero, performance_domain_count(dev_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(domain_count));
+
+        EXPECT_CALL(*m_levelzero, temperature_domain_count(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(domain_count));
+        EXPECT_CALL(*m_levelzero, temperature_domain_count(dev_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(domain_count));
 
         for (int sub_idx = 0; sub_idx < num_subdevice_per_device; ++sub_idx) {
             EXPECT_CALL(*m_levelzero, frequency_status(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(value + offset));
@@ -86,6 +93,9 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
 
             EXPECT_CALL(*m_levelzero, performance_factor(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(perf_value_chip_compute[offset]));
             EXPECT_CALL(*m_levelzero, performance_factor(dev_idx, MockLevelZero::M_DOMAIN_MEMORY, sub_idx)).WillOnce(Return(perf_value_chip_mem[offset]));
+
+            EXPECT_CALL(*m_levelzero, temperature_max(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(temp_value_chip_compute[offset]));
+            EXPECT_CALL(*m_levelzero, temperature_max(dev_idx, MockLevelZero::M_DOMAIN_MEMORY, sub_idx)).WillOnce(Return(temp_value_chip_mem[offset]));
             ++offset;
         }
     }
@@ -107,6 +117,9 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
 
         EXPECT_NO_THROW(m_device_pool.performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0.5));
         EXPECT_NO_THROW(m_device_pool.performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY, 0.5));
+
+        EXPECT_EQ(temp_value_chip_compute[sub_idx], m_device_pool.temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_EQ(temp_value_chip_mem[sub_idx], m_device_pool.temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
     }
 }
 

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -594,6 +594,9 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
     std::vector<double> mock_freq_max_gpu = {2000, 3200, 4200, 1350, 555, 666, 777, 888};
     std::vector<double> mock_freq_min_mem = {100, 220, 300, 450, 999, 1010, 1111, 1212};
     std::vector<double> mock_freq_max_mem = {1000, 2200, 3200, 1450, 1313, 1414, 1515, 1616};
+    //Temperature
+    std::vector<double> mock_temperature_max_gpu = {10, 23, 84, 123, 133, 200, 1555, 169};
+    std::vector<double> mock_temperature_max_mem = {10, 32, 89, 102, 130, 210, 1444, 168};
     //Active time
     std::vector<uint64_t> mock_active_time = {123, 970, 550, 20, 52, 567, 888, 923};
     std::vector<uint64_t> mock_active_time_compute = {1, 90, 50, 0, 123, 144, 521, 445};
@@ -616,6 +619,10 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
         EXPECT_CALL(*m_device_pool, frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_freq_max_gpu.at(sub_idx)));
         EXPECT_CALL(*m_device_pool, frequency_min(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_freq_min_mem.at(sub_idx)));
         EXPECT_CALL(*m_device_pool, frequency_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_freq_max_mem.at(sub_idx)));
+
+        //Temperature
+        EXPECT_CALL(*m_device_pool, temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY)).WillRepeatedly(Return(mock_temperature_max_mem.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).WillRepeatedly(Return(mock_temperature_max_gpu.at(sub_idx)));
 
         //Power & energy
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy_chip.at(sub_idx)));
@@ -651,6 +658,12 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
         EXPECT_DOUBLE_EQ(frequency, mock_freq_min_mem.at(sub_idx)*1e6);
         frequency = levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         EXPECT_DOUBLE_EQ(frequency, mock_freq_max_mem.at(sub_idx)*1e6);
+
+        //Temperature
+        double temperature = levelzero_io.read_signal("LEVELZERO::GPU_CORE_TEMPERATURE_MAXIMUM", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(temperature, mock_temperature_max_gpu.at(sub_idx));
+        temperature = levelzero_io.read_signal("LEVELZERO::GPU_MEMORY_TEMPERATURE_MAXIMUM", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(temperature, mock_temperature_max_mem.at(sub_idx));
 
         //Active time
         double active_time = levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx);

--- a/service/test/LevelZeroIOGroupTest.cpp
+++ b/service/test/LevelZeroIOGroupTest.cpp
@@ -179,6 +179,10 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
                     energy_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL));
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
                     performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(3);
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_TEMPERATURE_MAXIMUM
+                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_CALL(*m_device_pool, // GPU_MEMORY_TEMPERATURE_MAXIMUM
+                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
 
         // control pruning expectations
         // GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL, and the restore_control() direct call.
@@ -813,6 +817,10 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
         // EXPECT_CALL(*m_device_pool,
         //             frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE,
         //                               0, 0)).Times(3);
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_TEMPERATURE_MAXIMUM
+                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_CALL(*m_device_pool, // GPU_MEMORY_TEMPERATURE_MAXIMUM
+                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
 
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
                     performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(3);

--- a/service/test/MockLevelZero.hpp
+++ b/service/test/MockLevelZero.hpp
@@ -32,6 +32,13 @@ class MockLevelZero : public geopm::LevelZero
         MOCK_METHOD((std::pair<double, double>), frequency_range,
                     (unsigned int, int, int), (const, override));
 
+
+        MOCK_METHOD(double, temperature_max, (unsigned int, int, int),
+                    (const, override));
+        MOCK_METHOD(int, temperature_domain_count, (unsigned int, int),
+                    (const, override));
+
+
         MOCK_METHOD(int, engine_domain_count, (unsigned int, int),
                     (const, override));
         MOCK_METHOD((std::pair<uint64_t, uint64_t>), active_time_pair,

--- a/service/test/MockLevelZeroDevicePool.hpp
+++ b/service/test/MockLevelZeroDevicePool.hpp
@@ -29,6 +29,9 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
         MOCK_METHOD((std::pair<double, double>), frequency_range,
                     (int, unsigned int, int), (const, override));
 
+        MOCK_METHOD(double, temperature_max,
+                    (int, unsigned int, int), (const, override));
+
         MOCK_METHOD((std::pair<uint64_t, uint64_t>), active_time_pair,
                     (int, unsigned int, int), (const, override));
         MOCK_METHOD(uint64_t, active_time,


### PR DESCRIPTION
- Relates to #2742 story from github issues
- Fixes #2741 change request from github issues.

Update to levelzero code to provide GPU_CHIP temperature information. 