### PR TITLE
[WIP] Trying to get the geopm service running inside kubernetes

### DIFF
--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -27,9 +27,6 @@ BuildRequires: systemd-devel >= 221
 BuildRequires: python3
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
-BuildRequires: level-zero
-BuildRequires: level-zero-devel
-Requires: level-zero >= 1.8.1
 %if 0%{?suse_version}
 BuildRequires: fdupes
 BuildRequires: systemd-rpm-macros
@@ -136,7 +133,6 @@ CFLAGS= CXXFLAGS= CC=gcc CXX=g++ \
             --includedir=%{_includedir} --sbindir=%{_sbindir} \
             --mandir=%{_mandir} --docdir=%{docdir} \
             --with-python=%{python_bin} \
-            --enable-levelzero \
             || ( cat config.log && false )
 
 CFLAGS= CXXFLAGS= CC=gcc CXX=g++ \

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -145,7 +145,7 @@ rm -f $(find %{buildroot}/%{_libdir} -name '*.a'; \
 install -Dp -m644 geopm.service %{buildroot}%{_unitdir}/geopm.service
 install -Dp -m644 io.github.geopm.conf %{buildroot}%{_datadir}/dbus-1/system.d/io.github.geopm.conf
 install -Dp -m644 io.github.geopm.xml %{buildroot}%{_datadir}/dbus-1/interfaces/io.github.geopm.xml
-mkdir -p %{buildroot}%{_sysconfdir}/geopm-service
+mkdir -p -m 711 %{buildroot}%{_sysconfdir}/geopm-service
 mkdir -p %{buildroot}%{_sbindir}
 ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcgeopm
 %if 0%{?suse_version}

--- a/service/geopmdpy/__main__.py
+++ b/service/geopmdpy/__main__.py
@@ -2,8 +2,10 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 
+import sys
 from dasbus.loop import EventLoop
 from dasbus.connection import SystemMessageBus
+from dasbus.connection import AddressedMessageBus
 from signal import signal
 from signal import SIGTERM
 from . import service
@@ -21,11 +23,18 @@ def stop():
 
 def main():
     signal(SIGTERM, term_handler)
+    is_anonymous = False
+    if len(sys.argv) > 1 and sys.argv[1] == '--anonymous':
+        is_anonymous = True
     loop = EventLoop()
     global _bus
-    _bus = SystemMessageBus()
+    if is_anonymous:
+        socket_path = "/run/geopm-service/SESSION_BUS_SOCKET"
+        _bus = AddressedMessageBus(f'unix:path={socket_path}')
+    else:
+        _bus = SystemMessageBus()
     try:
-        _bus.publish_object("/io/github/geopm", service.GEOPMService())
+        _bus.publish_object("/io/github/geopm", service.GEOPMService(is_anonymous))
         _bus.register_service("io.github.geopm")
         loop.run()
     finally:

--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -22,6 +22,7 @@ from . import topo
 from . import dbus_xml
 from . import system_files
 from dasbus.connection import SystemMessageBus
+
 try:
     from dasbus.server.interface import accepts_additional_arguments
 except ImportError as ee:
@@ -676,6 +677,9 @@ class PlatformService(object):
         self._pio.write_control(control_name, domain, domain_idx, setting)
 
     def _write_mode(self, client_pid):
+        if self._is_anonymous:
+            # TODO: No save/restore for anonymous mode
+            return
         write_pid = client_pid
         do_open_session = False
         # If the session leader is an active process then tie the write lock
@@ -781,11 +785,15 @@ class GEOPMService(object):
     """
     __dbus_xml__ = dbus_xml.geopm_dbus_xml(TopoService, PlatformService)
 
-    def __init__(self):
+    def __init__(self, is_anonymous=False):
         self._topo = TopoService()
         self._platform = PlatformService()
-        self._dbus_proxy = SystemMessageBus().get_proxy('org.freedesktop.DBus',
-                                                        '/org/freedesktop/DBus')
+        self._is_anonymous = is_anonymous
+        if self._is_anonymous:
+            self._dbus_proxy = None
+        else:
+            self._dbus_proxy = SystemMessageBus().get_proxy('org.freedesktop.DBus',
+                                                            '/org/freedesktop/DBus')
 
     def TopoGetCache(self):
         return self._topo.get_cache()
@@ -872,6 +880,8 @@ class GEOPMService(object):
             (str): The Unix user name of the client process owner.
 
         """
+        if self._is_anonymous:
+            return ''
         unique_name = call_info['sender']
         uid = self._dbus_proxy.GetConnectionUnixUser(unique_name)
         return pwd.getpwuid(uid).pw_name
@@ -888,10 +898,14 @@ class GEOPMService(object):
             (int): The Linux PID of the client thread.
 
         """
+        if self._is_anonymous:
+            return 1
         unique_name = call_info['sender']
         return self._dbus_proxy.GetConnectionUnixProcessID(unique_name)
 
     def _check_cap_sys_admin(self, call_info, api_name):
+        if self._is_anonymous:
+            return False
         has_admin = False
         cap = 0
         cap_sys_admin = 0x00200000

--- a/service/geopmdpy/session.py
+++ b/service/geopmdpy/session.py
@@ -12,7 +12,10 @@ import time
 import math
 from argparse import ArgumentParser
 from dasbus.connection import SystemMessageBus
+from dasbus.connection import AddressedMessageBus
+from dasbus.connection import GLibConnection
 from dasbus.error import DBusError
+from gi.repository.GLib import Error as GLibError
 from . import topo
 from . import pio
 from . import runtime
@@ -351,8 +354,13 @@ def main():
                         help='When used with a read mode session reads all values out periodically with the specified period in seconds')
     args = parser.parse_args()
     try:
-        sess = Session(SystemMessageBus().get_proxy('io.github.geopm',
-                                                    '/io/github/geopm'))
+        try:
+            socket_path = "/run/geopm-service/SESSION_BUS_SOCKET"
+            bus = AddressedMessageBus(f'unix:path={socket_path}')
+        except GLibError:
+            bus = SystemMessageBus()
+        sess = Session(bus.get_proxy('io.github.geopm',
+                                     '/io/github/geopm'))
         sess.run(args.time, args.period)
     except RuntimeError as ee:
         if 'GEOPM_DEBUG' in os.environ:

--- a/service/kube/Dockerfile
+++ b/service/kube/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/leap
-RUN zypper install -y systemd systemd-sysvinit curl coreutils
-RUN curl -fsSL https://download.opensuse.org/repositories/hardware/15.4/repodata/repomd.xml.key > /tmp/suse-key
+RUN zypper install -y curl dbus-1
+RUN curl -fsSL https://download.opensuse.org/repositories/home:/cmcantal/15.4/repodata/repomd.xml.key > /tmp/suse-key
 RUN rpm --import /tmp/suse-key
-RUN zypper addrepo https://download.opensuse.org/repositories/hardware/15.4/hardware.repo
+RUN zypper addrepo https://download.opensuse.org/repositories/home:/cmcantal/15.4/home:cmcantal.repo
 RUN zypper install -y geopm-service

--- a/service/kube/Dockerfile
+++ b/service/kube/Dockerfile
@@ -1,0 +1,6 @@
+FROM opensuse/leap
+RUN zypper install -y systemd systemd-sysvinit curl coreutils
+RUN curl -fsSL https://download.opensuse.org/repositories/hardware/15.4/repodata/repomd.xml.key > /tmp/suse-key
+RUN rpm --import /tmp/suse-key
+RUN zypper addrepo https://download.opensuse.org/repositories/hardware/15.4/hardware.repo
+RUN zypper install -y geopm-service

--- a/service/kube/README.md
+++ b/service/kube/README.md
@@ -1,0 +1,20 @@
+Trying to get GEOPM service up and running.
+
+To create the client and server containers execute the
+`geopm-create.sh` script in this working directory.  This is currently
+failing as below:
+
+```
+$ ./geopm-create.sh
+pod/geopm-service-pod created
+Error: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender="(null)" (inactive) interface="org.freedesktop.DBus" member="Hello" error name="(unset)" requested_reply="0" destination="org.freedesktop.DBus" (bus) (9)
+
+command terminated with exit code 255
+$ kubectl logs pods/geopm-service-pod -c geopm-client
+Error: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender="(null)" (inactive) interface="org.freedesktop.DBus" member="Hello" error name="(unset)" requested_reply="0" destination="org.freedesktop.DBus" (bus) (9)
+
+$ kubectl logs pods/geopm-service-pod -c geopm-server
+```
+
+December 23, 2022
+Christopher Cantalupo

--- a/service/kube/README.md
+++ b/service/kube/README.md
@@ -1,20 +1,23 @@
-Trying to get GEOPM service up and running.
+USE AT YOUR OWN RISK, QoS (CONTROL SAVE/RESTORE) NOT IMPLEMENTED
+================================================================
+
+Trying to get GEOPM service up and running in kubernetes.  This uses
+an experimental build of the geopm-service.  In this build some
+features to allow anonymous access through the service have been
+added.  It is important to note that because PID origin is unknown in
+this implementation (no use of systemd dbus service), there is no
+save/restore mechanism for controls.  This feature will be added back
+later.
+
+The GEOPM service will filter requests based on the default access
+list as is defined in the geopm-server.sh script.  Currently that
+access list contains only the TIME signal.  However, if controls were
+also enabled, they may be modified without being restored when process
+session ends.  The authentication for the save/restore feature is
+managed by systemd in the non-containerized solution.
 
 To create the client and server containers execute the
-`geopm-create.sh` script in this working directory.  This is currently
-failing as below:
+`geopm-create.sh` script in this working directory.
 
-```
-$ ./geopm-create.sh
-pod/geopm-service-pod created
-Error: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender="(null)" (inactive) interface="org.freedesktop.DBus" member="Hello" error name="(unset)" requested_reply="0" destination="org.freedesktop.DBus" (bus) (9)
-
-command terminated with exit code 255
-$ kubectl logs pods/geopm-service-pod -c geopm-client
-Error: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender="(null)" (inactive) interface="org.freedesktop.DBus" member="Hello" error name="(unset)" requested_reply="0" destination="org.freedesktop.DBus" (bus) (9)
-
-$ kubectl logs pods/geopm-service-pod -c geopm-server
-```
-
-December 23, 2022
+December 24, 2022
 Christopher Cantalupo

--- a/service/kube/dbus-test-client.sh
+++ b/service/kube/dbus-test-client.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+strace dbus-send --address='unix:path=/tmp/dbus-test-socket' \
+	  --dest=org.freedesktop.ExampleName \
+	  /org/freedesktop/sample/object/name \
+	  org.freedesktop.ExampleInterface.ExampleMethod
+echo $?

--- a/service/kube/dbus-test-server.sh
+++ b/service/kube/dbus-test-server.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
-set -x
-echo Starting GEOPM Server: $(date)
-BASE_DIR=/run/geopm-service
-mkdir -p -m 711 ${BASE_DIR}
-chmod 711 ${BASE_DIR}
+
+BASE_DIR=/tmp
 export XDG_RUNTIME_DIR=${BASE_DIR}/XDG_RUNTIME_DIR
 mkdir -p --mode=700 ${XDG_RUNTIME_DIR}
 mkdir -p --mode=700 ${XDG_RUNTIME_DIR}/dbus-1
+
 cat <<EOF > geopm-dbus.conf
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
   <type>session</type>
   <keep_umask/>
-  <listen>unix:path=/run/geopm-service/SESSION_BUS_SOCKET</listen>
+  <listen>unix:path=/tmp/dbus-test-socket</listen>
   <auth>EXTERNAL</auth>
   <standard_session_servicedirs />
   <policy context="default">
@@ -46,14 +44,5 @@ cat <<EOF > geopm-dbus.conf
 </busconfig>
 EOF
 
-dbus-daemon --fork --config-file geopm-dbus.conf &>> /tmp/geopm-dbus-daemon.log
-# Enable users to access the TIME signal through the service
-echo "TIME" | geopmaccess --write --direct --force
-sleep 5
-ls -l ${BASE_DIR}
-CONFIG_DIR=/etc/geopm-service
-ls -ld ${CONFIG_DIR}
-cat ${CONFIG_DIR}/0.DEFAULT_ACCESS/allowed_signals
-nohup geopmd --anonymous &>> /tmp/geopmd.log < /dev/null &
-sleep 1
-ps -aux
+strace dbus-daemon --config-file geopm-dbus.conf
+

--- a/service/kube/geopm-client-single.sh
+++ b/service/kube/geopm-client-single.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+TIMESTAMP=$(date +%s)
+LOG=/tmp/geopm-client-single-${TIMESTAMP}.log
+echo Starting GEOPM Client: $(date) >> ${LOG}
+for ii in $(seq 0 10); do
+    geopmread TIME board 0 >> ${LOG}
+    sleep 1
+done

--- a/service/kube/geopm-client.sh
+++ b/service/kube/geopm-client.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
-TIMESTAMP=$(date +%s)
-LOG=/tmp/geopm-client-${TIMESTAMP}.log
-sleep 60
-echo Starting GEOPM Client: $(date) >> ${LOG}
-# Read the TIME signal from the GEOPM service every second for an hour
-echo "SERVICE::TIME board 0" | geopmsession -p 1 -t 3600 >> ${LOG}
+set -x
+export GEOPM_DEBUG=True
+echo Starting GEOPM Client: $(date)
+sleep 10
+ls -l /run/geopm-service/SESSION_BUS_SOCKET
+geopmread
+geopmread -d
+geopmread TIME board 0
+geopmread SERVICE::TIME board 0
+echo "SERVICE::TIME board 0" | geopmsession -p 1 -t 3600

--- a/service/kube/geopm-client.sh
+++ b/service/kube/geopm-client.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+TIMESTAMP=$(date +%s)
+LOG=/tmp/geopm-client-${TIMESTAMP}.log
+sleep 60
+echo Starting GEOPM Client: $(date) >> ${LOG}
+# Read the TIME signal from the GEOPM service every second for an hour
+echo "SERVICE::TIME board 0" | geopmsession -p 1 -t 3600 >> ${LOG}

--- a/service/kube/geopm-create.sh
+++ b/service/kube/geopm-create.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 cp -p geopm-server.sh geopm-client.sh /tmp
 kubectl create -f manifest.yml
-sleep 30
-kubectl exec pods/geopm-service-pod -c geopm-server -- /tmp/geopm-server.sh

--- a/service/kube/geopm-create.sh
+++ b/service/kube/geopm-create.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cp -p geopm-server.sh geopm-client.sh /tmp
+kubectl create -f manifest.yml
+sleep 30
+kubectl exec pods/geopm-service-pod -c geopm-server -- /tmp/geopm-server.sh

--- a/service/kube/geopm-server.sh
+++ b/service/kube/geopm-server.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+TIMESTAMP=$(date +%s)
+LOG=/tmp/geopm-server-${TIMESTAMP}.log
+echo Starting GEOPM Server: $(date) >> ${LOG}
+
+# Enable users to access the TIME signal through the service
+echo "TIME" | geopmaccess -w >> ${LOG}

--- a/service/kube/manifest-dbus-test.yml
+++ b/service/kube/manifest-dbus-test.yml
@@ -15,7 +15,7 @@ spec:
        capabilities:
          drop:
            - all
-     command: ['/tmp/geopm-server.sh']
+     command: ['/tmp/dbus-test-server.sh']
      volumeMounts:
      - name: tmp-mount
        mountPath: /tmp
@@ -31,7 +31,7 @@ spec:
        runAsNonRoot: true
        runAsUser: 10001
        runAsGroup: 10001
-     command: ['/tmp/geopm-client.sh']
+     command: ['/tmp/dbus-test-client.sh']
      volumeMounts:
      - name: tmp-mount
        mountPath: /tmp

--- a/service/kube/manifest-single.yml
+++ b/service/kube/manifest-single.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+   name: geopm-single-pod
+spec:
+   restartPolicy: Never
+   containers:
+   - name: geopm-client
+     image: cmcantal/geopm-service:dockerfile
+     imagePullPolicy: Always
+     command: [/tmp/geopm-client-single.sh]
+     volumeMounts:
+     - name: host-mount
+       mountPath: /tmp
+     ports:
+     - containerPort: 22
+   volumes:
+   - name: host-mount
+     hostPath:
+       path: /tmp

--- a/service/kube/manifest.yml
+++ b/service/kube/manifest.yml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Pod
+metadata:
+   name: geopm-service-pod
+spec:
+   restartPolicy: Never
+   containers:
+   - name: geopm-server
+     image: cmcantal/geopm-service:dockerfile
+     imagePullPolicy: Always
+     securityContext:
+       capabilities:
+         add: ["SYS_ADMIN"]
+     command: ['/usr/lib/systemd/systemd', '--system', '--unit=geopm']
+     volumeMounts:
+     - name: host-mount
+       mountPath: /tmp
+     - name: host-cgroup
+       mountPath: /sys/fs/cgroup
+     - name: geopm-mount
+       mountPath: /run/geopm-service
+     - name: dbus-mount
+       mountPath: /run/dbus
+     - name: systemd-mount
+       mountPath: /run/systemd
+   - name: geopm-client
+     image: cmcantal/geopm-service:dockerfile
+     imagePullPolicy: Always
+     command: [/tmp/geopm-client.sh]
+     volumeMounts:
+     - name: host-mount
+       mountPath: /tmp
+     - name: geopm-mount
+       mountPath: /run/geopm-service
+     - name: dbus-mount
+       mountPath: /run/dbus
+     - name: systemd-mount
+       mountPath: /run/systemd
+   volumes:
+   - name: host-mount
+     hostPath:
+       path: /tmp
+   - name: host-cgroup
+     hostPath:
+       path: /sys/fs/cgroup
+   - name: geopm-mount
+     hostPath:
+       path: /run/geopm-service
+   - name: dbus-mount
+     hostPath:
+       path: /run/dbus
+   - name: systemd-mount
+     hostPath:
+       path: /run/systemd

--- a/service/src/SDBus.cpp
+++ b/service/src/SDBus.cpp
@@ -9,6 +9,7 @@
 
 #include <sstream>
 #include <systemd/sd-bus.h>
+#include <unistd.h>
 
 #include "geopm/Helper.hpp"
 #include "geopm/Exception.hpp"
@@ -44,10 +45,15 @@ namespace geopm
         , m_dbus_interface("io.github.geopm")
         , m_dbus_timeout_usec(0)
     {
-        int err = sd_bus_open_system(&m_bus);
+        (void)setenv("DBUS_SESSION_BUS_ADDRESS",
+                     "/run/geopm-service/SESSION_BUS_SOCKET", 1);
+        int err = sd_bus_open_user(&m_bus);
         if (err < 0) {
-            throw Exception("ServiceProxy: Failed to open system bus",
-                            GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+            err = sd_bus_open_system(&m_bus);
+            if (err < 0) {
+                throw Exception("ServiceProxy: Failed to open system bus",
+                                GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
+            }
         }
     }
 


### PR DESCRIPTION
Posting the PR for review purposes, but it is not ready for merging yet (also git history is a bit messy).

- New directory geopm/service/kube introduced which has configuration files for k8
- First attempt (606c8d2de88102c5b769ab2eda1ce6af3716ab2c) tries to start up the GEOPM systemd service
  + This may be the correct approach in the long run, but I was having permissions issues.
  + This approach would not require any new features from geopm
  + Seems like the AppArmor configuration was forbidding access to systemd dbus for both client and server
- It would be preferable for clients of the geopm service not to have special privileges 
  + Implemented using the DBus session bus and populating the DBus socket inside of /run/geopm-service
  + K8 provides the restart feature we usually rely on systemd for
  + Authentication should be possible through the session DBus, but we will have to manage pid namespace translation (also an issue for the system DBus)
- Current implementation works outside of containerization (communication across the session bus works)
- When run inside of containers, the client is rejected from communicating across the session bus
  + This *may* be an issue with pid namespaces, but I'm really not sure

Current failure log on client side (GEOPM_DEBUG enabled)

```
+ echo 'SERVICE::TIME board 0'
+ geopmsession -p 1 -t 3600
Traceback (most recent call last):
  File "/usr/bin/geopmsession", line 11, in <module>
    sys.exit(main())
  File "/usr/lib/python3.6/site-packages/geopmdpy/session.py", line 368, in main
    raise ee
  File "/usr/lib/python3.6/site-packages/geopmdpy/session.py", line 363, in main
    '/io/github/geopm'))
  File "/usr/lib/python3.6/site-packages/geopmdpy/session.py", line 50, in __init__
    geopm_proxy.PlatformOpenSession
  File "/usr/lib/python3.6/site-packages/dasbus/client/proxy.py", line 161, in __getattr__
    member = self._get_member(self._get_interface(name), name)
  File "/usr/lib/python3.6/site-packages/dasbus/client/proxy.py", line 211, in _get_interface
    self._handler.specification.members
  File "/usr/lib/python3.6/site-packages/dasbus/client/handler.py", line 206, in specification
    self._specification = self._get_specification()
  File "/usr/lib/python3.6/site-packages/dasbus/client/handler.py", line 330, in _get_specification
    "(s)"
  File "/usr/lib/python3.6/site-packages/dasbus/client/handler.py", line 429, in _call_method
    self._message_bus.connection,
  File "/usr/lib/python3.6/site-packages/dasbus/connection.py", line 169, in connection
    self._connection = self._get_connection()
  File "/usr/lib/python3.6/site-packages/dasbus/connection.py", line 340, in _get_connection
    return self._provider.get_addressed_bus_connection(self._address)
  File "/usr/lib/python3.6/site-packages/dasbus/connection.py", line 80, in get_addressed_bus_connection
    cancellable
gi.repository.GLib.Error: g-io-error-quark: Could not connect: Connection refused (39)
```

DBus-free solution
-------------------

Started a new branch that will not use DBus at all, but rather use new pidfd feature of Linux to track process lifetime, and use gRPC for inter-process communication (in place of DBus).

https://github.com/cmcantalupo/geopm/tree/kube-proto