### PR TITLE
Add a Waiter class to support Agent::wait()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -492,6 +492,8 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/TreeCommLevel.hpp \
                             src/ValidateRecord.cpp \
                             src/ValidateRecord.hpp \
+                            src/Waiter.hpp \
+                            src/Waiter.cpp \
                             src/geopm_agent.h \
                             src/geopm_prof.h \
                             src/geopm_endpoint.h \

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -147,6 +147,7 @@ class Config(object):
         parser.add_argument('--geopm-launch-verbose', dest='quiet', action='store_false', default=True)
         parser.add_argument('--geopm-launch-script', dest='launch_script', type=str)
         parser.add_argument('--geopm-init-control', dest='init_control', type=str)
+        parser.add_argument('--geopm-period', dest='period', type=str)
         opts, self.argv_unparsed = parser.parse_known_args(argv)
         # Error check inputs
         if opts.ctl not in ('process', 'pthread', 'application'):
@@ -177,6 +178,7 @@ class Config(object):
         self.quiet = opts.quiet
         self.launch_script = opts.launch_script
         self.init_control = opts.init_control
+        self.period = opts.period
 
     def __repr__(self):
         """
@@ -241,6 +243,8 @@ class Config(object):
             result['GEOPM_RECORD_FILTER'] = self.record_filter
         if self.init_control:
             result['GEOPM_INIT_CONTROL'] = self.init_control
+        if self.period:
+            result['GEOPM_PERIOD'] = self.period
 
         # Add geopm installed OpenMP library to LD_LIBRARY_PATH if it
         # is present.
@@ -1760,6 +1764,7 @@ GEOPM_OPTIONS:
                                emit launch script to output_file
       --geopm-init-control=path
                                set initial control values with data read from "path"
+      --geopm-period=sec       Control loop period override for Agent value
 
 {}
 

--- a/service/docs/source/geopm.7.rst
+++ b/service/docs/source/geopm.7.rst
@@ -340,6 +340,10 @@ GEOPM Environment Variables
   The path to the control initialization file.  See the ``--geopm-init-control``
   :ref:`option description <geopm-init-control option>` in
   :doc:`geopmlaunch(1) <geopmlaunch.1>` for more details.
+``GEOPM_PERIOD``
+  The control loop period in seconds, if not specified this is determined by
+  the Agent. See the ``--geopm-period`` :ref:`option description <geopm-period option>`
+  in :doc:`geopmlaunch(1) <geopmlaunch.1>` for details.
 
 Other Environment Variables
 ---------------------------

--- a/service/docs/source/geopmlaunch.1.rst
+++ b/service/docs/source/geopmlaunch.1.rst
@@ -555,6 +555,16 @@ GEOPM Options
                       Disable OMPT detection of OpenMP regions.
                       See the :ref:`INTEGRATION WITH OMPT section of geopm(7)<geopm.7:Integration With OMPT>`
                       for more information about OpenMP region detection.
+--geopm-period  .. _geopm-period option:
+
+               Override the control loop period specified by the Agent.  All
+	       agents have a default control loop period, and this command
+	       line option allows users to set a different value in units of
+	       seconds.  With longer control loop periods, the overhead for
+	       using GEOPM will be reduced, but more interpolation will be
+	       required when aligning the sparsely sampled hardware signals
+	       with the application feedback.  Additionally agent reaction
+	       time is reduced with longer control loop period.
 
 Examples
 --------

--- a/service/docs/source/geopmlaunch.1.rst
+++ b/service/docs/source/geopmlaunch.1.rst
@@ -563,7 +563,7 @@ GEOPM Options
 	       seconds.  With longer control loop periods, the overhead for
 	       using GEOPM will be reduced, but more interpolation will be
 	       required when aligning the sparsely sampled hardware signals
-	       with the application feedback.  Additionally agent reaction
+	       with the application feedback.  Additionally, agent reaction
 	       time is reduced with longer control loop period.
 
 Examples

--- a/src/CPUActivityAgent.hpp
+++ b/src/CPUActivityAgent.hpp
@@ -8,7 +8,6 @@
 
 #include <vector>
 
-#include "geopm_time.h"
 #include "Agent.hpp"
 
 namespace geopm
@@ -16,6 +15,7 @@ namespace geopm
     class PlatformTopo;
     class PlatformIO;
     class FrequencyGovernor;
+    class Waiter;
 
     /// @brief Agent
     class CPUActivityAgent : public Agent
@@ -24,7 +24,8 @@ namespace geopm
             CPUActivityAgent();
             CPUActivityAgent(PlatformIO &plat_io,
                              const PlatformTopo &topo,
-                             std::shared_ptr<FrequencyGovernor> gov);
+                             std::shared_ptr<FrequencyGovernor> gov,
+                             std::shared_ptr<Waiter> waiter);
             virtual ~CPUActivityAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
             void validate_policy(std::vector<double> &in_policy) const override;
@@ -53,8 +54,7 @@ namespace geopm
         private:
             PlatformIO &m_platform_io;
             const PlatformTopo &m_platform_topo;
-            geopm_time_s m_last_wait;
-            double M_WAIT_SEC;
+            static constexpr double M_WAIT_SEC = 0.010; // 10ms wait default;
             const double M_POLICY_PHI_DEFAULT;
             const int M_NUM_PACKAGE;
             bool m_do_write_batch;
@@ -111,6 +111,7 @@ namespace geopm
             std::vector<signal> m_uncore_freq_status;
             std::vector<control> m_uncore_freq_min_control;
             std::vector<control> m_uncore_freq_max_control;
+            std::shared_ptr<Waiter> m_waiter;
 
             void init_platform_io(void);
             void init_constconfig_io(void);

--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -128,7 +128,8 @@ namespace geopm
                 "GEOPM_MAX_FAN_OUT",
                 "GEOPM_OMPT_DISABLE",
                 "GEOPM_RECORD_FILTER",
-                "GEOPM_INIT_CONTROL"};
+                "GEOPM_INIT_CONTROL",
+                "GEOPM_PERIOD"};
     }
 
     void EnvironmentImp::parse_environment()
@@ -227,6 +228,16 @@ namespace geopm
     std::string EnvironmentImp::agent(void) const
     {
         return lookup("GEOPM_AGENT");
+    }
+
+    double EnvironmentImp::period(double default_period) const
+    {
+        double result = default_period;
+        std::string period_str = lookup("GEOPM_PERIOD");
+        if (period_str.size() != 0) {
+            result = std::stod(period_str);
+        }
+        return result;
     }
 
     std::string EnvironmentImp::trace(void) const

--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -235,7 +235,17 @@ namespace geopm
         double result = default_period;
         std::string period_str = lookup("GEOPM_PERIOD");
         if (period_str.size() != 0) {
-            result = std::stod(period_str);
+            try {
+                result = std::stod(period_str);
+            }
+            catch (const std::invalid_argument &conv_ex) {
+                throw geopm::Exception("EnvironmentImp::period(): GEOPM_PERIOD environment variable could not be converted into a double: \"" + period_str + "\"",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            catch (const std::out_of_range &range_ex) {
+                throw geopm::Exception("EnvironmentImp::period(): GEOPM_PERIOD environment variable could not be converted into a double, out of range: \"" + period_str + "\"",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
         }
         return result;
     }
@@ -331,7 +341,20 @@ namespace geopm
 
     int EnvironmentImp::max_fan_out(void) const
     {
-        return std::stoi(lookup("GEOPM_MAX_FAN_OUT"));
+        int result = 0;
+        std::string fan_out_str = lookup("GEOPM_MAX_FAN_OUT");
+        try {
+            result = std::stoi(fan_out_str);
+        }
+        catch (const std::invalid_argument &conv_ex) {
+            throw geopm::Exception("EnvironmentImp::max_fan_out(): GEOPM_MAX_FAN_OUT environment variable could not be converted into an integer: \"" + fan_out_str + "\"",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        catch (const std::out_of_range &range_ex) {
+            throw geopm::Exception("EnvironmentImp::max_fan_out(): GEOPM_MAX_FAN_OUT environment variable could not be converted into an integer, out of range: \"" + fan_out_str + "\"",
+                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return result;
     }
 
     int EnvironmentImp::pmpi_ctl(void) const
@@ -389,6 +412,22 @@ namespace geopm
 
     int EnvironmentImp::timeout(void) const
     {
+        int result = 0;
+        std::string timeout_str = lookup("GEOPM_TIMEOUT");
+        try {
+            result = std::stoi(timeout_str);
+        }
+        catch (const std::invalid_argument &conv_ex) {
+            throw geopm::Exception("EnvironmentImp::timeout(): GEOPM_TIMEOUT environment variable could not be converted into an integer: \"" + timeout_str + "\"",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        catch (const std::out_of_range &range_ex) {
+            throw geopm::Exception("EnvironmentImp::timeout(): GEOPM_TIMEOUT environment variable could not be converted into an integer, out of range: \"" + timeout_str + "\"",
+                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        return result;
+
+
         return std::stoi(lookup("GEOPM_TIMEOUT"));
     }
 

--- a/src/Environment.hpp
+++ b/src/Environment.hpp
@@ -63,6 +63,7 @@ namespace geopm
             virtual bool do_init_control(void) const = 0;
             virtual int debug_attach_process(void) const = 0;
             virtual std::string init_control(void) const = 0;
+            virtual double period(double default_period) const = 0;
             static std::map<std::string, std::string> parse_environment_file(const std::string &env_file_path);
     };
 
@@ -113,6 +114,7 @@ namespace geopm
             bool do_init_control(void) const override;
             int debug_attach_process(void) const override;
             std::string init_control(void) const override;
+            double period(double default_period) const override;
         protected:
             void parse_environment(void);
             bool is_set(const std::string &env_var) const;

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <string>
 #include <utility>
+#include <memory>
 
 #include "Agent.hpp"
 #include "geopm_time.h"
@@ -20,6 +21,7 @@ namespace geopm
 {
     class PlatformTopo;
     class PlatformIO;
+    class Waiter;
 
     /// @brief Feed Forward Net Agent
     class FFNetAgent : public Agent
@@ -39,8 +41,8 @@ namespace geopm
             FFNetAgent(PlatformIO &plat_io,
                        const PlatformTopo &topo,
                        const std::map<std::pair<geopm_domain_e, int>, std::shared_ptr<DomainNetMap> > &net_map,
-                       const std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> > &freq_recommender
-            );
+                       const std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> > &freq_recommender,
+                       std::shared_ptr<Waiter> waiter);
             virtual ~FFNetAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
             void validate_policy(std::vector<double> &in_policy) const override;
@@ -87,7 +89,6 @@ namespace geopm
             void init_domain_indices(const PlatformTopo &topo);
 
             PlatformIO &m_platform_io;
-            geopm_time_s m_last_wait;
             static constexpr double M_WAIT_SEC = 0.020;
             bool m_do_write_batch;
 
@@ -101,6 +102,7 @@ namespace geopm
             std::map<m_domain_key_s, m_control_s> m_freq_control;
             std::vector<geopm_domain_e> m_domain_types;
             std::vector<m_domain_key_s> m_domains;
+            std::shared_ptr<Waiter> m_waiter;
 
             static const std::map<geopm_domain_e, std::string> M_NNET_ENVNAME;
             static const std::map<geopm_domain_e, std::string> M_FREQMAP_ENVNAME;

--- a/src/FrequencyMapAgent.hpp
+++ b/src/FrequencyMapAgent.hpp
@@ -13,23 +13,24 @@
 #include <functional>
 #include <set>
 
-#include "geopm_time.h"
-
 #include "Agent.hpp"
 
 namespace geopm
 {
     class PlatformIO;
     class PlatformTopo;
+    class Waiter;
 
     class FrequencyMapAgent : public Agent
     {
         public:
             FrequencyMapAgent();
-            FrequencyMapAgent(PlatformIO &plat_io, const PlatformTopo &topo);
-            FrequencyMapAgent(const std::map<uint64_t, double>& hash_freq_map,
-                              const std::set<uint64_t>& default_freq_hash,
-                              PlatformIO &plat_io, const PlatformTopo &topo);
+            FrequencyMapAgent(PlatformIO &plat_io, const PlatformTopo &topo,
+                              std::shared_ptr<Waiter> waiter);
+            FrequencyMapAgent(PlatformIO &plat_io, const PlatformTopo &topo,
+                              std::shared_ptr<Waiter> waiter,
+                              const std::map<uint64_t, double>& hash_freq_map,
+                              const std::set<uint64_t>& default_freq_hash);
             virtual ~FrequencyMapAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
             void validate_policy(std::vector<double> &policy) const override;
@@ -72,12 +73,9 @@ namespace geopm
                 M_NUM_POLICY = 65,
             };
 
-            const double M_WAIT_SEC;
+            static constexpr double M_WAIT_SEC = 0.002;
             PlatformIO &m_platform_io;
             const PlatformTopo &m_platform_topo;
-            geopm_time_s m_wait_time;
-            std::map<uint64_t, double> m_hash_freq_map;
-            std::set<uint64_t> m_default_freq_hash;
             std::vector<int> m_hash_signal_idx;
             std::vector<int> m_freq_control_idx;
             int m_gpu_min_control_idx;
@@ -105,6 +103,9 @@ namespace geopm
             double m_default_freq;
             double m_uncore_freq;
             double m_default_gpu_freq;
+            std::map<uint64_t, double> m_hash_freq_map;
+            std::set<uint64_t> m_default_freq_hash;
+            std::shared_ptr<Waiter> m_waiter;
     };
 }
 

--- a/src/GPUActivityAgent.hpp
+++ b/src/GPUActivityAgent.hpp
@@ -9,20 +9,21 @@
 #include <functional>
 #include <vector>
 
-#include "geopm_time.h"
 #include "Agent.hpp"
 
 namespace geopm
 {
     class PlatformTopo;
     class PlatformIO;
+    class Waiter;
 
     /// @brief Agent
     class GPUActivityAgent : public Agent
     {
         public:
             GPUActivityAgent();
-            GPUActivityAgent(PlatformIO &plat_io, const PlatformTopo &topo);
+            GPUActivityAgent(PlatformIO &plat_io, const PlatformTopo &topo,
+                             std::shared_ptr<Waiter> waiter);
             virtual ~GPUActivityAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
             void validate_policy(std::vector<double> &in_policy) const override;
@@ -51,8 +52,7 @@ namespace geopm
         private:
             PlatformIO &m_platform_io;
             const PlatformTopo &m_platform_topo;
-            geopm_time_s m_last_wait;
-            double M_WAIT_SEC;
+            static constexpr double M_WAIT_SEC = 0.020; // 20ms wait default
             const double M_POLICY_PHI_DEFAULT;
             const double M_GPU_ACTIVITY_CUTOFF;
             const int M_NUM_GPU;
@@ -109,6 +109,7 @@ namespace geopm
 
             std::vector<m_control> m_gpu_freq_min_control;
             std::vector<m_control> m_gpu_freq_max_control;
+            std::shared_ptr<Waiter> m_waiter;
 
             void init_platform_io(void);
     };

--- a/src/MonitorAgent.cpp
+++ b/src/MonitorAgent.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2015 - 2023, Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include "config.h"
 
 #include "MonitorAgent.hpp"
 
@@ -10,21 +11,23 @@
 #include "geopm/PlatformTopo.hpp"
 #include "geopm/Helper.hpp"
 #include "geopm/Exception.hpp"
-#include "config.h"
+#include "Waiter.hpp"
+#include "Environment.hpp"
 
 namespace geopm
 {
     MonitorAgent::MonitorAgent()
-        : MonitorAgent(PlatformIOProf::platform_io(), platform_topo())
+        : MonitorAgent(PlatformIOProf::platform_io(), platform_topo(),
+                       Waiter::make_unique(environment().period(M_WAIT_SEC)))
     {
 
     }
 
-    MonitorAgent::MonitorAgent(PlatformIO &plat_io, const PlatformTopo &topo)
-        : m_last_wait(time_zero())
-        , M_WAIT_SEC(0.005)
+    MonitorAgent::MonitorAgent(PlatformIO &plat_io, const PlatformTopo &topo,
+                               std::shared_ptr<Waiter> waiter)
+        : m_waiter(waiter)
     {
-        geopm_time(&m_last_wait);
+
     }
 
     std::string MonitorAgent::plugin_name(void)
@@ -86,10 +89,7 @@ namespace geopm
 
     void MonitorAgent::wait(void)
     {
-        while(geopm_time_since(&m_last_wait) < M_WAIT_SEC) {
-
-        }
-        geopm_time(&m_last_wait);
+        m_waiter->wait();
     }
 
     std::vector<std::string> MonitorAgent::policy_names(void)

--- a/src/MonitorAgent.hpp
+++ b/src/MonitorAgent.hpp
@@ -13,19 +13,20 @@
 #include <functional>
 
 #include "Agent.hpp"
-#include "geopm_time.h"
 
 namespace geopm
 {
     class PlatformIO;
     class PlatformTopo;
+    class Waiter;
 
     /// @brief Agent used to do sampling only; no policy will be enforced.
     class MonitorAgent : public Agent
     {
         public:
             MonitorAgent();
-            MonitorAgent(PlatformIO &plat_io, const PlatformTopo &topo);
+            MonitorAgent(PlatformIO &plat_io, const PlatformTopo &topo,
+                         std::shared_ptr<Waiter> waiter);
             virtual ~MonitorAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
             void validate_policy(std::vector<double> &policy) const override;
@@ -55,8 +56,9 @@ namespace geopm
             /// @return a list of sample names
             static std::vector<std::string> sample_names(void);
         private:
-            struct geopm_time_s m_last_wait;
-            const double M_WAIT_SEC;
+            static constexpr double M_WAIT_SEC = 0.005;
+            std::shared_ptr<Waiter> m_waiter;
+
     };
 }
 

--- a/src/PowerBalancerAgent.hpp
+++ b/src/PowerBalancerAgent.hpp
@@ -8,8 +8,8 @@
 
 #include <vector>
 #include <functional>
+#include <memory>
 
-#include "geopm_time.h"
 #include "Agent.hpp"
 
 namespace geopm
@@ -19,6 +19,7 @@ namespace geopm
     class PowerBalancer;
     class PowerGovernor;
     class SampleAggregator;
+    class Waiter;
 
     class PowerBalancerAgent : public Agent
     {
@@ -124,7 +125,8 @@ namespace geopm
                                std::shared_ptr<SampleAggregator> sample_agg,
                                std::vector<std::shared_ptr<PowerBalancer> > power_balancer,
                                double min_power,
-                               double max_power);
+                               double max_power,
+                               std::shared_ptr<Waiter> waiter);
             PowerBalancerAgent();
             virtual ~PowerBalancerAgent();
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
@@ -193,8 +195,7 @@ namespace geopm
             std::shared_ptr<SampleAggregator> m_sample_agg;
             std::shared_ptr<Role> m_role;
             std::vector<std::shared_ptr<PowerBalancer> > m_power_balancer;
-            struct geopm_time_s m_last_wait;
-            const double M_WAIT_SEC;
+            static constexpr double M_WAIT_SEC = 0.005;
             double m_power_tdp;
             bool m_do_send_sample;
             bool m_do_send_policy;
@@ -202,6 +203,7 @@ namespace geopm
             const double M_MIN_PKG_POWER_SETTING;
             const double M_MAX_PKG_POWER_SETTING;
             const double M_TIME_WINDOW;
+            std::shared_ptr<Waiter> m_waiter;
 
             class RootRole;
             class LeafRole;

--- a/src/PowerGovernorAgent.hpp
+++ b/src/PowerGovernorAgent.hpp
@@ -8,9 +8,9 @@
 
 #include <vector>
 #include <functional>
+#include <memory>
 
 #include "Agent.hpp"
-#include "geopm_time.h"
 
 namespace geopm
 {
@@ -19,6 +19,7 @@ namespace geopm
     template <class type>
     class CircularBuffer;
     class PowerGovernor;
+    class Waiter;
 
     class PowerGovernorAgent : public Agent
     {
@@ -44,7 +45,8 @@ namespace geopm
 
             PowerGovernorAgent();
             PowerGovernorAgent(PlatformIO &platform_io,
-                               std::unique_ptr<PowerGovernor> power_gov);
+                               std::unique_ptr<PowerGovernor> power_gov,
+                               std::shared_ptr<Waiter> waiter);
             virtual ~PowerGovernorAgent();
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
             void validate_policy(std::vector<double> &policy) const override;
@@ -92,8 +94,8 @@ namespace geopm
             const int m_ascend_period;
             const int m_min_num_converged;
             double m_adjusted_power;
-            geopm_time_s m_last_wait;
-            const double M_WAIT_SEC;
+            static constexpr double M_WAIT_SEC = 0.005;
+            std::shared_ptr<Waiter> m_waiter;
     };
 }
 

--- a/src/Waiter.cpp
+++ b/src/Waiter.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include "Waiter.hpp"
+
+#include <time.h>
+
+#include "geopm/Exception.hpp"
+#include "geopm_time.h"
+
+
+namespace geopm
+{
+    std::unique_ptr<Waiter> Waiter::make_unique(double period)
+    {
+        return Waiter::make_unique(period, "sleep");
+    }
+
+    std::unique_ptr<Waiter> Waiter::make_unique(double period,
+                                                std::string strategy)
+    {
+        if (strategy == "sleep") {
+            return std::make_unique<SleepWaiter>(period);
+        }
+        else {
+            throw Exception("Waiter::make_unique(): Unknown strategy: " + strategy,
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+
+    SleepWaiter::SleepWaiter(double period)
+        : m_period(period)
+    {
+        reset();
+    }
+
+    void SleepWaiter::reset(void)
+    {
+        geopm_time_real(&m_time_target);
+        geopm_time_add(&m_time_target, m_period, &m_time_target);
+    }
+
+    void SleepWaiter::reset(double period)
+    {
+        m_period = period;
+        reset();
+    }
+
+    void SleepWaiter::wait(void)
+    {
+        int err = 0;
+        do {
+            err = clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME,
+                                  &(m_time_target.t), nullptr);
+        } while(err == EINTR);
+
+        if (err != 0) {
+            throw Exception("Waiter::wait(): Failed with error: ",
+                            err, __FILE__, __LINE__);
+        }
+        geopm_time_add(&m_time_target, m_period, &m_time_target);
+    }
+
+    double SleepWaiter::period(void) const
+    {
+        return m_period;
+    }
+}

--- a/src/Waiter.hpp
+++ b/src/Waiter.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef WAITER_HPP_INCLUDE
+#define WAITER_HPP_INCLUDE
+
+#include <memory>
+#include "geopm_time.h"
+
+namespace geopm
+{
+    /// @brief Class to support a periodic wait loop
+    class Waiter
+    {
+        public:
+            /// @brief Create a Waiter with "sleep" strategy
+            /// @param [in] period Duration in seconds to wait
+            static std::unique_ptr<Waiter> make_unique(double period);
+            /// @brief Create a Waiter
+            /// @param [in] period Duration in seconds to wait
+            /// @param [in] strategy Wait algorithm ("sleep")
+            static std::unique_ptr<Waiter> make_unique(double period,
+                                                       std::string strategy);
+            Waiter() = default;
+            virtual ~Waiter() = default;
+            /// @brief Reset the timer for next wait
+            virtual void reset(void) = 0;
+            /// @brief Reset the timer for next wait and set period
+            /// @param [in] period Duration in seconds to wait
+            virtual void reset(double period) = 0;
+            /// @brief Wait until the period has elapsed since last call to
+            ///        reset() or wait()
+            virtual void wait(void) = 0;
+            /// @brief Get the period for the waiter
+            /// @return The duration of the wait
+            virtual double period(void) const = 0;
+    };
+
+    /// @brief Class to support a periodic wait loop based on
+    ///        clock_nanosleep() using CLOCK_REALTIME.
+    class SleepWaiter : public Waiter
+    {
+        public:
+            SleepWaiter(double period);
+            virtual ~SleepWaiter() = default;
+            void reset(void) override;
+            void reset(double period) override;
+            void wait(void) override;
+            double period(void) const override;
+        private:
+            double m_period;
+            geopm_time_s m_time_target;
+    };
+}
+
+#endif

--- a/test/CPUActivityAgentTest.cpp
+++ b/test/CPUActivityAgentTest.cpp
@@ -24,6 +24,7 @@
 #include "MockPlatformIO.hpp"
 #include "MockPlatformTopo.hpp"
 #include "MockFrequencyGovernor.hpp"
+#include "MockWaiter.hpp"
 #include "geopm/PlatformTopo.hpp"
 #include "geopm_prof.h"
 #include "geopm_test.hpp"
@@ -74,6 +75,7 @@ class CPUActivityAgentTest : public ::testing::Test
         std::vector<double> m_mbm_max;
         std::unique_ptr<MockPlatformIO> m_platform_io;
         std::unique_ptr<MockPlatformTopo> m_platform_topo;
+        std::shared_ptr<MockWaiter> m_waiter;
 };
 
 const int CPUActivityAgentTest::M_NUM_CPU = 1;
@@ -84,8 +86,9 @@ const size_t CPUActivityAgentTest::M_NUM_UNCORE_MBM_READINGS = 13;
 
 void CPUActivityAgentTest::SetUp()
 {
-    m_platform_io = geopm::make_unique<MockPlatformIO>();
-    m_platform_topo = geopm::make_unique<MockPlatformTopo>();
+    m_platform_io = std::make_unique<MockPlatformIO>();
+    m_platform_topo = std::make_unique<MockPlatformTopo>();
+    m_waiter = std::make_unique<MockWaiter>();
 
     ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD))
         .WillByDefault(Return(M_NUM_BOARD));
@@ -158,7 +161,7 @@ void CPUActivityAgentTest::SetUp()
     EXPECT_CALL(*m_gov, get_frequency_min())
         .WillRepeatedly(Return(m_cpu_freq_min));
 
-    m_agent = geopm::make_unique<CPUActivityAgent>(*m_platform_io, *m_platform_topo, m_gov);
+    m_agent = geopm::make_unique<CPUActivityAgent>(*m_platform_io, *m_platform_topo, m_gov, m_waiter);
     m_num_policy = m_agent->policy_names().size();
 
     m_default_policy = {NAN};

--- a/test/FFNetAgentTest.cpp
+++ b/test/FFNetAgentTest.cpp
@@ -29,6 +29,7 @@
 #include "MockPlatformTopo.hpp"
 #include "MockDomainNetMap.hpp"
 #include "MockRegionHintRecommender.hpp"
+#include "MockWaiter.hpp"
 #include "geopm/PlatformTopo.hpp"
 #include "geopm_prof.h"
 #include "geopm_test.hpp"
@@ -159,12 +160,13 @@ void FFNetAgentTest::construct()
         freq_recommender_arg[iter.first] = iter.second;
     }
 
+    std::shared_ptr<geopm::Waiter> waiter = std::make_unique<MockWaiter>();
     m_agent = geopm::make_unique<FFNetAgent>(
             *m_platform_io,
             *m_platform_topo,
             net_map_arg,
-            freq_recommender_arg
-            );
+            freq_recommender_arg,
+            waiter);
     m_agent->init(0, {}, false); 
 }
 

--- a/test/GPUActivityAgentTest.cpp
+++ b/test/GPUActivityAgentTest.cpp
@@ -21,6 +21,7 @@
 #include "geopm/Agg.hpp"
 #include "MockPlatformIO.hpp"
 #include "MockPlatformTopo.hpp"
+#include "MockWaiter.hpp"
 #include "geopm/PlatformTopo.hpp"
 #include "geopm_prof.h"
 #include "geopm_test.hpp"
@@ -69,6 +70,7 @@ class GPUActivityAgentTest : public :: testing :: Test
         std::unique_ptr<GPUActivityAgent> m_agent;
         std::unique_ptr<MockPlatformIO> m_platform_io;
         std::unique_ptr<MockPlatformTopo> m_platform_topo;
+        std::shared_ptr<MockWaiter> m_waiter;
 };
 
 const int GPUActivityAgentTest::M_NUM_CPU = 1;
@@ -82,8 +84,9 @@ const std::vector<double> GPUActivityAgentTest::M_DEFAULT_POLICY = {NAN};
 
 void GPUActivityAgentTest::SetUp()
 {
-    m_platform_io = geopm::make_unique<MockPlatformIO>();
-    m_platform_topo = geopm::make_unique<MockPlatformTopo>();
+    m_platform_io = std::make_unique<MockPlatformIO>();
+    m_platform_topo = std::make_unique<MockPlatformTopo>();
+    m_waiter = std::make_unique<MockWaiter>();
 
     ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_BOARD))
         .WillByDefault(Return(M_NUM_BOARD));
@@ -136,7 +139,7 @@ void GPUActivityAgentTest::SetUp()
 
     ON_CALL(*m_platform_io, signal_names()).WillByDefault(Return(signal_name_set));
 
-    m_agent = geopm::make_unique<GPUActivityAgent>(*m_platform_io, *m_platform_topo);
+    m_agent = geopm::make_unique<GPUActivityAgent>(*m_platform_io, *m_platform_topo, m_waiter);
     m_num_policy = m_agent->policy_names().size();
 
     // leaf agent

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -362,6 +362,10 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/TreeCommTest.send_receive \
               test/gtest_links/TRLFrequencyLimitDetectorTest.returns_single_core_limit_by_default \
               test/gtest_links/TRLFrequencyLimitDetectorTest.returns_max_observed_frequency_after_update \
+              test/gtest_links/WaiterTest.invalid_strategy_name \
+              test/gtest_links/WaiterTest.make_unique \
+              test/gtest_links/WaiterTest.reset \
+              test/gtest_links/WaiterTest.wait \
               test/gtest_links/ValidateRecordTest.valid_stream \
               test/gtest_links/ValidateRecordTest.process_change \
               test/gtest_links/ValidateRecordTest.entry_exit_paired \
@@ -523,6 +527,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/MockTracer.hpp \
                           test/MockTreeComm.hpp \
                           test/MockTreeCommLevel.hpp \
+                          test/MockWaiter.hpp \
                           test/ModelApplicationTest.cpp \
                           test/MonitorAgentTest.cpp \
                           test/OptionParserTest.cpp \
@@ -558,6 +563,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/TreeCommTest.cpp \
                           test/TRLFrequencyLimitDetectorTest.cpp \
                           test/ValidateRecordTest.cpp \
+                          test/WaiterTest.cpp \
                           test/geopm_test.cpp \
                           test/geopm_test_helper.cpp \
                           test/geopm_test.hpp \

--- a/test/MockWaiter.hpp
+++ b/test/MockWaiter.hpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOCKWAITER_HPP_INCLUDE
+#define MOCKWAITER_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "Waiter.hpp"
+
+class MockWaiter : public geopm::Waiter
+{
+        MOCK_METHOD(void, reset, (), (override));
+        MOCK_METHOD(void, reset, (double period), (override));
+        MOCK_METHOD(void, wait, (), (override));
+        MOCK_METHOD(double, period, (), (const, override));
+};
+
+#endif

--- a/test/MonitorAgentTest.cpp
+++ b/test/MonitorAgentTest.cpp
@@ -9,6 +9,7 @@
 #include "MonitorAgent.hpp"
 #include "MockPlatformIO.hpp"
 #include "MockPlatformTopo.hpp"
+#include "MockWaiter.hpp"
 #include "geopm/Helper.hpp"
 #include "geopm/Agg.hpp"
 
@@ -24,11 +25,13 @@ class MonitorAgentTest : public ::testing::Test
         MockPlatformIO m_platform_io;
         MockPlatformTopo m_platform_topo;
         std::unique_ptr<geopm::MonitorAgent> m_agent;
+        std::shared_ptr<MockWaiter> m_waiter;
 };
 
 void MonitorAgentTest::SetUp()
 {
-    m_agent = geopm::make_unique<MonitorAgent>(m_platform_io, m_platform_topo);
+    m_waiter = std::make_unique<MockWaiter>();
+    m_agent = std::make_unique<MonitorAgent>(m_platform_io, m_platform_topo, m_waiter);
 }
 
 TEST_F(MonitorAgentTest, sample_names)

--- a/test/WaiterTest.cpp
+++ b/test/WaiterTest.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "geopm_test.hpp"
+
+#include "Waiter.hpp"
+
+using geopm::Waiter;
+
+class WaiterTest : public ::testing::Test
+{
+    protected:
+        double m_period = 0.1;
+        double m_epsilon = 0.01;
+};
+
+
+TEST_F(WaiterTest, invalid_strategy_name)
+{
+    GEOPM_EXPECT_THROW_MESSAGE(Waiter::make_unique(1.0, "invalid_strategy_name"),
+                               GEOPM_ERROR_INVALID, "Unknown strategy");
+}
+
+TEST_F(WaiterTest, make_unique)
+{
+    std::shared_ptr<Waiter> waiter = Waiter::make_unique(1.0);
+    ASSERT_EQ(1.0, waiter->period());
+    waiter = Waiter::make_unique(2.0, "sleep");
+    ASSERT_EQ(2.0, waiter->period());
+}
+
+TEST_F(WaiterTest, reset)
+{
+    std::shared_ptr<Waiter> waiter = Waiter::make_unique(m_period);
+    geopm_time_s time_0;
+    geopm_time_s time_1;
+    timespec delay = {0,100000000};
+    nanosleep(&delay, nullptr);
+    waiter->reset();
+    geopm_time(&time_0);
+    waiter->wait();
+    geopm_time(&time_1);
+    EXPECT_NEAR(m_period, geopm_time_diff(&time_0, &time_1), m_epsilon);
+}
+
+TEST_F(WaiterTest, wait)
+{
+    geopm_time_s time_0;
+    geopm_time_s time_1;
+    std::shared_ptr<Waiter> waiter = Waiter::make_unique(m_period);
+    for (int count = 0; count < 10; ++count) {
+        geopm_time(&time_0);
+        waiter->wait();
+        geopm_time(&time_1);
+        EXPECT_NEAR(m_period, geopm_time_diff(&time_0, &time_1), m_epsilon);
+    }
+}


### PR DESCRIPTION
- Update all agents to use Waiter
- Add GEOPM_PERIOD environment variable that can be used to override agent default value.
- Update unit tests with mock waiter
- Added documentation for GEOPM_PERIOD environment variable and --geopm-period geopmlaunch CLI
- Uses sleep not spin which reduces CPU overhead for controller and reduces overall energy consumption
- Resolves #1065
