### PR TITLE
Fix bug in reporting

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -337,6 +337,7 @@ namespace geopm
         m_platform_io.read_batch();
         m_tracer->update(m_trace_sample);
         m_profile_tracer->update(m_application_sampler.get_records());
+        m_reporter->update();
 
         while (!m_application_io->do_shutdown()) {
             step();
@@ -346,6 +347,7 @@ namespace geopm
         m_platform_io.read_batch();
         m_tracer->update(m_trace_sample);
         m_profile_tracer->update(m_application_sampler.get_records());
+        m_reporter->update();
         generate();
         m_platform_io.restore_control();
     }

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -335,9 +335,9 @@ namespace geopm
         geopm_time(&curr_time);
         m_application_sampler.update(curr_time);
         m_platform_io.read_batch();
+        m_reporter->update();
         m_tracer->update(m_trace_sample);
         m_profile_tracer->update(m_application_sampler.get_records());
-        m_reporter->update();
 
         while (!m_application_io->do_shutdown()) {
             step();
@@ -345,9 +345,9 @@ namespace geopm
         geopm_time(&curr_time);
         m_application_sampler.update(curr_time);
         m_platform_io.read_batch();
+        m_reporter->update();
         m_tracer->update(m_trace_sample);
         m_profile_tracer->update(m_application_sampler.get_records());
-        m_reporter->update();
         generate();
         m_platform_io.restore_control();
     }


### PR DESCRIPTION
- Always update the reporter object each time the m_application_sampler is updated.
- Failure to do this can result is lost events that are not included in the reporter accounting.
- Fixes #2863
