### PR TITLE
Added GPU-CA On time tracking & idle time reaction

### DIFF
--- a/service/docs/source/geopm_agent_gpu_activity.7.rst
+++ b/service/docs/source/geopm_agent_gpu_activity.7.rst
@@ -51,6 +51,11 @@ extremely short phase behavior a 1 ms polling rate can be used.
 As the 1 ms polling rate is not officially recommended by the DCGM API the 100 ms
 setting should be used by default.
 
+If a ``phi`` value of 0.5 or greater is used and a long idle period, defined as
+10 samples with a ``GPU_UTILIZATION`` of 0, occurs the agent will request the
+minimum frequency for GPU as specified by the ``GPU_CORE_FREQUENCY_MIN_AVAIL``
+signal.
+
 Agent Name
 ----------
 

--- a/service/docs/source/geopm_agent_gpu_activity.7.rst
+++ b/service/docs/source/geopm_agent_gpu_activity.7.rst
@@ -41,6 +41,10 @@ agent towards higher frequencies by increasing the ``Fe`` value.
 In the extreme case (``phi`` of 0) ``Fe`` will be raised to ``Fmax``.  A ``phi`` value greater than
 0.5 biases the agent towards lower frequencies by reducing the ``Fmax`` value.
 In the extreme case (``phi`` of 1.0) ``Fmax`` will be lowered to ``Fe``.
+If a ``phi`` value of 0.5 or greater is used and a long idle period, defined as
+10 samples with a ``GPU_UTILIZATION`` of 0, occurs the agent will request the
+minimum frequency for GPU as specified by the ``GPU_CORE_FREQUENCY_MIN_AVAIL``
+signal.
 
 For NVIDIA based systems the agent should be used with DCGM settings of
 ``DCGM::FIELD_UPDATE_RATE`` = 100 ms, ``DCGM::MAX_STORAGE_TIME`` = 1 s, and ``DCGM::MAX_SAMPLES``
@@ -50,11 +54,6 @@ microsecond range. If the agent is intended to be used with workloads that exhib
 extremely short phase behavior a 1 ms polling rate can be used.
 As the 1 ms polling rate is not officially recommended by the DCGM API the 100 ms
 setting should be used by default.
-
-If a ``phi`` value of 0.5 or greater is used and a long idle period, defined as
-10 samples with a ``GPU_UTILIZATION`` of 0, occurs the agent will request the
-minimum frequency for GPU as specified by the ``GPU_CORE_FREQUENCY_MIN_AVAIL``
-signal.
 
 Agent Name
 ----------

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -23,6 +23,14 @@
 #include "Waiter.hpp"
 #include "Environment.hpp"
 
+// IDLE SAMPLE COUNT of 10 is based upon a study of the idle behavior of CORAL-2
+// workloads of interest assuming the default 20ms sample rate (200ms idle).
+// We could use 200ms as the default for the agent, but this does not provide a
+// mechanism for user control of the idle period.  Using a count provides partial
+// user control in that the idleness period is defined by the requested agent
+// control loop time.
+#define IDLE_SAMPLE_COUNT 10
+
 namespace geopm
 {
 
@@ -342,7 +350,10 @@ namespace geopm
                     }
                 }
                 else {
-                    m_gpu_idle_timer.at(domain_idx) = 10;
+                    // If no activity has been observed for a number of samples
+                    // IDLE_SAMPLE_COUNT we assume it is safe to reduce the frequency
+                    // to a minimum value.
+                    m_gpu_idle_timer.at(domain_idx) = IDLE_SAMPLE_COUNT;
                 }
 
                 if (m_gpu_idle_timer.at(domain_idx) <= 0) {

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -369,12 +369,18 @@ namespace geopm
                     }
 
                     // GPU on time tracking
-                    m_gpu_on_time.at(domain_idx) += m_time.value - m_prev_time;
-                    m_gpu_on_energy.at(domain_idx) += m_gpu_energy.at(domain_idx).value - m_prev_gpu_energy.at(domain_idx);
+                    if (m_time.value > m_prev_time) {
+                        m_gpu_on_time.at(domain_idx) += m_time.value - m_prev_time;
+                    }
+                    // TODO: handle roll-over more gracefully than dropping a sample
+                    if (m_gpu_energy.at(domain_idx).value < m_prev_gpu_energy.at(domain_idx)) {
+                        m_gpu_on_energy.at(domain_idx) += m_gpu_energy.at(domain_idx).value - m_prev_gpu_energy.at(domain_idx);
+                    }
                 }
                 else {
                     // ROI proxy tracking
-                    if (m_gpu_active_region_stop.at(domain_idx) == 0) {
+                    if (m_gpu_active_region_start.at(domain_idx) != 0 &&
+                        m_gpu_active_region_stop.at(domain_idx) == 0) {
                         m_gpu_active_region_stop.at(domain_idx) = m_time.value;
                         m_gpu_active_energy_stop.at(domain_idx) = m_gpu_energy.at(domain_idx).value;
                     }

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -150,7 +150,7 @@ namespace geopm
             m_gpu_freq_max_control.push_back(m_control{m_platform_io.push_control("GPU_CORE_FREQUENCY_MAX_CONTROL",
                                                        m_agent_domain,
                                                        domain_idx), NAN});
-            m_gpu_idle_timer.push_back(10);
+            m_gpu_idle_timer.push_back(IDLE_SAMPLE_COUNT);
             m_gpu_idle_samples.push_back(0);
         }
 

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -160,8 +160,6 @@ namespace geopm
         m_freq_gpu_min = m_platform_io.read_signal("GPU_CORE_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD, 0);
         m_freq_gpu_max = m_platform_io.read_signal("GPU_CORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD, 0);
 
-        //m_platform_io.write_control("GPU_CORE_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_BOARD, 0, m_freq_gpu_min);
-
         const auto ALL_NAMES = m_platform_io.signal_names();
         // F efficient values
         const std::string FE_CONSTCONFIG = "CONST_CONFIG::GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY";

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -372,8 +372,9 @@ namespace geopm
                     if (m_time.value > m_prev_time) {
                         m_gpu_on_time.at(domain_idx) += m_time.value - m_prev_time;
                     }
+
                     // TODO: handle roll-over more gracefully than dropping a sample
-                    if (m_gpu_energy.at(domain_idx).value < m_prev_gpu_energy.at(domain_idx)) {
+                    if (m_gpu_energy.at(domain_idx).value > m_prev_gpu_energy.at(domain_idx)) {
                         m_gpu_on_energy.at(domain_idx) += m_gpu_energy.at(domain_idx).value - m_prev_gpu_energy.at(domain_idx);
                     }
                 }

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -487,6 +487,15 @@ namespace geopm
             if (m_gpu_active_region_stop.at(domain_idx) == 0.0) {
                 region_stop = m_time.value;
             }
+            // Either the last energy value was at the point of roll-over or the GPU Utilization
+            // was above cutoff for the entire run.  In either case grabbing the last sample
+            // value is a safe decision (if rollover it'll be 0 still, if not i'll be the end of
+            // run value).  We have to account for the case where no GPU activity was seen however,
+            // so we check for an active region time of 0 (i.e. region start != region stop)
+            if (m_gpu_active_energy_stop.at(domain_idx) == 0 &&
+                region_stop != region_start) {
+                energy_stop = m_gpu_energy.at(domain_idx).value;
+            }
 
             result.push_back({"GPU " + std::to_string(domain_idx) +
                               " Active Region Energy", std::to_string(energy_stop - energy_start)});

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -468,8 +468,14 @@ namespace geopm
         for (int domain_idx = 0; domain_idx < M_NUM_GPU; ++domain_idx) {
             double energy_stop = m_gpu_active_energy_stop.at(domain_idx);
             double energy_start = m_gpu_active_energy_start.at(domain_idx);
-            double region_stop = m_gpu_active_region_stop.at(domain_idx);
             double region_start =  m_gpu_active_region_start.at(domain_idx);
+            double region_stop = m_gpu_active_region_stop.at(domain_idx);
+            // If the end of the active region was never seen assume that the end of the run
+            // is the end of the region.
+            if (m_gpu_active_region_stop.at(domain_idx) == 0.0) {
+                region_stop = m_time.value;
+            }
+
             result.push_back({"GPU " + std::to_string(domain_idx) +
                               " Active Region Energy", std::to_string(energy_stop - energy_start)});
             result.push_back({"GPU " + std::to_string(domain_idx) +

--- a/src/GPUActivityAgent.cpp
+++ b/src/GPUActivityAgent.cpp
@@ -507,6 +507,8 @@ namespace geopm
                               " On Time", std::to_string(m_gpu_on_time.at(domain_idx))});
         }
 
+        result.push_back({"Agent Idle Samples Required to Request Minimum Frequency", std::to_string(IDLE_SAMPLE_COUNT)});
+        result.push_back({"Agent Idle Time (estimate in seconds) Required to Request Minimum Frequency", std::to_string(IDLE_SAMPLE_COUNT * m_waiter->period())});
         for (int domain_idx = 0; domain_idx < m_agent_domain_count; ++domain_idx) {
             result.push_back({"GPU Chip " + std::to_string(domain_idx) +
                               " Idle Agent Actions", std::to_string(m_gpu_idle_samples.at(domain_idx))});

--- a/src/GPUActivityAgent.hpp
+++ b/src/GPUActivityAgent.hpp
@@ -101,11 +101,18 @@ namespace geopm
             std::vector<double> m_gpu_active_region_stop;
             std::vector<double> m_gpu_active_energy_start;
             std::vector<double> m_gpu_active_energy_stop;
+            std::vector<double> m_gpu_on_time;
+            std::vector<double> m_gpu_on_energy;
+            std::vector<int> m_gpu_idle_samples;
 
             std::vector<m_signal> m_gpu_core_activity;
             std::vector<m_signal> m_gpu_utilization;
             std::vector<m_signal> m_gpu_energy;
+            std::vector<int> m_gpu_idle_timer;
+
             m_signal m_time;
+            double m_prev_time;
+            std::vector<double> m_prev_gpu_energy;
 
             std::vector<m_control> m_gpu_freq_min_control;
             std::vector<m_control> m_gpu_freq_max_control;

--- a/src/GPUActivityAgent.hpp
+++ b/src/GPUActivityAgent.hpp
@@ -55,6 +55,7 @@ namespace geopm
             static constexpr double M_WAIT_SEC = 0.020; // 20ms wait default
             const double M_POLICY_PHI_DEFAULT;
             const double M_GPU_ACTIVITY_CUTOFF;
+            const int M_IDLE_SAMPLE_COUNT;
             const int M_NUM_GPU;
             const int M_NUM_GPU_CHIP;
             const int M_NUM_CHIP_PER_GPU;

--- a/test/GPUActivityAgentTest.cpp
+++ b/test/GPUActivityAgentTest.cpp
@@ -307,7 +307,7 @@ TEST_F(GPUActivityAgentTest, adjust_platform_long_idle)
     EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, M_FREQ_MIN)).Times(M_NUM_GPU_CHIP);
     EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, M_FREQ_MIN)).Times(M_NUM_GPU_CHIP);
 
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 11; i++) {
         //Sample
         std::vector<double> tmp;
         EXPECT_CALL(*m_platform_io, sample(GPU_CORE_ACTIVITY_IDX))
@@ -323,7 +323,7 @@ TEST_F(GPUActivityAgentTest, adjust_platform_long_idle)
         //Adjust
         m_agent->adjust_platform(policy);
 
-        if(i == 0 || i == 9) {
+        if(i == 0 || i == 10) {
             //Check a frequency decision resulted in write batch being true
             EXPECT_TRUE(m_agent->do_write_batch());
         }
@@ -349,12 +349,7 @@ TEST_F(GPUActivityAgentTest, adjust_platform_long_idle)
     std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
 
     EXPECT_EQ(expected_header.size(), report_header.size());
-    for (long unsigned int i = 0; i < expected_header.size(); ++i) {
-        EXPECT_EQ(expected_header.at(i).first, report_header.at(i).first);
-        if (expected_header.at(i).first != "Agent Domain") {
-            EXPECT_EQ(std::stod(expected_header.at(i).second), std::stod(report_header.at(i).second));
-        }
-    }
+    EXPECT_THAT(report_header, ::testing::ContainerEq(expected_header));
 }
 
 // this tests a 'full on' waveform
@@ -409,7 +404,7 @@ TEST_F(GPUActivityAgentTest, header_check_full_util)
     std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
 
     EXPECT_EQ(expected_header.size(), report_header.size());
-    EXPECT_THAT(expected_header, ::testing::ContainerEq(report_header));
+    EXPECT_THAT(report_header, ::testing::ContainerEq(expected_header));
 }
 
 // this tests a 'off on off on' waveform
@@ -468,7 +463,7 @@ TEST_F(GPUActivityAgentTest, header_check_on_off_util)
     std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
 
     EXPECT_EQ(expected_header.size(), report_header.size());
-    EXPECT_THAT(expected_header, ::testing::ContainerEq(report_header));
+    EXPECT_THAT(report_header, ::testing::ContainerEq(expected_header));
 }
 
 TEST_F(GPUActivityAgentTest, invalid_fe)

--- a/test/GPUActivityAgentTest.cpp
+++ b/test/GPUActivityAgentTest.cpp
@@ -334,18 +334,18 @@ TEST_F(GPUActivityAgentTest, adjust_platform_long_idle)
     }
 
     std::vector<std::pair<std::string, std::string> > expected_header = { {"Agent Domain", "gpu_chip"},
-                                                                          {"GPU Frequency Requests", "2.000000"},
-                                                                          {"GPU Clipped Frequency Requests", "0.000000"},
+                                                                          {"GPU Frequency Requests", std::to_string(2.0)},
+                                                                          {"GPU Clipped Frequency Requests", std::to_string(0.0)},
                                                                           {"Resolved Max Frequency", std::to_string(M_FREQ_MAX)},
                                                                           {"Resolved Efficient Frequency", std::to_string(M_FREQ_EFFICIENT)},
                                                                           {"Resolved Frequency Range", std::to_string(M_FREQ_MAX - M_FREQ_EFFICIENT)},
-                                                                          {"GPU 0 Active Region Energy", "0.000000"},
-                                                                          {"GPU 0 Active Region Time", "0.000000"},
-                                                                          {"GPU 0 On Energy", "0"},
-                                                                          {"GPU 0 On Time", "0.000000"},
-                                                                          {"Agent Idle Samples Required to Request Minimum Frequency", "10"},
-                                                                          {"Agent Idle Time (estimate in seconds) Required to Request Minimum Frequency", "0"},
-                                                                          {"GPU Chip 0 Idle Agent Actions", "1"}};
+                                                                          {"GPU 0 Active Region Energy", std::to_string(0.0)},
+                                                                          {"GPU 0 Active Region Time", std::to_string(0.0)},
+                                                                          {"GPU 0 On Energy", std::to_string(0.0)},
+                                                                          {"GPU 0 On Time", std::to_string(0.0)},
+                                                                          {"Agent Idle Samples Required to Request Minimum Frequency", std::to_string(10)},
+                                                                          {"Agent Idle Time (estimate in seconds) Required to Request Minimum Frequency", std::to_string(0.0)},
+                                                                          {"GPU Chip 0 Idle Agent Actions", std::to_string(1)}};
     std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
 
     EXPECT_EQ(expected_header.size(), report_header.size());
@@ -353,7 +353,7 @@ TEST_F(GPUActivityAgentTest, adjust_platform_long_idle)
         EXPECT_EQ(expected_header.at(i).first, report_header.at(i).first);
         if (expected_header.at(i).first != "Agent Domain") {
             EXPECT_EQ(std::stod(expected_header.at(i).second), std::stod(report_header.at(i).second));
-        };
+        }
     }
 }
 
@@ -394,27 +394,22 @@ TEST_F(GPUActivityAgentTest, header_check_full_util)
     }
 
     std::vector<std::pair<std::string, std::string> > expected_header = { {"Agent Domain", "gpu_chip"},
-                                                                          {"GPU Frequency Requests", "1"},
-                                                                          {"GPU Clipped Frequency Requests", "0"},
+                                                                          {"GPU Frequency Requests", std::to_string(1.0)},
+                                                                          {"GPU Clipped Frequency Requests", std::to_string(0.0)},
                                                                           {"Resolved Max Frequency", std::to_string(M_FREQ_MAX)},
                                                                           {"Resolved Efficient Frequency", std::to_string(M_FREQ_EFFICIENT)},
                                                                           {"Resolved Frequency Range", std::to_string(M_FREQ_MAX - M_FREQ_EFFICIENT)},
-                                                                          {"GPU 0 Active Region Energy", "9"},
-                                                                          {"GPU 0 Active Region Time", "18"},
-                                                                          {"GPU 0 On Energy", "9"},
-                                                                          {"GPU 0 On Time", "18"},
-                                                                          {"Agent Idle Samples Required to Request Minimum Frequency", "10"},
-                                                                          {"Agent Idle Time (estimate in seconds) Required to Request Minimum Frequency", "0"},
-                                                                          {"GPU Chip 0 Idle Agent Actions", "0"}};
+                                                                          {"GPU 0 Active Region Energy", std::to_string(9.0)},
+                                                                          {"GPU 0 Active Region Time", std::to_string(18.0)},
+                                                                          {"GPU 0 On Energy", std::to_string(9.0)},
+                                                                          {"GPU 0 On Time", std::to_string(18.0)},
+                                                                          {"Agent Idle Samples Required to Request Minimum Frequency", std::to_string(10)},
+                                                                          {"Agent Idle Time (estimate in seconds) Required to Request Minimum Frequency", std::to_string(0.0)},
+                                                                          {"GPU Chip 0 Idle Agent Actions", std::to_string(0)}};
     std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
 
     EXPECT_EQ(expected_header.size(), report_header.size());
-    for (long unsigned int i = 0; i < expected_header.size(); ++i) {
-        EXPECT_EQ(expected_header.at(i).first, report_header.at(i).first);
-        if (expected_header.at(i).first != "Agent Domain") {
-            EXPECT_EQ(std::stod(expected_header.at(i).second), std::stod(report_header.at(i).second));
-        };
-    }
+    EXPECT_THAT(expected_header, ::testing::ContainerEq(report_header));
 }
 
 // this tests a 'off on off on' waveform
@@ -458,27 +453,22 @@ TEST_F(GPUActivityAgentTest, header_check_on_off_util)
     }
 
     std::vector<std::pair<std::string, std::string> > expected_header = { {"Agent Domain", "gpu_chip"},
-                                                                          {"GPU Frequency Requests", "11"},
-                                                                          {"GPU Clipped Frequency Requests", "0"},
+                                                                          {"GPU Frequency Requests", std::to_string(11.0)},
+                                                                          {"GPU Clipped Frequency Requests", std::to_string(0.0)},
                                                                           {"Resolved Max Frequency", std::to_string(M_FREQ_MAX)},
                                                                           {"Resolved Efficient Frequency", std::to_string(M_FREQ_EFFICIENT)},
                                                                           {"Resolved Frequency Range", std::to_string(M_FREQ_MAX - M_FREQ_EFFICIENT)},
-                                                                          {"GPU 0 Active Region Energy", "9"},
-                                                                          {"GPU 0 Active Region Time", "18"},
-                                                                          {"GPU 0 On Energy", "5"},
-                                                                          {"GPU 0 On Time", "10"},
-                                                                          {"Agent Idle Samples Required to Request Minimum Frequency", "10"},
-                                                                          {"Agent Idle Time (estimate in seconds) Required to Request Minimum Frequency", "0"},
-                                                                          {"GPU Chip 0 Idle Agent Actions", "0"}};
+                                                                          {"GPU 0 Active Region Energy", std::to_string(9.0)},
+                                                                          {"GPU 0 Active Region Time", std::to_string(18.0)},
+                                                                          {"GPU 0 On Energy", std::to_string(5.0)},
+                                                                          {"GPU 0 On Time", std::to_string(10.0)},
+                                                                          {"Agent Idle Samples Required to Request Minimum Frequency", std::to_string(10)},
+                                                                          {"Agent Idle Time (estimate in seconds) Required to Request Minimum Frequency", std::to_string(0.0)},
+                                                                          {"GPU Chip 0 Idle Agent Actions", std::to_string(0)}};
     std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
 
     EXPECT_EQ(expected_header.size(), report_header.size());
-    for (long unsigned int i = 0; i < expected_header.size(); ++i) {
-        EXPECT_EQ(expected_header.at(i).first, report_header.at(i).first);
-        if (expected_header.at(i).first != "Agent Domain") {
-            EXPECT_EQ(std::stod(expected_header.at(i).second), std::stod(report_header.at(i).second));
-        };
-    }
+    EXPECT_THAT(expected_header, ::testing::ContainerEq(report_header));
 }
 
 TEST_F(GPUActivityAgentTest, invalid_fe)

--- a/test/GPUActivityAgentTest.cpp
+++ b/test/GPUActivityAgentTest.cpp
@@ -343,11 +343,13 @@ TEST_F(GPUActivityAgentTest, adjust_platform_long_idle)
                                                                           {"GPU 0 Active Region Time", "0.000000"},
                                                                           {"GPU 0 On Energy", "0"},
                                                                           {"GPU 0 On Time", "0.000000"},
+                                                                          {"Agent Idle Samples Required to Request Minimum Frequency", "10"},
+                                                                          {"Agent Idle Time (estimate in seconds) Required to Request Minimum Frequency", "0"},
                                                                           {"GPU Chip 0 Idle Agent Actions", "1"}};
     std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
 
     EXPECT_EQ(expected_header.size(), report_header.size());
-    for (int i = 0; i < expected_header.size(); ++i) {
+    for (long unsigned int i = 0; i < expected_header.size(); ++i) {
         EXPECT_EQ(expected_header.at(i).first, report_header.at(i).first);
         if (expected_header.at(i).first != "Agent Domain") {
             EXPECT_EQ(std::stod(expected_header.at(i).second), std::stod(report_header.at(i).second));
@@ -401,11 +403,13 @@ TEST_F(GPUActivityAgentTest, header_check_full_util)
                                                                           {"GPU 0 Active Region Time", "18"},
                                                                           {"GPU 0 On Energy", "9"},
                                                                           {"GPU 0 On Time", "18"},
+                                                                          {"Agent Idle Samples Required to Request Minimum Frequency", "10"},
+                                                                          {"Agent Idle Time (estimate in seconds) Required to Request Minimum Frequency", "0"},
                                                                           {"GPU Chip 0 Idle Agent Actions", "0"}};
     std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
 
     EXPECT_EQ(expected_header.size(), report_header.size());
-    for (int i = 0; i < expected_header.size(); ++i) {
+    for (long unsigned int i = 0; i < expected_header.size(); ++i) {
         EXPECT_EQ(expected_header.at(i).first, report_header.at(i).first);
         if (expected_header.at(i).first != "Agent Domain") {
             EXPECT_EQ(std::stod(expected_header.at(i).second), std::stod(report_header.at(i).second));
@@ -463,15 +467,13 @@ TEST_F(GPUActivityAgentTest, header_check_on_off_util)
                                                                           {"GPU 0 Active Region Time", "18"},
                                                                           {"GPU 0 On Energy", "5"},
                                                                           {"GPU 0 On Time", "10"},
+                                                                          {"Agent Idle Samples Required to Request Minimum Frequency", "10"},
+                                                                          {"Agent Idle Time (estimate in seconds) Required to Request Minimum Frequency", "0"},
                                                                           {"GPU Chip 0 Idle Agent Actions", "0"}};
     std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
 
-    for (const auto&[first, second] : report_header) {
-        std::cout << "\t"  << first << ": " << second << std::endl;
-    }
-
     EXPECT_EQ(expected_header.size(), report_header.size());
-    for (int i = 0; i < expected_header.size(); ++i) {
+    for (long unsigned int i = 0; i < expected_header.size(); ++i) {
         EXPECT_EQ(expected_header.at(i).first, report_header.at(i).first);
         if (expected_header.at(i).first != "Agent Domain") {
             EXPECT_EQ(std::stod(expected_header.at(i).second), std::stod(report_header.at(i).second));

--- a/test/GPUActivityAgentTest.cpp
+++ b/test/GPUActivityAgentTest.cpp
@@ -288,7 +288,6 @@ TEST_F(GPUActivityAgentTest, adjust_platform_signal_out_of_bounds_low)
     double mock_active = -12345;
     double mock_util = 1.0;
     test_adjust_platform(policy, mock_active, mock_util, M_FREQ_EFFICIENT);
-
 }
 
 TEST_F(GPUActivityAgentTest, adjust_platform_long_idle)
@@ -300,9 +299,11 @@ TEST_F(GPUActivityAgentTest, adjust_platform_long_idle)
     double mock_active = 0.0;
     double mock_util = 0.0;
 
+    // We should see one write to efficient freq, subsequent writes are masked
     EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, M_FREQ_EFFICIENT)).Times(M_NUM_GPU_CHIP);
     EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, M_FREQ_EFFICIENT)).Times(M_NUM_GPU_CHIP);
 
+    // We should see one write to min freq after long idle
     EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, M_FREQ_MIN)).Times(M_NUM_GPU_CHIP);
     EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, M_FREQ_MIN)).Times(M_NUM_GPU_CHIP);
 
@@ -314,7 +315,7 @@ TEST_F(GPUActivityAgentTest, adjust_platform_long_idle)
         EXPECT_CALL(*m_platform_io, sample(GPU_UTILIZATION_IDX))
                  .WillRepeatedly(Return(mock_util));
         EXPECT_CALL(*m_platform_io, sample(GPU_ENERGY_IDX))
-                 .WillRepeatedly(Return(123456789));
+                 .WillRepeatedly(Return(123456789 + i));
         EXPECT_CALL(*m_platform_io, sample(TIME_IDX))
                  .Times(1);
         m_agent->sample_platform(tmp);
@@ -331,8 +332,152 @@ TEST_F(GPUActivityAgentTest, adjust_platform_long_idle)
             EXPECT_FALSE(m_agent->do_write_batch());
         }
     }
+
+    std::vector<std::pair<std::string, std::string> > expected_header = { {"Agent Domain", "gpu_chip"},
+                                                                          {"GPU Frequency Requests", "2.000000"},
+                                                                          {"GPU Clipped Frequency Requests", "0.000000"},
+                                                                          {"Resolved Max Frequency", std::to_string(M_FREQ_MAX)},
+                                                                          {"Resolved Efficient Frequency", std::to_string(M_FREQ_EFFICIENT)},
+                                                                          {"Resolved Frequency Range", std::to_string(M_FREQ_MAX - M_FREQ_EFFICIENT)},
+                                                                          {"GPU 0 Active Region Energy", "0.000000"},
+                                                                          {"GPU 0 Active Region Time", "0.000000"},
+                                                                          {"GPU 0 On Energy", "0"},
+                                                                          {"GPU 0 On Time", "0.000000"},
+                                                                          {"GPU Chip 0 Idle Agent Actions", "1"}};
+    std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
+
+    EXPECT_EQ(expected_header.size(), report_header.size());
+    for (int i = 0; i < expected_header.size(); ++i) {
+        EXPECT_EQ(expected_header.at(i).first, report_header.at(i).first);
+        if (expected_header.at(i).first != "Agent Domain") {
+            EXPECT_EQ(std::stod(expected_header.at(i).second), std::stod(report_header.at(i).second));
+        };
+    }
 }
 
+// this tests a 'full on' waveform
+// waveform: ‾‾‾‾‾‾‾‾
+TEST_F(GPUActivityAgentTest, header_check_full_util)
+{
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    set_up_val_policy_expectations();
+    EXPECT_NO_THROW(m_agent->validate_policy(policy));
+
+    double mock_active = 0.12345;
+    double mock_util = 1.0;
+
+    double expected_freq = M_FREQ_EFFICIENT +
+            (M_FREQ_MAX - M_FREQ_EFFICIENT) * mock_active;
+
+    //Check frequency
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, expected_freq)).Times(M_NUM_GPU_CHIP);
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, expected_freq)).Times(M_NUM_GPU_CHIP);
+
+    // waveform: ‾‾‾‾‾‾‾‾
+    for (int i = 0; i < 10; i++) {
+        //Sample
+        std::vector<double> tmp;
+        EXPECT_CALL(*m_platform_io, sample(GPU_CORE_ACTIVITY_IDX))
+                 .WillRepeatedly(Return(mock_active));
+        EXPECT_CALL(*m_platform_io, sample(GPU_UTILIZATION_IDX))
+                 .WillRepeatedly(Return(mock_util));
+        EXPECT_CALL(*m_platform_io, sample(GPU_ENERGY_IDX))
+                 .WillRepeatedly(Return(123456789 + i));
+        EXPECT_CALL(*m_platform_io, sample(TIME_IDX))
+                 .WillRepeatedly(Return(21 + i*2));
+        m_agent->sample_platform(tmp);
+
+        //Adjust
+        m_agent->adjust_platform(policy);
+    }
+
+    std::vector<std::pair<std::string, std::string> > expected_header = { {"Agent Domain", "gpu_chip"},
+                                                                          {"GPU Frequency Requests", "1"},
+                                                                          {"GPU Clipped Frequency Requests", "0"},
+                                                                          {"Resolved Max Frequency", std::to_string(M_FREQ_MAX)},
+                                                                          {"Resolved Efficient Frequency", std::to_string(M_FREQ_EFFICIENT)},
+                                                                          {"Resolved Frequency Range", std::to_string(M_FREQ_MAX - M_FREQ_EFFICIENT)},
+                                                                          {"GPU 0 Active Region Energy", "9"},
+                                                                          {"GPU 0 Active Region Time", "18"},
+                                                                          {"GPU 0 On Energy", "9"},
+                                                                          {"GPU 0 On Time", "18"},
+                                                                          {"GPU Chip 0 Idle Agent Actions", "0"}};
+    std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
+
+    EXPECT_EQ(expected_header.size(), report_header.size());
+    for (int i = 0; i < expected_header.size(); ++i) {
+        EXPECT_EQ(expected_header.at(i).first, report_header.at(i).first);
+        if (expected_header.at(i).first != "Agent Domain") {
+            EXPECT_EQ(std::stod(expected_header.at(i).second), std::stod(report_header.at(i).second));
+        };
+    }
+}
+
+// this tests a 'off on off on' waveform
+// waveform: _‾_‾_‾_‾_‾_
+TEST_F(GPUActivityAgentTest, header_check_on_off_util)
+{
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    set_up_val_policy_expectations();
+    EXPECT_NO_THROW(m_agent->validate_policy(policy));
+
+    // waveform: _‾_‾_‾_‾_‾_
+    // Five on samples
+    // Seven off samples
+    // Nine 'active region' samples from to last high sample
+    for (int i = 0; i < 11; i++) {
+
+        double mock_active = i % 2;
+        double mock_util = i % 2;
+
+        double expected_freq = M_FREQ_EFFICIENT +
+                               (M_FREQ_MAX - M_FREQ_EFFICIENT) * mock_active;
+
+        //Check frequency
+        EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, expected_freq)).Times(M_NUM_GPU_CHIP);
+        EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, expected_freq)).Times(M_NUM_GPU_CHIP);
+
+        //Sample
+        std::vector<double> tmp;
+        EXPECT_CALL(*m_platform_io, sample(GPU_CORE_ACTIVITY_IDX))
+                 .WillRepeatedly(Return(mock_active));
+        EXPECT_CALL(*m_platform_io, sample(GPU_UTILIZATION_IDX))
+                 .WillRepeatedly(Return(mock_util));
+        EXPECT_CALL(*m_platform_io, sample(GPU_ENERGY_IDX))
+                 .WillRepeatedly(Return(123456789 + i));
+        EXPECT_CALL(*m_platform_io, sample(TIME_IDX))
+                 .WillRepeatedly(Return(21 + i*2));
+        m_agent->sample_platform(tmp);
+
+        //Adjust
+        m_agent->adjust_platform(policy);
+    }
+
+    std::vector<std::pair<std::string, std::string> > expected_header = { {"Agent Domain", "gpu_chip"},
+                                                                          {"GPU Frequency Requests", "11"},
+                                                                          {"GPU Clipped Frequency Requests", "0"},
+                                                                          {"Resolved Max Frequency", std::to_string(M_FREQ_MAX)},
+                                                                          {"Resolved Efficient Frequency", std::to_string(M_FREQ_EFFICIENT)},
+                                                                          {"Resolved Frequency Range", std::to_string(M_FREQ_MAX - M_FREQ_EFFICIENT)},
+                                                                          {"GPU 0 Active Region Energy", "9"},
+                                                                          {"GPU 0 Active Region Time", "18"},
+                                                                          {"GPU 0 On Energy", "5"},
+                                                                          {"GPU 0 On Time", "10"},
+                                                                          {"GPU Chip 0 Idle Agent Actions", "0"}};
+    std::vector<std::pair<std::string, std::string> > report_header = m_agent->report_host();
+
+    for (const auto&[first, second] : report_header) {
+        std::cout << "\t"  << first << ": " << second << std::endl;
+    }
+
+    EXPECT_EQ(expected_header.size(), report_header.size());
+    for (int i = 0; i < expected_header.size(); ++i) {
+        EXPECT_EQ(expected_header.at(i).first, report_header.at(i).first);
+        if (expected_header.at(i).first != "Agent Domain") {
+            EXPECT_EQ(std::stod(expected_header.at(i).second), std::stod(report_header.at(i).second));
+        };
+    }
+}
 
 TEST_F(GPUActivityAgentTest, invalid_fe)
 {

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -217,10 +217,13 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/GPUActivityAgentTest.validate_policy \
               test/gtest_links/GPUActivityAgentTest.adjust_platform_high \
               test/gtest_links/GPUActivityAgentTest.adjust_platform_medium \
+              test/gtest_links/GPUActivityAgentTest.adjust_platform_long_idle \
               test/gtest_links/GPUActivityAgentTest.adjust_platform_low \
               test/gtest_links/GPUActivityAgentTest.adjust_platform_zero \
               test/gtest_links/GPUActivityAgentTest.adjust_platform_signal_out_of_bounds_high \
               test/gtest_links/GPUActivityAgentTest.adjust_platform_signal_out_of_bounds_low \
+              test/gtest_links/GPUActivityAgentTest.header_check_full_util \
+              test/gtest_links/GPUActivityAgentTest.header_check_on_off_util \
               test/gtest_links/GPUActivityAgentTest.invalid_fe \
               test/gtest_links/InitControlTest.parse_valid_file \
               test/gtest_links/InitControlTest.parse_valid_file_2 \


### PR DESCRIPTION
Signed-off-by: lhlawson <lowren.h.lawson@intel.com>

- Relates to #2839 story from github issues
- Fixes #2840 change request from github issues.

Provides a report entry for tracking the GPU energy usage when the GPU is above a utilization threshold.
Provides an algorithm update to target long idle periods.