### PR TITLE
Align the build scripts with the source code for plugins

### DIFF
--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -48,7 +48,7 @@ install-exec-hook: install-python install-plugin-dir
 dist: dist-googletest base_man
 
 install-plugin-dir:
-	$(INSTALL) -d $(DESTDIR)/$(pkglibdir)
+	$(INSTALL) -d $(DESTDIR)/$(libdir)/geopm
 
 dist_doc_DATA = COPYING \
                 COPYING-TPP \

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -253,7 +253,7 @@ ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcgeopm
 %defattr(-,root,root,-)
 %{_libdir}/libgeopmd.so.1.0.0
 %{_libdir}/libgeopmd.so.1
-%dir %{_libdir}/geopm-service
+%dir %{_libdir}/geopm
 
 %files -n python%{python3_pkgversion}-geopmdpy
 %defattr(-,root,root,-)


### PR DESCRIPTION
- The Makefile and spec file assumed that the plugin directory is /usr/lib64/geopm-service
- The man page for plugin factory is aligned with the the plugin factory implementation both use a default plugin path of /usr/lib64/geopm
- Note the is the path used for all GEOPM plugins, including IOGroups and Agents.
- Fixes #2823
