### PR TITLE
Combined LocalNeuralNet code with interface/implementation separation…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -415,6 +415,9 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/FrequencyMapAgent.cpp \
                             src/FrequencyMapAgent.hpp \
                             src/Imbalancer.cpp \
+                            src/LocalNeuralNet.cpp \
+                            src/LocalNeuralNet.hpp \
+                            src/LocalNeuralNetImp.hpp \
                             src/ModelParse.cpp \
                             src/ModelParse.hpp \
                             src/MonitorAgent.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-#  Copyright (c) 2015 - 2022, Intel Corporation
+#  Copyright (c) 2015 - 2023, Intel Corporation
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/src/LocalNeuralNet.cpp
+++ b/src/LocalNeuralNet.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "config.h"
+#include "LocalNeuralNet.hpp"
+#include "LocalNeuralNetImp.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <numeric>
+
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+
+namespace geopm
+{
+    std::unique_ptr<LocalNeuralNet> LocalNeuralNet::make_unique(std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > input) {
+        return geopm::make_unique<LocalNeuralNetImp>(input);
+    }
+
+    LocalNeuralNetImp::LocalNeuralNetImp(std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > input)
+    {
+        if (input.size() == 0u) {
+            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::size_t nlayers = input.size();
+
+        m_layers.resize(nlayers);
+        for (std::size_t idx = 0; idx < nlayers; idx++) {
+            m_layers[idx] = std::make_pair(LocalNeuralNetImp::TensorTwoD(input[idx].first),
+                                           LocalNeuralNetImp::TensorOneD(input[idx].second));
+            if (m_layers[idx].first.get_rows() != m_layers[idx].second.get_dim()) {
+                throw geopm::Exception("Incompatible dimensions for weights and biases.",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            if (idx > 0 && m_layers[idx].first.get_cols() != m_layers[idx-1].first.get_rows()) {
+                throw geopm::Exception("Incompatible dimensions for consecutive layers.",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+        }
+    }
+
+    std::vector<float>
+    LocalNeuralNetImp::model(std::vector<float> inp_vector)
+    {
+        LocalNeuralNetImp::TensorOneD inp(inp_vector);
+
+        if (inp.get_dim() != m_layers[0].first.get_cols()) {
+            throw geopm::Exception("Input vector dimension is incompatible with network.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        LocalNeuralNetImp::TensorOneD tmp = inp;
+        std::size_t nlayers = m_layers.size();
+        for (std::size_t idx = 0; idx < nlayers; idx++) {
+            // Tensor operations
+            tmp = m_layers[idx].first * tmp + m_layers[idx].second;
+
+            // Apply a sigmoid on all but the last layer
+            if (idx != m_layers.size() - 1) {
+                tmp = tmp.sigmoid();
+            }
+        }
+        return tmp.to_vector();
+    }
+
+    LocalNeuralNetImp::TensorOneD::TensorOneD(std::size_t dim)
+    {
+        set_dim(dim);
+    }
+
+    LocalNeuralNetImp::TensorOneD::TensorOneD(const TensorOneD &other)
+        : m_vec(other.m_vec)
+    {
+    }
+
+    LocalNeuralNetImp::TensorOneD::TensorOneD(TensorOneD &&other)
+        : m_vec(std::move(other.m_vec))
+    {
+    }
+
+    void LocalNeuralNetImp::TensorOneD::set_dim(std::size_t dim)
+    {
+        m_vec.resize(dim);
+    }
+
+    std::size_t LocalNeuralNetImp::TensorOneD::get_dim() const
+    {
+        return m_vec.size();
+    }
+
+    LocalNeuralNetImp::TensorOneD::TensorOneD(std::vector<float> input)
+    {
+        set_dim(input.size());
+        std::size_t vec_size = m_vec.size();
+
+        for (std::size_t idx = 0; idx < vec_size; ++idx) {
+            m_vec[idx] = input[idx];
+        }
+    }
+
+    LocalNeuralNetImp::TensorOneD LocalNeuralNetImp::TensorOneD::operator+(const LocalNeuralNetImp::TensorOneD& other)
+    {
+        if (get_dim() != other.get_dim()) {
+            throw geopm::Exception("Adding vectors of mismatched dimensions.",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        LocalNeuralNetImp::TensorOneD rval(m_vec.size());
+        std::transform(m_vec.begin(), m_vec.end(), other.m_vec.begin(), rval.m_vec.begin(), std::plus<float>());
+
+        return rval;
+    }
+
+    LocalNeuralNetImp::TensorOneD LocalNeuralNetImp::TensorOneD::operator-(const LocalNeuralNetImp::TensorOneD& other)
+    {
+        if (get_dim() != other.get_dim()) {
+            throw geopm::Exception("Subtracting vectors of mismatched dimensions.",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        LocalNeuralNetImp::TensorOneD rval(m_vec.size());
+        std::transform(m_vec.begin(), m_vec.end(), other.m_vec.begin(), rval.m_vec.begin(), std::minus<float>());
+
+        return rval;
+    }
+
+
+    float LocalNeuralNetImp::TensorOneD::operator*(const LocalNeuralNetImp::TensorOneD& other)
+    {
+        if (get_dim() != other.get_dim()) {
+            throw geopm::Exception("Inner product of vectors of mismatched dimensions.",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return std::inner_product(m_vec.begin(), m_vec.end(), other.m_vec.begin(), 0);
+    }
+
+    LocalNeuralNetImp::TensorOneD& LocalNeuralNetImp::TensorOneD::operator=(const LocalNeuralNetImp::TensorOneD &other)
+    {
+        m_vec = other.m_vec;
+        return *this;
+    }
+
+    LocalNeuralNetImp::TensorOneD& LocalNeuralNetImp::TensorOneD::operator=(LocalNeuralNetImp::TensorOneD &&other)
+    {
+        if (&other == this) {
+            return *this;
+        }
+
+        m_vec = std::move(other.m_vec);
+        return *this;
+    }
+
+    float& LocalNeuralNetImp::TensorOneD::operator[] (std::size_t idx)
+    {
+        return m_vec.at(idx);
+    }
+
+    float LocalNeuralNetImp::TensorOneD::operator[] (std::size_t idx) const
+    {
+        return m_vec.at(idx);
+    }
+
+    LocalNeuralNetImp::TensorOneD LocalNeuralNetImp::TensorOneD::sigmoid() const
+    {
+        std::size_t vec_size = m_vec.size();
+        LocalNeuralNetImp::TensorOneD rval(vec_size);
+        for(std::size_t idx = 0; idx < vec_size; idx++) {
+            rval[idx] = 1/(1 + expf(-(m_vec.at(idx))));
+        }
+        return rval;
+    }
+
+    std::vector<float> LocalNeuralNetImp::TensorOneD::to_vector() const
+    {
+        return m_vec;
+    }
+
+    LocalNeuralNetImp::TensorTwoD::TensorTwoD(std::size_t rows, std::size_t cols)
+    {
+        set_dim(rows, cols);
+    }
+
+    LocalNeuralNetImp::TensorTwoD::TensorTwoD(const LocalNeuralNetImp::TensorTwoD &other)
+        : m_mat(other.m_mat)
+    {
+    }
+
+    LocalNeuralNetImp::TensorTwoD::TensorTwoD(std::vector<std::vector<float> > input)
+    {
+        if (input.size() == 0) {
+            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        std::size_t rows = input.size();
+        std::size_t cols = input[0].size();
+        set_dim(rows, cols);
+        for (std::size_t idx = 0; idx < rows; ++idx) {
+            if (input[idx].size() != cols) {
+                throw geopm::Exception("Attempt to load non-rectangular matrix.",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            m_mat[idx] = LocalNeuralNetImp::TensorOneD(input[idx]);
+        }
+    }
+
+    std::size_t LocalNeuralNetImp::TensorTwoD::get_rows() const
+    {
+        return m_mat.size();
+    }
+
+    std::size_t LocalNeuralNetImp::TensorTwoD::get_cols() const
+    {
+        if (m_mat.size() == 0) {
+            return 0;
+        }
+        return m_mat[0].get_dim();
+    }
+
+    void LocalNeuralNetImp::TensorTwoD::set_dim(std::size_t rows, std::size_t cols)
+    {
+        if ((rows == 0 && cols > 0) || (rows > 0 && cols == 0)) {
+            throw geopm::Exception("Tried to allocate degenerate matrix.",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        m_mat.resize(rows);
+        for (auto &row : m_mat) {
+            row.set_dim(cols);
+        }
+    }
+
+
+    LocalNeuralNetImp::TensorOneD LocalNeuralNetImp::TensorTwoD::operator*(const LocalNeuralNetImp::TensorOneD& other)
+    {
+        if (get_cols() != other.get_dim()) {
+            throw geopm::Exception("Attempted to multiply matrix and vector with incompatible dimensions.",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        LocalNeuralNetImp::TensorOneD rval(get_rows());
+
+        for (std::size_t idx = 0; idx < get_rows(); ++idx) {
+            rval[idx] = m_mat[idx] * other;
+        }
+        return rval;
+    }
+
+    LocalNeuralNetImp::TensorOneD& LocalNeuralNetImp::TensorTwoD::operator[](size_t idx)
+    {
+        return m_mat.at(idx);
+    }
+
+    LocalNeuralNetImp::TensorOneD LocalNeuralNetImp::TensorTwoD::operator[](size_t idx) const
+    {
+        return m_mat.at(idx);
+    }
+
+    LocalNeuralNetImp::TensorTwoD& LocalNeuralNetImp::TensorTwoD::operator=(const LocalNeuralNetImp::TensorTwoD &other)
+    {
+        m_mat = other.m_mat;
+
+        return *this;
+    }
+}

--- a/src/LocalNeuralNet.hpp
+++ b/src/LocalNeuralNet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2022, Intel Corporation
+ * Copyright (c) 2015 - 2023, Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -11,6 +11,10 @@
 
 namespace geopm
 {
+    typedef std::vector<std::vector<float> > Weight;
+    typedef std::vector<float> Bias;
+    typedef std::pair<Weight, Bias> Layer;
+
     ///  @brief Class to manage data and operations of feed forward neural nets
     ///         required for neural net inference.
 
@@ -19,14 +23,14 @@ namespace geopm
         public:
             /// @brief Returns a unique_ptr to a concrete object
             ///        constructed using the underlying implementation
-            ///        from an array of doubles of weights and biases.
+            ///        from an array of pairs of weights and biases.
             /// 
             /// @param [in] vector of pairs of weight matrices (as
             ///             double vectors of floats) and bias vectors
             ///             as vectors of floats.
             /// 
             /// @throws geopm::Exception if dimensions are incompatible.
-            static std::unique_ptr<LocalNeuralNet> make_unique(std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > input);
+            static std::unique_ptr<LocalNeuralNet> make_unique(std::vector<Layer> input);
             /// @brief Default destructor of pure virtual base class.
             virtual ~LocalNeuralNet() = default;
 
@@ -38,7 +42,20 @@ namespace geopm
             ///
             /// @throws geopm::Exception if input dimension is incompatible
             /// with network.
-            virtual std::vector<float> model(std::vector<float> inp) = 0;
+            virtual std::vector<float> forward(std::vector<float> inp) = 0;
+
+            /// @brief Perform inference using the instance weights and biases.
+            ///        (Short-hand for the forward method.)
+            /// 
+            /// @param [in] std::vector<float> of input signals.
+            ///
+            /// @return Returns a std::vector<float> of output values.
+            ///
+            /// @throws geopm::Exception if input dimension is incompatible
+            /// with network.
+            std::vector<float> operator()(std::vector<float> inp) {
+                return forward(inp);
+            }
         protected:
             LocalNeuralNet() = default;
     };

--- a/src/LocalNeuralNet.hpp
+++ b/src/LocalNeuralNet.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef LOCALNEURALNET_HPP_INCLUDE
+#define LOCALNEURALNET_HPP_INCLUDE
+
+#include <memory>
+#include <vector>
+
+namespace geopm
+{
+    ///  @brief Class to manage data and operations of feed forward neural nets
+    ///         required for neural net inference.
+
+    class LocalNeuralNet
+    {
+        public:
+            /// @brief Returns a unique_ptr to a concrete object
+            ///        constructed using the underlying implementation
+            ///        from an array of doubles of weights and biases.
+            /// 
+            /// @param [in] vector of pairs of weight matrices (as
+            ///             double vectors of floats) and bias vectors
+            ///             as vectors of floats.
+            /// 
+            /// @throws geopm::Exception if dimensions are incompatible.
+            static std::unique_ptr<LocalNeuralNet> make_unique(std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > input);
+            /// @brief Default destructor of pure virtual base class.
+            virtual ~LocalNeuralNet() = default;
+
+            /// @brief Perform inference using the instance weights and biases.
+            /// 
+            /// @param [in] std::vector<float> of input signals.
+            ///
+            /// @return Returns a std::vector<float> of output values.
+            ///
+            /// @throws geopm::Exception if input dimension is incompatible
+            /// with network.
+            virtual std::vector<float> model(std::vector<float> inp) = 0;
+        protected:
+            LocalNeuralNet() = default;
+    };
+}
+
+#endif  /* LOCALNEURALNET_HPP_INCLUDE */

--- a/src/LocalNeuralNetImp.hpp
+++ b/src/LocalNeuralNetImp.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2022, Intel Corporation
+ * Copyright (c) 2015 - 2023, Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -13,8 +13,8 @@ namespace geopm
     class LocalNeuralNetImp : public LocalNeuralNet
     {
         public:
-            LocalNeuralNetImp(std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > input);
-            std::vector<float> model(std::vector<float> inp);
+            LocalNeuralNetImp(std::vector<Layer> input);
+            std::vector<float> forward(std::vector<float> inp);
 
         private:
             /// @brief Class to store and perform operations on 1D Tensors,
@@ -169,7 +169,7 @@ namespace geopm
                     std::vector<TensorOneD> m_mat;
             };
 
-            std::vector<std::pair<TensorTwoD, LocalNeuralNetImp::TensorOneD> > m_layers;
+            std::vector<std::pair<TensorTwoD, TensorOneD> > m_layers;
     };
 }
 

--- a/src/LocalNeuralNetImp.hpp
+++ b/src/LocalNeuralNetImp.hpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef LOCALNEURALNETIMP_HPP_INCLUDE
+#define LOCALNEURALNETIMP_HPP_INCLUDE
+
+#include "LocalNeuralNet.hpp"
+
+namespace geopm
+{
+    class LocalNeuralNetImp : public LocalNeuralNet
+    {
+        public:
+            LocalNeuralNetImp(std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > input);
+            std::vector<float> model(std::vector<float> inp);
+
+        private:
+            /// @brief Class to store and perform operations on 1D Tensors,
+            ///        aka vectors, suitable for use in feed-forward neural
+            ///        networks.
+            class TensorOneD
+            {
+                public:
+                    TensorOneD() = default;
+                    /// @brief Constructor with size specified 
+                    ///
+                    /// @param [in] n Size of 1D tensor
+                    TensorOneD(std::size_t n);
+                    /// @brief Constructs a deep copy of the argument
+                    ///
+                    /// @param [in] TensorOneD Tensor to copy
+                    TensorOneD(const TensorOneD&);
+
+                    TensorOneD(TensorOneD &&other);
+                    /// @param [in] input std::vector<float> input the data
+                    ///
+                    /// @throws geopm::Exception if input is empty.
+                    TensorOneD(std::vector<float> input);
+                    /// @brief Set length of 1D tensor
+                    ///
+                    /// If the instance has more than n elements, it will
+                    /// be truncated. If it has fewer than n elements, the
+                    /// tensor will be expanded to a total size of n, uninitialized.
+                    ///
+                    /// @param [in] n Resulting size of 1D tensor
+                    void set_dim(std::size_t dim);
+                    /// @brief Get the length of the 1D tensor
+                    ///
+                    /// @return Returns the length of the 1D tensor
+                    std::size_t get_dim() const;
+                    /// @brief Add two 1D tensors, element-wise
+                    ///
+                    /// The tensors need to be the same length. 
+                    ///
+                    /// @throws geopm::Exception if the lengths do not match.
+                    ///
+                    /// @param [in] other The summand
+                    ///
+                    /// @return Returns a 1D tensor, the sum of two 1D tensors
+                    TensorOneD operator+(const TensorOneD& other);
+                    /// @brief Subtract two 1D tensors, element-wise
+                    ///
+                    /// @throws geopm::Exception if the lengths do not match.
+                    ///
+                    /// @param [in] other The subtrahend
+                    ///
+                    /// @return A 1D tensor, the difference of two 1D tensors.
+                    TensorOneD operator-(const TensorOneD& other);
+                    /// @brief Multiply two 1D tensors, element-wise
+                    ///
+                    /// @throws geopm::Exception if the lengths do not match.
+                    ///
+                    /// @param [in] other The multiplicand
+                    ///
+                    /// @return Returns a 1D tensor, the product of two 1D tensors
+                    float operator*(const TensorOneD& other);
+                    /// @brief Overload = operator with an in-place deep copy
+                    ///
+                    /// @param [in] other The assignee (tensor to be copied)
+                    TensorOneD& operator=(const TensorOneD& other);
+
+                    TensorOneD& operator=(TensorOneD &&other);
+                    /// @brief Reference indexing of 1D tensor value at idx
+                    ///
+                    /// @param [in] idx The index at which to look for the value
+                    ///
+                    /// @return Returns a reference to the 1D tensor at idx
+                    float &operator[](std::size_t idx);
+                    /// @brief Value access of 1D Tensor value at idx.
+                    ///
+                    /// @param [in] idx The index at which to look for the value
+                    ///
+                    /// @return Returns the value of the 1D tensor at idx
+                    float operator[](std::size_t idx) const;
+                    /// @brief Compute logistic sigmoid function of 1D Tensor
+                    TensorOneD sigmoid() const;
+                    /// TODO
+                    std::vector<float> to_vector() const;
+
+                private:
+                    std::vector<float> m_vec;
+            };
+
+            class TensorTwoD
+            {
+                public:
+                    TensorTwoD() = default;
+                    /// @brief Constructor setting dimensions
+                    TensorTwoD(std::size_t rows, std::size_t cols);
+                    /// @brief Copy constructor using a deep copy
+                    /// 
+                    /// @param [in] TensorTwoD& 2D Tensor to copy
+                    TensorTwoD(const TensorTwoD&);
+                    /// @brief Constructor input from a vector of vectors of values.
+                    /// 
+                    /// @param [in] input std::vector<std::vector<float> > instance
+                    /// 
+                    /// @throws geopm::Exception if input is not rectangular or
+                    /// if input is empty.
+                    TensorTwoD(std::vector<std::vector<float> > input);
+                    /// @brief Set dimensions of 2D tensor
+                    /// 
+                    /// @param [in] rows The number of "rows" or 1D tensors
+                    /// @param [in] cols The number of "cols" or the size of each 1D tensor
+                    /// 
+                    /// If the instance contains more than \p rows 1D tensors,
+                    /// it will be truncated. If the instance contains fewer
+                    /// than \p rows 1D tensors, it will be expanded to a total
+                    /// number of rows, uninitialized. The individual 1D tensors
+                    /// will be managed similarly. 
+                    /// 
+                    /// @throws geopm::Exception if \p rows = 0 and \p cols > 0
+                    void set_dim(std::size_t rows, std::size_t cols);
+                    /// @brief Get number of rows in the 2D tensor
+                    /// 
+                    /// @return Number of rows of the 2D tensor
+                    std::size_t get_rows() const;
+                    /// @brief get number of columns in 2D tensor
+                    /// 
+                    /// @return Number of columns in the 2D tensor
+                    std::size_t get_cols() const;
+                    /// @brief Multiply a 2D tensor by a 1D tensor
+                    /// 
+                    /// @param [in] TensorOneD& Reference to the multiplicand
+                    /// 
+                    /// @throws geopm::Exception if the sizes are incompatible, i.e. if 2D tensor
+                    /// number of columns is unequal to 1D tensor number of rows
+                    TensorOneD operator*(const TensorOneD&);
+                    /// @brief Reference indexing of 1D Tensor at idx of the 2D Tensor
+                    /// 
+                    /// @param [in] idx The index at which to look for the value
+                    /// 
+                    /// @return Returns a reference to the 1D Tensor at idx
+                    TensorOneD &operator[](size_t idx);
+                    /// @brief Value access of 1D Tensor value at idx
+                    /// 
+                    /// @pram [in] idx The index at which to look for the value
+                    /// 
+                    /// @return Returns the values of 1D Tensors at idx
+                    TensorOneD operator[](size_t idx) const;
+                    /// @brief Oerload = operator with an in-place deep copy
+                    /// 
+                    /// @param [in] TensorTwoD& Reference to the 2D Tensor to copy
+                    TensorTwoD& operator=(const TensorTwoD&);
+
+                private:
+                    std::vector<TensorOneD> m_mat;
+            };
+
+            std::vector<std::pair<TensorTwoD, LocalNeuralNetImp::TensorOneD> > m_layers;
+    };
+}
+
+#endif  /* LOCALNEURALNETIMP_HPP_INCLUDE */

--- a/test/LocalNeuralNetTest.cpp
+++ b/test/LocalNeuralNetTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2022, Intel Corporation
+ * Copyright (c) 2015 - 2023, Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -15,7 +15,8 @@ class LocalNeuralNetTest : public ::testing::Test
 {
 };
 
-TEST_F(LocalNeuralNetTest, test_inference) {
+TEST_F(LocalNeuralNetTest, test_inference)
+{
     LocalNeuralNetImp net(
             std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
                 std::make_pair (
@@ -30,12 +31,13 @@ TEST_F(LocalNeuralNetTest, test_inference) {
           );
 
     std::vector<float> inp = {1, 2};
-    std::vector<float> out = net.model(inp);
+    std::vector<float> out = net(inp);
     EXPECT_EQ(1u, out.size());
     EXPECT_NEAR(1/(1 + expf(-43)), out[0], 1e-6);
 }
 
-TEST_F(LocalNeuralNetTest, test_bad_layers) {
+TEST_F(LocalNeuralNetTest, test_bad_layers)
+{
     EXPECT_THROW(LocalNeuralNetImp (
             std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
                 std::make_pair (
@@ -59,14 +61,16 @@ TEST_F(LocalNeuralNetTest, test_bad_layers) {
           ), geopm::Exception);
 }
 
-TEST_F(LocalNeuralNetTest, test_empty_array) {
+TEST_F(LocalNeuralNetTest, test_empty_array)
+{
     EXPECT_THROW(LocalNeuralNetImp (
             std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
             }
           ), geopm::Exception);
 }
 
-TEST_F(LocalNeuralNetTest, test_inference_bad_input_dimensions) {
+TEST_F(LocalNeuralNetTest, test_inference_bad_input_dimensions)
+{
     std::vector<float> inp = {1, 2, 3};
     LocalNeuralNetImp net(
             std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
@@ -80,10 +84,11 @@ TEST_F(LocalNeuralNetTest, test_inference_bad_input_dimensions) {
                 )
             }
           );
-    EXPECT_THROW(net.model(inp), geopm::Exception);
+    EXPECT_THROW(net(inp), geopm::Exception);
 }
 
-TEST_F(LocalNeuralNetTest, test_non_rectangular_weights) {
+TEST_F(LocalNeuralNetTest, test_non_rectangular_weights)
+{
     EXPECT_THROW(
             LocalNeuralNetImp net(
                     std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
@@ -96,7 +101,8 @@ TEST_F(LocalNeuralNetTest, test_non_rectangular_weights) {
             geopm::Exception);
 }
 
-TEST_F(LocalNeuralNetTest, test_empty_bias) {
+TEST_F(LocalNeuralNetTest, test_empty_bias)
+{
     EXPECT_THROW(
             LocalNeuralNetImp net(
                     std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {

--- a/test/LocalNeuralNetTest.cpp
+++ b/test/LocalNeuralNetTest.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2015 - 2022, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm/Exception.hpp"
+
+#include "LocalNeuralNetImp.hpp"
+
+using geopm::LocalNeuralNetImp;
+
+class LocalNeuralNetTest : public ::testing::Test
+{
+};
+
+TEST_F(LocalNeuralNetTest, test_inference) {
+    LocalNeuralNetImp net(
+            std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
+                std::make_pair (
+                    std::vector<std::vector<float> > {  std::vector<float> {8, 16} },
+                    std::vector<float> {3}
+                ),
+                std::make_pair (
+                    std::vector<std::vector<float> > {  std::vector<float> { 1 } },
+                    std::vector<float> {0}
+                )
+            }
+          );
+
+    std::vector<float> inp = {1, 2};
+    std::vector<float> out = net.model(inp);
+    EXPECT_EQ(1u, out.size());
+    EXPECT_NEAR(1/(1 + expf(-43)), out[0], 1e-6);
+}
+
+TEST_F(LocalNeuralNetTest, test_bad_layers) {
+    EXPECT_THROW(LocalNeuralNetImp (
+            std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
+                std::make_pair (
+                    std::vector<std::vector<float> > {  std::vector<float> {8, 16} },
+                    std::vector<float> {3, 0}
+                ),
+            }
+          ), geopm::Exception);
+
+    EXPECT_THROW(LocalNeuralNetImp (
+            std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
+                std::make_pair (
+                    std::vector<std::vector<float> > {  std::vector<float> {8, 16} },
+                    std::vector<float> {3}
+                ),
+                std::make_pair (
+                    std::vector<std::vector<float> > {  std::vector<float> {1, 2} },
+                    std::vector<float> {0}
+                ),
+            }
+          ), geopm::Exception);
+}
+
+TEST_F(LocalNeuralNetTest, test_empty_array) {
+    EXPECT_THROW(LocalNeuralNetImp (
+            std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
+            }
+          ), geopm::Exception);
+}
+
+TEST_F(LocalNeuralNetTest, test_inference_bad_input_dimensions) {
+    std::vector<float> inp = {1, 2, 3};
+    LocalNeuralNetImp net(
+            std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
+                std::make_pair (
+                    std::vector<std::vector<float> > {  std::vector<float> {8, 16} },
+                    std::vector<float> {3}
+                ),
+                std::make_pair (
+                    std::vector<std::vector<float> > {  std::vector<float> { 1 } },
+                    std::vector<float> {0}
+                )
+            }
+          );
+    EXPECT_THROW(net.model(inp), geopm::Exception);
+}
+
+TEST_F(LocalNeuralNetTest, test_non_rectangular_weights) {
+    EXPECT_THROW(
+            LocalNeuralNetImp net(
+                    std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
+                        std::make_pair (
+                            std::vector<std::vector<float> > { std::vector<float> {8, 16}, std::vector<float> {1} },
+                            std::vector<float> {3, 1}
+                        ),
+                    }
+                  ),
+            geopm::Exception);
+}
+
+TEST_F(LocalNeuralNetTest, test_empty_bias) {
+    EXPECT_THROW(
+            LocalNeuralNetImp net(
+                    std::vector<std::pair<std::vector<std::vector<float> >, std::vector<float> > > {
+                        std::make_pair (
+                            std::vector<std::vector<float> > { std::vector<float> {8, 16} },
+                            std::vector<float> {}
+                        ),
+                    }
+                  ),
+            geopm::Exception);
+}

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -185,6 +185,12 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/FrequencyMapAgentTest.report_neither_map_nor_set \
               test/gtest_links/FrequencyMapAgentTest.split_policy \
               test/gtest_links/FrequencyMapAgentTest.validate_policy \
+              test/gtest_links/LocalNeuralNetTest.test_inference \
+              test/gtest_links/LocalNeuralNetTest.test_bad_layers \
+              test/gtest_links/LocalNeuralNetTest.test_empty_array \
+              test/gtest_links/LocalNeuralNetTest.test_inference_bad_input_dimensions \
+              test/gtest_links/LocalNeuralNetTest.test_non_rectangular_weights \
+              test/gtest_links/LocalNeuralNetTest.test_empty_bias \
               test/gtest_links/ModelApplicationTest.parse_config_errors \
               test/gtest_links/MonitorAgentTest.policy_names \
               test/gtest_links/MonitorAgentTest.sample_names \
@@ -397,6 +403,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/FilePolicyTest.cpp \
                           test/FrequencyGovernorTest.cpp \
                           test/FrequencyMapAgentTest.cpp \
+                          test/LocalNeuralNetTest.cpp \
                           test/MockAgent.hpp \
                           test/MockApplicationIO.hpp \
                           test/MockApplicationRecordLog.hpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -1,4 +1,4 @@
-#  Copyright (c) 2015 - 2022, Intel Corporation
+#  Copyright (c) 2015 - 2023, Intel Corporation
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 


### PR DESCRIPTION
- Relates to #2617 
-  Adds LocalNeuralNet class which builds on TensorOneD and TensorTwoD to do neural net json parsing and feed-forward inference, and is used by the Feed Forward agent
- Addresses #2693 
- Replaces #2618 
- Replaces #2628 
- …, tensors moved to inner classes, and JSON11 constructors replaced with STL-based interface.