### PR TITLE
Split the skip install options for the build script

### DIFF
--- a/integration/config/build.sh
+++ b/integration/config/build.sh
@@ -110,14 +110,11 @@ CFLAGS= CXXFLAGS= CC=gcc CXX=g++ build "${GEOPM_SERVICE_CONFIG_OPTIONS}"
 
 # Run the base build
 cd ${GEOPM_SOURCE}
-if [ -z ${GEOPM_SKIP_INSTALL+x} ]; then
-    build "${GEOPM_BASE_CONFIG_OPTIONS}"
+
+if [ ! -z ${GEOPM_OBJDIR+x} ]; then
+    build "--with-geopmd-lib=${GEOPM_SOURCE}/service/${GEOPM_OBJDIR}/.libs \
+           --with-geopmd-include=${GEOPM_SOURCE}/service/src \
+           ${GEOPM_BASE_CONFIG_OPTIONS}"
 else
-    if [ ! -z ${GEOPM_OBJDIR+x} ]; then
-        build "--with-geopmd-lib=${GEOPM_SOURCE}/service/${GEOPM_OBJDIR}/.libs \
-               --with-geopmd-include=${GEOPM_SOURCE}/service/src \
-               ${GEOPM_BASE_CONFIG_OPTIONS}"
-    else
-        build "${GEOPM_BASE_CONFIG_OPTIONS}"
-    fi
+    build "${GEOPM_BASE_CONFIG_OPTIONS}"
 fi

--- a/integration/config/build.sh
+++ b/integration/config/build.sh
@@ -98,13 +98,13 @@ build(){
         ./autogen.sh
     fi
 
-    if [ ! -z ${GEOPM_OBJDIR+x} ]; then
+    if [ ! -z ${GEOPM_OBJDIR} ]; then
         mkdir -p ${GEOPM_OBJDIR} # Objects created at configure time will go here
         cd ${GEOPM_OBJDIR}
     fi
 
     if [ ! -f "Makefile" ]; then
-        if [ ! -z ${GEOPM_OBJDIR+x} ]; then
+        if [ ! -z ${GEOPM_OBJDIR} ]; then
             ${BUILDROOT}/configure ${CONFIG_OPTS}
         else
             ./configure ${CONFIG_OPTS}
@@ -113,7 +113,7 @@ build(){
     make -j${GEOPM_NUM_THREAD}
 
     # By default, the tests are skipped
-    if [ ! -z ${GEOPM_RUN_TESTS+x} ]; then
+    if [ ! -z ${GEOPM_RUN_TESTS} ]; then
         make -j${GEOPM_NUM_THREAD} checkprogs
         make check
     fi
@@ -132,7 +132,7 @@ CFLAGS= CXXFLAGS= CC=gcc CXX=g++ build "${GEOPM_SERVICE_CONFIG_OPTIONS}" ${GEOPM
 # Run the base build
 cd ${GEOPM_SOURCE}
 
-if [ ! -z ${GEOPM_OBJDIR+x} ]; then
+if [ ! -z ${GEOPM_OBJDIR} ]; then
     build "--with-geopmd-lib=${GEOPM_SOURCE}/service/${GEOPM_OBJDIR}/.libs \
            --with-geopmd-include=${GEOPM_SOURCE}/service/src \
            ${GEOPM_BASE_CONFIG_OPTIONS}" ${GEOPM_SKIP_BASE_INSTALL}

--- a/integration/config/build.sh
+++ b/integration/config/build.sh
@@ -111,7 +111,7 @@ CFLAGS= CXXFLAGS= CC=gcc CXX=g++ build "${GEOPM_SERVICE_CONFIG_OPTIONS}"
 # Run the base build
 cd ${GEOPM_SOURCE}
 if [ -z ${GEOPM_SKIP_INSTALL+x} ]; then
-    build "--with-geopmd=${GEOPM_INSTALL} ${GEOPM_BASE_CONFIG_OPTIONS}"
+    build "${GEOPM_BASE_CONFIG_OPTIONS}"
 else
     if [ ! -z ${GEOPM_OBJDIR+x} ]; then
         build "--with-geopmd-lib=${GEOPM_SOURCE}/service/${GEOPM_OBJDIR}/.libs \


### PR DESCRIPTION
- Relates to #2676.
- Required for systems where our build time dependencies are not installed.  The procedure would be to build the service with ```--disable-systemd```, skip ```make install``` of the service, then build and install the runtime into e.g. ```~/build```.  This way, when running on a compute node, the runtime binaries that need ```libgeopmd``` will dynamically link against the system installed version which will include systemd support and a functioning ServiceIOGroup.
- Note that because libgeopmd would be missing on the head or MOM node, interactive sessions (e.g. salloc) with ```geopmlaunch``` will not work because the launcher will try to use ```LD_PRELOAD=libgeopm.so``` which will try to pull in ```libgeopmd.so.1``` and it won't be available.  
- Batch jobs work just fine.