### PR TITLE
Do not truncate long error messages with the C API - geopm_error_message()

### DIFF
--- a/examples/geopm_platform_supported.cpp
+++ b/examples/geopm_platform_supported.cpp
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <limits.h>
 
 #include "geopm/PlatformTopo.hpp"
 #include "geopm_hash.h"
@@ -19,8 +20,8 @@
 int main(int argc, char **argv)
 {
     int err = 0;
-    char error_msg[512];
-    error_msg[511] = '\0';
+    char error_msg[PATH_MAX];
+    error_msg[PATH_MAX - 1] = '\0';
 
     if (argc == 2 &&
         strncmp(argv[1], "crc32", strlen("crc32") + 1) == 0) {
@@ -42,14 +43,14 @@ int main(int argc, char **argv)
             cpu_id != 0x64F &&
             cpu_id != 0x657) {
             err = GEOPM_ERROR_PLATFORM_UNSUPPORTED;
-            geopm_error_message(err, error_msg, 511);
+            geopm_error_message(err, error_msg, PATH_MAX);
             std::cerr << "Warning: <geopm_platform_supported>: Platform 0x" << std::hex << cpu_id << " is not a supported CPU" << " " << error_msg << "." << std::endl;
         }
         if (!err) {
             int fd = open("/dev/cpu/0/msr_safe", O_RDONLY);
             if (fd == -1) {
                 err = GEOPM_ERROR_MSR_OPEN;
-                geopm_error_message(err, error_msg, 511);
+                geopm_error_message(err, error_msg, PATH_MAX);
                 std::cerr << "Warning: <geopm_platform_supported>: Not able to open msr_safe device. " << error_msg << "." << std::endl;
 
             }

--- a/examples/geopm_print_error.c
+++ b/examples/geopm_print_error.c
@@ -7,11 +7,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <limits.h>
 
 #include "geopm_error.h"
-#ifndef NAME_MAX
-#define NAME_MAX 512
-#endif
 
 int main(int argc, char **argv)
 {
@@ -65,7 +63,7 @@ int main(int argc, char **argv)
     const char *tag = "<geopm> ";
     int format_type = GEOPM_FORMAT_TYPE_HUMAN;
     const char *usage = "%s [--help] [--roff]\n";
-    char message[NAME_MAX];
+    char message[PATH_MAX];
     int i;
 
     if (argc == 2 && strncmp(argv[1], "--roff", strlen("--roff")) == 0 ) {
@@ -89,8 +87,8 @@ int main(int argc, char **argv)
         printf("GEOPM ERROR CODES\n");
     }
     for (i = 0; !return_code && i < num_error; ++i) {
-        geopm_error_message(error_codes[i], message, NAME_MAX);
-        message[NAME_MAX - 1] = '\0';
+        geopm_error_message(error_codes[i], message, PATH_MAX);
+        message[PATH_MAX - 1] = '\0';
         if (strstr(message, tag) == message) {
             switch (format_type) {
                 case GEOPM_FORMAT_TYPE_HUMAN:

--- a/examples/simple_pio_example.c
+++ b/examples/simple_pio_example.c
@@ -66,8 +66,8 @@ int main(int argc, char **argv)
         printf("Total energy for package 0: %0.2f (joules)\n", total_energy);
     }
     if (err) {
-        char error_string[NAME_MAX];
-        geopm_error_message(err, error_string, NAME_MAX);
+        char error_string[PATH_MAX];
+        geopm_error_message(err, error_string, PATH_MAX);
         fprintf(stderr, "Error: %s\n", error_string);
     }
     return err;

--- a/integration/test/test_enforce_policy.c
+++ b/integration/test/test_enforce_policy.c
@@ -13,8 +13,8 @@ int main(int argc, char *argv[])
 {
     int err = geopm_agent_enforce_policy();
     if (err) {
-        char err_msg[NAME_MAX];
-        geopm_error_message(err, err_msg, NAME_MAX);
+        char err_msg[PATH_MAX];
+        geopm_error_message(err, err_msg, PATH_MAX);
         printf("enforce policy failed: %s\n", err_msg);
     }
     return err;

--- a/service/geopmdpy/error.py
+++ b/service/geopmdpy/error.py
@@ -57,7 +57,7 @@ def message(err_number):
     """
     global _dl
 
-    name_max = 1024
-    result_cstr = gffi.gffi.new("char[]", name_max)
-    _dl.geopm_error_message(err_number, result_cstr, name_max)
+    path_max = 4096
+    result_cstr = gffi.gffi.new("char[]", path_max)
+    _dl.geopm_error_message(err_number, result_cstr, path_max)
     return gffi.gffi.string(result_cstr).decode()

--- a/service/geopmdpy/pio.py
+++ b/service/geopmdpy/pio.py
@@ -150,7 +150,7 @@ def control_names():
     num_control = _dl.geopm_pio_num_control_name()
     if num_control < 0:
         raise RuntimeError('geopm_pio_num_control_name() failed: {}'.format(error.message(num_control)))
-    name_max = 1024
+    name_max = 255
     control_name_cstr = gffi.gffi.new("char[]", name_max)
     for control_idx in range(num_control):
         err = _dl.geopm_pio_control_name(control_idx, name_max, control_name_cstr)
@@ -503,7 +503,6 @@ def save_control_dir(save_dir):
 
     """
     global _dl
-    name_max = 1024
     save_dir_cstr = gffi.gffi.new("char[]", save_dir.encode())
     err = _dl.geopm_pio_save_control_dir(save_dir_cstr)
     if err < 0:
@@ -526,7 +525,6 @@ def restore_control_dir(save_dir):
 
     """
     global _dl
-    name_max = 1024
     save_dir_cstr = gffi.gffi.new("char[]", save_dir.encode())
     err = _dl.geopm_pio_restore_control_dir(save_dir_cstr)
     if err < 0:
@@ -559,7 +557,6 @@ def signal_info(signal_name):
 
     """
     global _dl
-    name_max = 1024
     signal_name_cstr = gffi.gffi.new("char[]", signal_name.encode())
     aggregation_type = gffi.gffi.new("int*")
     format_type = gffi.gffi.new("int*")

--- a/service/integration/test/save_restore.sh
+++ b/service/integration/test/save_restore.sh
@@ -42,7 +42,7 @@ check_control() {
 
     # CHECK THAT THE VALUE OF THE CONTROL REGISTER HAS BEEN CHANGED
     test ${SESSION_VALUE} == ${REQUEST_VALUE} ||
-        test_error "Writing the new value has failed"
+        test_error "Writing the new value has failed: $(cat ${TEST_ERROR})"
 }
 
 restore_control() {

--- a/service/src/BatchServer.cpp
+++ b/service/src/BatchServer.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdlib>
 #include <cerrno>
+#include <limits.h>
 #include <unistd.h>
 #include <wait.h>
 #include <iostream>
@@ -289,8 +290,8 @@ namespace geopm
             m_is_active = false;
             --g_sigchld_count;
             if (g_wait_status != 0) {
-                char err_msg[NAME_MAX];
-                geopm_error_message(g_wait_status, err_msg, NAME_MAX);
+                char err_msg[PATH_MAX];
+                geopm_error_message(g_wait_status, err_msg, PATH_MAX);
                 std::cerr << "Warning: <geopm> " << __FILE__ << ":" << __LINE__
                           << " :  Received SIGCHLD but wait() failed: "
                           << g_wait_status << " : \"" << err_msg << "\"\n";

--- a/service/src/Exception.cpp
+++ b/service/src/Exception.cpp
@@ -31,7 +31,7 @@ namespace geopm
             virtual ~ErrorMessage() = default;
             const std::map<int, std::string> M_VALUE_MESSAGE_MAP;
             int m_error_value;
-            char m_error_message[NAME_MAX];
+            char m_error_message[PATH_MAX];
             std::mutex m_lock;
         public:
             ErrorMessage(const ErrorMessage &other) = delete;
@@ -143,7 +143,7 @@ namespace geopm
             {GEOPM_ERROR_DATA_STORE, "Encountered a data store error"}}
         , m_error_value(0)
     {
-        std::fill(m_error_message, m_error_message + NAME_MAX, '\0');
+        std::fill(m_error_message, m_error_message + PATH_MAX, '\0');
     }
 
     ErrorMessage &ErrorMessage::get(void)
@@ -155,8 +155,8 @@ namespace geopm
     void ErrorMessage::update(int error_value, const std::string &error_message)
     {
         size_t num_copy = error_message.size();
-        if (num_copy > NAME_MAX - 1) {
-            num_copy = NAME_MAX - 1;
+        if (num_copy > PATH_MAX - 1) {
+            num_copy = PATH_MAX - 1;
         }
         std::lock_guard<std::mutex> guard(m_lock);
         std::copy_n(error_message.data(), num_copy, m_error_message);
@@ -177,7 +177,7 @@ namespace geopm
 
     std::string ErrorMessage::message_fixed(int err)
     {
-        char error_message[NAME_MAX];
+        char error_message[PATH_MAX];
         err = err ? err : GEOPM_ERROR_RUNTIME;
         std::string result("<geopm> ");
         auto it = M_VALUE_MESSAGE_MAP.find(err);
@@ -185,7 +185,7 @@ namespace geopm
             result += it->second;
         }
         else {
-            result += strerror_r(err, error_message, NAME_MAX);
+            result += strerror_r(err, error_message, PATH_MAX);
         }
         return result;
     }

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -159,9 +159,9 @@ namespace geopm
                       << step << ", running without geopm." << std::endl;
             int err = ex.err_value();
             if (err != GEOPM_ERROR_RUNTIME) {
-                char tmp_msg[NAME_MAX];
+                char tmp_msg[PATH_MAX];
                 geopm_error_message(err, tmp_msg, sizeof(tmp_msg));
-                tmp_msg[NAME_MAX-1] = '\0';
+                tmp_msg[PATH_MAX-1] = '\0';
                 std::cerr << tmp_msg << std::endl;
             }
             m_is_enabled = false;

--- a/src/geopm_pmpi_helper.cpp
+++ b/src/geopm_pmpi_helper.cpp
@@ -210,8 +210,8 @@ static int geopm_pmpi_init(const char *exec_name)
         }
 #ifdef GEOPM_DEBUG
         if (err) {
-            char err_msg[NAME_MAX];
-            geopm_error_message(err, err_msg, NAME_MAX);
+            char err_msg[PATH_MAX];
+            geopm_error_message(err, err_msg, PATH_MAX);
             fprintf(stderr, "%s", err_msg);
         }
 #endif

--- a/src/geopmbench_main.cpp
+++ b/src/geopmbench_main.cpp
@@ -162,8 +162,8 @@ int main(int argc, char **argv)
     }
 
     if (err) {
-        char err_msg[NAME_MAX] = {};
-        geopm_error_message(err, err_msg, NAME_MAX);
+        char err_msg[PATH_MAX] = {};
+        geopm_error_message(err, err_msg, PATH_MAX);
         std::cerr << "ERROR: " << argv[0] << ": " << err_msg << std::endl;
     }
 


### PR DESCRIPTION
- Fixes #2887.