### PR TITLE
Avoid loading SSTIOGroup if we cannot read association of all cores

### DIFF
--- a/service/src/SSTIOGroup.cpp
+++ b/service/src/SSTIOGroup.cpp
@@ -348,6 +348,14 @@ namespace geopm
             add_mmio_controls(raw_name, raw_desc.domain_type, raw_desc.register_offset,
                               raw_desc.fields, control_read_mask);
         }
+
+        // Attempt to read the priority of each core. On a system that does not
+        // support this action, the read_signal will throw. Let that exception
+        // bubble up to indicated to the owner of this IOGroup that this
+        // IOGroup should not be loaded.
+        for (int core = 0; core < m_topo.num_domain(GEOPM_DOMAIN_CORE); ++core) {
+            read_signal("SST::COREPRIORITY:ASSOCIATION", GEOPM_DOMAIN_CORE, core);
+        }
     }
 
     std::set<std::string> SSTIOGroup::signal_names(void) const

--- a/service/test/SSTIOGroupTest.cpp
+++ b/service/test/SSTIOGroupTest.cpp
@@ -430,3 +430,12 @@ TEST_F(SSTIOGroupTest, restored_controls_follow_ordered_dependencies_enabled)
                 && *std::prev(sst_tf_it) == SST_CP_COMMAND)
         << "Expected SST-TF to be enabled after SST-CP in restore()";
 }
+
+TEST_F(SSTIOGroupTest, constructor_throws_if_priority_not_readable)
+{
+    EXPECT_CALL(*m_sstio, get_punit_from_cpu(_)).Times(m_num_package * m_num_core);
+    EXPECT_CALL(*m_sstio, read_mmio_once(_, _)).Times(AtLeast(0))
+        .WillRepeatedly(Throw(geopm::Exception("Test-injected failure", GEOPM_ERROR_RUNTIME, __FILE__, __LINE__)));
+    EXPECT_THROW(geopm::make_unique<SSTIOGroup>(*m_topo, m_sstio, m_mock_save_ctl),
+                 geopm::Exception);
+}


### PR DESCRIPTION
- Resolves #2861