### PR TITLE
Fix sampling issues with the GEOPM endpoint

### DIFF
--- a/service/docs/source/geopm_endpoint.3.rst
+++ b/service/docs/source/geopm_endpoint.3.rst
@@ -196,10 +196,49 @@ All functions described on this man page return an error code.  See
 :doc:`geopm_error(3) <geopm_error.3>` for a full description of the error numbers and how
 to convert them to strings.
 
+Example
+-------
+The endpoint interface needs to be opened and attached to an agent. The
+following pseudocode illustrates the order of function calls that would enable
+an endpoint user to interact with an agent after a job has already started
+executing, instead of writing a static policy to a file and waiting for job
+completion to receive feedback.
+
+Error-checking is omitted from this example for brevity. See
+:doc:`geopm_error(3) <geopm_error.3>` for interpretation of the return values
+from these functions.
+
+.. code-block:: c
+
+    char agent_name[128];
+    char profile_name[128];
+    char node_name[128];
+    int num_node;
+    struct geopm_endpoint_c* endpoint;
+    geopm_endpoint_create("my_endpoint", &endpoint);
+    geopm_endpoint_open(endpoint);
+    geopm_endpoint_wait_for_agent_attach(endpoint, 1.0);
+    geopm_endpoint_agent(endpoint, sizeof agent_name, agent_name);
+    // Now you can look up agent properties by agent_name, such as the names of
+    // policy and sample vector elements. See geopm_agent(3).
+    geopm_endpoint_profile_name(endpoint, sizeof profile_name, profile_name);
+    // Now you have the user-provided profile name for the job
+    geopm_endpoint_num_node(endpoint, &num_node);
+    geopm_endpoint_node_name(endpoint, num_node-1 /* The last node's name */,
+                             sizeof node_name, node_name);
+    double *policy = /* populate the array based on the agent policy */;
+    geopm_endpoint_write_policy(endpoint, policy, num_policy);
+    double *sample = /* Allocate large enough to hold agent's samples */;
+    double sample_age_sec; // How old the sample is by the time you request it
+    geopm_endpoint_read_sample(endpoint, num_sample, sample, &sample_age_sec);
+    geopm_endpoint_close(endpoint);
+    geopm_endpoint_destroy(endpoint);
+
 See Also
 --------
 
-:doc:`geopm(7) <geopm.7>`\ ,
-:doc:`geopm_error(3) <geopm_error.3>`\ ,
-:doc:`geopm::Endpoint(3) <GEOPM_CXX_MAN_Endpoint.3>`\ ,
-:doc:`geopmendpoint(1) <geopmendpoint.1>`
+:doc:`geopm(7) <geopm.7>`,
+:doc:`geopm_error(3) <geopm_error.3>`,
+:doc:`geopm::Endpoint(3) <GEOPM_CXX_MAN_Endpoint.3>`,
+:doc:`geopmendpoint(1) <geopmendpoint.1>`,
+:doc:`geopm_agent(3) <geopm_agent.3>`

--- a/src/Endpoint.cpp
+++ b/src/Endpoint.cpp
@@ -435,6 +435,7 @@ int geopm_endpoint_read_sample(struct geopm_endpoint_c *endpoint,
     try {
         std::vector<double> sample(agent_num_sample);
         *sample_age_sec = end->read_sample(sample);
+        std::copy_n(sample.begin(), agent_num_sample, sample_array);
     }
     catch (...) {
         err = geopm::exception_handler(std::current_exception(), true);

--- a/src/EndpointUser.cpp
+++ b/src/EndpointUser.cpp
@@ -68,6 +68,9 @@ namespace geopm
             throw Exception("EndpointImp(): Profile name is too long for endpoint storage: " + profile_name,
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
+        data->count = m_num_sample;
+        std::fill(data->values, data->values + m_num_sample, NAN);
+        geopm_time(&data->timestamp);
         data->agent[GEOPM_ENDPOINT_AGENT_NAME_MAX - 1] = '\0';
         data->profile_name[GEOPM_ENDPOINT_PROFILE_NAME_MAX - 1] = '\0';
         strncpy(data->agent, agent_name.c_str(), GEOPM_ENDPOINT_AGENT_NAME_MAX - 1);

--- a/test/EndpointTest.cpp
+++ b/test/EndpointTest.cpp
@@ -105,12 +105,22 @@ TEST_F(EndpointTest, parse_shm_sample)
     geopm_time(&now);
     data->timestamp = now;
 
+    // From C++ interface
     std::vector<double> result(num_sample);
     double age = gp.read_sample(result);
     std::vector<double> expected {tmp, tmp + num_sample};
     EXPECT_EQ(expected, result);
     EXPECT_LT(0.0, age);
     EXPECT_LT(age, 0.01);
+
+    // From C interface
+    std::vector<double> result_c(result.size());
+    age = 0;
+    geopm_endpoint_read_sample(reinterpret_cast<geopm_endpoint_c*>(&gp), result_c.size(), &result_c[0], &age);
+    EXPECT_EQ(expected, result_c);
+    EXPECT_LT(0.0, age);
+    EXPECT_LT(age, 0.01);
+
     gp.close();
 }
 

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -131,6 +131,7 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/EndpointTest.get_agent \
               test/gtest_links/EndpointTest.wait_attach_timeout_0 \
               test/gtest_links/EndpointTest.wait_detach_timeout_0 \
+              test/gtest_links/EndpointTestIntegration.read_sample_before_data_exists \
               test/gtest_links/EndpointTestIntegration.write_shm \
               test/gtest_links/EndpointTestIntegration.write_read_policy \
               test/gtest_links/EndpointTestIntegration.write_read_sample \


### PR DESCRIPTION
- Fixes #2830
- geopm_endpoint_read_sample() reads samples to a local vector. The
  caller of that function provides a destination buffer, but this function does
  not populate that destination buffer. This change copies the local
  vector's contents to the caller's destination buffer.
- Fixes #2873
- The GEOPM endpoint was not initializing sample data (values, length,
  and age). Attempts to read a sample from the endpoint between agent
  initialization and an agent's first sample would result in an
  exception from the EndpointImpUser. This change initializes sample
  data, setting NAN for unknown values.