### PR TITLE
Addition of LevelZero metric support to the LevelZero device pool and IO Group

### DIFF
--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -220,7 +220,7 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
-            metric_group_cache(gpu_idx);
+            metric_group_init(gpu_idx);
         }
     }
 
@@ -551,11 +551,11 @@ namespace geopm
     //      - metric group handle
     //      - sampling period
     //      - data storage for the ComputeBasics metric group
-    void LevelZeroImp::metric_group_cache(unsigned int device_idx) {
+    void LevelZeroImp::metric_group_init(unsigned int device_idx) {
         for (int subdevice_idx = 0;
              subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
              ++subdevice_idx) {
-            // Setup tracking of the caching and initilization steps
+            // Setup tracking of the caching and initialization steps
             m_devices.at(device_idx).subdevice.metric_domain_cached.push_back(false);
             m_devices.at(device_idx).subdevice.metrics_initialized.push_back(false);
 
@@ -603,70 +603,72 @@ namespace geopm
 
             for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
                  metric_group_idx++) {
-                 zet_metric_group_properties_t metric_group_properties;
-                 ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
-                                             &metric_group_properties);
-                 check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
-                                 "LevelZero::" + std::string(__func__) +
-                                 ": LevelZero Metric Group property acquisition failed",
-                                 __LINE__);
+                zet_metric_group_properties_t metric_group_properties;
+                ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
+                                            &metric_group_properties);
+                check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Metric Group property acquisition failed",
+                                __LINE__);
 
-                 std::string metric_group_name (metric_group_properties.name);
+                std::string metric_group_name (metric_group_properties.name);
 
-                 //Confirm metric groups of interest exist
-                 if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
-                     && metric_group_name == "ComputeBasic") {
+                // Confirm metric groups of interest exist
+                // Eventually the metric group of interest may be configurable,
+                // to start we're using compute basics
+                if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
+                    && metric_group_name == "ComputeBasic") {
 
-                    //cache compute basic metric group
-                    m_devices.at(device_idx).subdevice.metric_group_handle.push_back(metric_group_handle.at(metric_group_idx));
+                   //cache compute basic metric group
+                   m_devices.at(device_idx).subdevice.metric_group_handle.push_back(metric_group_handle.at(metric_group_idx));
 
-                    // could likely use metric_group_properties.metricCount instead
-                    uint32_t num_metric = 0;
-                    ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
-                    check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                    "LevelZero::" + std::string(__func__) +
-                                    ": LevelZero Metric Count query failed",
-                                    __LINE__);
+                   // could likely use metric_group_properties.metricCount instead
+                   uint32_t num_metric = 0;
+                   ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
+                   check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                   "LevelZero::" + std::string(__func__) +
+                                   ": LevelZero Metric Count query failed",
+                                   __LINE__);
 
-                    //Cache compute basic number of metrics
-                    m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
+                   //Cache compute basic number of metrics
+                   m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
 
-                    //Build metric map
-                    for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
-                    {
+                   //Build metric map
+                   for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+                   {
 
-                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
-                                                 &num_metric, metric_handle.data());
+                       std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                       ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
+                                                &num_metric, metric_handle.data());
 
-                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                        "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric handle acquisition failed",
-                                        __LINE__);
-                        zet_metric_properties_t metric_properties;
-                        ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+                       check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                       "LevelZero::" + std::string(__func__) +
+                                       ": LevelZero Metric handle acquisition failed",
+                                       __LINE__);
+                       zet_metric_properties_t metric_properties;
+                       ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
 
-                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                        "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric Property acquisition failed",
-                                        __LINE__);
+                       check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                       "LevelZero::" + std::string(__func__) +
+                                       ": LevelZero Metric Property acquisition failed",
+                                       __LINE__);
 
-                        std::string metric_name (metric_properties.name);
+                       std::string metric_name (metric_properties.name);
 
-                        //m_devices is a std::vector of structs, indexed by GPU
-                        // subdevice is a struct inside of it.  One per GPU
-                        //  m_metric_data is a vector, indexed by CHIP
-                        //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
-                        if (m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
-                            throw Exception("LevelZero::" + std::string(__func__) +
-                                            ": Metric group has two metrics with the same name",
-                                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-                        }
-                        m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
-                        m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
-                    }
-                    // Break out of loop once we've found the group of interest
-                    break;
+                       //m_devices is a std::vector of structs, indexed by GPU
+                       // subdevice is a struct inside of it.  One per GPU
+                       //  m_metric_data is a vector, indexed by CHIP
+                       //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
+                       if (m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
+                           throw Exception("LevelZero::" + std::string(__func__) +
+                                           ": Metric group has two metrics with the same name",
+                                           GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                       }
+                       m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
+                       m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
+                   }
+                   // Break out of loop once we've found the group of interest
+                   break;
                 }
             }
             m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
@@ -675,6 +677,16 @@ namespace geopm
 
     void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
+        GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) == true,
+                           "metric caching for GPU " + std::to_string(l0_device_idx) +
+                           ", CHIP " + std::to_string(l0_domain_idx) +
+                           " not completed prior to metric_calc call.");
+
+        GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) == true,
+                           "metric initialization for GPU " + std::to_string(l0_device_idx) +
+                           ", CHIP " + std::to_string(l0_domain_idx) +
+                           " not completed prior to metric_calc call.");
+
         ze_result_t ze_result;
 
         if (m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
@@ -714,7 +726,7 @@ namespace geopm
     }
 
 
-    void LevelZeroImp::metric_init(unsigned int l0_device_idx, unsigned int l0_domain_idx)
+    void LevelZeroImp::metric_execute(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
         ze_result_t ze_result;
         ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
@@ -878,7 +890,7 @@ namespace geopm
     {
         if (m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
             if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
-                metric_init(l0_device_idx, l0_domain_idx);
+                metric_execute(l0_device_idx, l0_domain_idx);
                 m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
             }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -11,8 +11,6 @@
 #include <cstdlib>
 #include <utility>
 
-#include <chrono>
-
 #include "geopm/Exception.hpp"
 #include "geopm/Agg.hpp"
 #include "geopm/Helper.hpp"
@@ -652,7 +650,6 @@ namespace geopm
         }
     }
 
-    //TODO: need metric destory
     void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
 ////        //std::cout << "ZET_DESTROY - gpu " << std::to_string(l0_device_idx) << std::endl;
@@ -760,9 +757,6 @@ namespace geopm
         //////////////////////
         // Convert Raw Data //
         //////////////////////
-        std::chrono::time_point<std::chrono::system_clock> start, end;
-        std::chrono::duration<double> elapsed_seconds;
-
         size_t data_size = 0;
         uint32_t report_count_req = 100;//UINT32_MAX; //100;
         ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr );
@@ -784,23 +778,14 @@ namespace geopm
         uint32_t num_metric_values = 0;
         uint32_t data_count = 0;
         zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
-        //ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
         ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
-
-        end = std::chrono::system_clock::now();
-        elapsed_seconds = end - start;
-//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " pre-calculate time: " << elapsed_seconds.count() << "s" << std::endl;
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric group calculate metric values to find num metrics failed",
                         __LINE__);
-//        std::cout << "\t\tNum metric values from calculate metric values: " << std::to_string(num_metric_values) << std::endl;
-//        std::cout << "\t\tNum data count from calculate metric values: " << std::to_string(data_count) << std::endl;
 
-        start = std::chrono::system_clock::now();
         std::vector<uint32_t> metric_count(data_count);
         std::vector<zet_typed_value_t> metric_values(num_metric_values);
-        //ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
         ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
 //        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
 //                        "LevelZero::" + std::string(__func__) +
@@ -809,30 +794,12 @@ namespace geopm
 //        //std::cout << "\tmetric group calculate metric values: " << std::to_string(num_metric_values) << std::endl;
 //        ze_result = ZE_RESULT_ERROR_UNKNOWN;
 
-        end = std::chrono::system_clock::now();
-        elapsed_seconds = end - start;
-//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " calculate time: " << elapsed_seconds.count() << "s" << std::endl;
-
-        //uint32_t num_metric = m_devices.at(l0_device_idx).num_metric;
         uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
-        //unsigned int num_reports = num_metric_values/num_metric;
-        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " num reports: " << std::to_string(num_reports) <<
-                  //std::endl;
-
         if (ze_result == ZE_RESULT_SUCCESS) {
-            start = std::chrono::system_clock::now();
-
-
             unsigned int num_reports = num_metric_values / num_metric;
 
             for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
             {
-                std::chrono::time_point<std::chrono::system_clock> start2, end2;
-                std::chrono::duration<double> elapsed_seconds;
-                start2 = std::chrono::system_clock::now();
-////
-
-
                 //TODO: It is possible that simply parsing all the metrics is
                 //      faster than the additional API calls to check the metric
                 //      name.  This should be studied
@@ -853,9 +820,6 @@ namespace geopm
                                 __LINE__);
 
                 std::string metric_name (metric_properties.name);
-                end2 = std::chrono::system_clock::now();
-                elapsed_seconds = end2 - start2;
-                //std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " name find time: " << elapsed_seconds.count() << "s" << std::endl;
 
                 //TODO: check timing impact of only processing metrics supported by IOGroup
                 if(metric_name.compare("XVE_ACTIVE") == 0 ||
@@ -900,40 +864,21 @@ namespace geopm
             m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_ACTIVE") = {};
             m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_STALL") = {};
         }
-        end = std::chrono::system_clock::now();
-        elapsed_seconds = end - start;
-//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
     }
 
     void LevelZeroImp::metric_read(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
         if (m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
             if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
-                std::chrono::time_point<std::chrono::system_clock> start, end;
-                std::chrono::duration<double> elapsed_seconds;
-                start = std::chrono::system_clock::now();
-
                 metric_init(l0_device_idx, l0_domain_idx);
                 m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
-
-                end = std::chrono::system_clock::now();
-                elapsed_seconds = end - start;
-//                std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_init time: " << elapsed_seconds.count() << "s" << std::endl;
             }
 
             ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).subdevice.event.at(l0_domain_idx), 0);
 
             if (ze_host_result != ZE_RESULT_NOT_READY) {
-                std::chrono::time_point<std::chrono::system_clock> start, end;
-                std::chrono::duration<double> elapsed_seconds;
-                start = std::chrono::system_clock::now();
-
                 metric_calc(l0_device_idx, l0_domain_idx,
                             m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
-
-                end = std::chrono::system_clock::now();
-                elapsed_seconds = end - start;
-//                std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_calc time: " << elapsed_seconds.count() << "s" << std::endl;
             }
             else {
                 metric_read(l0_device_idx, l0_domain_idx); //TODO: possible infinite loop
@@ -946,6 +891,12 @@ namespace geopm
                                                     std::string metric_name) const
     {
         std::vector<double> result = {};
+        if (!m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
+            throw Exception("LevelZero::" + std::string(__func__) +
+                            ": Metric groups not cached" ,
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
         if(m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).count(metric_name) == 0) {
             throw Exception("LevelZero::" + std::string(__func__) +
                             ": No metric named " + metric_name  + " found." ,

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -225,7 +225,7 @@ namespace geopm
     }
 
     LevelZeroImp::~LevelZeroImp() {
-        for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; gpu_idx++) {
+        for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
             for (int subdevice_idx = 0;
              subdevice_idx < m_devices.at(gpu_idx).num_subdevice;
              ++subdevice_idx) {
@@ -597,7 +597,7 @@ namespace geopm
                             __LINE__);
 
             // set metric_notifcation_event sampling period in nanoseconds
-            m_devices.at(device_idx).metric_sampling_period_ns =   1000000;
+            m_devices.at(device_idx).metric_sampling_period_ns = 1000000; // 1 ms
 
             m_devices.at(device_idx).subdevice.metric_data.push_back({});
 
@@ -634,7 +634,7 @@ namespace geopm
                    m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
 
                    //Build metric map
-                   for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+                   for (unsigned int metric_idx = 0; metric_idx < num_metric; ++metric_idx)
                    {
 
                        std::vector<zet_metric_handle_t> metric_handle(num_metric);

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -764,7 +764,8 @@ namespace geopm
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,
-            4, // number of reports to notify on.
+            4, // number of reports to notify on.  Targeting 4 reports, 1 per millisecond as that will, generally, 
+                // fall within the 5ms control loop and is a good tradeoff in terms of overhead vs visibility within the sampling period.
             m_devices.at(l0_device_idx).metric_sampling_period_ns};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -153,6 +153,7 @@ namespace geopm
                                         __LINE__);
 
                         m_devices.push_back({
+                            m_levelzero_driver.at(driver),
                             device_handle.at(device_idx),
                             property,
                             num_subdevice, //if there are no subdevices leave this as 0
@@ -160,7 +161,6 @@ namespace geopm
                             {}, //subdevice
                             0, //num_device_power_domain
                             {}, //power domain
-                            context,
                         });
                     }
 #ifdef GEOPM_DEBUG
@@ -536,162 +536,188 @@ namespace geopm
         }
     }
     void LevelZeroImp::metric_group_cache(unsigned int device_idx) {
-        //assume false
-        m_devices.at(device_idx).metric_domain_cached = false;
+        for (int subdevice_idx = 0;
+         subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
+         ++subdevice_idx) {
+            //assume false
+            m_devices.at(device_idx).subdevice.metric_domain_cached.push_back(false);
+            m_devices.at(device_idx).subdevice.metrics_initialized.push_back(false);
 
-        char *zet_enable_metrics = getenv("ZET_ENABLE_METRICS");
-        if (zet_enable_metrics == NULL || strcmp(zet_enable_metrics, "1") != 0) {
+            char *zet_enable_metrics = getenv("ZET_ENABLE_METRICS");
+            if (zet_enable_metrics == NULL || strcmp(zet_enable_metrics, "1") != 0) {
 #ifdef GEOPM_DEBUG
-            std::cerr << "Warning: <geopm>: ZET_ENABLE_METRICS not set to 1.  Skipping metric caching" <<
-                         " for device " << std::to_string(device_idx) << std::endl;
+                std::cerr << "Warning: <geopm>: ZET_ENABLE_METRICS not set to 1.  Skipping metric caching" <<
+                             " for device " << std::to_string(device_idx) << " subdevice " <<
+                             std::to_srting(subdevice_idx) << std::endl;
 #endif
-        }
-        else {
-            ze_result_t ze_result;
+            }
+            else {
+                ze_result_t ze_result;
 
-            //Metric groups
-            uint32_t num_metric_group = 0;
-            ze_result = zetMetricGroupGet(m_devices.at(device_idx).device_handle,
-                                          &num_metric_group, nullptr);
+                // We create a context to support the ZET commands
+                ze_context_desc_t context_desc = {
+                   ZE_STRUCTURE_TYPE_CONTEXT_DESC,
+                   nullptr,
+                   0
+                };
+                ze_context_handle_t context = nullptr;
+                ze_result = zeContextCreate(m_devices.at(device_idx).driver,
+                                            &context_desc, &context);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero context creation failed",
+                                __LINE__);
 
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Group enumeration failed.",
-                             __LINE__);
+                m_devices.at(device_idx).subdevice.context.push_back(context);
 
-            std::vector<zet_metric_group_handle_t> metric_group_handle(num_metric_group);
+                //Metric groups
+                uint32_t num_metric_group = 0;
+                ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
+                                              &num_metric_group, nullptr);
 
-            //TODO: save the relevant per GPU pointers
-            ze_result = zetMetricGroupGet(m_devices.at(device_idx).device_handle,
-                                          &num_metric_group, metric_group_handle.data());
-
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Group handle acquisition failed",
-                            __LINE__);
-
-            //sampling period in nanoseconds
-            m_devices.at(device_idx).metric_sampling_period = 2000000; //2ms
-//            m_devices.at(device_idx).metric_sampling_period = 100000; //0.1ms
-
-
-            for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
-                 metric_group_idx++) {
-                 zet_metric_group_properties_t metric_group_properties;
-                 ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
-                                             &metric_group_properties);
-                 check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
-                                 "LevelZero::" + std::string(__func__) +
-                                 ": LevelZero Metric Group property acquisition failed",
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Metric Group enumeration failed.",
                                  __LINE__);
 
-                 //Confirm metric groups of interest exist
-                 if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
-                     && strcmp(metric_group_properties.name, "ComputeBasic") == 0) {
+                std::vector<zet_metric_group_handle_t> metric_group_handle(num_metric_group);
 
-                    //cache compute basic metric group
-                    m_devices.at(device_idx).metric_group_handle = metric_group_handle.at(metric_group_idx);
+                //TODO: save the relevant per GPU pointers
+                ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
+                                              &num_metric_group, metric_group_handle.data());
 
-                    // could likely use metric_group_properties.metricCount instead
-                    uint32_t num_metric = 0;
-                    ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
-                    check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                    "LevelZero::" + std::string(__func__) +
-                                    ": LevelZero Metric Count query failed",
-                                    __LINE__);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Metric Group handle acquisition failed",
+                                __LINE__);
 
-                    //Cache compute basic number of metrics
-                    m_devices.at(device_idx).num_metric = num_metric;
+                //sampling period in nanoseconds
+                m_devices.at(device_idx).metric_sampling_period = 2000000;
 
-                    //Build metric map
-                    for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
-                    {
+                m_devices.at(device_idx).subdevice.m_metric_data.push_back({});
 
-                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
-                                                 &num_metric, metric_handle.data());
+                for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
+                     metric_group_idx++) {
+                     zet_metric_group_properties_t metric_group_properties;
+                     ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
+                                                 &metric_group_properties);
+                     check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
+                                     "LevelZero::" + std::string(__func__) +
+                                     ": LevelZero Metric Group property acquisition failed",
+                                     __LINE__);
 
+                     //Confirm metric groups of interest exist
+                     if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
+                         && strcmp(metric_group_properties.name, "ComputeBasic") == 0) {
+
+                        //cache compute basic metric group
+                        m_devices.at(device_idx).subdevice.metric_group_handle.push_back(metric_group_handle.at(metric_group_idx));
+
+                        // could likely use metric_group_properties.metricCount instead
+                        uint32_t num_metric = 0;
+                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
                         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                                         "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric handle acquisition failed",
+                                        ": LevelZero Metric Count query failed",
                                         __LINE__);
-                        zet_metric_properties_t metric_properties;
-                        ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
-                        std::string metric_name (metric_properties.name);
 
-                        if(m_devices.at(device_idx).m_metric_data.count(metric_name) == 0) {
-                            m_devices.at(device_idx).m_metric_data[metric_name] = {};
+                        //Cache compute basic number of metrics
+                        //m_devices.at(device_idx).subdevice.num_metric.at(subdevice_idx) = num_metric;
+                        m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
+
+                        //Build metric map
+                        for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+                        {
+
+                            std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                            ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
+                                                     &num_metric, metric_handle.data());
+
+                            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                            "LevelZero::" + std::string(__func__) +
+                                            ": LevelZero Metric handle acquisition failed",
+                                            __LINE__);
+                            zet_metric_properties_t metric_properties;
+                            ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+                            std::string metric_name (metric_properties.name);
+
+                            if(m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) == 0) {
+                                m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
+                            }
                         }
                     }
                 }
+                m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
             }
-            m_devices.at(device_idx).metric_domain_cached = true;
         }
     }
 
     //TODO: need metric destory
-    void LevelZeroImp::metric_destroy(unsigned int l0_device_idx)
+    void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-//        //std::cout << "ZET_DESTROY - gpu " << std::to_string(l0_device_idx) << std::endl;
-        ze_result_t ze_result;
-
-        if (m_devices.at(l0_device_idx).metrics_initialized) {
-            m_devices.at(l0_device_idx).metrics_initialized = false;
-
-            // Close metric streamer
-            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).metric_streamer);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Streamer Close failed",
-                            __LINE__);
-
-            // Destroy Event
-            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).event);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Event Destroy failed",
-                            __LINE__);
-
-            // Destroy Event Pool
-            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).event_pool);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Event Pool Destroy failed",
-                            __LINE__);
-
-            // Deactivate the device context
-            ze_context_handle_t context = m_devices.at(l0_device_idx).context;
-            ze_result = zetContextActivateMetricGroups(context,
-                                                       m_devices.at(l0_device_idx).device_handle,
-                                                       0, nullptr);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Context Deactivation failed",
-                            __LINE__);
-        }
+////        //std::cout << "ZET_DESTROY - gpu " << std::to_string(l0_device_idx) << std::endl;
+//        ze_result_t ze_result;
+//
+//        if (m_devices.at(l0_device_idx).metrics_initialized) {
+//            m_devices.at(l0_device_idx).metrics_initialized = false;
+//
+//            // Close metric streamer
+//            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).metric_streamer);
+//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+//                            "LevelZero::" + std::string(__func__) +
+//                            ": LevelZero Metric Streamer Close failed",
+//                            __LINE__);
+//
+//            // Destroy Event
+//            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).event);
+//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+//                            "LevelZero::" + std::string(__func__) +
+//                            ": LevelZero Metric Event Destroy failed",
+//                            __LINE__);
+//
+//            // Destroy Event Pool
+//            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).event_pool);
+//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+//                            "LevelZero::" + std::string(__func__) +
+//                            ": LevelZero Metric Event Pool Destroy failed",
+//                            __LINE__);
+//
+//            // Deactivate the device context
+//            ze_context_handle_t context = m_devices.at(l0_device_idx).context;
+//            ze_result = zetContextActivateMetricGroups(context,
+//                                                       m_devices.at(l0_device_idx).device_handle,
+//                                                       0, nullptr);
+//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+//                            "LevelZero::" + std::string(__func__) +
+//                            ": LevelZero Metric Context Deactivation failed",
+//                            __LINE__);
+//        }
     }
 
 
-    void LevelZeroImp::metric_init(unsigned int l0_device_idx)
+    void LevelZeroImp::metric_init(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-//        //std::cout << "ZET_INIT - gpu " << std::to_string(l0_device_idx) << std::endl;
         ze_result_t ze_result;
-        ze_context_handle_t context = m_devices.at(l0_device_idx).context;
-        ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).device_handle,
-                                                   1, &m_devices.at(l0_device_idx).metric_group_handle);
+        ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
+        //ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).device_handle,
+        //                                           1, &m_devices.at(l0_device_idx).metric_group_handle);
+        ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
+                                                   1, &m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx));
 
         ze_event_pool_handle_t event_pool_handle = nullptr;
         ze_event_pool_desc_t event_pool_desc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC, nullptr, 0, 1};
 
         ze_result = zeEventPoolCreate(context, &event_pool_desc, 1,
-                                      &m_devices.at(l0_device_idx).device_handle,
+                                      //&m_devices.at(l0_device_idx).device_handle,
+                                      &m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
                                       &event_pool_handle);
 
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Event Pool Create failed",
                         __LINE__);
-        m_devices.at(l0_device_idx).event_pool = event_pool_handle;
+        //m_devices.at(l0_device_idx).event_pool = event_pool_handle;
+        m_devices.at(l0_device_idx).subdevice.event_pool.push_back(event_pool_handle);
 
         ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
                                       ZE_EVENT_SCOPE_FLAG_HOST, ZE_EVENT_SCOPE_FLAG_HOST};
@@ -703,7 +729,10 @@ namespace geopm
                         ": LevelZero Event Create failed",
                         __LINE__);
 
-        m_devices.at(l0_device_idx).event = event;
+        //m_devices.at(l0_device_idx).event = event;
+
+//        std::cout << "ZET_INIT - pushing back event for gpu " << std::to_string(l0_device_idx) << std::endl;
+        m_devices.at(l0_device_idx).subdevice.event.push_back(event);
 
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
@@ -712,17 +741,20 @@ namespace geopm
             m_devices.at(l0_device_idx).metric_sampling_period};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
 
-        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).device_handle, m_devices.at(l0_device_idx).metric_group_handle, &metric_streamer_desc, event, &metric_streamer);
+        //ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).device_handle, m_devices.at(l0_device_idx).metric_group_handle, &metric_streamer_desc, event, &metric_streamer);
+        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx), m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), &metric_streamer_desc, event, &metric_streamer);
 
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric Streamer Open failed",
                         __LINE__);
 
-        m_devices.at(l0_device_idx).metric_streamer = metric_streamer;
+        //m_devices.at(l0_device_idx).metric_streamer = metric_streamer;
+        m_devices.at(l0_device_idx).subdevice.metric_streamer.push_back(metric_streamer);
     }
 
-    void LevelZeroImp::metric_calc(unsigned int l0_device_idx, zet_metric_streamer_handle_t metric_streamer) const
+    void LevelZeroImp::metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
+                                   zet_metric_streamer_handle_t metric_streamer) const
     {
         ze_result_t ze_result;
         //////////////////////
@@ -732,7 +764,7 @@ namespace geopm
         std::chrono::duration<double> elapsed_seconds;
 
         size_t data_size = 0;
-        uint32_t report_count_req = 10;//UINT32_MAX; //100;
+        uint32_t report_count_req = 100;//UINT32_MAX; //100;
         ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr );
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
@@ -752,22 +784,24 @@ namespace geopm
         uint32_t num_metric_values = 0;
         uint32_t data_count = 0;
         zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
-        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
+        //ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
+        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
 
         end = std::chrono::system_clock::now();
         elapsed_seconds = end - start;
-        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " pre-calculate time: " << elapsed_seconds.count() << "s" << std::endl;
+//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " pre-calculate time: " << elapsed_seconds.count() << "s" << std::endl;
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric group calculate metric values to find num metrics failed",
                         __LINE__);
-        //std::cout << "\tNum metric values from calculate metric values: " << std::to_string(num_metric_values) << std::endl;
-        //std::cout << "\tNum data count from calculate metric values: " << std::to_string(data_count) << std::endl;
+//        std::cout << "\t\tNum metric values from calculate metric values: " << std::to_string(num_metric_values) << std::endl;
+//        std::cout << "\t\tNum data count from calculate metric values: " << std::to_string(data_count) << std::endl;
 
         start = std::chrono::system_clock::now();
         std::vector<uint32_t> metric_count(data_count);
         std::vector<zet_typed_value_t> metric_values(num_metric_values);
-        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
+        //ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
+        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
 //        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
 //                        "LevelZero::" + std::string(__func__) +
 //                        ": LevelZero Metric group calculate metric values to calculate data failed",
@@ -777,129 +811,147 @@ namespace geopm
 
         end = std::chrono::system_clock::now();
         elapsed_seconds = end - start;
-        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " calculate time: " << elapsed_seconds.count() << "s" << std::endl;
+//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " calculate time: " << elapsed_seconds.count() << "s" << std::endl;
 
-        uint32_t num_metric = m_devices.at(l0_device_idx).num_metric;
+        //uint32_t num_metric = m_devices.at(l0_device_idx).num_metric;
+        uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
         //unsigned int num_reports = num_metric_values/num_metric;
         //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " num reports: " << std::to_string(num_reports) <<
                   //std::endl;
 
         if (ze_result == ZE_RESULT_SUCCESS) {
-            uint32_t startIndex = 0;
             start = std::chrono::system_clock::now();
-            for (uint32_t data_index = 0; data_index < data_count; ++data_index) {
-    //            //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " data count: " << std::to_string(data_count) <<
-    //                      std::endl;
-                const uint32_t metricCountForDataIndex = metric_count[data_index];
-                const uint32_t reportCount = metricCountForDataIndex / num_metric;
-                for (uint32_t report = 0; report < reportCount; report++) {
-    //                //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " report count: " << std::to_string(reportCount) <<
-    //                          std::endl;
-                    for (uint32_t metric = 0; metric < num_metric; metric++) {
-    //                    //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric count: " << std::to_string(num_metric) <<
-    //                                std::endl;
 
-                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                        ze_result = zetMetricGet(m_devices.at(l0_device_idx).metric_group_handle,
-                                                 &num_metric, metric_handle.data());
-                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                        "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric handle acquisition failed",
-                                        __LINE__);
 
-                        // process metrics
-                        zet_metric_properties_t metric_properties;
-                        ze_result = zetMetricGetProperties(metric_handle.at(metric), &metric_properties);
-                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                        "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric property acquisition failed",
-                                        __LINE__);
+            unsigned int num_reports = num_metric_values / num_metric;
 
-                        std::string metric_name (metric_properties.name);
+            for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+            {
+                std::chrono::time_point<std::chrono::system_clock> start2, end2;
+                std::chrono::duration<double> elapsed_seconds;
+                start2 = std::chrono::system_clock::now();
+////
 
-                        if(metric_name.compare("XVE_ACTIVE") == 0 ||
-                           metric_name.compare("XVE_STALL") == 0) {
-                            double data_double = NAN;
-                            const size_t metricIndex = report * num_metric+ metric;
-                            zet_typed_value_t data = metric_values.at(startIndex + metricIndex);
-                            switch( data.type )
-                            {
-                            case ZET_VALUE_TYPE_UINT32:
-                                data_double = data.value.ui32;
-                                break;
-                            case ZET_VALUE_TYPE_UINT64:
-                                data_double = data.value.ui64;
-                                break;
-                            case ZET_VALUE_TYPE_FLOAT32:
-                                data_double = data.value.fp32;
-                                break;
-                            case ZET_VALUE_TYPE_FLOAT64:
-                                data_double = data.value.fp64;
-                                break;
-                            case ZET_VALUE_TYPE_BOOL8:
-                                data_double = data.value.ui32;
-                            default:
-                                break;
-                            };
 
-                            //Clear cached values
-                            if(report == 0) {
-                                m_devices.at(l0_device_idx).m_metric_data.at(metric_name) = {};
-                            }
-                            m_devices.at(l0_device_idx).m_metric_data.at(metric_name).push_back(data_double);
+                //TODO: It is possible that simply parsing all the metrics is
+                //      faster than the additional API calls to check the metric
+                //      name.  This should be studied
+                std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                ze_result = zetMetricGet(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx),
+                                         &num_metric, metric_handle.data());
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Metric handle acquisition failed",
+                                __LINE__);
+
+                // process metrics
+                zet_metric_properties_t metric_properties;
+                ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Metric property acquisition failed",
+                                __LINE__);
+
+                std::string metric_name (metric_properties.name);
+                end2 = std::chrono::system_clock::now();
+                elapsed_seconds = end2 - start2;
+                //std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " name find time: " << elapsed_seconds.count() << "s" << std::endl;
+
+                //TODO: check timing impact of only processing metrics supported by IOGroup
+                if(metric_name.compare("XVE_ACTIVE") == 0 ||
+                   metric_name.compare("XVE_STALL") == 0) {
+                    for (unsigned int report_idx = 0; report_idx < num_reports; report_idx++)
+                    {
+                        //This is the actual gathering of the data
+                        zet_typed_value_t data = metric_values.at(report_idx*num_metric + metric_idx);
+                        double data_double = NAN;
+                        switch( data.type )
+                        {
+                        case ZET_VALUE_TYPE_UINT32:
+                            data_double = data.value.ui32;
+                            break;
+                        case ZET_VALUE_TYPE_UINT64:
+                            data_double = data.value.ui64;
+                            break;
+                        case ZET_VALUE_TYPE_FLOAT32:
+                            data_double = data.value.fp32;
+                            break;
+                        case ZET_VALUE_TYPE_FLOAT64:
+                            data_double = data.value.fp64;
+                            break;
+                        case ZET_VALUE_TYPE_BOOL8:
+                            data_double = data.value.ui32;
+                            break;
+                        default:
+                            break;
+                        };
+                        //Clear cached values
+                        if(report_idx == 0) {
+                            //m_devices.at(l0_device_idx).m_metric_data.at(metric_name) = {};
+                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
                         }
+                        //m_devices.at(l0_device_idx).m_metric_data.at(metric_name).push_back(data_double);
+                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
                     }
                 }
-                startIndex += metricCountForDataIndex;
             }
         }
         else {
-            m_devices.at(l0_device_idx).m_metric_data.at("XVE_ACTIVE") = {};
-            m_devices.at(l0_device_idx).m_metric_data.at("XVE_STALL") = {};
+            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_ACTIVE") = {};
+            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_STALL") = {};
         }
         end = std::chrono::system_clock::now();
         elapsed_seconds = end - start;
-        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
+//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
     }
 
-    void LevelZeroImp::metric_read(unsigned int l0_device_idx)
+    void LevelZeroImp::metric_read(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-        if (m_devices.at(l0_device_idx).metric_domain_cached) {
-            if (!m_devices.at(l0_device_idx).metrics_initialized) {
-                metric_init(l0_device_idx);
-                m_devices.at(l0_device_idx).metrics_initialized = true;
+        if (m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
+            if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
+                std::chrono::time_point<std::chrono::system_clock> start, end;
+                std::chrono::duration<double> elapsed_seconds;
+                start = std::chrono::system_clock::now();
+
+                metric_init(l0_device_idx, l0_domain_idx);
+                m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
+
+                end = std::chrono::system_clock::now();
+                elapsed_seconds = end - start;
+//                std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_init time: " << elapsed_seconds.count() << "s" << std::endl;
             }
 
-            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).event, 0);
+            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).subdevice.event.at(l0_domain_idx), 0);
 
             if (ze_host_result != ZE_RESULT_NOT_READY) {
                 std::chrono::time_point<std::chrono::system_clock> start, end;
                 std::chrono::duration<double> elapsed_seconds;
                 start = std::chrono::system_clock::now();
 
-                metric_calc(l0_device_idx, m_devices.at(l0_device_idx).metric_streamer);
+                metric_calc(l0_device_idx, l0_domain_idx,
+                            m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
 
                 end = std::chrono::system_clock::now();
                 elapsed_seconds = end - start;
-                //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_calc time: " << elapsed_seconds.count() << "s" << std::endl;
+//                std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_calc time: " << elapsed_seconds.count() << "s" << std::endl;
             }
             else {
-                metric_read(l0_device_idx);
+                metric_read(l0_device_idx, l0_domain_idx); //TODO: possible infinite loop
             }
         }
     }
 
     std::vector<double> LevelZeroImp::metric_sample(unsigned int l0_device_idx,
+                                                    unsigned int l0_domain_idx,
                                                     std::string metric_name) const
     {
-//        //std::cout << "ZET_SAMPLE - gpu " << std::to_string(l0_device_idx) << std::endl;
         std::vector<double> result = {};
-        if(m_devices.at(l0_device_idx).m_metric_data.count(metric_name) == 0) {
+        if(m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).count(metric_name) == 0) {
             throw Exception("LevelZero::" + std::string(__func__) +
                             ": No metric named " + metric_name  + " found." ,
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        result = m_devices.at(l0_device_idx).m_metric_data.at(metric_name);
+        result = m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name);
         return result;
     }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -11,11 +11,19 @@
 #include <cstdlib>
 #include <utility>
 
+#include <chrono>
+
 #include "geopm/Exception.hpp"
 #include "geopm/Agg.hpp"
 #include "geopm/Helper.hpp"
 
 #include "LevelZeroImp.hpp"
+
+static void __attribute__((constructor)) geopm_levelzero_init(void)
+{
+    setenv("ZES_ENABLE_SYSMAN", "1", 1);
+    setenv("ZET_ENABLE_METRICS", "1", 1);
+}
 
 namespace geopm
 {
@@ -26,7 +34,8 @@ namespace geopm
         }
         return result;
     }
-    const LevelZero &levelzero()
+
+    LevelZero &levelzero()
     {
         static LevelZeroImp instance;
         return instance;
@@ -129,7 +138,20 @@ namespace geopm
                             m_num_gpu_subdevice += 1;
                         }
 
-                        //NOTE: We're only supporting Board GPUs to start with
+                        // We create a context to support the ZET commands
+                        ze_context_desc_t context_desc = {
+                           ZE_STRUCTURE_TYPE_CONTEXT_DESC,
+                           nullptr,
+                           0
+                        };
+                        ze_context_handle_t context = nullptr;
+                        ze_result_t ze_result = zeContextCreate(m_levelzero_driver.at(driver),
+                                                    &context_desc, &context);
+                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                        "LevelZero::" + std::string(__func__) +
+                                        ": LevelZero context creation failed",
+                                        __LINE__);
+
                         m_devices.push_back({
                             device_handle.at(device_idx),
                             property,
@@ -138,7 +160,7 @@ namespace geopm
                             {}, //subdevice
                             0, //num_device_power_domain
                             {}, //power domain
-                            0, // cached_energy_timestamp
+                            context,
                         });
                     }
 #ifdef GEOPM_DEBUG
@@ -199,6 +221,7 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
+            metric_group_cache(gpu_idx);
         }
     }
 
@@ -511,6 +534,373 @@ namespace geopm
                 }
             }
         }
+    }
+    void LevelZeroImp::metric_group_cache(unsigned int device_idx) {
+        //assume false
+        m_devices.at(device_idx).metric_domain_cached = false;
+
+        char *zet_enable_metrics = getenv("ZET_ENABLE_METRICS");
+        if (zet_enable_metrics == NULL || strcmp(zet_enable_metrics, "1") != 0) {
+#ifdef GEOPM_DEBUG
+            std::cerr << "Warning: <geopm>: ZET_ENABLE_METRICS not set to 1.  Skipping metric caching" <<
+                         " for device " << std::to_string(device_idx) << std::endl;
+#endif
+        }
+        else {
+            ze_result_t ze_result;
+
+            //Metric groups
+            uint32_t num_metric_group = 0;
+            ze_result = zetMetricGroupGet(m_devices.at(device_idx).device_handle,
+                                          &num_metric_group, nullptr);
+
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Group enumeration failed.",
+                             __LINE__);
+
+            std::vector<zet_metric_group_handle_t> metric_group_handle(num_metric_group);
+
+            //TODO: save the relevant per GPU pointers
+            ze_result = zetMetricGroupGet(m_devices.at(device_idx).device_handle,
+                                          &num_metric_group, metric_group_handle.data());
+
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Group handle acquisition failed",
+                            __LINE__);
+
+            //sampling period in nanoseconds
+            m_devices.at(device_idx).metric_sampling_period = 2000000; //2ms
+//            m_devices.at(device_idx).metric_sampling_period = 100000; //0.1ms
+
+
+            for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
+                 metric_group_idx++) {
+                 zet_metric_group_properties_t metric_group_properties;
+                 ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
+                                             &metric_group_properties);
+                 check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
+                                 "LevelZero::" + std::string(__func__) +
+                                 ": LevelZero Metric Group property acquisition failed",
+                                 __LINE__);
+
+                 //Confirm metric groups of interest exist
+                 if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
+                     && strcmp(metric_group_properties.name, "ComputeBasic") == 0) {
+
+                    //cache compute basic metric group
+                    m_devices.at(device_idx).metric_group_handle = metric_group_handle.at(metric_group_idx);
+
+                    // could likely use metric_group_properties.metricCount instead
+                    uint32_t num_metric = 0;
+                    ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
+                    check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                    "LevelZero::" + std::string(__func__) +
+                                    ": LevelZero Metric Count query failed",
+                                    __LINE__);
+
+                    //Cache compute basic number of metrics
+                    m_devices.at(device_idx).num_metric = num_metric;
+
+                    //Build metric map
+                    for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+                    {
+
+                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
+                                                 &num_metric, metric_handle.data());
+
+                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                        "LevelZero::" + std::string(__func__) +
+                                        ": LevelZero Metric handle acquisition failed",
+                                        __LINE__);
+                        zet_metric_properties_t metric_properties;
+                        ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+                        std::string metric_name (metric_properties.name);
+
+                        if(m_devices.at(device_idx).m_metric_data.count(metric_name) == 0) {
+                            m_devices.at(device_idx).m_metric_data[metric_name] = {};
+                        }
+                    }
+                }
+            }
+            m_devices.at(device_idx).metric_domain_cached = true;
+        }
+    }
+
+    //TODO: need metric destory
+    void LevelZeroImp::metric_destroy(unsigned int l0_device_idx)
+    {
+//        //std::cout << "ZET_DESTROY - gpu " << std::to_string(l0_device_idx) << std::endl;
+        ze_result_t ze_result;
+
+        if (m_devices.at(l0_device_idx).metrics_initialized) {
+            m_devices.at(l0_device_idx).metrics_initialized = false;
+
+            // Close metric streamer
+            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).metric_streamer);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Streamer Close failed",
+                            __LINE__);
+
+            // Destroy Event
+            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).event);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Event Destroy failed",
+                            __LINE__);
+
+            // Destroy Event Pool
+            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).event_pool);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Event Pool Destroy failed",
+                            __LINE__);
+
+            // Deactivate the device context
+            ze_context_handle_t context = m_devices.at(l0_device_idx).context;
+            ze_result = zetContextActivateMetricGroups(context,
+                                                       m_devices.at(l0_device_idx).device_handle,
+                                                       0, nullptr);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Context Deactivation failed",
+                            __LINE__);
+        }
+    }
+
+
+    void LevelZeroImp::metric_init(unsigned int l0_device_idx)
+    {
+//        //std::cout << "ZET_INIT - gpu " << std::to_string(l0_device_idx) << std::endl;
+        ze_result_t ze_result;
+        ze_context_handle_t context = m_devices.at(l0_device_idx).context;
+        ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).device_handle,
+                                                   1, &m_devices.at(l0_device_idx).metric_group_handle);
+
+        ze_event_pool_handle_t event_pool_handle = nullptr;
+        ze_event_pool_desc_t event_pool_desc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC, nullptr, 0, 1};
+
+        ze_result = zeEventPoolCreate(context, &event_pool_desc, 1,
+                                      &m_devices.at(l0_device_idx).device_handle,
+                                      &event_pool_handle);
+
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Event Pool Create failed",
+                        __LINE__);
+        m_devices.at(l0_device_idx).event_pool = event_pool_handle;
+
+        ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
+                                      ZE_EVENT_SCOPE_FLAG_HOST, ZE_EVENT_SCOPE_FLAG_HOST};
+
+        ze_event_handle_t event = nullptr;
+        ze_result = zeEventCreate(event_pool_handle, &event_desc, &event);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Event Create failed",
+                        __LINE__);
+
+        m_devices.at(l0_device_idx).event = event;
+
+        zet_metric_streamer_desc_t metric_streamer_desc = {
+            ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
+            nullptr,
+            32768, /* reports to collect before notify */
+            m_devices.at(l0_device_idx).metric_sampling_period};
+        zet_metric_streamer_handle_t metric_streamer = nullptr;
+
+        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).device_handle, m_devices.at(l0_device_idx).metric_group_handle, &metric_streamer_desc, event, &metric_streamer);
+
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Metric Streamer Open failed",
+                        __LINE__);
+
+        m_devices.at(l0_device_idx).metric_streamer = metric_streamer;
+    }
+
+    void LevelZeroImp::metric_calc(unsigned int l0_device_idx, zet_metric_streamer_handle_t metric_streamer) const
+    {
+        ze_result_t ze_result;
+        //////////////////////
+        // Convert Raw Data //
+        //////////////////////
+        std::chrono::time_point<std::chrono::system_clock> start, end;
+        std::chrono::duration<double> elapsed_seconds;
+
+        size_t data_size = 0;
+        uint32_t report_count_req = 10;//UINT32_MAX; //100;
+        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr );
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Read Data get size failed",
+                        __LINE__);
+
+        std::vector<uint8_t> data(data_size);
+        zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Read Data failed",
+                        __LINE__);
+
+        /////////////////////////////////////
+        // Calculate & convert metric data //
+        /////////////////////////////////////
+        uint32_t num_metric_values = 0;
+        uint32_t data_count = 0;
+        zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
+        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
+
+        end = std::chrono::system_clock::now();
+        elapsed_seconds = end - start;
+        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " pre-calculate time: " << elapsed_seconds.count() << "s" << std::endl;
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Metric group calculate metric values to find num metrics failed",
+                        __LINE__);
+        //std::cout << "\tNum metric values from calculate metric values: " << std::to_string(num_metric_values) << std::endl;
+        //std::cout << "\tNum data count from calculate metric values: " << std::to_string(data_count) << std::endl;
+
+        start = std::chrono::system_clock::now();
+        std::vector<uint32_t> metric_count(data_count);
+        std::vector<zet_typed_value_t> metric_values(num_metric_values);
+        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
+//        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+//                        "LevelZero::" + std::string(__func__) +
+//                        ": LevelZero Metric group calculate metric values to calculate data failed",
+//                        __LINE__);
+//        //std::cout << "\tmetric group calculate metric values: " << std::to_string(num_metric_values) << std::endl;
+//        ze_result = ZE_RESULT_ERROR_UNKNOWN;
+
+        end = std::chrono::system_clock::now();
+        elapsed_seconds = end - start;
+        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " calculate time: " << elapsed_seconds.count() << "s" << std::endl;
+
+        uint32_t num_metric = m_devices.at(l0_device_idx).num_metric;
+        //unsigned int num_reports = num_metric_values/num_metric;
+        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " num reports: " << std::to_string(num_reports) <<
+                  //std::endl;
+
+        if (ze_result == ZE_RESULT_SUCCESS) {
+            uint32_t startIndex = 0;
+            start = std::chrono::system_clock::now();
+            for (uint32_t data_index = 0; data_index < data_count; ++data_index) {
+    //            //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " data count: " << std::to_string(data_count) <<
+    //                      std::endl;
+                const uint32_t metricCountForDataIndex = metric_count[data_index];
+                const uint32_t reportCount = metricCountForDataIndex / num_metric;
+                for (uint32_t report = 0; report < reportCount; report++) {
+    //                //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " report count: " << std::to_string(reportCount) <<
+    //                          std::endl;
+                    for (uint32_t metric = 0; metric < num_metric; metric++) {
+    //                    //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric count: " << std::to_string(num_metric) <<
+    //                                std::endl;
+
+                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                        ze_result = zetMetricGet(m_devices.at(l0_device_idx).metric_group_handle,
+                                                 &num_metric, metric_handle.data());
+                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                        "LevelZero::" + std::string(__func__) +
+                                        ": LevelZero Metric handle acquisition failed",
+                                        __LINE__);
+
+                        // process metrics
+                        zet_metric_properties_t metric_properties;
+                        ze_result = zetMetricGetProperties(metric_handle.at(metric), &metric_properties);
+                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                        "LevelZero::" + std::string(__func__) +
+                                        ": LevelZero Metric property acquisition failed",
+                                        __LINE__);
+
+                        std::string metric_name (metric_properties.name);
+
+                        if(metric_name.compare("XVE_ACTIVE") == 0 ||
+                           metric_name.compare("XVE_STALL") == 0) {
+                            double data_double = NAN;
+                            const size_t metricIndex = report * num_metric+ metric;
+                            zet_typed_value_t data = metric_values.at(startIndex + metricIndex);
+                            switch( data.type )
+                            {
+                            case ZET_VALUE_TYPE_UINT32:
+                                data_double = data.value.ui32;
+                                break;
+                            case ZET_VALUE_TYPE_UINT64:
+                                data_double = data.value.ui64;
+                                break;
+                            case ZET_VALUE_TYPE_FLOAT32:
+                                data_double = data.value.fp32;
+                                break;
+                            case ZET_VALUE_TYPE_FLOAT64:
+                                data_double = data.value.fp64;
+                                break;
+                            case ZET_VALUE_TYPE_BOOL8:
+                                data_double = data.value.ui32;
+                            default:
+                                break;
+                            };
+
+                            //Clear cached values
+                            if(report == 0) {
+                                m_devices.at(l0_device_idx).m_metric_data.at(metric_name) = {};
+                            }
+                            m_devices.at(l0_device_idx).m_metric_data.at(metric_name).push_back(data_double);
+                        }
+                    }
+                }
+                startIndex += metricCountForDataIndex;
+            }
+        }
+        else {
+            m_devices.at(l0_device_idx).m_metric_data.at("XVE_ACTIVE") = {};
+            m_devices.at(l0_device_idx).m_metric_data.at("XVE_STALL") = {};
+        }
+        end = std::chrono::system_clock::now();
+        elapsed_seconds = end - start;
+        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
+    }
+
+    void LevelZeroImp::metric_read(unsigned int l0_device_idx)
+    {
+        if (m_devices.at(l0_device_idx).metric_domain_cached) {
+            if (!m_devices.at(l0_device_idx).metrics_initialized) {
+                metric_init(l0_device_idx);
+                m_devices.at(l0_device_idx).metrics_initialized = true;
+            }
+
+            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).event, 0);
+
+            if (ze_host_result != ZE_RESULT_NOT_READY) {
+                std::chrono::time_point<std::chrono::system_clock> start, end;
+                std::chrono::duration<double> elapsed_seconds;
+                start = std::chrono::system_clock::now();
+
+                metric_calc(l0_device_idx, m_devices.at(l0_device_idx).metric_streamer);
+
+                end = std::chrono::system_clock::now();
+                elapsed_seconds = end - start;
+                //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_calc time: " << elapsed_seconds.count() << "s" << std::endl;
+            }
+            else {
+                metric_read(l0_device_idx);
+            }
+        }
+    }
+
+    std::vector<double> LevelZeroImp::metric_sample(unsigned int l0_device_idx,
+                                                    std::string metric_name) const
+    {
+//        //std::cout << "ZET_SAMPLE - gpu " << std::to_string(l0_device_idx) << std::endl;
+        std::vector<double> result = {};
+        if(m_devices.at(l0_device_idx).m_metric_data.count(metric_name) == 0) {
+            throw Exception("LevelZero::" + std::string(__func__) +
+                            ": No metric named " + metric_name  + " found." ,
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        result = m_devices.at(l0_device_idx).m_metric_data.at(metric_name);
+        return result;
     }
 
     void LevelZeroImp::ras_domain_cache(unsigned int device_idx)
@@ -1076,6 +1466,26 @@ namespace geopm
         check_ze_result(zesPerformanceFactorSetConfig(handle, setting),
                         GEOPM_ERROR_RUNTIME, "LevelZero::" + std::string(__func__) +
                         ": Sysman failed to set performance factor values", __LINE__);
+    }
+
+    uint32_t LevelZeroImp::metric_update_rate(unsigned int l0_device_idx) const
+    {
+        return m_devices.at(l0_device_idx).metric_sampling_period;
+    }
+
+    void LevelZeroImp::metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting)
+    {
+        m_devices.at(l0_device_idx).metric_sampling_period = setting;
+    }
+
+    uint32_t LevelZeroImp::metric_update_rate(unsigned int l0_device_idx) const
+    {
+        return m_devices.at(l0_device_idx).metric_sampling_period;
+    }
+
+    void LevelZeroImp::metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting)
+    {
+        m_devices.at(l0_device_idx).metric_sampling_period = setting;
     }
 
     void LevelZeroImp::check_ze_result(ze_result_t ze_result, int error,

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
 #include "geopm_debug.hpp"
 
 #include "LevelZeroImp.hpp"

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -160,6 +160,7 @@ namespace geopm
                             {}, //subdevice
                             0, //num_device_power_domain
                             {}, //power domain
+                            0, // cached_energy_timestamp
                         });
                     }
 #ifdef GEOPM_DEBUG

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -667,7 +667,7 @@ namespace geopm
                        m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)[metric_name] = {};
                        m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
                    }
-                   // Break out of the metric group for loop once we've found the group of interest (ComputeBasic, time based sampling).  
+                   // Break out of the metric group for loop once we've found the group of interest (ComputeBasic, time based sampling).
                    break;
                 }
             }
@@ -781,7 +781,7 @@ namespace geopm
         // Allocate memory for future reads
         size_t data_size = 0;
         ze_result = zetMetricStreamerReadData(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx),
-                                              UINT32_MAX, &data_size, nullptr);
+                                              UINT32_MAX, &data_size, nullptr); //TODO: this value should match the report_count_req in metric_read
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Read Data get size failed",
@@ -937,14 +937,6 @@ namespace geopm
                                 "LevelZero::" + std::string(__func__) +
                                 ": LevelZero Read Data failed",
                                 __LINE__);
-
-                if (report_count_req != UINT32_MAX) {
-                    // Dump all other reports if we're not gathering them
-                    size_t temp_data_size = 0;
-                    ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, nullptr );
-                    std::vector<uint8_t>temp_data(temp_data_size);
-                    ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, temp_data.data());
-                }
 
                 metric_calc(l0_device_idx, l0_domain_idx,
                             m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -20,7 +20,7 @@
 static void __attribute__((constructor)) geopm_levelzero_init(void)
 {
     setenv("ZES_ENABLE_SYSMAN", "1", 1);
-    setenv("ZET_ENABLE_METRICS", "1", 1);
+//    setenv("ZET_ENABLE_METRICS", "1", 1);
 }
 
 namespace geopm
@@ -546,7 +546,7 @@ namespace geopm
 #ifdef GEOPM_DEBUG
                 std::cerr << "Warning: <geopm>: ZET_ENABLE_METRICS not set to 1.  Skipping metric caching" <<
                              " for device " << std::to_string(device_idx) << " subdevice " <<
-                             std::to_srting(subdevice_idx) << std::endl;
+                             std::to_string(subdevice_idx) << std::endl;
 #endif
             }
             else {
@@ -620,7 +620,6 @@ namespace geopm
                                         __LINE__);
 
                         //Cache compute basic number of metrics
-                        //m_devices.at(device_idx).subdevice.num_metric.at(subdevice_idx) = num_metric;
                         m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
 
                         //Build metric map
@@ -696,8 +695,6 @@ namespace geopm
     {
         ze_result_t ze_result;
         ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
-        //ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).device_handle,
-        //                                           1, &m_devices.at(l0_device_idx).metric_group_handle);
         ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
                                                    1, &m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx));
 
@@ -705,7 +702,6 @@ namespace geopm
         ze_event_pool_desc_t event_pool_desc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC, nullptr, 0, 1};
 
         ze_result = zeEventPoolCreate(context, &event_pool_desc, 1,
-                                      //&m_devices.at(l0_device_idx).device_handle,
                                       &m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
                                       &event_pool_handle);
 
@@ -713,7 +709,6 @@ namespace geopm
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Event Pool Create failed",
                         __LINE__);
-        //m_devices.at(l0_device_idx).event_pool = event_pool_handle;
         m_devices.at(l0_device_idx).subdevice.event_pool.push_back(event_pool_handle);
 
         ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
@@ -726,19 +721,15 @@ namespace geopm
                         ": LevelZero Event Create failed",
                         __LINE__);
 
-        //m_devices.at(l0_device_idx).event = event;
-
-//        std::cout << "ZET_INIT - pushing back event for gpu " << std::to_string(l0_device_idx) << std::endl;
         m_devices.at(l0_device_idx).subdevice.event.push_back(event);
 
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,
-            32768, /* reports to collect before notify */
+            32768,
             m_devices.at(l0_device_idx).metric_sampling_period};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
 
-        //ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).device_handle, m_devices.at(l0_device_idx).metric_group_handle, &metric_streamer_desc, event, &metric_streamer);
         ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx), m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), &metric_streamer_desc, event, &metric_streamer);
 
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
@@ -746,7 +737,6 @@ namespace geopm
                         ": LevelZero Metric Streamer Open failed",
                         __LINE__);
 
-        //m_devices.at(l0_device_idx).metric_streamer = metric_streamer;
         m_devices.at(l0_device_idx).subdevice.metric_streamer.push_back(metric_streamer);
     }
 
@@ -758,7 +748,7 @@ namespace geopm
         // Convert Raw Data //
         //////////////////////
         size_t data_size = 0;
-        uint32_t report_count_req = 100;//UINT32_MAX; //100;
+        uint32_t report_count_req = 100;
         ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr );
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
@@ -851,10 +841,8 @@ namespace geopm
                         };
                         //Clear cached values
                         if(report_idx == 0) {
-                            //m_devices.at(l0_device_idx).m_metric_data.at(metric_name) = {};
                             m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
                         }
-                        //m_devices.at(l0_device_idx).m_metric_data.at(metric_name).push_back(data_double);
                         m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
                     }
                 }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -14,13 +14,14 @@
 #include "geopm/Exception.hpp"
 #include "geopm/Agg.hpp"
 #include "geopm/Helper.hpp"
+#include "geopm_debug.hpp"
 
 #include "LevelZeroImp.hpp"
 
 static void __attribute__((constructor)) geopm_levelzero_init(void)
 {
     setenv("ZES_ENABLE_SYSMAN", "1", 1);
-//    setenv("ZET_ENABLE_METRICS", "1", 1);
+    setenv("ZET_ENABLE_METRICS", "1", 1);
 }
 
 namespace geopm
@@ -219,8 +220,16 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
-            if (gpu_idx < 1) {
-                metric_group_cache(gpu_idx);
+            metric_group_cache(gpu_idx);
+        }
+    }
+
+    LevelZeroImp::~LevelZeroImp() {
+        for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; gpu_idx++) {
+            for (int subdevice_idx = 0;
+             subdevice_idx < m_devices.at(gpu_idx).m_num_subdevice;
+             ++subdevice_idx) {
+                metric_destroy(gpu_idx, subdevice_idx);
             }
         }
     }
@@ -536,179 +545,172 @@ namespace geopm
         }
     }
 
+    //  Cache the following per gpu_idx:
+    //      - caching & initialization tracking variable
+    //      - L0 context
+    //      - metric group handle
+    //      - sampling period
+    //      - data storage for the ComputeBasics metric group
     void LevelZeroImp::metric_group_cache(unsigned int device_idx) {
         for (int subdevice_idx = 0;
-         subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
-         ++subdevice_idx) {
-            //assume false
+             subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
+             ++subdevice_idx) {
+            // Setup tracking of the caching and initilization steps
             m_devices.at(device_idx).subdevice.metric_domain_cached.push_back(false);
             m_devices.at(device_idx).subdevice.metrics_initialized.push_back(false);
 
-            char *zet_enable_metrics = getenv("ZET_ENABLE_METRICS");
-            if (zet_enable_metrics == NULL || strcmp(zet_enable_metrics, "1") != 0) {
-#ifdef GEOPM_DEBUG
-                std::cerr << "Warning: <geopm>: ZET_ENABLE_METRICS not set to 1.  Skipping metric caching" <<
-                             " for device " << std::to_string(device_idx) << " subdevice " <<
-                             std::to_string(subdevice_idx) << std::endl;
-#endif
-            }
-            else {
-                ze_result_t ze_result;
+            ze_result_t ze_result;
 
-                // We create a context to support the ZET commands
-                ze_context_desc_t context_desc = {
-                   ZE_STRUCTURE_TYPE_CONTEXT_DESC,
-                   nullptr,
-                   0
-                };
-                ze_context_handle_t context = nullptr;
-                ze_result = zeContextCreate(m_devices.at(device_idx).driver,
-                                            &context_desc, &context);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero context creation failed",
-                                __LINE__);
+            // We create a context to support the ZET commands
+            ze_context_desc_t context_desc = {
+               ZE_STRUCTURE_TYPE_CONTEXT_DESC,
+               nullptr,
+               0
+            };
+            ze_context_handle_t context = nullptr;
+            ze_result = zeContextCreate(m_devices.at(device_idx).driver,
+                                        &context_desc, &context);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero context creation failed",
+                            __LINE__);
 
-                m_devices.at(device_idx).subdevice.context.push_back(context);
+            m_devices.at(device_idx).subdevice.context.push_back(context);
 
-                //Metric groups
-                uint32_t num_metric_group = 0;
-                ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
-                                              &num_metric_group, nullptr);
+            //Metric groups
+            uint32_t num_metric_group = 0;
+            ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
+                                          &num_metric_group, nullptr);
 
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Metric Group enumeration failed.",
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Group enumeration failed.",
+                             __LINE__);
+
+            std::vector<zet_metric_group_handle_t> metric_group_handle(num_metric_group);
+            ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
+                                          &num_metric_group, metric_group_handle.data());
+
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Group handle acquisition failed",
+                            __LINE__);
+
+            // set metric_notifcation_event sampling period in nanoseconds
+            m_devices.at(device_idx).metric_sampling_period_ns =   1000000;
+
+            m_devices.at(device_idx).subdevice.m_metric_data.push_back({});
+
+            for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
+                 metric_group_idx++) {
+                 zet_metric_group_properties_t metric_group_properties;
+                 ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
+                                             &metric_group_properties);
+                 check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
+                                 "LevelZero::" + std::string(__func__) +
+                                 ": LevelZero Metric Group property acquisition failed",
                                  __LINE__);
 
-                std::vector<zet_metric_group_handle_t> metric_group_handle(num_metric_group);
+                 std::string metric_group_name (metric_group_properties.name);
 
-                //TODO: save the relevant per GPU pointers
-                ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
-                                              &num_metric_group, metric_group_handle.data());
+                 //Confirm metric groups of interest exist
+                 if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
+                     && metric_group_name == "ComputeBasic") {
 
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Metric Group handle acquisition failed",
-                                __LINE__);
+                    //cache compute basic metric group
+                    m_devices.at(device_idx).subdevice.metric_group_handle.push_back(metric_group_handle.at(metric_group_idx));
 
-                //sampling period in nanoseconds
-                //m_devices.at(device_idx).metric_sampling_period = 2000000;
-                m_devices.at(device_idx).metric_sampling_period =   1000000;
+                    // could likely use metric_group_properties.metricCount instead
+                    uint32_t num_metric = 0;
+                    ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
+                    check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                    "LevelZero::" + std::string(__func__) +
+                                    ": LevelZero Metric Count query failed",
+                                    __LINE__);
 
-                m_devices.at(device_idx).subdevice.m_metric_data.push_back({});
+                    //Cache compute basic number of metrics
+                    m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
 
-                for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
-                     metric_group_idx++) {
-                     zet_metric_group_properties_t metric_group_properties;
-                     ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
-                                                 &metric_group_properties);
-                     check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
-                                     "LevelZero::" + std::string(__func__) +
-                                     ": LevelZero Metric Group property acquisition failed",
-                                     __LINE__);
+                    //Build metric map
+                    for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+                    {
 
-                     //Confirm metric groups of interest exist
-                     if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
-                         && strcmp(metric_group_properties.name, "ComputeBasic") == 0) {
+                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
+                                                 &num_metric, metric_handle.data());
 
-                        //cache compute basic metric group
-                        m_devices.at(device_idx).subdevice.metric_group_handle.push_back(metric_group_handle.at(metric_group_idx));
-
-                        // could likely use metric_group_properties.metricCount instead
-                        uint32_t num_metric = 0;
-                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
                         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                                         "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric Count query failed",
+                                        ": LevelZero Metric handle acquisition failed",
+                                        __LINE__);
+                        zet_metric_properties_t metric_properties;
+                        ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+
+                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                        "LevelZero::" + std::string(__func__) +
+                                        ": LevelZero Metric Property acquisition failed",
                                         __LINE__);
 
-                        //Cache compute basic number of metrics
-                        m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
+                        std::string metric_name (metric_properties.name);
 
-                        //Build metric map
-                        for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
-                        {
-
-                            std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                            ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
-                                                     &num_metric, metric_handle.data());
-
-                            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                            "LevelZero::" + std::string(__func__) +
-                                            ": LevelZero Metric handle acquisition failed",
-                                            __LINE__);
-                            zet_metric_properties_t metric_properties;
-                            ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
-
-                            // TODO: confirm we get the metric name
-                            //check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            //                "LevelZero::" + std::string(__func__) +
-                            //                ": LevelZero Metric handle acquisition failed",
-                            //                __LINE__);
-                            std::string metric_name (metric_properties.name);
-
-                            //m_devices is a std::vector of structs, indexed by GPU
-                            // subdevice is a struct inside of it.  One per GPU
-                            //  m_metric_data is a vector, indexed by CHIP
-                            //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
-
-                            if(m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
-                                throw Exception("LevelZero::" + std::string(__func__) +
-                                                ": Metric group has two metrics with the same name",
-                                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-                            }
-                            m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
-                            m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
+                        //m_devices is a std::vector of structs, indexed by GPU
+                        // subdevice is a struct inside of it.  One per GPU
+                        //  m_metric_data is a vector, indexed by CHIP
+                        //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
+                        if (m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
+                            throw Exception("LevelZero::" + std::string(__func__) +
+                                            ": Metric group has two metrics with the same name",
+                                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                         }
-                        // Break out of loop once we've found the group of interest
-                        break;
+                        m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
+                        m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
                     }
+                    // Break out of loop once we've found the group of interest
+                    break;
                 }
-                m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
             }
+            m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
         }
     }
 
     void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-////        //std::cout << "ZET_DESTROY - gpu " << std::to_string(l0_device_idx) << std::endl;
-//        ze_result_t ze_result;
-//
-//        if (m_devices.at(l0_device_idx).metrics_initialized) {
-//            m_devices.at(l0_device_idx).metrics_initialized = false;
-//
-//            // Close metric streamer
-//            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).metric_streamer);
-//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-//                            "LevelZero::" + std::string(__func__) +
-//                            ": LevelZero Metric Streamer Close failed",
-//                            __LINE__);
-//
-//            // Destroy Event
-//            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).event);
-//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-//                            "LevelZero::" + std::string(__func__) +
-//                            ": LevelZero Metric Event Destroy failed",
-//                            __LINE__);
-//
-//            // Destroy Event Pool
-//            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).event_pool);
-//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-//                            "LevelZero::" + std::string(__func__) +
-//                            ": LevelZero Metric Event Pool Destroy failed",
-//                            __LINE__);
-//
-//            // Deactivate the device context
-//            ze_context_handle_t context = m_devices.at(l0_device_idx).context;
-//            ze_result = zetContextActivateMetricGroups(context,
-//                                                       m_devices.at(l0_device_idx).device_handle,
-//                                                       0, nullptr);
-//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-//                            "LevelZero::" + std::string(__func__) +
-//                            ": LevelZero Metric Context Deactivation failed",
-//                            __LINE__);
-//        }
+        ze_result_t ze_result;
+
+        if (m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
+            m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = false;
+
+            // Close metric streamer
+            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Streamer Close failed",
+                            __LINE__);
+
+            // Destroy metric_notifcation_event
+            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).subdevice.metric_notifcation_event.at(l0_domain_idx));
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Event Destroy failed",
+                            __LINE__);
+
+            // Destroy Event Pool
+            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).subdevice.event_pool.at(l0_domain_idx));
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Event Pool Destroy failed",
+                            __LINE__);
+
+            // Deactivate the device context
+            ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
+            ze_result = zetContextActivateMetricGroups(context,
+                                                       m_devices.at(l0_device_idx).device_handle,
+                                                       0, nullptr);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Context Deactivation failed",
+                            __LINE__);
+        }
     }
 
 
@@ -737,24 +739,24 @@ namespace geopm
         ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
                                       ZE_EVENT_SCOPE_FLAG_HOST, ZE_EVENT_SCOPE_FLAG_HOST};
 
-        ze_event_handle_t event = nullptr;
-        ze_result = zeEventCreate(event_pool_handle, &event_desc, &event);
+        ze_event_handle_t metric_notifcation_event = nullptr;
+        ze_result = zeEventCreate(event_pool_handle, &event_desc, &metric_notifcation_event);
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Event Create failed",
                         __LINE__);
 
         // TODO: nothing guarantees CHIP 0 was called first
-        m_devices.at(l0_device_idx).subdevice.event.push_back(event);
+        m_devices.at(l0_device_idx).subdevice.metric_notifcation_event.push_back(metric_notifcation_event);
 
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,
-            32768,
-            m_devices.at(l0_device_idx).metric_sampling_period};
+            4, // number of reports to notify on.
+            m_devices.at(l0_device_idx).metric_sampling_period_ns};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
 
-        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx), m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), &metric_streamer_desc, event, &metric_streamer);
+        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx), m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), &metric_streamer_desc, metric_notifcation_event, &metric_streamer);
 
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
@@ -767,49 +769,23 @@ namespace geopm
 
     // TODO don't pass metric_streamer
     void LevelZeroImp::metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
-                                   zet_metric_streamer_handle_t metric_streamer) const
+                                   size_t data_size, std::vector<uint8_t> data)
     {
-//        std::chrono::time_point<std::chrono::system_clock> start, end;
-//        std::chrono::duration<double> elapsed_seconds;
-//        start = std::chrono::system_clock::now();
+
+        GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) == true,
+                           "metric caching for GPU " + std::to_string(l0_device_idx) +
+                           ", CHIP " + std::to_string(l0_domain_idx) +
+                           " not completed prior to metric_calc call.");
+
+        GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) == true,
+                           "metric initialization for GPU " + std::to_string(l0_device_idx) +
+                           ", CHIP " + std::to_string(l0_domain_idx) +
+                           " not completed prior to metric_calc call.");
+
         ze_result_t ze_result;
-        //////////////////////
-        // Convert Raw Data //
-        //////////////////////
-        size_t data_size = 0;
-        uint32_t report_count_req = UINT32_MAX;//10;
-        //ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &data_size, nullptr);
-        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr);
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                        "LevelZero::" + std::string(__func__) +
-                        ": LevelZero Read Data get size failed",
-                        __LINE__);
-
-        std::vector<uint8_t> data(data_size);
-        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                        "LevelZero::" + std::string(__func__) +
-                        ": LevelZero Read Data failed",
-                        __LINE__);
-
-        // Dump all other reports
-//        size_t temp_data_size = 0;
-//        ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, nullptr );
-//        std::vector<uint8_t>temp_data(temp_data_size);
-//        ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, temp_data.data());
-
-//        end = std::chrono::system_clock::now();
-//        elapsed_seconds = end - start;
-//        std::cout << "MetricStreamerReadData Time: " <<
-//                     elapsed_seconds.count() << "s, report req is: " << std::to_string(report_count_req) <<
-//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
-//                     std::to_string(l0_domain_idx) << std::endl;
-
-
         /////////////////////////////////////
         // Calculate & convert metric data //
         /////////////////////////////////////
-//        start = std::chrono::system_clock::now();
         uint32_t num_metric_values = 0;
         zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
         ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &num_metric_values, nullptr);
@@ -824,90 +800,78 @@ namespace geopm
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric group calculate metric values to calculate data failed",
                         __LINE__);
-//        end = std::chrono::system_clock::now();
-//        elapsed_seconds = end - start;
-//        std::cout << "CalculateMetric Time: " <<
-//                     elapsed_seconds.count() << "s" <<
-//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
-//                     std::to_string(l0_domain_idx) << std::endl;
-        //std::cout << "\tmetric group calculate metric values: " << std::to_string(num_metric_values) << std::endl;
-        //ze_result = ZE_RESULT_ERROR_UNKNOWN;
 
-//        start = std::chrono::system_clock::now();
         uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
-        //if (ze_result == ZE_RESULT_SUCCESS) {
-            unsigned int num_reports = num_metric_values / num_metric;
+        unsigned int num_reports = num_metric_values / num_metric;
+        for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+        {
+            //TODO: It is possible that simply parsing all the metrics is
+            //      faster than the additional API calls to check the metric
+            //      name.  This should be studied
+            std::vector<zet_metric_handle_t> metric_handle(num_metric);
+            ze_result = zetMetricGet(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx),
+                                     &num_metric, metric_handle.data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric handle acquisition failed",
+                            __LINE__);
 
-            for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
-            {
-                //TODO: It is possible that simply parsing all the metrics is
-                //      faster than the additional API calls to check the metric
-                //      name.  This should be studied
-                std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                ze_result = zetMetricGet(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx),
-                                         &num_metric, metric_handle.data());
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Metric handle acquisition failed",
-                                __LINE__);
+            // process metrics
+            zet_metric_properties_t metric_properties;
+            ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric property acquisition failed",
+                            __LINE__);
 
-                // process metrics
-                zet_metric_properties_t metric_properties;
-                ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Metric property acquisition failed",
-                                __LINE__);
+            std::string metric_name (metric_properties.name);
 
-                std::string metric_name (metric_properties.name);
+            //TODO: check timing impact of only processing metrics supported by IOGroup
+            if (metric_name == "XVE_ACTIVE" ||
+                metric_name == "XVE_STALL") {
+                for (unsigned int report_idx = 0; report_idx < num_reports; report_idx++) {
+                    // Each report contains num_metric entries of data.  We need to access
+                    // this metric (metric_idx) from each report ( report_idx * num_metric)
+                    zet_typed_value_t data = metric_values.at(report_idx * num_metric + metric_idx);
+                    double data_double = metric_data_convert(data);
 
-                //TODO: check timing impact of only processing metrics supported by IOGroup
-                if(metric_name.compare("XVE_ACTIVE") == 0 ||
-                   metric_name.compare("XVE_STALL") == 0) {
-                    for (unsigned int report_idx = 0; report_idx < num_reports; report_idx++)
-                    {
-                        //This is the actual gathering of the data
-                        zet_typed_value_t data = metric_values.at(report_idx*num_metric + metric_idx);
-                        double data_double = NAN;
-                        switch( data.type )
-                        {
-                        case ZET_VALUE_TYPE_UINT32:
-                            data_double = data.value.ui32;
-                            break;
-                        case ZET_VALUE_TYPE_UINT64:
-                            data_double = data.value.ui64;
-                            break;
-                        case ZET_VALUE_TYPE_FLOAT32:
-                            data_double = data.value.fp32;
-                            break;
-                        case ZET_VALUE_TYPE_FLOAT64:
-                            data_double = data.value.fp64;
-                            break;
-                        case ZET_VALUE_TYPE_BOOL8:
-                            data_double = data.value.ui32;
-                            break;
-                        default:
-                            break;
-                        };
-                        //Clear cached values
-                        if(report_idx == 0) {
-                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
-                            //m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).clear();
-                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
-                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
-                        }
-                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
-                        if(report_idx == 1) {
-                        }
+                    if (report_idx == 0) {
+                        // Clear cached values
+                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
+                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
+
+                        // Update num_reports
+                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
                     }
+                    m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
                 }
             }
-//        end = std::chrono::system_clock::now();
-//        elapsed_seconds = end - start;
-//        std::cout << "Process Time: " <<
-//                     elapsed_seconds.count() << "s" <<
-//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
-//                     std::to_string(l0_domain_idx) << std::endl;
+        }
+    }
+
+    double LevelZeroImp::metric_data_convert(zet_typed_value_t data) const
+    {
+        double data_double = NAN;
+        switch(data.type) {
+        case ZET_VALUE_TYPE_UINT32:
+            data_double = data.value.ui32;
+            break;
+        case ZET_VALUE_TYPE_UINT64:
+            data_double = data.value.ui64;
+            break;
+        case ZET_VALUE_TYPE_FLOAT32:
+            data_double = data.value.fp32;
+            break;
+        case ZET_VALUE_TYPE_FLOAT64:
+            data_double = data.value.fp64;
+            break;
+        case ZET_VALUE_TYPE_BOOL8:
+            data_double = data.value.ui32;
+            break;
+        default:
+            break;
+        };
+        return data_double;
     }
 
     void LevelZeroImp::metric_read(unsigned int l0_device_idx, unsigned int l0_domain_idx)
@@ -918,11 +882,39 @@ namespace geopm
                 m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
             }
 
-            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).subdevice.event.at(l0_domain_idx), 0);
+            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).subdevice.metric_notifcation_event.at(l0_domain_idx), 0);
 
             if (ze_host_result != ZE_RESULT_NOT_READY) {
-                metric_calc(l0_device_idx, l0_domain_idx,
-                            m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
+                ze_result_t ze_result;
+                zet_metric_streamer_handle_t metric_streamer = m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
+
+                ///////////////////
+                // Read Raw Data //
+                ///////////////////
+                size_t data_size = 0;
+                uint32_t report_count_req = UINT32_MAX; //10; using UINT32_MAX is a temporary workaround
+                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Read Data get size failed",
+                                __LINE__);
+
+                std::vector<uint8_t> data(data_size);
+                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Read Data failed",
+                                __LINE__);
+
+                if (report_count_req != UINT32_MAX) {
+                    // Dump all other reports if we're not gathering them
+                    size_t temp_data_size = 0;
+                    ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, nullptr );
+                    std::vector<uint8_t>temp_data(temp_data_size);
+                    ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, temp_data.data());
+                }
+
+                metric_calc(l0_device_idx, l0_domain_idx, data_size, data);
             }
         }
     }
@@ -938,7 +930,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if(m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).count(metric_name) == 0) {
+        if (m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).count(metric_name) == 0) {
             throw Exception("LevelZero::" + std::string(__func__) +
                             ": No metric named " + metric_name  + " found." ,
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -1385,11 +1377,11 @@ namespace geopm
     {
         uint64_t timestamp = 0;
         //PACKAGE
-        if(geopm_domain == GEOPM_DOMAIN_GPU) {
+        if (geopm_domain == GEOPM_DOMAIN_GPU) {
             timestamp = m_devices.at(l0_device_idx).cached_energy_timestamp;
         }
         //TILE
-        else if(geopm_domain == GEOPM_DOMAIN_GPU_CHIP) {
+        else if (geopm_domain == GEOPM_DOMAIN_GPU_CHIP) {
             timestamp = m_devices.at(l0_device_idx).subdevice.cached_energy_timestamp.at(l0_domain_idx);
         }
         return timestamp;
@@ -1524,12 +1516,7 @@ namespace geopm
 
     uint32_t LevelZeroImp::metric_update_rate(unsigned int l0_device_idx) const
     {
-        return m_devices.at(l0_device_idx).metric_sampling_period;
-    }
-
-    void LevelZeroImp::metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting)
-    {
-        m_devices.at(l0_device_idx).metric_sampling_period = setting;
+        return m_devices.at(l0_device_idx).metric_sampling_period_ns;
     }
 
     void LevelZeroImp::check_ze_result(ze_result_t ze_result, int error,

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -777,6 +777,19 @@ namespace geopm
 
         // TODO: nothing guarantees CHIP 0 was called first
         m_devices.at(l0_device_idx).subdevice.metric_streamer.push_back(metric_streamer);
+
+        // Allocate memory for future reads
+        size_t data_size = 0;
+        ze_result = zetMetricStreamerReadData(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx),
+                                              UINT32_MAX, &data_size, nullptr);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Read Data get size failed",
+                        __LINE__);
+
+        std::vector<uint8_t> data(data_size);
+        m_devices.at(l0_device_idx).subdevice.zet_data_size.push_back(data_size);
+        m_devices.at(l0_device_idx).subdevice.zet_data.push_back(data);
     }
 
     // TODO don't pass metric_streamer
@@ -911,21 +924,15 @@ namespace geopm
 
             if (ze_host_result != ZE_RESULT_NOT_READY) {
                 ze_result_t ze_result;
+                uint32_t report_count_req = UINT32_MAX;
                 zet_metric_streamer_handle_t metric_streamer = m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
 
                 ///////////////////
                 // Read Raw Data //
                 ///////////////////
-                size_t data_size = 0;
-                uint32_t report_count_req = UINT32_MAX; //10; using UINT32_MAX is a temporary workaround
-                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Read Data get size failed",
-                                __LINE__);
-
-                std::vector<uint8_t> data(data_size);
-                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
+                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req,
+                                                      &m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
+                                                      m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data());
                 check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                                 "LevelZero::" + std::string(__func__) +
                                 ": LevelZero Read Data failed",
@@ -939,7 +946,9 @@ namespace geopm
                     ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, temp_data.data());
                 }
 
-                metric_calc(l0_device_idx, l0_domain_idx, data_size, data);
+                metric_calc(l0_device_idx, l0_domain_idx,
+                            m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
+                            m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx));
             }
         }
     }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -831,12 +831,12 @@ namespace geopm
         uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
         unsigned int num_reports = num_metric_values / num_metric;
 
-        // If num_metric_values is not evenly divisble by num_metrics
+        // If num_metric_values is not evenly divisible by num_metrics
         // skip the metric and report processing for this sample
         if (num_metric_values % num_metric != 0) {
 #ifdef GEOPM_DEBUG
             std::cerr << "LevelZero::" << std::string(__func__)  <<
-                         ": ZET metric_calc call retunred a number of metric values "
+                         ": ZET metric_calc call returned a number of metric values "
                          "that is not evenly divisible by the number of metrics.  This "
                          "may indicate a ZET report erroor, skipping data processing." << std::endl;
 #endif

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -667,7 +667,7 @@ namespace geopm
                        m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)[metric_name] = {};
                        m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
                    }
-                   // Break out of loop once we've found the group of interest
+                   // Break out of the metric group for loop once we've found the group of interest (ComputeBasic, time based sampling).  
                    break;
                 }
             }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -219,7 +219,9 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
-            metric_group_cache(gpu_idx);
+            if (gpu_idx < 1) {
+                metric_group_cache(gpu_idx);
+            }
         }
     }
 
@@ -533,6 +535,7 @@ namespace geopm
             }
         }
     }
+
     void LevelZeroImp::metric_group_cache(unsigned int device_idx) {
         for (int subdevice_idx = 0;
          subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
@@ -590,7 +593,8 @@ namespace geopm
                                 __LINE__);
 
                 //sampling period in nanoseconds
-                m_devices.at(device_idx).metric_sampling_period = 2000000;
+                //m_devices.at(device_idx).metric_sampling_period = 2000000;
+                m_devices.at(device_idx).metric_sampling_period =   1000000;
 
                 m_devices.at(device_idx).subdevice.m_metric_data.push_back({});
 
@@ -636,12 +640,29 @@ namespace geopm
                                             __LINE__);
                             zet_metric_properties_t metric_properties;
                             ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+
+                            // TODO: confirm we get the metric name
+                            //check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            //                "LevelZero::" + std::string(__func__) +
+                            //                ": LevelZero Metric handle acquisition failed",
+                            //                __LINE__);
                             std::string metric_name (metric_properties.name);
 
-                            if(m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) == 0) {
-                                m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
+                            //m_devices is a std::vector of structs, indexed by GPU
+                            // subdevice is a struct inside of it.  One per GPU
+                            //  m_metric_data is a vector, indexed by CHIP
+                            //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
+
+                            if(m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
+                                throw Exception("LevelZero::" + std::string(__func__) +
+                                                ": Metric group has two metrics with the same name",
+                                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                             }
+                            m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
+                            m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
                         }
+                        // Break out of loop once we've found the group of interest
+                        break;
                     }
                 }
                 m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
@@ -709,6 +730,8 @@ namespace geopm
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Event Pool Create failed",
                         __LINE__);
+
+        // TODO: nothing guarantees CHIP 0 was called first
         m_devices.at(l0_device_idx).subdevice.event_pool.push_back(event_pool_handle);
 
         ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
@@ -721,6 +744,7 @@ namespace geopm
                         ": LevelZero Event Create failed",
                         __LINE__);
 
+        // TODO: nothing guarantees CHIP 0 was called first
         m_devices.at(l0_device_idx).subdevice.event.push_back(event);
 
         zet_metric_streamer_desc_t metric_streamer_desc = {
@@ -737,55 +761,81 @@ namespace geopm
                         ": LevelZero Metric Streamer Open failed",
                         __LINE__);
 
+        // TODO: nothing guarantees CHIP 0 was called first
         m_devices.at(l0_device_idx).subdevice.metric_streamer.push_back(metric_streamer);
     }
 
+    // TODO don't pass metric_streamer
     void LevelZeroImp::metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
                                    zet_metric_streamer_handle_t metric_streamer) const
     {
+//        std::chrono::time_point<std::chrono::system_clock> start, end;
+//        std::chrono::duration<double> elapsed_seconds;
+//        start = std::chrono::system_clock::now();
         ze_result_t ze_result;
         //////////////////////
         // Convert Raw Data //
         //////////////////////
         size_t data_size = 0;
-        uint32_t report_count_req = 100;
-        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr );
+        uint32_t report_count_req = UINT32_MAX;//10;
+        //ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &data_size, nullptr);
+        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr);
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Read Data get size failed",
                         __LINE__);
 
         std::vector<uint8_t> data(data_size);
-        zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
+        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Read Data failed",
                         __LINE__);
 
+        // Dump all other reports
+//        size_t temp_data_size = 0;
+//        ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, nullptr );
+//        std::vector<uint8_t>temp_data(temp_data_size);
+//        ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, temp_data.data());
+
+//        end = std::chrono::system_clock::now();
+//        elapsed_seconds = end - start;
+//        std::cout << "MetricStreamerReadData Time: " <<
+//                     elapsed_seconds.count() << "s, report req is: " << std::to_string(report_count_req) <<
+//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
+//                     std::to_string(l0_domain_idx) << std::endl;
+
+
         /////////////////////////////////////
         // Calculate & convert metric data //
         /////////////////////////////////////
+//        start = std::chrono::system_clock::now();
         uint32_t num_metric_values = 0;
-        uint32_t data_count = 0;
         zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
-        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
+        ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &num_metric_values, nullptr);
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric group calculate metric values to find num metrics failed",
                         __LINE__);
 
-        std::vector<uint32_t> metric_count(data_count);
         std::vector<zet_typed_value_t> metric_values(num_metric_values);
-        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
-//        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-//                        "LevelZero::" + std::string(__func__) +
-//                        ": LevelZero Metric group calculate metric values to calculate data failed",
-//                        __LINE__);
-//        //std::cout << "\tmetric group calculate metric values: " << std::to_string(num_metric_values) << std::endl;
-//        ze_result = ZE_RESULT_ERROR_UNKNOWN;
+        ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &num_metric_values, metric_values.data());
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Metric group calculate metric values to calculate data failed",
+                        __LINE__);
+//        end = std::chrono::system_clock::now();
+//        elapsed_seconds = end - start;
+//        std::cout << "CalculateMetric Time: " <<
+//                     elapsed_seconds.count() << "s" <<
+//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
+//                     std::to_string(l0_domain_idx) << std::endl;
+        //std::cout << "\tmetric group calculate metric values: " << std::to_string(num_metric_values) << std::endl;
+        //ze_result = ZE_RESULT_ERROR_UNKNOWN;
 
+//        start = std::chrono::system_clock::now();
         uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
-        if (ze_result == ZE_RESULT_SUCCESS) {
+        //if (ze_result == ZE_RESULT_SUCCESS) {
             unsigned int num_reports = num_metric_values / num_metric;
 
             for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
@@ -842,16 +892,22 @@ namespace geopm
                         //Clear cached values
                         if(report_idx == 0) {
                             m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
+                            //m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).clear();
+                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
+                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
                         }
                         m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
+                        if(report_idx == 1) {
+                        }
                     }
                 }
             }
-        }
-        else {
-            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_ACTIVE") = {};
-            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_STALL") = {};
-        }
+//        end = std::chrono::system_clock::now();
+//        elapsed_seconds = end - start;
+//        std::cout << "Process Time: " <<
+//                     elapsed_seconds.count() << "s" <<
+//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
+//                     std::to_string(l0_domain_idx) << std::endl;
     }
 
     void LevelZeroImp::metric_read(unsigned int l0_device_idx, unsigned int l0_domain_idx)
@@ -867,9 +923,6 @@ namespace geopm
             if (ze_host_result != ZE_RESULT_NOT_READY) {
                 metric_calc(l0_device_idx, l0_domain_idx,
                             m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
-            }
-            else {
-                metric_read(l0_device_idx, l0_domain_idx); //TODO: possible infinite loop
             }
         }
     }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -4,7 +4,6 @@
  */
 
 
-#include <unistd.h>
 #include <string>
 #include <iostream>
 #include <map>
@@ -12,8 +11,6 @@
 #include <utility>
 
 #include "geopm/Exception.hpp"
-#include "geopm/Agg.hpp"
-#include "geopm/Helper.hpp"
 #include "geopm_debug.hpp"
 
 #include "LevelZeroImp.hpp"
@@ -138,18 +135,22 @@ namespace geopm
                         }
 
                         // We create a context to support the ZET commands
-                        ze_context_desc_t context_desc = {
-                           ZE_STRUCTURE_TYPE_CONTEXT_DESC,
-                           nullptr,
-                           0
-                        };
-                        ze_context_handle_t context = nullptr;
-                        ze_result_t ze_result = zeContextCreate(m_levelzero_driver.at(driver),
-                                                    &context_desc, &context);
-                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                        "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero context creation failed",
-                                        __LINE__);
+                        // NOTE: a context is being created per subdevice, making this context
+                        // unnecessary. Commenting out for now.
+                        // TODO: Explore replacing per-subdevice contexts with a single context
+                        // (per-device or globally)
+                        // ze_context_desc_t context_desc = {
+                        //    ZE_STRUCTURE_TYPE_CONTEXT_DESC,
+                        //    nullptr,
+                        //    0
+                        // };
+                        // ze_context_handle_t context = nullptr;
+                        // ze_result_t ze_result = zeContextCreate(m_levelzero_driver.at(driver),
+                        //                             &context_desc, &context);
+                        // check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        //                 "LevelZero::" + std::string(__func__) +
+                        //                 ": LevelZero context creation failed",
+                        //                 __LINE__);
 
                         m_devices.push_back({
                             m_levelzero_driver.at(driver),
@@ -724,6 +725,7 @@ namespace geopm
                             "LevelZero::" + std::string(__func__) +
                             ": LevelZero Metric Context Deactivation failed",
                             __LINE__);
+            zeContextDestroy(context);
         }
     }
 
@@ -766,7 +768,7 @@ namespace geopm
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,
-            4, // number of reports to notify on.  Targeting 4 reports, 1 per millisecond as that will, generally, 
+            4, // number of reports to notify on.  Targeting 4 reports, 1 per millisecond as that will, generally,
                 // fall within the 5ms control loop and is a good tradeoff in terms of overhead vs visibility within the sampling period.
             m_devices.at(l0_device_idx).metric_sampling_period_ns};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
@@ -971,7 +973,7 @@ namespace geopm
     void LevelZeroImp::ras_domain_cache(unsigned int device_idx)
     {
         uint32_t ras_handle_count = 0;
-        uint32_t num_subdevice = m_devices.at(device_idx).m_num_subdevice;
+        uint32_t num_subdevice = m_devices.at(device_idx).num_subdevice;
         // Find number of RAS error sets for the GPU
         uint32_t num_errset = 0;
         ze_result_t ze_result = zesDeviceEnumRasErrorSets(m_devices.at(device_idx).device_handle,
@@ -991,8 +993,8 @@ namespace geopm
                             GEOPM_ERROR_RUNTIME, "LevelZero::" + std::string(__func__) +
                             ": Sysman failed to get errorset handle(s).", __LINE__);
 
-	    // Note: RAS domain errorset handles are being stored in a 2D vector with
-	    //       dimensions := (number of subdevices) x (number of RAS error types)
+	        // Note: RAS domain errorset handles are being stored in a 2D vector with
+	        //       dimensions := (number of subdevices) x (number of RAS error types)
 
             // Allocate size for a 2D vector to store all the RAS domain handles for errorsets:
             //       m_num_subdevice = number of subdevices on specific GPU device

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -201,7 +201,7 @@ namespace geopm
             // If we have more than one device confirm all devices have the same
             // number of subdevices
             for (unsigned int idx = 1; idx < m_devices.size(); ++idx) {
-                if (m_devices.at(idx).m_num_subdevice != m_devices.at(idx - 1).m_num_subdevice) {
+                if (m_devices.at(idx).num_subdevice != m_devices.at(idx - 1).num_subdevice) {
                     throw Exception("LevelZero::" + std::string(__func__) +
                                     ": GEOPM Requires the number of subdevices to be" +
                                     " the same on all devices. " +
@@ -227,7 +227,7 @@ namespace geopm
     LevelZeroImp::~LevelZeroImp() {
         for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; gpu_idx++) {
             for (int subdevice_idx = 0;
-             subdevice_idx < m_devices.at(gpu_idx).m_num_subdevice;
+             subdevice_idx < m_devices.at(gpu_idx).num_subdevice;
              ++subdevice_idx) {
                 metric_destroy(gpu_idx, subdevice_idx);
             }
@@ -265,7 +265,7 @@ namespace geopm
                                 GEOPM_ERROR_RUNTIME, "LevelZero::" + std::string(__func__) +
                                 ": Sysman failed to get domain properties.", __LINE__);
 
-                if (property.onSubdevice == 0 && m_devices.at(device_idx).m_num_subdevice != 0) {
+                if (property.onSubdevice == 0 && m_devices.at(device_idx).num_subdevice != 0) {
 #ifdef GEOPM_DEBUG
                     std::cerr << "Warning: <geopm> LevelZero: A device level "
                               << "frequency domain was found but is not currently supported.\n";
@@ -341,12 +341,12 @@ namespace geopm
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
 
-            if (num_subdevice_power_domain > m_devices.at(device_idx).m_num_subdevice) {
+            if (num_subdevice_power_domain > m_devices.at(device_idx).num_subdevice) {
                 throw Exception("LevelZero::" + std::string(__func__) +
                                 ": Number of subdevice power domains (" +
                                 std::to_string(num_device_power_domain) +
                                 ") exceeds the number of subdevices (" +
-                                std::to_string(m_devices.at(device_idx).m_num_subdevice) + ").",
+                                std::to_string(m_devices.at(device_idx).num_subdevice) + ").",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
 
@@ -440,7 +440,7 @@ namespace geopm
                                 GEOPM_ERROR_RUNTIME, "LevelZero::" + std::string(__func__) +
                                 ": Sysman failed to get domain engine properties", __LINE__);
 
-                if (property.onSubdevice == 0 && m_devices.at(device_idx).m_num_subdevice != 0) {
+                if (property.onSubdevice == 0 && m_devices.at(device_idx).num_subdevice != 0) {
 #ifdef GEOPM_DEBUG
                     std::cerr << "Warning: <geopm> LevelZero: A device level "
                               << "engine domain was found but is not currently supported.\n";
@@ -553,7 +553,7 @@ namespace geopm
     //      - data storage for the ComputeBasics metric group
     void LevelZeroImp::metric_group_init(unsigned int device_idx) {
         for (int subdevice_idx = 0;
-             subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
+             subdevice_idx < m_devices.at(device_idx).num_subdevice;
              ++subdevice_idx) {
             // Setup tracking of the caching and initialization steps
             m_devices.at(device_idx).subdevice.metric_domain_cached.push_back(false);
@@ -599,7 +599,7 @@ namespace geopm
             // set metric_notifcation_event sampling period in nanoseconds
             m_devices.at(device_idx).metric_sampling_period_ns =   1000000;
 
-            m_devices.at(device_idx).subdevice.m_metric_data.push_back({});
+            m_devices.at(device_idx).subdevice.metric_data.push_back({});
 
             for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
                  metric_group_idx++) {
@@ -657,15 +657,15 @@ namespace geopm
 
                        //m_devices is a std::vector of structs, indexed by GPU
                        // subdevice is a struct inside of it.  One per GPU
-                       //  m_metric_data is a vector, indexed by CHIP
+                       //  metric_data is a vector, indexed by CHIP
                        //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
-                       if (m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
+                       if (m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx).count(metric_name) != 0) {
                            throw Exception("LevelZero::" + std::string(__func__) +
                                            ": Metric group has two metrics with the same name",
                                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                        }
-                       m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
-                       m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
+                       m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)[metric_name] = {};
+                       m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
                    }
                    // Break out of loop once we've found the group of interest
                    break;
@@ -680,12 +680,12 @@ namespace geopm
         GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) == true,
                            "metric caching for GPU " + std::to_string(l0_device_idx) +
                            ", CHIP " + std::to_string(l0_domain_idx) +
-                           " not completed prior to metric_calc call.");
+                           " not completed prior to metric_destroy call.");
 
         GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) == true,
                            "metric initialization for GPU " + std::to_string(l0_device_idx) +
                            ", CHIP " + std::to_string(l0_domain_idx) +
-                           " not completed prior to metric_calc call.");
+                           " not completed prior to metric_destroy call.");
 
         ze_result_t ze_result;
 
@@ -815,6 +815,19 @@ namespace geopm
 
         uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
         unsigned int num_reports = num_metric_values / num_metric;
+
+        // If num_metric_values is not evenly divisble by num_metrics
+        // skip the metric and report processing for this sample
+        if (num_metric_values % num_metric != 0) {
+#ifdef GEOPM_DEBUG
+            std::cerr << "LevelZero::" << std::string(__func__)  <<
+                         ": ZET metric_calc call retunred a number of metric values "
+                         "that is not evenly divisible by the number of metrics.  This "
+                         "may indicate a ZET report erroor, skipping data processing." << std::endl;
+#endif
+            num_metric = 0;
+        }
+
         for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
         {
             //TODO: It is possible that simply parsing all the metrics is
@@ -849,13 +862,13 @@ namespace geopm
 
                     if (report_idx == 0) {
                         // Clear cached values
-                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
-                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
+                        m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name) = {};
+                        m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
 
                         // Update num_reports
-                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
+                        m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
                     }
-                    m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
+                    m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
                 }
             }
         }
@@ -942,12 +955,12 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).count(metric_name) == 0) {
+        if (m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).count(metric_name) == 0) {
             throw Exception("LevelZero::" + std::string(__func__) +
                             ": No metric named " + metric_name  + " found." ,
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        result = m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name);
+        result = m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name);
         return result;
     }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -161,6 +161,7 @@ namespace geopm
                             0, //num_device_power_domain
                             {}, //power domain
                             0, // cached_energy_timestamp
+                            0, // metric_sampling_period_ns
                         });
                     }
 #ifdef GEOPM_DEBUG
@@ -227,7 +228,7 @@ namespace geopm
 
     LevelZeroImp::~LevelZeroImp() {
         for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
-            for (int subdevice_idx = 0;
+            for (unsigned int subdevice_idx = 0;
              subdevice_idx < m_devices.at(gpu_idx).num_subdevice;
              ++subdevice_idx) {
                 metric_destroy(gpu_idx, subdevice_idx);
@@ -553,7 +554,7 @@ namespace geopm
     //      - sampling period
     //      - data storage for the ComputeBasics metric group
     void LevelZeroImp::metric_group_init(unsigned int device_idx) {
-        for (int subdevice_idx = 0;
+        for (unsigned int subdevice_idx = 0;
              subdevice_idx < m_devices.at(device_idx).num_subdevice;
              ++subdevice_idx) {
             // Setup tracking of the caching and initialization steps
@@ -1534,17 +1535,12 @@ namespace geopm
 
     uint32_t LevelZeroImp::metric_update_rate(unsigned int l0_device_idx) const
     {
-        return m_devices.at(l0_device_idx).metric_sampling_period;
+        return m_devices.at(l0_device_idx).metric_sampling_period_ns;
     }
 
     void LevelZeroImp::metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting)
     {
-        m_devices.at(l0_device_idx).metric_sampling_period = setting;
-    }
-
-    uint32_t LevelZeroImp::metric_update_rate(unsigned int l0_device_idx) const
-    {
-        return m_devices.at(l0_device_idx).metric_sampling_period_ns;
+        m_devices.at(l0_device_idx).metric_sampling_period_ns = setting;
     }
 
     void LevelZeroImp::check_ze_result(ze_result_t ze_result, int error,

--- a/libgeopmd/src/LevelZero.hpp
+++ b/libgeopmd/src/LevelZero.hpp
@@ -358,6 +358,7 @@ namespace geopm
                                                       unsigned int l0_domain_idx,
                                                       std::string metric_name) const = 0;
             virtual uint32_t metric_update_rate(unsigned int l0_device_idx) const = 0;
+            virtual void metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting) = 0;
 
             virtual void metric_read(unsigned int l0_device_idx,
                                      unsigned int l0_domain_idx) = 0;

--- a/libgeopmd/src/LevelZero.hpp
+++ b/libgeopmd/src/LevelZero.hpp
@@ -355,11 +355,16 @@ namespace geopm
 
             //Level Zero Tools/ZET
             virtual std::vector<double> metric_sample(unsigned int l0_device_idx,
+                                                      unsigned int l0_domain_idx,
                                                       std::string metric_name) const = 0;
             virtual uint32_t metric_update_rate(unsigned int l0_device_idx) const = 0;
-            virtual void metric_read(unsigned int l0_device_idx) = 0;
-            virtual void metric_init(unsigned int l0_device_idx) = 0;
-            virtual void metric_destroy(unsigned int l0_device_idx) = 0;
+
+            virtual void metric_read(unsigned int l0_device_idx,
+                                     unsigned int l0_domain_idx) = 0;
+            virtual void metric_init(unsigned int l0_device_idx,
+                                     unsigned int l0_domain_idx) = 0;
+            virtual void metric_destroy(unsigned int l0_device_idx,
+                                        unsigned int l0_domain_idx) = 0;
             virtual void metric_update_rate_control(unsigned int l0_device_idx,
                                                     uint32_t setting) = 0;
     };

--- a/libgeopmd/src/LevelZero.hpp
+++ b/libgeopmd/src/LevelZero.hpp
@@ -361,12 +361,6 @@ namespace geopm
 
             virtual void metric_read(unsigned int l0_device_idx,
                                      unsigned int l0_domain_idx) = 0;
-            virtual void metric_init(unsigned int l0_device_idx,
-                                     unsigned int l0_domain_idx) = 0;
-            virtual void metric_destroy(unsigned int l0_device_idx,
-                                        unsigned int l0_domain_idx) = 0;
-            virtual void metric_update_rate_control(unsigned int l0_device_idx,
-                                                    uint32_t setting) = 0;
     };
 
     LevelZero &levelzero();

--- a/libgeopmd/src/LevelZero.hpp
+++ b/libgeopmd/src/LevelZero.hpp
@@ -352,8 +352,18 @@ namespace geopm
             /// @return Display Error Count
             virtual double ras_display_errcount_uncorrectable(unsigned int l0_device_idx,
                                                 int l0_domain, int l0_domain_idx) const = 0;
+
+            //Level Zero Tools/ZET
+            virtual std::vector<double> metric_sample(unsigned int l0_device_idx,
+                                                      std::string metric_name) const = 0;
+            virtual uint32_t metric_update_rate(unsigned int l0_device_idx) const = 0;
+            virtual void metric_read(unsigned int l0_device_idx) = 0;
+            virtual void metric_init(unsigned int l0_device_idx) = 0;
+            virtual void metric_destroy(unsigned int l0_device_idx) = 0;
+            virtual void metric_update_rate_control(unsigned int l0_device_idx,
+                                                    uint32_t setting) = 0;
     };
 
-    const LevelZero &levelzero();
+    LevelZero &levelzero();
 }
 #endif

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -813,37 +813,44 @@ namespace geopm
     //TODO: consider adding 'group_name' parameter?
     void LevelZeroDevicePoolImp::metric_read(int domain, unsigned int domain_idx) const
     {
-        if (domain != GEOPM_DOMAIN_GPU) {
+        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
             throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
                             ": domain " + std::to_string(domain) +
                             " is not supported for metrics.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::chrono::time_point<std::chrono::system_clock> start, end;
-        start = std::chrono::system_clock::now();
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        m_levelzero.metric_read(domain_idx);
+//        std::chrono::time_point<std::chrono::system_clock> start, end;
+//        start = std::chrono::system_clock::now();
 
-        end = std::chrono::system_clock::now();
-        std::chrono::duration<double> elapsed_seconds = end - start;
-        std::cout << "metric_read - gpu " << std::to_string(domain_idx) << " read time: " << elapsed_seconds.count() << "s" << std::endl;
+        m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
+
+//        end = std::chrono::system_clock::now();
+//        std::chrono::duration<double> elapsed_seconds = end - start;
+//        std::cout << "metric_read - gpu " << std::to_string(domain_idx) << " read time: " << elapsed_seconds.count() << "s" << std::endl;
     }
 
     double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
                                                  std::string metric_name) const
     {
         double result = NAN;
-        if (domain != GEOPM_DOMAIN_GPU) {
+        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
             throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
                             ": domain " + std::to_string(domain) +
                             " is not supported for metrics.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
         //std::chrono::time_point<std::chrono::system_clock> start, end;
 
-        std::vector<double> data = m_levelzero.metric_sample(domain_idx, metric_name);
+        std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
+                                                             dev_subdev_idx_pair.second,
+                                                             metric_name);
 
         //std::cout << "Data size is: " << std::to_string(data.size()) << std::endl;
         //start = std::chrono::system_clock::now();

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -7,6 +7,13 @@
 #include <algorithm>
 #include <string>
 #include <cstdint>
+#include <numeric>
+
+//DELETEME
+#include <iostream>
+#include <chrono>
+#include <ctime>
+//DELETEME
 
 #include "geopm/Exception.hpp"
 #include "geopm/Agg.hpp"
@@ -17,13 +24,13 @@
 
 namespace geopm
 {
-    const LevelZeroDevicePool &levelzero_device_pool()
+    LevelZeroDevicePool &levelzero_device_pool()
     {
         static LevelZeroDevicePoolImp instance(levelzero());
         return instance;
     }
 
-    LevelZeroDevicePoolImp::LevelZeroDevicePoolImp(const LevelZero &levelzero)
+    LevelZeroDevicePoolImp::LevelZeroDevicePoolImp(LevelZero &levelzero)
         : m_levelzero(levelzero)
     {
     }
@@ -803,4 +810,85 @@ namespace geopm
     }
 
 
+    //TODO: consider adding 'group_name' parameter?
+    void LevelZeroDevicePoolImp::metric_read(int domain, unsigned int domain_idx) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for metrics.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::chrono::time_point<std::chrono::system_clock> start, end;
+        start = std::chrono::system_clock::now();
+
+        m_levelzero.metric_read(domain_idx);
+
+        end = std::chrono::system_clock::now();
+        std::chrono::duration<double> elapsed_seconds = end - start;
+        std::cout << "metric_read - gpu " << std::to_string(domain_idx) << " read time: " << elapsed_seconds.count() << "s" << std::endl;
+    }
+
+    double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
+                                                 std::string metric_name) const
+    {
+        double result = NAN;
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for metrics.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        //std::chrono::time_point<std::chrono::system_clock> start, end;
+
+        std::vector<double> data = m_levelzero.metric_sample(domain_idx, metric_name);
+
+        //std::cout << "Data size is: " << std::to_string(data.size()) << std::endl;
+        //start = std::chrono::system_clock::now();
+        if (data.size() > 0) {
+            //TODO: add min, max, avg etc handling.
+            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+            //result = data.at(data.size()-1);
+        }
+        //end = std::chrono::system_clock::now();
+        //elapsed_seconds = end - start;
+        //std::cout << "gpu " << std::to_string(domain_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
+
+        return result;
+    }
+
+    uint32_t LevelZeroDevicePoolImp::metric_update_rate(int domain, unsigned int domain_idx) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for metrics.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_levelzero.metric_update_rate(domain_idx);
+    }
+
+//    void LevelZeroDevicePoolImp::metric_polling_disable()
+//    {
+//        unsigned int num_device = num_gpu(GEOPM_DOMAIN_GPU);
+//        for (unsigned int l0_device_idx = 0; l0_device_idx < num_device; l0_device_idx++) {
+//            m_levelzero.metric_destroy(l0_device_idx);
+//        }
+//    }
+
+    void LevelZeroDevicePoolImp::metric_update_rate_control(int domain, unsigned int domain_idx,
+                                                            uint32_t setting) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for metrics.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        m_levelzero.metric_update_rate_control(domain_idx, setting);
+    }
 }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -818,12 +818,10 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 2) {
-            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
-        }
+        m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
     }
 
     double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
@@ -837,19 +835,17 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 2) {
-            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
-                                                                 dev_subdev_idx_pair.second,
-                                                                 metric_name);
+        std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
+                                                             dev_subdev_idx_pair.second,
+                                                             metric_name);
 
-            if (data.size() > 0) {
-                //TODO: add min, max, avg etc handling.
-                result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
-                //result = data.at(data.size()-1);
-            }
+        if (data.size() > 0) {
+            //TODO: add min, max, avg etc handling.
+            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+            //result = data.at(data.size()-1);
         }
         return result;
     }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -818,10 +818,12 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        if (domain_idx < 2) {
+            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
+            m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
+        }
     }
 
     double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
@@ -835,17 +837,19 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        if (domain_idx < 2) {
+            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
-                                                             dev_subdev_idx_pair.second,
-                                                             metric_name);
+            std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
+                                                                 dev_subdev_idx_pair.second,
+                                                                 metric_name);
 
-        if (data.size() > 0) {
-            //TODO: add min, max, avg etc handling.
-            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
-            //result = data.at(data.size()-1);
+            if (data.size() > 0) {
+                //TODO: add min, max, avg etc handling.
+                result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+                //result = data.at(data.size()-1);
+            }
         }
         return result;
     }
@@ -860,26 +864,5 @@ namespace geopm
         }
 
         return m_levelzero.metric_update_rate(domain_idx);
-    }
-
-//    void LevelZeroDevicePoolImp::metric_polling_disable()
-//    {
-//        unsigned int num_device = num_gpu(GEOPM_DOMAIN_GPU);
-//        for (unsigned int l0_device_idx = 0; l0_device_idx < num_device; l0_device_idx++) {
-//            m_levelzero.metric_destroy(l0_device_idx);
-//        }
-//    }
-
-    void LevelZeroDevicePoolImp::metric_update_rate_control(int domain, unsigned int domain_idx,
-                                                            uint32_t setting) const
-    {
-        if (domain != GEOPM_DOMAIN_GPU) {
-            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
-                            ": domain " + std::to_string(domain) +
-                            " is not supported for metrics.",
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-
-        m_levelzero.metric_update_rate_control(domain_idx, setting);
     }
 }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -844,7 +844,7 @@ namespace geopm
 
         if (data.size() > 0) {
             //TODO: add min, max, avg etc handling.
-            result = std::reduce(data.begin(), data.end(), 0.0) / data.size();
+            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
             //result = data.at(data.size()-1);
         }
         return result;

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -844,7 +844,7 @@ namespace geopm
 
         if (data.size() > 0) {
             //TODO: add min, max, avg etc handling.
-            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+            result = std::reduce(data.begin(), data.end(), 0.0) / data.size();
             //result = data.at(data.size()-1);
         }
         return result;

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -11,8 +11,6 @@
 
 //DELETEME
 #include <iostream>
-#include <chrono>
-#include <ctime>
 //DELETEME
 
 #include "geopm/Exception.hpp"
@@ -823,14 +821,7 @@ namespace geopm
         std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
         dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-//        std::chrono::time_point<std::chrono::system_clock> start, end;
-//        start = std::chrono::system_clock::now();
-
         m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
-
-//        end = std::chrono::system_clock::now();
-//        std::chrono::duration<double> elapsed_seconds = end - start;
-//        std::cout << "metric_read - gpu " << std::to_string(domain_idx) << " read time: " << elapsed_seconds.count() << "s" << std::endl;
     }
 
     double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
@@ -846,23 +837,16 @@ namespace geopm
 
         std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
         dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
-        //std::chrono::time_point<std::chrono::system_clock> start, end;
 
         std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
                                                              dev_subdev_idx_pair.second,
                                                              metric_name);
 
-        //std::cout << "Data size is: " << std::to_string(data.size()) << std::endl;
-        //start = std::chrono::system_clock::now();
         if (data.size() > 0) {
             //TODO: add min, max, avg etc handling.
             result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
             //result = data.at(data.size()-1);
         }
-        //end = std::chrono::system_clock::now();
-        //elapsed_seconds = end - start;
-        //std::cout << "gpu " << std::to_string(domain_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
-
         return result;
     }
 

--- a/libgeopmd/src/LevelZeroDevicePool.hpp
+++ b/libgeopmd/src/LevelZeroDevicePool.hpp
@@ -312,9 +312,18 @@ namespace geopm
             /// @return Display Error Count
             virtual double ras_display_errcount_uncorrectable(int domain, unsigned int domain_idx,
                                                 int l0_domain) const = 0;
+
+            //ZET Metrics
+            virtual double metric_sample(int domain, unsigned int domain_idx,
+                                         std::string metric) const = 0;
+            virtual uint32_t metric_update_rate(int domain, unsigned int domain_idx) const = 0;
+            virtual void metric_read(int domain, unsigned int domain_idx) const = 0;
+//            virtual void metric_polling_disable(void) = 0;
+            virtual void metric_update_rate_control(int domain, unsigned int domain_idx,
+                                                    uint32_t setting) const = 0;
         private:
     };
 
-    const LevelZeroDevicePool &levelzero_device_pool();
+    LevelZeroDevicePool &levelzero_device_pool();
 }
 #endif

--- a/libgeopmd/src/LevelZeroDevicePool.hpp
+++ b/libgeopmd/src/LevelZeroDevicePool.hpp
@@ -318,9 +318,6 @@ namespace geopm
                                          std::string metric) const = 0;
             virtual uint32_t metric_update_rate(int domain, unsigned int domain_idx) const = 0;
             virtual void metric_read(int domain, unsigned int domain_idx) const = 0;
-//            virtual void metric_polling_disable(void) = 0;
-            virtual void metric_update_rate_control(int domain, unsigned int domain_idx,
-                                                    uint32_t setting) const = 0;
         private:
     };
 

--- a/libgeopmd/src/LevelZeroDevicePoolImp.hpp
+++ b/libgeopmd/src/LevelZeroDevicePoolImp.hpp
@@ -103,9 +103,6 @@ namespace geopm
             uint32_t metric_update_rate(int domain, unsigned int domain_idx) const override;
 
             void metric_read(int domain, unsigned int domain_idx) const override;
-//            void metric_polling_disable(void) override;
-            void metric_update_rate_control(int domain, unsigned int domain_idx,
-                                            uint32_t setting) const override;
 
         private:
             LevelZero &m_levelzero;

--- a/libgeopmd/src/LevelZeroDevicePoolImp.hpp
+++ b/libgeopmd/src/LevelZeroDevicePoolImp.hpp
@@ -21,7 +21,7 @@ namespace geopm
     {
         public:
             LevelZeroDevicePoolImp();
-            LevelZeroDevicePoolImp(const LevelZero &levelzero);
+            LevelZeroDevicePoolImp(LevelZero &levelzero);
             virtual ~LevelZeroDevicePoolImp() = default;
             int num_gpu(int domain_type) const override;
             double frequency_status(int domain, unsigned int domain_idx,
@@ -96,8 +96,19 @@ namespace geopm
                                       int l0_domain) const override;
             double ras_display_errcount_uncorrectable(int domain, unsigned int domain_idx,
                                         int l0_domain) const override;
+
+            //ZET Metrics
+            double metric_sample(int domain, unsigned int domain_idx,
+                                 std::string metric_name) const override;
+            uint32_t metric_update_rate(int domain, unsigned int domain_idx) const override;
+
+            void metric_read(int domain, unsigned int domain_idx) const override;
+//            void metric_polling_disable(void) override;
+            void metric_update_rate_control(int domain, unsigned int domain_idx,
+                                            uint32_t setting) const override;
+
         private:
-            const LevelZero &m_levelzero;
+            LevelZero &m_levelzero;
 
             void check_idx_range(int domain, unsigned int domain_idx) const;
             void check_domain_exists(int size, const char *func, int line) const;

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -42,7 +42,7 @@ namespace geopm
 
     // Set up mapping between signal and control names and corresponding indices
     LevelZeroIOGroup::LevelZeroIOGroup(const PlatformTopo &platform_topo,
-                                       const LevelZeroDevicePool &device_pool,
+                                       LevelZeroDevicePool &device_pool,
                                        std::shared_ptr<SaveControl> save_control_test)
         : m_platform_topo(platform_topo)
         , m_levelzero_device_pool(device_pool)
@@ -764,8 +764,43 @@ namespace geopm
                                                    geopm::LevelZero::M_DOMAIN_ALL);
                                   },
                                   1
+                                  }},
+                              {M_NAME_PREFIX + "METRIC:XVE_ACTIVE", {
+                                  //TODO: pull from L0 metrics programatically
+                                  "Percentage of time in which at least one pipe is active in XVE",
+                                  GEOPM_DOMAIN_GPU, //TODO: GPU_CHIP is possible, this is a simplification
+                                  M_UNITS_NONE,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.metric_sample(
+                                                   GEOPM_DOMAIN_GPU,
+                                                   domain_idx,
+                                                   "XVE_ACTIVE");
+                                  },
+                                  .01
+                                  }},
+                              {M_NAME_PREFIX + "METRIC:XVE_STALL", {
+                                  //TODO: pull from L0 metrics programatically
+                                  "Percentage of time in which any threads are loaded but not even a single pipe is active in XVE",
+                                  GEOPM_DOMAIN_GPU, //TODO: GPU_CHIP is possible, this is a simplification
+                                  M_UNITS_NONE,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.metric_sample(
+                                                   GEOPM_DOMAIN_GPU,
+                                                   domain_idx,
+                                                   "XVE_STALL");
+                                  },
+                                  .01
                                   }}
-
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
                                     "Sets the minimum frequency request for the GPU Compute Hardware.",
@@ -933,6 +968,12 @@ namespace geopm
         // Used for control trimming and save/restore.  See man page for more info.
         register_signal_alias(M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR_CONTROL",
                               M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR");
+
+        // popluate tracking structure for L0 metrics
+        for (int domain_idx = 0; domain_idx <
+             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
+            m_metric_signal_pushed.push_back(false);
+        }
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {
@@ -1118,6 +1159,15 @@ namespace geopm
         }
 
         int result = -1;
+        bool is_found = false;
+
+        if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
+            //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&
+            domain_type == GEOPM_DOMAIN_GPU) {
+
+            m_metric_signal_pushed.at(domain_idx) = true;
+        }
+
         // Guarantee base signal was pushed before any timestamp signals
         if (string_ends_with(signal_name, "_TIMESTAMP")) {
             std::string base_signal_name = signal_name.substr(
@@ -1221,6 +1271,13 @@ namespace geopm
                 m_signal_pushed[ii]->set_sample(m_signal_pushed[ii]->read());
             }
         }
+
+        for (int domain_idx = 0; domain_idx <
+             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
+            if (m_metric_signal_pushed.at(domain_idx)) {
+                m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU, domain_idx);
+            }
+        }
     }
 
     // Write all controls that have been pushed and adjusted
@@ -1322,6 +1379,17 @@ namespace geopm
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {
+
+            if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
+                //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&
+                domain_type == GEOPM_DOMAIN_GPU) {
+
+                for (int domain_idx = 0; domain_idx <
+                     m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
+                    m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU, domain_idx);
+                }
+            }
+
             result = (it->second.m_signals.at(domain_idx))->read();
         }
         else {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -816,7 +816,7 @@ namespace geopm
                                                    domain_idx,
                                                    "NUM_REPORTS");
                                   },
-                                  .01
+                                  1
                                   }},
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
@@ -1398,15 +1398,6 @@ namespace geopm
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {
-            if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
-                //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&
-                domain_type == GEOPM_DOMAIN_GPU_CHIP) {
-                for (int domain_idx = 0; domain_idx <
-                     m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
-                    m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU_CHIP, domain_idx);
-                }
-            }
-
             result = (it->second.m_signals.at(domain_idx))->read();
         }
         else {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -800,7 +800,24 @@ namespace geopm
                                                    "XVE_STALL");
                                   },
                                   .01
-                                  }}
+                                  }},
+                              {M_NAME_PREFIX + "METRIC:NUM_REPORTS", {
+                                  //TODO: pull from L0 metrics programmatically
+                                  "Number of Level Zero Tools reports processed this sample",
+                                  GEOPM_DOMAIN_GPU_CHIP,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.metric_sample(
+                                                   GEOPM_DOMAIN_GPU_CHIP,
+                                                   domain_idx,
+                                                   "NUM_REPORTS");
+                                  },
+                                  .01
+                                  }},
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
                                     "Sets the minimum frequency request for the GPU Compute Hardware.",

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1176,7 +1176,6 @@ namespace geopm
         }
 
         int result = -1;
-        bool is_found = false;
 
         if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
             //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1397,13 +1397,11 @@ namespace geopm
 
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
-        if (it != m_signal_available.end()) {
-            if (signal_name.find(":METRIC:") != std::string::npos) {
-                throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
-                                ": " + signal_name + " only supports batch access.",
-                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-            }
-
+        if (it != m_signal_available.end()
+            && signal_name.find(":METRIC:") == std::string::npos) {
+            // PlatformIO will try and read a METRIC signal in some instances before
+            // allowing a push_signal & read batch to occur, so we can't just error
+            // on METRIC signals.  We can skip them though.
             result = (it->second.m_signals.at(domain_idx))->read();
         }
         else {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1398,6 +1398,12 @@ namespace geopm
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {
+            if (signal_name.find(":METRIC:") != std::string::npos) {
+                throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                                ":l " + signal_name + " only supports batch access.",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+
             result = (it->second.m_signals.at(domain_idx))->read();
         }
         else {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -766,9 +766,9 @@ namespace geopm
                                   1
                                   }},
                               {M_NAME_PREFIX + "METRIC:XVE_ACTIVE", {
-                                  //TODO: pull from L0 metrics programatically
+                                  //TODO: pull from L0 metrics programmatically
                                   "Percentage of time in which at least one pipe is active in XVE",
-                                  GEOPM_DOMAIN_GPU, //TODO: GPU_CHIP is possible, this is a simplification
+                                  GEOPM_DOMAIN_GPU_CHIP,
                                   M_UNITS_NONE,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -777,16 +777,16 @@ namespace geopm
                                   [this](unsigned int domain_idx) -> double
                                   {
                                       return this->m_levelzero_device_pool.metric_sample(
-                                                   GEOPM_DOMAIN_GPU,
+                                                   GEOPM_DOMAIN_GPU_CHIP,
                                                    domain_idx,
                                                    "XVE_ACTIVE");
                                   },
                                   .01
                                   }},
                               {M_NAME_PREFIX + "METRIC:XVE_STALL", {
-                                  //TODO: pull from L0 metrics programatically
+                                  //TODO: pull from L0 metrics programmatically
                                   "Percentage of time in which any threads are loaded but not even a single pipe is active in XVE",
-                                  GEOPM_DOMAIN_GPU, //TODO: GPU_CHIP is possible, this is a simplification
+                                  GEOPM_DOMAIN_GPU_CHIP,
                                   M_UNITS_NONE,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -795,7 +795,7 @@ namespace geopm
                                   [this](unsigned int domain_idx) -> double
                                   {
                                       return this->m_levelzero_device_pool.metric_sample(
-                                                   GEOPM_DOMAIN_GPU,
+                                                   GEOPM_DOMAIN_GPU_CHIP,
                                                    domain_idx,
                                                    "XVE_STALL");
                                   },
@@ -971,7 +971,7 @@ namespace geopm
 
         // popluate tracking structure for L0 metrics
         for (int domain_idx = 0; domain_idx <
-             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
+             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
             m_metric_signal_pushed.push_back(false);
         }
 
@@ -1163,7 +1163,7 @@ namespace geopm
 
         if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
             //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&
-            domain_type == GEOPM_DOMAIN_GPU) {
+            domain_type == GEOPM_DOMAIN_GPU_CHIP) {
 
             m_metric_signal_pushed.at(domain_idx) = true;
         }
@@ -1263,19 +1263,21 @@ namespace geopm
     void LevelZeroIOGroup::read_batch(void)
     {
         m_is_batch_read = true;
+
+        // Consider doing this first vs second
+        for (int domain_idx = 0; domain_idx <
+             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
+            if (m_metric_signal_pushed.at(domain_idx)) {
+                m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU_CHIP, domain_idx);
+            }
+        }
+
         for (size_t ii = 0; ii < m_signal_pushed.size(); ++ii) {
             // If the current signal index (ii) is in the derivative_signal_pushed_set do not read().
             // Derivative signals are comprised of base signals, and thus cannot be read directly.
             // The base signals are automatically pushed when a derivative signal is requested.
             if (m_derivative_signal_pushed_set.find(ii) == m_derivative_signal_pushed_set.end()) {
                 m_signal_pushed[ii]->set_sample(m_signal_pushed[ii]->read());
-            }
-        }
-
-        for (int domain_idx = 0; domain_idx <
-             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
-            if (m_metric_signal_pushed.at(domain_idx)) {
-                m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU, domain_idx);
             }
         }
     }
@@ -1379,14 +1381,12 @@ namespace geopm
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {
-
             if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
                 //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&
-                domain_type == GEOPM_DOMAIN_GPU) {
-
+                domain_type == GEOPM_DOMAIN_GPU_CHIP) {
                 for (int domain_idx = 0; domain_idx <
-                     m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
-                    m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU, domain_idx);
+                     m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
+                    m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU_CHIP, domain_idx);
                 }
             }
 

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1281,7 +1281,6 @@ namespace geopm
     {
         m_is_batch_read = true;
 
-        // Consider doing this first vs second
         for (int domain_idx = 0; domain_idx <
              m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
             if (m_metric_signal_pushed.at(domain_idx)) {
@@ -1395,6 +1394,7 @@ namespace geopm
         if (string_ends_with(signal_name, "_TIMESTAMP")) {
             return NAN;
         }
+
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -805,6 +805,7 @@ namespace geopm
                                   //TODO: pull from L0 metrics programmatically
                                   "Number of Level Zero Tools reports processed this sample",
                                   GEOPM_DOMAIN_GPU_CHIP,
+                                  M_UNITS_NONE,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
@@ -910,14 +911,14 @@ namespace geopm
             m_is_perf_factor_enabled = true;
         }
         catch (const geopm::Exception &ex) {
-
         }
 
         // populate signals for each domain
         for (auto &sv : m_signal_available) {
             std::vector<std::shared_ptr<Signal> > result;
-            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(
-                                     signal_domain_type(sv.first)); ++domain_idx) {
+            for (int domain_idx = 0;
+                 domain_idx < m_platform_topo.num_domain(signal_domain_type(sv.first));
+                 ++domain_idx) {
                 try {
                     if (sv.first.find("_PERFORMANCE_") != std::string::npos && !m_is_perf_factor_enabled) {
                         unsupported_signal_names.push_back(sv.first);
@@ -957,7 +958,6 @@ namespace geopm
         }
 
         register_derivative_signals();
-
 
         register_signal_alias("GPU_CORE_FREQUENCY_STATUS", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS");
         register_signal_alias("GPU_ENERGY", M_NAME_PREFIX + "GPU_ENERGY");
@@ -1440,7 +1440,7 @@ namespace geopm
         }
 
         if (control_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL" ||
-           control_name == "GPU_CORE_FREQUENCY_MIN_CONTROL") {
+            control_name == "GPU_CORE_FREQUENCY_MIN_CONTROL") {
             double curr_max = read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL",
                                           domain_type, domain_idx);
             m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
@@ -1448,7 +1448,7 @@ namespace geopm
                                                       setting / 1e6, curr_max / 1e6);
         }
         else if (control_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL" ||
-                control_name == "GPU_CORE_FREQUENCY_MAX_CONTROL") {
+                 control_name == "GPU_CORE_FREQUENCY_MAX_CONTROL") {
             double curr_min = read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL",
                                           domain_type, domain_idx);
             m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
@@ -1682,7 +1682,7 @@ namespace geopm
     {
         if (m_control_available.find(alias_name) != m_control_available.end()) {
             throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
-                            ": contro1_name " + alias_name +
+                            ": control_name " + alias_name +
                             " was previously registered.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1397,12 +1397,13 @@ namespace geopm
 
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
-        if (it != m_signal_available.end()
-            && signal_name.find(":METRIC:") == std::string::npos) {
-            // PlatformIO will try and read a METRIC signal in some instances before
-            // allowing a push_signal & read batch to occur, so we can't just error
-            // on METRIC signals.  We can skip them though.
-            result = (it->second.m_signals.at(domain_idx))->read();
+        if (it != m_signal_available.end()) {
+            if (signal_name.find(":METRIC:") == std::string::npos) {
+                // PlatformIO will try and read a METRIC signal in some instances before
+                // allowing a push_signal & read batch to occur, so we can't just error
+                // on METRIC signals.  We can skip them though.
+                result = (it->second.m_signals.at(domain_idx))->read();
+            } // else: skip "METRIC" signals for now
         }
         else {
     #ifdef GEOPM_DEBUG

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1400,7 +1400,7 @@ namespace geopm
         if (it != m_signal_available.end()) {
             if (signal_name.find(":METRIC:") != std::string::npos) {
                 throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
-                                ":l " + signal_name + " only supports batch access.",
+                                ": " + signal_name + " only supports batch access.",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
 

--- a/libgeopmd/src/LevelZeroIOGroup.hpp
+++ b/libgeopmd/src/LevelZeroIOGroup.hpp
@@ -27,7 +27,7 @@ namespace geopm
         public:
             LevelZeroIOGroup();
             LevelZeroIOGroup(const PlatformTopo &platform_topo,
-                             const LevelZeroDevicePool &device_pool,
+                             LevelZeroDevicePool &device_pool,
                              std::shared_ptr<SaveControl> save_control_test);
             virtual ~LevelZeroIOGroup() = default;
             std::set<std::string> signal_names(void) const override;
@@ -113,7 +113,7 @@ namespace geopm
             static const std::string M_PLUGIN_NAME;
             static const std::string M_NAME_PREFIX;
             const PlatformTopo &m_platform_topo;
-            const LevelZeroDevicePool &m_levelzero_device_pool;
+            LevelZeroDevicePool &m_levelzero_device_pool;
             bool m_is_batch_read;
             int m_native_domain;
 
@@ -124,6 +124,7 @@ namespace geopm
             const std::set<std::string> m_special_signal_set;
             std::map<std::string, derivative_signal_info> m_derivative_signal_map;
             std::set<int> m_derivative_signal_pushed_set;
+            std::vector<bool> m_metric_signal_pushed;
 
             //GEOPM Domain indexed
             std::vector<std::pair<double,double> > m_frequency_range;

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -220,6 +220,9 @@ namespace geopm
             };
 
             void ras_domain_cache(unsigned int l0_device_idx);
+            //size_t zet_temp_data_size;
+            //std::vector<uint8_t> zet_temp_data;
+
             void frequency_domain_cache(unsigned int l0_device_idx);
             void power_domain_cache(unsigned int l0_device_idx);
             void perf_domain_cache(unsigned int l0_device_idx);

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -128,12 +128,16 @@ namespace geopm
                                                       int l0_domain,
                                                       int l0_domain_idx) const override;
             std::vector<double> metric_sample(unsigned int l0_device_idx,
+                                              unsigned int l0_domain_idx,
                                               std::string metric_name) const override;
             uint32_t metric_update_rate(unsigned int l0_device_idx) const override;
 
-            void metric_read(unsigned int l0_device_idx) override;
-            void metric_init(unsigned int l0_device_idx) override;
-            void metric_destroy(unsigned int l0_device_idx) override;
+            void metric_read(unsigned int l0_device_idx,
+                             unsigned int l0_domain_idx) override;
+            void metric_init(unsigned int l0_device_idx,
+                             unsigned int l0_domain_idx) override;
+            void metric_destroy(unsigned int l0_device_idx,
+                                unsigned int l0_domain_idx) override;
             void metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting) override;
 
         private:
@@ -179,9 +183,25 @@ namespace geopm
                 // then by error set type (correctable vs uncorrectable)
                 std::vector<zes_ras_handle_t> ras_domain;
 
+                //ZE Context used for ZET data collection
+                std::vector<ze_context_handle_t> context;
+
+                // required for L0 metric querying
+                std::vector<uint32_t> num_metric;
+                std::vector<uint32_t> num_reports;
+                std::vector<bool> metric_domain_cached;
+                std::vector<ze_event_pool_handle_t> event_pool;
+                std::vector<ze_event_handle_t> event; //TODO: rename metric_notification_event?
+                std::vector<zet_metric_streamer_handle_t> metric_streamer;
+                std::vector<zet_metric_group_handle_t> metric_group_handle; //compute basic only
+
+                // required for L0 metric result tracking
+                mutable std::vector<std::map<std::string, std::vector<double>>> m_metric_data;
+                mutable std::vector<bool> metrics_initialized;
             };
 
             struct m_device_info_s {
+                ze_driver_handle_t driver;
                 zes_device_handle_t device_handle;
                 ze_device_properties_t property;
                 uint32_t m_num_subdevice;
@@ -195,25 +215,11 @@ namespace geopm
 
                 // Device/Package domains
                 zes_pwr_handle_t power_domain;
-                //ZE Context used for ZET data collection
-                ze_context_handle_t context;
 
                 uint32_t num_device_power_domain;
                 mutable uint64_t cached_energy_timestamp;
 
-                // required for L0 metric result tracking
-                mutable std::map<std::string, std::vector<double>> m_metric_data;
-                mutable bool metrics_initialized;
-
-                // required for L0 metric querying
-                uint32_t num_metric;
-                uint32_t num_reports;
                 uint32_t metric_sampling_period;
-                bool metric_domain_cached;
-                ze_event_pool_handle_t event_pool;
-                ze_event_handle_t event; //TODO: rename metric_notification_event?
-                zet_metric_streamer_handle_t metric_streamer;
-                zet_metric_group_handle_t metric_group_handle; //compute basic only
             };
 
             void ras_domain_cache(unsigned int l0_device_idx);
@@ -245,7 +251,7 @@ namespace geopm
             std::vector<m_device_info_s> m_devices;
 
             void metric_group_cache(unsigned int l0_device_idx);
-            void metric_calc(unsigned int l0_device_idx,
+            void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
                              zet_metric_streamer_handle_t metric_streamer) const;
     };
 }

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -186,7 +186,7 @@ namespace geopm
                 //ZE Context used for ZET data collection
                 std::vector<ze_context_handle_t> context;
 
-                // required for L0 metric querying
+                // required for L0 metric querying.  Chip indexed
                 std::vector<uint32_t> num_metric;
                 std::vector<uint32_t> num_reports;
                 std::vector<bool> metric_domain_cached;
@@ -195,7 +195,7 @@ namespace geopm
                 std::vector<zet_metric_streamer_handle_t> metric_streamer;
                 std::vector<zet_metric_group_handle_t> metric_group_handle; //compute basic only
 
-                // required for L0 metric result tracking
+                // required for L0 metric result tracking.  Chip indexed
                 mutable std::vector<std::map<std::string, std::vector<double>>> m_metric_data;
                 mutable std::vector<bool> metrics_initialized;
             };

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -10,6 +10,7 @@
 
 #include <level_zero/ze_api.h>
 #include <level_zero/zes_api.h>
+#include <level_zero/zet_api.h>
 
 #include "LevelZero.hpp"
 
@@ -126,6 +127,14 @@ namespace geopm
             double ras_display_errcount_uncorrectable(unsigned int l0_device_idx,
                                                       int l0_domain,
                                                       int l0_domain_idx) const override;
+            std::vector<double> metric_sample(unsigned int l0_device_idx,
+                                              std::string metric_name) const override;
+            uint32_t metric_update_rate(unsigned int l0_device_idx) const override;
+
+            void metric_read(unsigned int l0_device_idx) override;
+            void metric_init(unsigned int l0_device_idx) override;
+            void metric_destroy(unsigned int l0_device_idx) override;
+            void metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting) override;
 
         private:
             enum m_error_type {
@@ -185,9 +194,26 @@ namespace geopm
                 m_subdevice_s subdevice;
 
                 // Device/Package domains
-                uint32_t num_device_power_domain;
                 zes_pwr_handle_t power_domain;
+                //ZE Context used for ZET data collection
+                ze_context_handle_t context;
+
+                uint32_t num_device_power_domain;
                 mutable uint64_t cached_energy_timestamp;
+
+                // required for L0 metric result tracking
+                mutable std::map<std::string, std::vector<double>> m_metric_data;
+                mutable bool metrics_initialized;
+
+                // required for L0 metric querying
+                uint32_t num_metric;
+                uint32_t num_reports;
+                uint32_t metric_sampling_period;
+                bool metric_domain_cached;
+                ze_event_pool_handle_t event_pool;
+                ze_event_handle_t event; //TODO: rename metric_notification_event?
+                zet_metric_streamer_handle_t metric_streamer;
+                zet_metric_group_handle_t metric_group_handle; //compute basic only
             };
 
             void ras_domain_cache(unsigned int l0_device_idx);
@@ -217,6 +243,10 @@ namespace geopm
 
             std::vector<ze_driver_handle_t> m_levelzero_driver;
             std::vector<m_device_info_s> m_devices;
+
+            void metric_group_cache(unsigned int l0_device_idx);
+            void metric_calc(unsigned int l0_device_idx,
+                             zet_metric_streamer_handle_t metric_streamer) const;
     };
 }
 #endif

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -249,8 +249,8 @@ namespace geopm
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
                              size_t data_size, std::vector<uint8_t> data);
 
-            void metric_init(unsigned int l0_device_idx,
-                             unsigned int l0_domain_idx);
+            void metric_execute(unsigned int l0_device_idx,
+                                unsigned int l0_domain_idx);
             void metric_destroy(unsigned int l0_device_idx,
                                 unsigned int l0_domain_idx);
 

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -131,6 +131,7 @@ namespace geopm
                                               unsigned int l0_domain_idx,
                                               std::string metric_name) const override;
             uint32_t metric_update_rate(unsigned int l0_device_idx) const override;
+            void metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting) override;
 
             void metric_read(unsigned int l0_device_idx,
                              unsigned int l0_domain_idx) override;

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -191,7 +191,7 @@ namespace geopm
                 std::vector<zet_metric_group_handle_t> metric_group_handle; //compute basic only
 
                 // required for L0 metric result tracking.  Chip indexed
-                std::vector<std::map<std::string, std::vector<double>>> m_metric_data;
+                std::vector<std::map<std::string, std::vector<double>>> metric_data;
                 mutable std::vector<bool> metrics_initialized;
             };
 
@@ -199,7 +199,7 @@ namespace geopm
                 ze_driver_handle_t driver;
                 zes_device_handle_t device_handle;
                 ze_device_properties_t property;
-                uint32_t m_num_subdevice;
+                uint32_t num_subdevice;
                 std::vector<zes_device_handle_t> subdevice_handle;
 
                 // Sub-Device domain tracking.  Because levelzero returns ALL handles for a

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -245,7 +245,7 @@ namespace geopm
             std::vector<ze_driver_handle_t> m_levelzero_driver;
             std::vector<m_device_info_s> m_devices;
 
-            void metric_group_cache(unsigned int l0_device_idx);
+            void metric_group_init(unsigned int l0_device_idx);
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
                              size_t data_size, std::vector<uint8_t> data);
 

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -186,9 +186,11 @@ namespace geopm
                 std::vector<uint32_t> num_reports;
                 std::vector<bool> metric_domain_cached;
                 std::vector<ze_event_pool_handle_t> event_pool;
-                std::vector<ze_event_handle_t> metric_notifcation_event; //TODO: rename metric_notification_event?
+                std::vector<ze_event_handle_t> metric_notifcation_event;
                 std::vector<zet_metric_streamer_handle_t> metric_streamer;
-                std::vector<zet_metric_group_handle_t> metric_group_handle; //compute basic only
+                std::vector<zet_metric_group_handle_t> metric_group_handle; //ComputeBasic only
+                std::vector<size_t> zet_data_size;
+                std::vector<std::vector<uint8_t>> zet_data;
 
                 // required for L0 metric result tracking.  Chip indexed
                 std::vector<std::map<std::string, std::vector<double>>> metric_data;

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -22,7 +22,7 @@ namespace geopm
     {
         public:
             LevelZeroImp();
-            virtual ~LevelZeroImp() = default;
+            virtual ~LevelZeroImp();
             int num_gpu(void) const override;
             int num_gpu(int domain) const override;
             int frequency_domain_count(unsigned int l0_device_idx,
@@ -134,11 +134,6 @@ namespace geopm
 
             void metric_read(unsigned int l0_device_idx,
                              unsigned int l0_domain_idx) override;
-            void metric_init(unsigned int l0_device_idx,
-                             unsigned int l0_domain_idx) override;
-            void metric_destroy(unsigned int l0_device_idx,
-                                unsigned int l0_domain_idx) override;
-            void metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting) override;
 
         private:
             enum m_error_type {
@@ -191,12 +186,12 @@ namespace geopm
                 std::vector<uint32_t> num_reports;
                 std::vector<bool> metric_domain_cached;
                 std::vector<ze_event_pool_handle_t> event_pool;
-                std::vector<ze_event_handle_t> event; //TODO: rename metric_notification_event?
+                std::vector<ze_event_handle_t> metric_notifcation_event; //TODO: rename metric_notification_event?
                 std::vector<zet_metric_streamer_handle_t> metric_streamer;
                 std::vector<zet_metric_group_handle_t> metric_group_handle; //compute basic only
 
                 // required for L0 metric result tracking.  Chip indexed
-                mutable std::vector<std::map<std::string, std::vector<double>>> m_metric_data;
+                std::vector<std::map<std::string, std::vector<double>>> m_metric_data;
                 mutable std::vector<bool> metrics_initialized;
             };
 
@@ -219,7 +214,7 @@ namespace geopm
                 uint32_t num_device_power_domain;
                 mutable uint64_t cached_energy_timestamp;
 
-                uint32_t metric_sampling_period;
+                uint32_t metric_sampling_period_ns;
             };
 
             void ras_domain_cache(unsigned int l0_device_idx);
@@ -252,7 +247,14 @@ namespace geopm
 
             void metric_group_cache(unsigned int l0_device_idx);
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
-                             zet_metric_streamer_handle_t metric_streamer) const;
+                             size_t data_size, std::vector<uint8_t> data);
+
+            void metric_init(unsigned int l0_device_idx,
+                             unsigned int l0_domain_idx);
+            void metric_destroy(unsigned int l0_device_idx,
+                                unsigned int l0_domain_idx);
+
+            double metric_data_convert(zet_typed_value_t data) const;
     };
 }
 #endif

--- a/libgeopmd/src/LevelZeroThrow.cpp
+++ b/libgeopmd/src/LevelZeroThrow.cpp
@@ -9,7 +9,7 @@
 
 namespace geopm
 {
-    const LevelZero &levelzero()
+    LevelZero &levelzero()
     {
         throw Exception("LevelZeroThrow::" + std::string(__func__) +
                         ": GEOPM configured without Level Zero library support.  Please configure with --enable-levelzero",

--- a/libgeopmd/test/LevelZeroDevicePoolTest.cpp
+++ b/libgeopmd/test/LevelZeroDevicePoolTest.cpp
@@ -7,6 +7,7 @@
 
 #include <fstream>
 #include <string>
+#include <numeric>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
@@ -124,6 +125,8 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
     std::vector<double> temp_value_chip_compute = {99, 12, 25, 356, 58, 79, 76, 21};
     std::vector<double> temp_value_chip_mem = {42, 59, 66, 78, 92, 88, 1, 16};
 
+    std::vector<std::vector<double> > metric_value_chip = {{41, 41}, {51, 53}, {16}, {71}, {12, 13, 14}, {18}, {11}, {1,6,1}};
+
     int offset = 0;
     int domain_count = 1; //any non-zero number to ensure we don't throw
     for (int dev_idx = 0; dev_idx < num_gpu; ++dev_idx) {
@@ -168,6 +171,9 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
 
             EXPECT_CALL(*m_levelzero, temperature_max(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(temp_value_chip_compute[offset]));
             EXPECT_CALL(*m_levelzero, temperature_max(dev_idx, MockLevelZero::M_DOMAIN_MEMORY, sub_idx)).WillOnce(Return(temp_value_chip_mem[offset]));
+
+            EXPECT_CALL(*m_levelzero, metric_sample(dev_idx, sub_idx, "NUM_REPORTS")).WillOnce(Return(metric_value_chip[offset]));
+            EXPECT_CALL(*m_levelzero, metric_read(dev_idx, sub_idx));
             ++offset;
         }
     }
@@ -208,6 +214,12 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
 
         EXPECT_EQ(temp_value_chip_compute[sub_idx], m_device_pool.temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_EQ(temp_value_chip_mem[sub_idx], m_device_pool.temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
+
+        double expected = (double) std::reduce(metric_value_chip[sub_idx].begin(),
+                                               metric_value_chip[sub_idx].end(), 0) /  metric_value_chip[sub_idx].size();
+        EXPECT_EQ(expected,
+                  m_device_pool.metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
+        EXPECT_NO_THROW(m_device_pool.metric_read(GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
 }
 
@@ -282,6 +294,10 @@ TEST_F(LevelZeroDevicePoolTest, domain_error)
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_tdp(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU_CHIP) + " is not supported for the power domain");
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_min(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU_CHIP) + " is not supported for the power domain");
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_max(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU_CHIP) + " is not supported for the power domain");
+
+    //ZET
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.metric_read(GEOPM_DOMAIN_GPU, dev_idx), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for metrics");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.metric_sample(GEOPM_DOMAIN_GPU, dev_idx, "NUM_REPORTS"), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for metrics");
 }
 
 TEST_F(LevelZeroDevicePoolTest, subdevice_range_check)

--- a/libgeopmd/test/LevelZeroDevicePoolTest.cpp
+++ b/libgeopmd/test/LevelZeroDevicePoolTest.cpp
@@ -215,8 +215,9 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
         EXPECT_EQ(temp_value_chip_compute[sub_idx], m_device_pool.temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_EQ(temp_value_chip_mem[sub_idx], m_device_pool.temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
 
-        double expected = (double) std::reduce(metric_value_chip[sub_idx].begin(),
-                                               metric_value_chip[sub_idx].end(), 0) /  metric_value_chip[sub_idx].size();
+        double expected = (double)std::accumulate(metric_value_chip[sub_idx].begin(),
+                                                  metric_value_chip[sub_idx].end(), 0) /
+                                                      metric_value_chip[sub_idx].size();
         EXPECT_EQ(expected,
                   m_device_pool.metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
         EXPECT_NO_THROW(m_device_pool.metric_read(GEOPM_DOMAIN_GPU_CHIP, sub_idx));

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -210,9 +210,22 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
         // 1. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR_CONTROL
         // 2. Per gpu-chip / control pruning: GPU_CORE_PERFORMANCE_FACTOR_CONTROL (Alias to PERFORMANCE_FACTOR)
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
-                    performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(2);
+                    performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(3);
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_TEMPERATURE_MAXIMUM
+                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_CALL(*m_device_pool, // GPU_MEMORY_TEMPERATURE_MAXIMUM
+                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
 
-        // GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL, and the restore_control() call
+        // ZET testing
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE"));
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL"));
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
+
+        // control pruning expectations
+        // GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL, and the restore_control() direct call.
         EXPECT_CALL(*m_device_pool,
                     frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE,
                                       0, 0)).Times(3);
@@ -889,6 +902,14 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
         //                               0, 0)).Times(3);
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
                     performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+
+        // ZET testing
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE"));
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL"));
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
     }
 
     // Expectations for signal pruning code in the constructor

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -370,6 +370,11 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
                                           6, 12, 22, 15};
     std::vector<double> mock_energy_chip = {4000000, 5000000, 1100000, 2621000000,
                                             4200000, 5200000, 1120000, 2621200000,};
+
+    std::vector<double> mock_zet_num_reports = {23, 70, 50, 2, 5, 57, 88, 93};
+    std::vector<double> mock_zet_stall = {10, 9, 150, 510, 13, 14, 51, 45};
+    std::vector<double> mock_zet_active = {124, 12, 23, 42, 45, 54, 68, 97};
+
     std::vector<int> batch_idx;
 
     LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool, nullptr);
@@ -389,6 +394,14 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
         EXPECT_CALL(*m_device_pool, energy_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_time_chip.at(sub_idx)));
         batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_CORE_ENERGY", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
+
+    for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
+        // On live systems we do not support read_signal of ZET signals.
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS")).WillOnce(Return(mock_zet_num_reports.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE")).WillOnce(Return(mock_zet_active.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL")).WillOnce(Return(mock_zet_stall.at(sub_idx)));
+    }
+
 
     for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(gpu_idx)));
@@ -420,6 +433,14 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
 
         EXPECT_DOUBLE_EQ(energy_chip, mock_energy_chip.at(sub_idx)/1e6);
         EXPECT_DOUBLE_EQ(energy_chip, energy_chip_batch);
+
+        //ZET
+        double num_reps = levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(num_reps, mock_zet_num_reports.at(sub_idx));
+        double zet_stall = levelzero_io.read_signal("LEVELZERO::METRIC:XVE_STALL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(zet_stall, mock_zet_stall.at(sub_idx) / 100);
+        double zet_active = levelzero_io.read_signal("LEVELZERO::METRIC:XVE_ACTIVE", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(zet_active, mock_zet_active.at(sub_idx) / 100);
     }
 
     for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
@@ -913,18 +934,19 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
     }
 
     // Expectations for signal pruning code in the constructor
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
-                energy(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
-                energy_timestamp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
-                power_limit_tdp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
-                power_limit_max(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
-                power_limit_min(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-
-    // End copy/paste from SetUpDefualtExpectCalls
+    for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
+        EXPECT_CALL(*m_device_pool, // GPU_ENERGY
+                    energy(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
+        EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
+                    energy_timestamp(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
+        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
+                    power_limit_tdp(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
+        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
+                    power_limit_max(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
+        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
+                    power_limit_min(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
+    }
+    // End copy/paste from SetUpDefaultExpectCalls
 
     // The implementation of the pruning code only tests each control on a
     // single domain index if a problem is encountered.  If there is a problem

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -139,14 +139,31 @@ void LevelZeroIOGroupTest::SetUp()
 
 void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
 {
-    // Expectations for domain_idx 0 on calls made in the constructor
+    // EXPECT_CALLS for domain idx = 0
     EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
                 performance_factor(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(4);
-    // Times(4) explanation:
-    //   1. Per gpu-chip / signal pruning: GPU_CORE_PERFORMANCE_FACTOR
-    //   2. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR_CONTROL
-    //   3. Per gpu-chip / control pruning: GPU_CORE_PERFORMANCE_FACTOR_CONTROL (Alias to PERFORMANCE_FACTOR)
-    //   4. Check if perf factor is enabled
+    // Times(2) explanation:
+    // 1. check if perf factor is enabled
+    // 2. signal pruning
+    // 3. save_control
+    // 4. control pruning
+    EXPECT_CALL(*m_device_pool,
+                frequency_range(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(7);
+    // Times(7) explanation:
+    // 1. signal pruning = 2 (GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL)
+    // 2. save_control = 1
+    // 3. control pruning = 2
+    // 4. write_control = 2 (it reads min and max freq. before writing)
+    EXPECT_CALL(*m_device_pool,
+                frequency_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE, 0, 0)).Times(3);
+    // Times(3) explanation:
+    // 1. control pruning = 2 (GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL)
+    // 2. restore_control
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
+                performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+    // Times(2) explanation:
+    // 1. control pruning
+    // 2. restore_control
 
     // The EXPECT_CALLS below are default Times(1) for the signal pruning code
     EXPECT_CALL(*m_device_pool, // GPU_ACTIVE_TIME
@@ -161,26 +178,20 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
                 active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_ACTIVE_TIME_TIMESTAMP
                 active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_ENERGY
                 energy(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
+    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
+                energy(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_ENERGY_TIMESTAMP
                 energy_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
+                energy_timestamp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_EFFICIENT
                 frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MAX_AVAIL
                 frequency_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_FREQUENCY_MAX_AVAIL
                 frequency_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
-    EXPECT_CALL(*m_device_pool,
-                frequency_range(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(7);
-    // Times(7) explanation:
-    // 1. Per gpu-chip / signal_pruning: GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 2. Per gpu-chip / signal_pruning: GPU_CORE_FREQUENCY_MIN_CONTROL
-    // 3. Per gpu-chip save_control() call,
-    // 4. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 5. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 6. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MIN_CONTROL
-    // 7. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MIN_CONTROL
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MIN_AVAIL
                 frequency_min(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_FREQUENCY_MIN_AVAIL
@@ -197,37 +208,30 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
                 temperature_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_THROTTLE_REASONS
                 frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
-    EXPECT_CALL(*m_device_pool,
-                frequency_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE,
-                                  0, 0)).Times(3);
-    EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
-                performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
+                power_limit_tdp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
+                power_limit_max(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
+                power_limit_min(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "XVE_ACTIVE"));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "XVE_STALL"));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "NUM_REPORTS"));
 
     // Expectations for save_control() and control pruning code in the constructor
     for (int sub_idx = 1; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
-        // the save_control() call, GPU_CORE_FREQUENCY_MAX_CONTROL (control pruning) * 2,
-        // and GPU_CORE_FREQUENCY_MIN_CONTROL (control pruning) * 2 = 5 times
+        // Doesn't include signal pruning
         EXPECT_CALL(*m_device_pool,
                     frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(5);
 
-        // 1. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR_CONTROL
+        // 1. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR
         // 2. Per gpu-chip / control pruning: GPU_CORE_PERFORMANCE_FACTOR_CONTROL (Alias to PERFORMANCE_FACTOR)
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
-                    performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(3);
-        EXPECT_CALL(*m_device_pool, // GPU_CORE_TEMPERATURE_MAXIMUM
-                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_CALL(*m_device_pool, // GPU_MEMORY_TEMPERATURE_MAXIMUM
-                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
+                    performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(2);
 
-        // ZET testing
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE"));
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL"));
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
-
-        // control pruning expectations
         // GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL, and the restore_control() direct call.
         EXPECT_CALL(*m_device_pool,
                     frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE,
@@ -235,18 +239,6 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
                     performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
     }
-
-    // Expectations for signal pruning code in the constructor
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
-                energy(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
-                energy_timestamp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
-                power_limit_tdp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
-                power_limit_max(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
-                power_limit_min(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
 }
 
 void LevelZeroIOGroupTest::TearDown()
@@ -263,7 +255,6 @@ TEST_F(LevelZeroIOGroupTest, valid_signals)
         EXPECT_LT(-1, levelzero_io.signal_behavior(sig));
     }
 }
-
 
 TEST_F(LevelZeroIOGroupTest, save_restore)
 {
@@ -843,11 +834,12 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU_CHIP, -1, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+
     EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, 0)));
     EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:XVE_ACTIVE", GEOPM_DOMAIN_GPU_CHIP, 0)));
     EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:XVE_STALL", GEOPM_DOMAIN_GPU_CHIP, 0)));
@@ -855,18 +847,26 @@ TEST_F(LevelZeroIOGroupTest, error_path)
 
 TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
 {
-    // The following was copy/pasted from SetUpDefaultExpect calls, with the lines commented out that will be
-    // specifically examined by this test.
-
-    // BEGIN COPY/PASTE
-    // Expectations for domain_idx 0 on calls made in the constructor
+    // EXPECT_CALLS for domain idx = 0
     EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
                 performance_factor(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(4);
-    // Times(4) explanation:
-    //   1. Per gpu-chip / signal pruning: GPU_CORE_PERFORMANCE_FACTOR
-    //   2. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR_CONTROL
-    //   3. Per gpu-chip / control pruning: GPU_CORE_PERFORMANCE_FACTOR_CONTROL (Alias to PERFORMANCE_FACTOR)
-    //   4. Check once at the beginning of the constructor to see if perf factor is supported
+    // Times(2) explanation:
+    // 1. check if perf factor is enabled
+    // 2. signal pruning
+    // 3. save_control
+    // 4. control pruning
+    EXPECT_CALL(*m_device_pool,
+                frequency_range(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(7);
+    // Times(7) explanation:
+    // 1. signal pruning = 2 (GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL)
+    // 2. save_control = 1
+    // 3. control pruning = 2
+    // 4. write_control = 2 (it reads min and max freq. before writing)
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
+                performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+    // Times(2) explanation:
+    // 1. control pruning
+    // 2. restore_control
 
     // The EXPECT_CALLS below are default Times(1) for the signal pruning code
     EXPECT_CALL(*m_device_pool, // GPU_ACTIVE_TIME
@@ -881,34 +881,24 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
                 active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_ACTIVE_TIME_TIMESTAMP
                 active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_ENERGY
                 energy(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
+    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
+                energy(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_ENERGY_TIMESTAMP
                 energy_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
+                energy_timestamp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_EFFICIENT
                 frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MAX_AVAIL
                 frequency_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_FREQUENCY_MAX_AVAIL
                 frequency_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
-    // EXPECT_CALL(*m_device_pool,
-    //             frequency_range(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(7);
-    // Times(7) explanation:
-    // 1. Per gpu-chip / signal_pruning: GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 2. Per gpu-chip / signal_pruning: GPU_CORE_FREQUENCY_MIN_CONTROL
-    // 3. Per gpu-chip save_control() call,
-    // 4. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 5. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 6. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MIN_CONTROL
-    // 7. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MIN_CONTROL
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MIN_AVAIL
                 frequency_min(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_FREQUENCY_MIN_AVAIL
                 frequency_min(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
-    // EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_STATUS
-    //             frequency_status(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
-    // EXPECT_CALL(*m_device_pool, // GPU_UNCORE_FREQUENCY_STATUS
-    //             frequency_status(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MAX_AVAIL
                 frequency_step(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_TEMPERATURE_MAXIMUM
@@ -917,64 +907,40 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
                 temperature_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_THROTTLE_REASONS
                 frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
-    // EXPECT_CALL(*m_device_pool,
-    //             frequency_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE,
-    //                               0, 0)).Times(3);
-    // Times(3) explanation:
-    // 1. Per gpu-chip / control_pruning: GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 2. Per gpu-chip / control_pruning: GPU_CORE_FREQUENCY_MIN_CONTROL
-    // 3. Per_gpu-chip restore_control() call.
-    EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
-                performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
+                power_limit_tdp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
+                power_limit_max(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
+                power_limit_min(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "XVE_ACTIVE"));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "XVE_STALL"));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "NUM_REPORTS"));
 
     // Expectations for save_control() and control pruning code in the constructor
     for (int sub_idx = 1; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
-        // the save_control() call, GPU_CORE_FREQUENCY_MAX_CONTROL (control pruning) * 2,
-        // and GPU_CORE_FREQUENCY_MIN_CONTROL (control pruning) * 2 = 5 times
-        // EXPECT_CALL(*m_device_pool,
-        //             frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(5);
+        // Only expecting the call from save_control() for domain idx > 0. The control pruning code
+        // will give up at the first exception thrown when checking
+        // GPU_CORE_FREQUENCY_[MIN|MAX]_CONTROL with domain idx = 0
+        EXPECT_CALL(*m_device_pool,
+                    frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(1);
 
-        // 1. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR_CONTROL
+        // 1. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR
         // 2. Per gpu-chip / control pruning: GPU_CORE_PERFORMANCE_FACTOR_CONTROL (Alias to PERFORMANCE_FACTOR)
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
                     performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(2);
 
-        // GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL, and the restore_control() call
-        // EXPECT_CALL(*m_device_pool,
-        //             frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE,
-        //                               0, 0)).Times(3);
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
                     performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
-
-        // ZET testing
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE"));
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL"));
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
     }
-
-    // Expectations for signal pruning code in the constructor
-    for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
-        EXPECT_CALL(*m_device_pool, // GPU_ENERGY
-                    energy(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
-        EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
-                    energy_timestamp(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
-        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
-                    power_limit_tdp(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
-        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
-                    power_limit_max(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
-        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
-                    power_limit_min(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
-    }
-    // End copy/paste from SetUpDefaultExpectCalls
 
     // The implementation of the pruning code only tests each control on a
     // single domain index if a problem is encountered.  If there is a problem
     // on any chip, the signal is pruned and the remaining GPU_CHIPs are not
     // checked.
-    //Frequency
     EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).
                 WillOnce(Throw(geopm::Exception("Not Supported", GEOPM_ERROR_RUNTIME, __FILE__, __LINE__)));
     EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY)).
@@ -982,12 +948,6 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
 
     EXPECT_CALL(*m_device_pool, frequency_control(GEOPM_DOMAIN_GPU_CHIP, _, MockLevelZero::M_DOMAIN_COMPUTE, _, _)).
                 WillRepeatedly(Throw(geopm::Exception("Not Supported", GEOPM_ERROR_RUNTIME, __FILE__, __LINE__)));
-    for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
-        // frequency_range is called a non-standard number of times due to the implementation of the pruning code.
-        // Only one chip is checked if there is a failure.
-        EXPECT_CALL(*m_device_pool,
-                    frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(AtLeast(1));
-    }
 
     LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool, nullptr);
 

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -372,7 +372,6 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
                                             4200000, 5200000, 1120000, 2621200000,};
 
     std::vector<double> mock_zet_num_reports = {23, 70, 50, 2, 5, 57, 88, 93};
-    std::vector<double> mock_zet_stall = {10, 9, 150, 510, 13, 14, 51, 45};
     std::vector<double> mock_zet_active = {124, 12, 23, 42, 45, 54, 68, 97};
 
     std::vector<int> batch_idx;
@@ -398,8 +397,13 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
         // On live systems we do not support read_signal of ZET signals.
         EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS")).WillOnce(Return(mock_zet_num_reports.at(sub_idx)));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+        EXPECT_CALL(*m_device_pool, metric_read(GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+    }
+
+    for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
         EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE")).WillOnce(Return(mock_zet_active.at(sub_idx)));
-        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL")).WillOnce(Return(mock_zet_stall.at(sub_idx)));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::METRIC:XVE_ACTIVE", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
 
 
@@ -431,21 +435,19 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
         double energy_chip = levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         double energy_chip_batch = levelzero_io.sample(batch_idx.at(sub_idx + 2 * m_num_gpu_subdevice));
 
-        EXPECT_DOUBLE_EQ(energy_chip, mock_energy_chip.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(energy_chip, mock_energy_chip.at(sub_idx) / 1e6);
         EXPECT_DOUBLE_EQ(energy_chip, energy_chip_batch);
 
         //ZET
-        double num_reps = levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double num_reps = levelzero_io.sample(batch_idx.at(sub_idx + 3 * m_num_gpu_subdevice));
         EXPECT_DOUBLE_EQ(num_reps, mock_zet_num_reports.at(sub_idx));
-        double zet_stall = levelzero_io.read_signal("LEVELZERO::METRIC:XVE_STALL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
-        EXPECT_DOUBLE_EQ(zet_stall, mock_zet_stall.at(sub_idx) / 100);
-        double zet_active = levelzero_io.read_signal("LEVELZERO::METRIC:XVE_ACTIVE", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double zet_active = levelzero_io.sample(batch_idx.at(sub_idx + 4 * m_num_gpu_subdevice));
         EXPECT_DOUBLE_EQ(zet_active, mock_zet_active.at(sub_idx) / 100);
     }
 
     for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
         double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_GPU, gpu_idx);
-        double energy_batch = levelzero_io.sample(batch_idx.at(3 * m_num_gpu_subdevice + gpu_idx));
+        double energy_batch = levelzero_io.sample(batch_idx.at(5 * m_num_gpu_subdevice + gpu_idx));
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(gpu_idx)/1e6);
         EXPECT_DOUBLE_EQ(energy, energy_batch);
     }
@@ -470,6 +472,14 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(gpu_idx)));
     }
 
+    for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
+        // On live systems we do not support read_signal of ZET signals.
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS")).WillOnce(Return(mock_zet_num_reports.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE")).WillOnce(Return(mock_zet_active.at(sub_idx)));
+        //EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL")).WillOnce(Return(mock_zet_stall.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, metric_read(GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+    }
+
     levelzero_io.read_batch();
     for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
         double frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
@@ -487,11 +497,17 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
 
         EXPECT_DOUBLE_EQ(energy_chip, mock_energy_chip.at(sub_idx)/1e6);
         EXPECT_DOUBLE_EQ(energy_chip, energy_chip_batch);
+
+        //ZET
+        double num_reps = levelzero_io.sample(batch_idx.at(sub_idx + 3 * m_num_gpu_subdevice));
+        EXPECT_DOUBLE_EQ(num_reps, mock_zet_num_reports.at(sub_idx));
+        double zet_active = levelzero_io.sample(batch_idx.at(sub_idx + 4 * m_num_gpu_subdevice));
+        EXPECT_DOUBLE_EQ(zet_active, mock_zet_active.at(sub_idx) / 100);
     }
 
     for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
         double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_GPU, gpu_idx);
-        double energy_batch = levelzero_io.sample(batch_idx.at(3 * m_num_gpu_subdevice + gpu_idx));
+        double energy_batch = levelzero_io.sample(batch_idx.at(5 * m_num_gpu_subdevice + gpu_idx));
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(gpu_idx) / 1e6);
         EXPECT_DOUBLE_EQ(energy, energy_batch);
     }
@@ -824,11 +840,12 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU_CHIP, -1, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 
-    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
-    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
-    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
-    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0)));
-    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "only supports batch access.");
 }
 
 TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -5,6 +5,9 @@
 
 
 #include <unistd.h>
+#include <limits.h>
+
+#include <cmath>
 #include <fstream>
 #include <string>
 #include <cmath>
@@ -845,7 +848,9 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "only supports batch access.");
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:XVE_ACTIVE", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:XVE_STALL", GEOPM_DOMAIN_GPU_CHIP, 0)));
 }
 
 TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)

--- a/libgeopmd/test/MockLevelZero.hpp
+++ b/libgeopmd/test/MockLevelZero.hpp
@@ -105,6 +105,12 @@ class MockLevelZero : public geopm::LevelZero
                     (unsigned int, int, int, double, double), (const, override));
         MOCK_METHOD(void, performance_factor_control,
                     (unsigned int, int, int, double), (const, override));
+
+        MOCK_METHOD(std::vector<double>, metric_sample,
+                    (unsigned int, unsigned int, std::string),
+                    (const, override));
+        MOCK_METHOD(uint32_t, metric_update_rate, (unsigned int), (const, override));
+        MOCK_METHOD(void, metric_read, (unsigned int, unsigned int), (override));
 };
 
 #endif

--- a/libgeopmd/test/MockLevelZero.hpp
+++ b/libgeopmd/test/MockLevelZero.hpp
@@ -110,6 +110,7 @@ class MockLevelZero : public geopm::LevelZero
                     (unsigned int, unsigned int, std::string),
                     (const, override));
         MOCK_METHOD(uint32_t, metric_update_rate, (unsigned int), (const, override));
+        MOCK_METHOD(void, metric_update_rate_control, (unsigned int, uint32_t), (override));
         MOCK_METHOD(void, metric_read, (unsigned int, unsigned int), (override));
 };
 

--- a/libgeopmd/test/MockLevelZeroDevicePool.hpp
+++ b/libgeopmd/test/MockLevelZeroDevicePool.hpp
@@ -91,6 +91,11 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
                     (int, unsigned int, int, double, double),(const, override));
         MOCK_METHOD(void, performance_factor_control,
                     (int, unsigned int, int, double),(const, override));
+
+        MOCK_METHOD(double, metric_sample,
+                    (int, unsigned int, std::string), (const, override));
+        MOCK_METHOD(uint32_t, metric_update_rate, (int, unsigned int), (const, override));
+        MOCK_METHOD(void, metric_read, (int, unsigned int), (const, override));
 };
 
 #endif


### PR DESCRIPTION
- Relates to #2148 feature quest from github issues
- Provides Intel hardware support analogous to the NVIDIA support added in #1917 and #1914

The addition of ZET metric polling capability to the LevelZero IO Group, Device Pool, and API shim.   

General Metric Streamer flowchart implemented follows the LevelZero approach shown [here](https://spec.oneapi.io/level-zero/latest/_images/tools_metric_streamer.png)

Details of change:
- Updated LevelZero.cpp to set ZET environment variables and follow the general time based metric query approach outlined in the [LevelZero Tools API](https://spec.oneapi.io/level-zero/latest/tools/PROG.html#metrics). 
- Added querying for the 'ComputeBasics' group of Intel Hardware.  An additional metric group may be queried but is not supported at this time.  

Additional Tasks:
- [x] Define Default LevelZero Tools report/event rate based on workload performance
- [x] Add Test for signal and control of LevelZero Tools.
- [ ] Later PR: Consider adding LEVELZERO::METRICS:XVE_*:AGGREGATION.  Currently all signals are averaged over the number of reports received, but this could be modified to be AVG, LAST, MIN, MAX, etc
- [x] Test dynamic tracing with geopm controller (read_signal and batch read have been tested, but not with the controller) 
- [x] Add multi-tile support
- [x] Re-implement metric_destroy/teardown mechanism
- [x] Remove geopmread functionality until an appropriate tear-down handling with read_batch and read_signal can occur.
- [ ] Later PR: Add 'check and fail' if the metric group is changed out  from under the user
