### PR TITLE
Full draft of FFNetAgent and supporting classes.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -433,9 +433,9 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/ModelParse.hpp \
                             src/MonitorAgent.cpp \
                             src/MonitorAgent.hpp \
+                            src/NNFactory.cpp \
                             src/NNFactory.hpp \
                             src/NNFactoryImp.hpp \
-                            src/NNFactory.cpp \
                             src/OptionParser.cpp \
                             src/OptionParser.hpp \
                             src/PowerBalancer.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -433,6 +433,9 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/ModelParse.hpp \
                             src/MonitorAgent.cpp \
                             src/MonitorAgent.hpp \
+                            src/NNFactory.hpp \
+                            src/NNFactoryImp.hpp \
+                            src/NNFactory.cpp \
                             src/OptionParser.cpp \
                             src/OptionParser.hpp \
                             src/PowerBalancer.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -206,10 +206,10 @@ EXTRA_DIST = $(TUTORIAL_DIST) \
              geopm-tutorial.tar.gz \
              indicators/index.html \
              indicators/indicators.py \
-	     json_schemas/domainnetmap_neural_net.schema.json \
+             json_schemas/domainnetmap_neural_net.schema.json \
              json_schemas/geopmagent_policy.schema.json \
              json_schemas/geopmbench_config.schema.json \
-	     json_schemas/regionhintrecommender_fmap.schema.json \
+             json_schemas/regionhintrecommender_fmap.schema.json \
              man/geopmadmin.1 \
              man/geopmagent.1 \
              man/geopm_agent.3 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -389,6 +389,7 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/DenseLayerImp.hpp \
                             src/DomainNetMap.cpp \
                             src/DomainNetMap.hpp \
+                            src/DomainNetMapImp.hpp \
                             src/EditDistPeriodicityDetector.cpp \
                             src/EditDistPeriodicityDetector.hpp \
                             src/EditDistEpochRecordFilter.cpp \
@@ -463,6 +464,7 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/RecordFilter.hpp \
                             src/RegionHintRecommender.cpp \
                             src/RegionHintRecommender.hpp \
+                            src/RegionHintRecommenderImp.hpp \
                             src/Reporter.cpp \
                             src/Reporter.hpp \
                             src/SampleAggregator.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -206,6 +206,7 @@ EXTRA_DIST = $(TUTORIAL_DIST) \
              geopm-tutorial.tar.gz \
              indicators/index.html \
              indicators/indicators.py \
+	     json_schemas/domainnetmap_neural_net.schema.json \
              json_schemas/geopmagent_policy.schema.json \
              json_schemas/geopmbench_config.schema.json \
              man/geopmadmin.1 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -410,8 +410,6 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/Environment.hpp \
                             src/EpochIOGroup.cpp \
                             src/EpochIOGroup.hpp \
-                            src/FFNetAgent.cpp \
-                            src/FFNetAgent.hpp \
                             src/FilePolicy.cpp \
                             src/FilePolicy.hpp \
                             src/FrequencyGovernor.cpp \
@@ -509,6 +507,8 @@ beta_source_files = src/CPUActivityAgent.cpp \
                     src/Daemon.cpp \
                     src/Daemon.hpp \
                     src/DaemonImp.hpp \
+                    src/FFNetAgent.cpp \
+                    src/FFNetAgent.hpp \
                     src/GPUActivityAgent.cpp \
                     src/GPUActivityAgent.hpp \
                     src/PolicyStore.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -209,6 +209,7 @@ EXTRA_DIST = $(TUTORIAL_DIST) \
 	     json_schemas/domainnetmap_neural_net.schema.json \
              json_schemas/geopmagent_policy.schema.json \
              json_schemas/geopmbench_config.schema.json \
+	     json_schemas/regionhintrecommender_fmap.schema.json \
              man/geopmadmin.1 \
              man/geopmagent.1 \
              man/geopm_agent.3 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -384,6 +384,11 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/CSV.hpp \
                             src/DebugIOGroup.cpp \
                             src/DebugIOGroup.hpp \
+                            src/DenseLayer.cpp \
+                            src/DenseLayer.hpp \
+                            src/DenseLayerImp.hpp \
+                            src/DomainNetMap.cpp \
+                            src/DomainNetMap.hpp \
                             src/EditDistPeriodicityDetector.cpp \
                             src/EditDistPeriodicityDetector.hpp \
                             src/EditDistEpochRecordFilter.cpp \
@@ -402,6 +407,8 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/Environment.hpp \
                             src/EpochIOGroup.cpp \
                             src/EpochIOGroup.hpp \
+                            src/FFNetAgent.cpp \
+                            src/FFNetAgent.hpp \
                             src/FilePolicy.cpp \
                             src/FilePolicy.hpp \
                             src/FrequencyGovernor.cpp \
@@ -417,6 +424,9 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/TRLFrequencyLimitDetector.hpp \
                             src/FrequencyMapAgent.cpp \
                             src/FrequencyMapAgent.hpp \
+                            src/LocalNeuralNet.cpp \
+                            src/LocalNeuralNet.hpp \
+                            src/LocalNeuralNetImp.hpp \
                             src/Imbalancer.cpp \
                             src/ModelParse.cpp \
                             src/ModelParse.hpp \
@@ -451,6 +461,8 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/ProcessRegionAggregator.hpp \
                             src/RecordFilter.cpp \
                             src/RecordFilter.hpp \
+                            src/RegionHintRecommender.cpp \
+                            src/RegionHintRecommender.hpp \
                             src/Reporter.cpp \
                             src/Reporter.hpp \
                             src/SampleAggregator.cpp \
@@ -461,6 +473,12 @@ libgeopmpolicy_la_SOURCES = src/Accumulator.cpp \
                             src/SSTClosGovernor.cpp \
                             src/SSTClosGovernor.hpp \
                             src/SSTClosGovernorImp.hpp \
+                            src/TensorMath.cpp \
+                            src/TensorMath.hpp \
+                            src/TensorOneD.cpp \
+                            src/TensorOneD.hpp \
+                            src/TensorTwoD.cpp \
+                            src/TensorTwoD.hpp \
                             src/Tracer.cpp \
                             src/Tracer.hpp \
                             src/TreeComm.cpp \

--- a/copying_headers/MANIFEST.EXEMPT
+++ b/copying_headers/MANIFEST.EXEMPT
@@ -67,6 +67,7 @@ integration/experiment/uncore_frequency_sweep/README.md
 integration/README.md
 integration/requirements.txt
 integration/test/README.md
+json_schemas/domainnetmap_neural_net.schema.json
 json_schemas/geopmbench_config.schema.json
 json_schemas/geopmagent_policy.schema.json
 MANIFEST
@@ -92,6 +93,7 @@ service/docs/source/geopmadmin.1.rst
 service/docs/source/geopmagent.1.rst
 service/docs/source/geopm_agent.3.rst
 service/docs/source/geopm_agent_cpu_activity.7.rst
+service/docs/source/geopm_agent_ffnet.7.rst
 service/docs/source/geopm_agent_frequency_map.7.rst
 service/docs/source/geopm_agent_gpu_activity.7.rst
 service/docs/source/geopm_agent_monitor.7.rst

--- a/copying_headers/MANIFEST.EXEMPT
+++ b/copying_headers/MANIFEST.EXEMPT
@@ -70,6 +70,7 @@ integration/test/README.md
 json_schemas/domainnetmap_neural_net.schema.json
 json_schemas/geopmbench_config.schema.json
 json_schemas/geopmagent_policy.schema.json
+json_schemas/regionhintrecommender_fmap.schema.json
 MANIFEST
 .pre-commit-config.yaml
 pull_request_template.md

--- a/json_schemas/domainnetmap_neural_net.schema.json
+++ b/json_schemas/domainnetmap_neural_net.schema.json
@@ -4,51 +4,58 @@
     "title": "NeuralNet",
     "type": "object",
     "properties": {
-      "layers": {
-        "type": "array",
-        "items": {
-          "type": "array",
-          "prefixItems": [
-            { "type": "array",
-              "items": {
+        "layers": {
+            "type": "array",
+            "items": {
                 "type": "array",
-                "items": "number"
-              }
-            },
-            { "type": "array",
-              "items": "number"
+                "prefixItems": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": "number"
+                      }
+                    },
+                    {
+                      "type": "array",
+                      "items": "number"
+                    }
+                ],
+                "additionalItems": false,
+                "minItems": 2,
+                "maxItems": 2
             }
-          ],
-          "additionalItems": false,
-          "minItems": 2,
-          "maxItems": 2
+        },
+        "signal_inputs": {
+            "type": "array",
+            "items": { "type": "string" }
+        },
+        "delta_inputs": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "prefixItems": [
+                    { "type": "string" },
+                    { "type": "string" }
+                ],
+                "additionalItems": false,
+                "minItems": 2,
+                "maxItems": 2
+            }
+        },
+        "trace_outputs": {
+            "type": "array",
+            "items": { "type": "string" }
+        },
+        "description": {
+            "type": "string"
         }
-      },
-      "signal_inputs": {
-        "type": "array",
-        "items": { "type": "string" }
-      },
-      "delta_inputs": {
-        "type": "array",
-        "items": {
-          "type": "array",
-          "prefixItems": [
-            { "type": "string" },
-            { "type": "string" }
-          ],
-          "additionalItems": false,
-          "minItems": 2,
-          "maxItems": 2
-        }
-      },
-      "trace_outputs": {
-        "type": "array",
-        "items": { "type": "string" }
-      },
-      "description": {
-        "type": "string"
-      }
     },
+    "required": ["layers", "trace_outputs"],
+    "oneOf": [
+        {"required": ["signal_inputs"]},
+        {"required": ["delta_inputs"]}
+    ],
     "additionalProperties": false
 }
 

--- a/json_schemas/domainnetmap_neural_net.schema.json
+++ b/json_schemas/domainnetmap_neural_net.schema.json
@@ -2,19 +2,6 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://geopm.github.io/domainnetmap_neural_net.schema.json",
     "title": "NeuralNet",
-    "definitions" : {
-        "msr": {
-          "type": "array",
-          "prefixItems": [
-            { "type": "string" },
-            { "type": "integer" },
-            { "type": "integer" }
-          ],
-          "additionalItems": false,
-          "minItems": 3,
-          "maxItems": 3
-        }
-    },
     "type": "object",
     "properties": {
       "layers": {
@@ -39,28 +26,20 @@
       },
       "signal_inputs": {
         "type": "array",
-        "items": { "$ref": "#/definitions/msr" }
+        "items": { "type": "string" }
       },
       "delta_inputs": {
         "type": "array",
         "items": {
           "type": "array",
           "prefixItems": [
-            { "$ref": "#/definitions/msr" },
-            { "$ref": "#/definitions/msr" }
+            { "type": "string" },
+            { "type": "string" }
           ],
           "additionalItems": false,
           "minItems": 2,
           "maxItems": 2
         }
-      },
-      "policy_inputs": {
-        "type": "array",
-        "items": { "type": "string" }
-      },
-      "control_outputs": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/msr" }
       },
       "trace_outputs": {
         "type": "array",

--- a/json_schemas/domainnetmap_neural_net.schema.json
+++ b/json_schemas/domainnetmap_neural_net.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://geopm.github.io/nnet.schema.json",
+    "id": "https://geopm.github.io/domainnetmap_neural_net.schema.json",
     "title": "NeuralNet",
     "definitions" : {
         "msr": {

--- a/json_schemas/domainnetmap_neural_net.schema.json
+++ b/json_schemas/domainnetmap_neural_net.schema.json
@@ -1,0 +1,75 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://geopm.github.io/nnet.schema.json",
+    "title": "NeuralNet",
+    "definitions" : {
+        "msr": {
+          "type": "array",
+          "prefixItems": [
+            { "type": "string" },
+            { "type": "integer" },
+            { "type": "integer" }
+          ],
+          "additionalItems": false,
+          "minItems": 3,
+          "maxItems": 3
+        }
+    },
+    "type": "object",
+    "properties": {
+      "layers": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "prefixItems": [
+            { "type": "array",
+              "items": {
+                "type": "array",
+                "items": "number"
+              }
+            },
+            { "type": "array",
+              "items": "number"
+            }
+          ],
+          "additionalItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      },
+      "signal_inputs": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/msr" }
+      },
+      "delta_inputs": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "prefixItems": [
+            { "$ref": "#/definitions/msr" },
+            { "$ref": "#/definitions/msr" }
+          ],
+          "additionalItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      },
+      "policy_inputs": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "control_outputs": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/msr" }
+      },
+      "trace_outputs": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "description": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false
+}
+

--- a/json_schemas/regionhintrecommender_fmap.schema.json
+++ b/json_schemas/regionhintrecommender_fmap.schema.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://geopm.github.io/regionhintrecommender_fmap.schema.json",
+    "title": "Region Frequency Map",
+    "type": "object",
+    "additionalProperties": {
+        "type": "array",
+        "items": {
+            "type": "number"
+        }
+    }
+}

--- a/service/docs/Makefile.mk
+++ b/service/docs/Makefile.mk
@@ -41,6 +41,7 @@ all_man_rst = docs/source/geopm.7.rst \
               docs/source/geopmagent.1.rst \
               docs/source/geopm_agent.3.rst \
               docs/source/geopm_agent_cpu_activity.7.rst \
+	      docs/source/geopm_agent_ffnet.7.rst \
               docs/source/geopm_agent_frequency_map.7.rst \
               docs/source/geopm_agent_gpu_activity.7.rst \
               docs/source/geopm_agent_monitor.7.rst \

--- a/service/docs/source/geopm.7.rst
+++ b/service/docs/source/geopm.7.rst
@@ -380,6 +380,7 @@ See Also
 :doc:`geopmpy(7) <geopmpy.7>`,
 :doc:`geopmdpy(7) <geopmdpy.7>`,
 :doc:`geopm_agent_frequency_map(7) <geopm_agent_frequency_map.7>`,
+:doc:`geopm_agent_ffnet(7) <geopm_agent_ffnet.7>`,
 :doc:`geopm_agent_monitor(7) <geopm_agent_monitor.7>`,
 :doc:`geopm_agent_gpu_activity(7) <geopm_agent_gpu_activity.7>`,
 :doc:`geopm_agent_power_balancer(7) <geopm_agent_power_balancer.7>`,

--- a/service/docs/source/geopm_agent_ffnet.7.rst
+++ b/service/docs/source/geopm_agent_ffnet.7.rst
@@ -1,0 +1,72 @@
+
+geopm_agent_ffnet(7) -- agent for adjusting frequencies based on application behavior
+=====================================================================================
+
+
+
+
+
+
+Description
+-----------
+
+The FFNet agent adjusts frequencies per domain for the goal of improved energy
+efficiency with minimal performance loss. The agent instantiates a neural net
+per domain that ingests hardware telemetry and outputs a probability distribution
+of region classes. This probability distribution is used to determine an optimal
+per-domain frequency. The agent policy can specify an energy-performance bias which
+determines the degree to which the frequency recommender is adverse to potentially
+reducing performance by reducing frequency to save energy.
+
+.. note::
+    This agent can be used at the package scope to control CPU frequency
+    and/or at the per-GPU scope to control GPU frequency.
+
+Agent Name
+----------
+
+The agent described in this manual is selected in many geopm
+interfaces with the ``"ffnet"`` agent name.  This name can be
+passed to :doc:`geopmlaunch(1) <geopmlaunch.1>` as the argument to the ``--geopm-agent``
+option, or the ``GEOPM_AGENT`` environment variable can be set to this
+name (see :doc:`geopm(7) <geopm.7>`\ ).  This name can also be passed to the
+:doc:`geopmagent(1) <geopmagent.1>` as the argument to the ``'-a'`` option.
+
+Policy Parameters
+-----------------
+
+  ``PERF_ENERGY_BIAS`` \:
+      A value between [0-1] that determines how aggressively
+      the agent will reduce frequency in order to save energy.
+      A value of 0 indicates that no performance loss can be
+      tolerated, while a value of 1 indicates that energy
+      efficiency is paramount. Note that there are no absolute
+      guarantees about performance; rather, the general trend
+      of performance impact and energy efficiency will be
+      monotonic relative to this bias.
+
+
+Policy Requirements
+-------------------
+
+The ``PERF_ENERGY_BIAS`` must be between 0 and 1.
+
+Report Extensions
+-----------------
+
+N/A
+
+Control Loop Rate
+-----------------
+
+The agent gates the control loop to sample hardware telemetry and 
+control frequency at 20 milisecond intervals.
+
+See Also
+--------
+
+:doc:`geopm(7) <geopm.7>`\ ,
+:doc:`geopm::Agent(3) <GEOPM_CXX_MAN_Agent.3>`\ ,
+:doc:`geopm_agent(3) <geopm_agent.3>`\ ,
+:doc:`geopmagent(1) <geopmagent.1>`\ ,
+:doc:`geopmlaunch(1) <geopmlaunch.1>`

--- a/service/docs/source/geopm_agent_ffnet.7.rst
+++ b/service/docs/source/geopm_agent_ffnet.7.rst
@@ -60,7 +60,7 @@ Control Loop Rate
 -----------------
 
 The agent gates the control loop to sample hardware telemetry and 
-control frequency at 20 milisecond intervals.
+control frequency at 20 millisecond intervals.
 
 See Also
 --------

--- a/service/docs/source/geopm_agent_ffnet.7.rst
+++ b/service/docs/source/geopm_agent_ffnet.7.rst
@@ -11,7 +11,7 @@ Description
     to change, including being combined with other agents. Also, this agent 
     requires a neural net json file, the format of which is described by 
     the schema domainnetmap_neural_net.schema.json and a region hint 
-    recommendor json file described by the schema 
+    recommender json file described by the schema
     regionhintrecommender_fmap.schema.json. Without these inputs, the agent 
     will throw an error. The autogeneration of these files is future work.
 
@@ -22,6 +22,18 @@ of region classes. This probability distribution is used to determine an optimal
 per-domain frequency. The agent policy can specify an energy-performance bias which
 determines the degree to which the frequency recommender is adverse to potentially
 reducing performance by reducing frequency to save energy.
+
+The neural net for region classification must be provided in a json configuration
+file, which must comply with the following schema:
+
+.. literalinclude:: ../../../json_schemas/domainnetmap_neural_net.schema.json
+    :language: json
+
+The per-region frequency recommendations must be provided in a json configuration
+file, which must comply with the following schema:
+
+.. literalinclude:: ../../../json_schemas/regionhintrecommender_fmap.schema.json
+    :language: json
 
 This agent can be used at the package scope to control CPU frequency
 and/or at the per-GPU scope to control GPU frequency.

--- a/service/docs/source/geopm_agent_ffnet.7.rst
+++ b/service/docs/source/geopm_agent_ffnet.7.rst
@@ -24,16 +24,21 @@ determines the degree to which the frequency recommender is adverse to potential
 reducing performance by reducing frequency to save energy.
 
 The neural net for region classification must be provided in a json configuration
-file, which must comply with the following schema:
+file pointed to by environment variables GEOPM_CPU_NN_PATH and/or GEOPM_GPU_NN_PATH, 
+which must comply with the following schema:
 
 .. literalinclude:: ../../../json_schemas/domainnetmap_neural_net.schema.json
     :language: json
 
 The per-region frequency recommendations must be provided in a json configuration
-file, which must comply with the following schema:
+file pointed to by environment variables GEOPM_CPU_FMAP_PATH and/or GEOPM_GPU_FMAP_PATH, 
+which must comply with the following schema:
 
 .. literalinclude:: ../../../json_schemas/regionhintrecommender_fmap.schema.json
     :language: json
+
+If you specify a neural net for a domain (CPU/GPU), you must specify a frequency 
+recommendation as well.
 
 This agent can be used at the package scope to control CPU frequency
 and/or at the per-GPU scope to control GPU frequency.

--- a/service/docs/source/geopm_agent_ffnet.7.rst
+++ b/service/docs/source/geopm_agent_ffnet.7.rst
@@ -9,9 +9,9 @@ Description
     This is currently an experimental agent and is only available when
     building GEOPM with the ``--enable-beta`` flag. The agent is subject
     to change, including being combined with other agents. Also, this agent 
-    requires a neural net json file, the format of which is described by 
+    requires a neural net JSON file, the format of which is described by 
     the schema domainnetmap_neural_net.schema.json and a region hint 
-    recommender json file described by the schema
+    recommender JSON file described by the schema
     regionhintrecommender_fmap.schema.json. Without these inputs, the agent 
     will throw an error. The autogeneration of these files is future work.
 
@@ -23,14 +23,14 @@ per-domain frequency. The agent policy can specify an energy-performance bias wh
 determines the degree to which the frequency recommender is adverse to potentially
 reducing performance by reducing frequency to save energy.
 
-The neural net for region classification must be provided in a json configuration
+The neural net for region classification must be provided in a JSON configuration
 file pointed to by environment variables GEOPM_CPU_NN_PATH and/or GEOPM_GPU_NN_PATH, 
 which must comply with the following schema:
 
 .. literalinclude:: ../../../json_schemas/domainnetmap_neural_net.schema.json
     :language: json
 
-The per-region frequency recommendations must be provided in a json configuration
+The per-region frequency recommendations must be provided in a JSON configuration
 file pointed to by environment variables GEOPM_CPU_FMAP_PATH and/or GEOPM_GPU_FMAP_PATH, 
 which must comply with the following schema:
 

--- a/service/docs/source/geopm_agent_ffnet.7.rst
+++ b/service/docs/source/geopm_agent_ffnet.7.rst
@@ -5,6 +5,16 @@ geopm_agent_ffnet(7) -- agent for adjusting frequencies based on application beh
 Description
 -----------
 
+.. note::
+    This is currently an experimental agent and is only available when
+    building GEOPM with the ``--enable-beta`` flag. The agent is subject
+    to change, including being combined with other agents. Also, this agent 
+    requires a neural net json file, the format of which is described by 
+    the schema domainnetmap_neural_net.schema.json and a region hint 
+    recommendor json file described by the schema 
+    regionhintrecommender_fmap.schema.json. Without these inputs, the agent 
+    will throw an error. The autogeneration of these files is future work.
+
 The FFNet agent adjusts frequencies per domain for the goal of improved energy
 efficiency with minimal performance loss. The agent instantiates a neural net
 per domain that ingests hardware telemetry and outputs a probability distribution
@@ -13,9 +23,8 @@ per-domain frequency. The agent policy can specify an energy-performance bias wh
 determines the degree to which the frequency recommender is adverse to potentially
 reducing performance by reducing frequency to save energy.
 
-.. note::
-    This agent can be used at the package scope to control CPU frequency
-    and/or at the per-GPU scope to control GPU frequency.
+This agent can be used at the package scope to control CPU frequency
+and/or at the per-GPU scope to control GPU frequency.
 
 Agent Name
 ----------

--- a/service/docs/source/geopm_agent_ffnet.7.rst
+++ b/service/docs/source/geopm_agent_ffnet.7.rst
@@ -2,11 +2,6 @@
 geopm_agent_ffnet(7) -- agent for adjusting frequencies based on application behavior
 =====================================================================================
 
-
-
-
-
-
 Description
 -----------
 

--- a/service/docs/source/geopmagent.1.rst
+++ b/service/docs/source/geopmagent.1.rst
@@ -108,4 +108,5 @@ See Also
 :doc:`geopm_agent_monitor(7) <geopm_agent_monitor.7>`,
 :doc:`geopm_agent_power_balancer(7) <geopm_agent_power_balancer.7>`,
 :doc:`geopm_agent_power_governor(7) <geopm_agent_power_governor.7>`,
+:doc:`geopm_agent_ffnet(7) <geopm_agent_ffnet.7>`,
 :doc:`geopm_agent(3) <geopm_agent.3>`

--- a/service/docs/source/geopmlaunch.1.rst
+++ b/service/docs/source/geopmlaunch.1.rst
@@ -309,9 +309,11 @@ GEOPM Options
                       :doc:`geopm_agent_power_balancer(7)
                       <geopm_agent_power_balancer.7>`,
                       :doc:`geopm_agent_power_governor(7)
-                      <geopm_agent_power_governor.7>`, and
+                      <geopm_agent_power_governor.7>`,
                       :doc:`geopm_agent_frequency_map(7)
-                      <geopm_agent_frequency_map.7>` for descriptions of each
+                      <geopm_agent_frequency_map.7>` and
+                      :doc:`geopm_agent_ffnet(7)
+                      <geopm_agent_ffnet.7>` for descriptions of each
                       agent.
 
                       For more details on the responsibilities of an agent,

--- a/src/DenseLayer.cpp
+++ b/src/DenseLayer.cpp
@@ -29,21 +29,21 @@ namespace geopm
 	      , m_biases(biases)
     {
         if (weights.get_rows() == 0 && weights.get_cols() == 0) {
-            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("Empty array is invalid for neural network weights.\n",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         if (weights.get_rows() != biases.get_dim()) {
-            throw geopm::Exception("Incompatible dimensions for weights and biases.\n",
-                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("Incompatible dimensions for weights and biases.\n",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
     }
 
     TensorOneD DenseLayerImp::forward(const TensorOneD &input) const
     {
         if (input.get_dim() != m_weights.get_cols()) {
-            throw geopm::Exception("Input vector dimension is incompatible with network.\n",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("Input vector dimension is incompatible with network.\n",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         return m_biases + m_weights * input;

--- a/src/DenseLayer.cpp
+++ b/src/DenseLayer.cpp
@@ -14,9 +14,14 @@
 
 namespace geopm
 {
-    std::unique_ptr<DenseLayer> DenseLayer::make_unique(const TensorTwoD &weights, const TensorOneD &biases)
+    std::unique_ptr<DenseLayer> DenseLayer::make_unique(const TensorTwoD &weights,
+                                                        const TensorOneD &biases)
     {
         return geopm::make_unique<DenseLayerImp>(weights, biases);
+    }
+
+    TensorOneD DenseLayer::operator()(const TensorOneD &input) const {
+        return forward(input);
     }
 
     DenseLayerImp::DenseLayerImp(const DenseLayerImp &other)
@@ -26,7 +31,7 @@ namespace geopm
 
     DenseLayerImp::DenseLayerImp(const TensorTwoD &weights, const TensorOneD &biases) 
 	    : m_weights(weights)
-	      , m_biases(biases)
+	    , m_biases(biases)
     {
         if (weights.get_rows() == 0 && weights.get_cols() == 0) {
             throw Exception("DenseLayerImp::" + std::string(__func__) +

--- a/src/DenseLayer.cpp
+++ b/src/DenseLayer.cpp
@@ -25,6 +25,8 @@ namespace geopm
     }
 
     DenseLayerImp::DenseLayerImp(const TensorTwoD &weights, const TensorOneD &biases) 
+	    : m_weights(weights)
+	      , m_biases(biases)
     {
         if (weights.get_rows() == 0 && weights.get_cols() == 0) {
             throw geopm::Exception("Empty array is invalid for neural network weights.\n",
@@ -35,9 +37,6 @@ namespace geopm
             throw geopm::Exception("Incompatible dimensions for weights and biases.",
                     GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-
-        m_weights = weights;
-        m_biases = biases;
     }
 
     TensorOneD DenseLayerImp::forward(const TensorOneD &input) const

--- a/src/DenseLayer.cpp
+++ b/src/DenseLayer.cpp
@@ -29,12 +29,14 @@ namespace geopm
 	      , m_biases(biases)
     {
         if (weights.get_rows() == 0 && weights.get_cols() == 0) {
-            throw Exception("Empty array is invalid for neural network weights.\n",
+            throw Exception("DenseLayerImp::" + std::string(__func__) +
+                            ": Empty array is invalid for neural network weights.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         if (weights.get_rows() != biases.get_dim()) {
-            throw Exception("Incompatible dimensions for weights and biases.\n",
+            throw Exception("DenseLayerImp::" + std::string(__func__) +
+                            "Incompatible dimensions for weights and biases.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
     }
@@ -42,7 +44,8 @@ namespace geopm
     TensorOneD DenseLayerImp::forward(const TensorOneD &input) const
     {
         if (input.get_dim() != m_weights.get_cols()) {
-            throw Exception("Input vector dimension is incompatible with network.\n",
+            throw Exception("DenseLayerImp::" + std::string(__func__) +
+                            "Input vector dimension is incompatible with network.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 

--- a/src/DenseLayer.cpp
+++ b/src/DenseLayer.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
 #include "DenseLayer.hpp"
 #include "DenseLayerImp.hpp"
 

--- a/src/DenseLayer.cpp
+++ b/src/DenseLayer.cpp
@@ -34,7 +34,7 @@ namespace geopm
         }
 
         if (weights.get_rows() != biases.get_dim()) {
-            throw geopm::Exception("Incompatible dimensions for weights and biases.",
+            throw geopm::Exception("Incompatible dimensions for weights and biases.\n",
                     GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
     }
@@ -46,9 +46,7 @@ namespace geopm
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        TensorOneD output = (const TensorTwoD)m_weights * input + m_biases;
-
-        return output;
+        return m_biases + m_weights * input;
     }
 
     size_t DenseLayerImp::get_input_dim() const

--- a/src/DenseLayer.cpp
+++ b/src/DenseLayer.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "DenseLayer.hpp"
+#include "DenseLayerImp.hpp"
+
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+
+namespace geopm
+{
+    std::unique_ptr<DenseLayer> DenseLayer::make_unique(const TensorTwoD &weights, const TensorOneD &biases)
+    {
+        return geopm::make_unique<DenseLayerImp>(weights, biases);
+    }
+
+    DenseLayerImp::DenseLayerImp(const DenseLayerImp &other)
+        : DenseLayerImp(other.m_weights, other.m_biases)
+    {
+    }
+
+    DenseLayerImp::DenseLayerImp(const TensorTwoD &weights, const TensorOneD &biases) 
+    {
+        if (weights.get_rows() == 0 && weights.get_cols() == 0) {
+            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (weights.get_rows() != biases.get_dim()) {
+            throw geopm::Exception("Incompatible dimensions for weights and biases.",
+                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        m_weights = weights;
+        m_biases = biases;
+    }
+
+    TensorOneD DenseLayerImp::forward(const TensorOneD &input) const
+    {
+        if (input.get_dim() != m_weights.get_cols()) {
+            throw geopm::Exception("Input vector dimension is incompatible with network.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        TensorOneD output = (const TensorTwoD)m_weights * input + m_biases;
+
+        return output;
+    }
+
+    size_t DenseLayerImp::get_input_dim() const
+    {
+        return m_weights.get_cols();
+    }
+
+    size_t DenseLayerImp::get_output_dim() const
+    {
+        return m_weights.get_rows();
+    }
+}

--- a/src/DenseLayer.hpp
+++ b/src/DenseLayer.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef DENSELAYER_HPP_INCLUDE
+#define DENSELAYER_HPP_INCLUDE
+
+#include "TensorOneD.hpp"
+
+namespace geopm
+{
+    class TensorTwoD;
+
+    /// @brief Class to perform operations on 1D and 2D Tensors,
+    ///        aka vectors and matrices, suitable for use in
+    ///        feed-forward neural networks.
+    ///  @brief Class to store dense layers
+    class DenseLayer
+    {
+        public:
+            /// @brief Returns a unique_ptr to a concrete object
+            ///        constructed using the underlying implementation
+            ///        from an pair of weights and biases.
+            /// 
+            /// @param [in] weight matrix (TensorTwoD instance) and bias
+            ///             vector (TensorOneD instance)
+            /// 
+            /// @throws geopm::Exception if dimensions are incompatible.
+            static std::unique_ptr<DenseLayer> make_unique(const TensorTwoD &weights, const TensorOneD &biases);
+            virtual ~DenseLayer() = default;
+            /// @brief Perform inference using the instance weights and biases.
+            /// 
+            /// @param [in] TensorOneD vector of input signals.
+            ///
+            /// @return Returns a TensorOneD vector of output values.
+            ///
+            /// @throws geopm::Exception if input dimension is incompatible
+            /// with the layer.
+            virtual TensorOneD forward(const TensorOneD &input) const = 0;
+
+            /// TODO docstrings
+            virtual size_t get_input_dim() const = 0;
+            virtual size_t get_output_dim() const = 0;
+
+            TensorOneD operator()(const TensorOneD &input) const {
+                return forward(input);
+            }
+    };
+}
+
+#endif /* DENSELAYER_HPP_INCLUDE */

--- a/src/DenseLayer.hpp
+++ b/src/DenseLayer.hpp
@@ -30,7 +30,8 @@ namespace geopm
             ///
             /// @throws geopm::Exception if weights and biases dimensions are incompatible.
             ///         i.e. if weights rows is inequal to bias dimension.
-            static std::unique_ptr<DenseLayer> make_unique(const TensorTwoD &weights, const TensorOneD &biases);
+            static std::unique_ptr<DenseLayer> make_unique(const TensorTwoD &weights,
+                                                           const TensorOneD &biases);
             virtual ~DenseLayer() = default;
             /// @brief Perform inference using the instance weights and biases.
             /// 
@@ -50,9 +51,7 @@ namespace geopm
             /// @return Returns a size_t equal to the number of rows of weights 
             virtual size_t get_output_dim() const = 0;
 
-            TensorOneD operator()(const TensorOneD &input) const {
-                return forward(input);
-            }
+            TensorOneD operator()(const TensorOneD &input) const;
     };
 }
 

--- a/src/DenseLayer.hpp
+++ b/src/DenseLayer.hpp
@@ -12,10 +12,9 @@ namespace geopm
 {
     class TensorTwoD;
 
-    /// @brief Class to perform operations on 1D and 2D Tensors,
-    ///        aka vectors and matrices, suitable for use in
-    ///        feed-forward neural networks.
-    ///  @brief Class to store dense layers
+    /// @brief Class to store dense layers and perform operations on 
+    ///        the layers' 1D and 2D Tensors, aka vectors and matrices, 
+    ///        suitable for use in feed-forward neural networks.
     class DenseLayer
     {
         public:
@@ -23,24 +22,32 @@ namespace geopm
             ///        constructed using the underlying implementation
             ///        from an pair of weights and biases.
             /// 
-            /// @param [in] weight matrix (TensorTwoD instance) and bias
-            ///             vector (TensorOneD instance)
-            /// 
-            /// @throws geopm::Exception if dimensions are incompatible.
+            /// @param [in] weight matrix (TensorTwoD instance)
+            ///
+            /// @param [in] bias vector (TensorOneD instance)
+            ///
+            /// @throws geopm::Exception if weights is empty
+            ///
+            /// @throws geopm::Exception if weights and biases dimensions are incompatible.
+            ///         i.e. if weights rows is inequal to bias dimension.
             static std::unique_ptr<DenseLayer> make_unique(const TensorTwoD &weights, const TensorOneD &biases);
             virtual ~DenseLayer() = default;
             /// @brief Perform inference using the instance weights and biases.
             /// 
-            /// @param [in] TensorOneD vector of input signals.
-            ///
-            /// @return Returns a TensorOneD vector of output values.
+            /// @param [in] input TensorOneD vector of input signals.
             ///
             /// @throws geopm::Exception if input dimension is incompatible
-            /// with the layer.
+            ///         with the DenseLayer.
+            ///
+            /// @return Returns a TensorOneD vector of output values.
             virtual TensorOneD forward(const TensorOneD &input) const = 0;
-
-            /// TODO docstrings
+            /// @brief Get the dimension required for the input TensorOneD
+            /// 
+            /// @return Returns a size_t equal to the number of columns of weights
             virtual size_t get_input_dim() const = 0;
+            /// @brief Get the dimension of the resulting TensorOneD
+            /// 
+            /// @return Returns a size_t equal to the number of rows of weights 
             virtual size_t get_output_dim() const = 0;
 
             TensorOneD operator()(const TensorOneD &input) const {

--- a/src/DenseLayerImp.hpp
+++ b/src/DenseLayerImp.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef DENSELAYERIMP_HPP_INCLUDE
+#define DENSELAYERIMP_HPP_INCLUDE
+
+#include "DenseLayer.hpp"
+
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+namespace geopm
+{
+    class DenseLayerImp : public DenseLayer
+    {
+        public:
+            // TODO docstring
+            DenseLayerImp(const DenseLayerImp &other);
+
+            /// @brief Constructor ingesting a TensoTwoD and TensorOneD object
+            ///
+            /// @param [in] weights The TensorTwoD object containing weights
+            ///
+            /// @param [in] biases The TensorOneD object containing biases
+            ///
+            /// @throws geopm::Exception if the dimensions are incompatible,
+            ///         i.e. if weights rows is inequal to bias dimension.
+            ///
+            /// @throws geopm::Exception if the weights is empty
+            DenseLayerImp(const TensorTwoD &weights, const TensorOneD &biases);
+            /// @brief Inference step
+            ///
+            /// @param [in] input The TensorOneD object operating upon the DenseLayer
+            ///
+            /// @throws geopm::Exception if input vector is incompatible with the DenseLayer
+            ///
+            /// @returns Returns a TensorOneD object of output values
+            TensorOneD forward(const TensorOneD &input) const override;
+
+            size_t get_input_dim() const override;
+            size_t get_output_dim() const override;
+
+        private:
+            TensorTwoD m_weights;
+            TensorOneD m_biases;
+    };
+}
+
+#endif /* DENSELAYERIMP_HPP_INCLUDE */

--- a/src/DenseLayerImp.hpp
+++ b/src/DenseLayerImp.hpp
@@ -16,19 +16,17 @@ namespace geopm
     class DenseLayerImp : public DenseLayer
     {
         public:
-            // TODO docstring
             DenseLayerImp(const DenseLayerImp &other);
-
             /// @brief Constructor ingesting a TensoTwoD and TensorOneD object
             ///
             /// @param [in] weights The TensorTwoD object containing weights
             ///
             /// @param [in] biases The TensorOneD object containing biases
             ///
+            /// @throws geopm::Exception if the weights is empty
+            ///
             /// @throws geopm::Exception if the dimensions are incompatible,
             ///         i.e. if weights rows is inequal to bias dimension.
-            ///
-            /// @throws geopm::Exception if the weights is empty
             DenseLayerImp(const TensorTwoD &weights, const TensorOneD &biases);
             /// @brief Inference step
             ///
@@ -38,8 +36,13 @@ namespace geopm
             ///
             /// @returns Returns a TensorOneD object of output values
             TensorOneD forward(const TensorOneD &input) const override;
-
+            /// @brief Get the dimension required for the input TensorOneD
+            /// 
+            /// @return Returns a size_t equal to the number of columns of weights
             size_t get_input_dim() const override;
+            /// @brief Get the dimension of the resulting TensorOneD
+            /// 
+            /// @return Returns a size_t equal to the number of rows of weights 
             size_t get_output_dim() const override;
 
         private:

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -13,6 +13,7 @@
 #include "geopm/Helper.hpp"
 #include "NNFactoryImp.hpp"
 
+// TODO: Change from logits to probabilities
 namespace geopm
 {
     std::unique_ptr<DomainNetMap> DomainNetMap::make_unique(const std::string nn_path, geopm_domain_e domain_type, int domain_index)

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -79,7 +79,7 @@ namespace geopm
             layers.push_back(json_to_DenseLayer(nnet_json["layers"][layer_idx]));
         }
 
-        m_neural_net = std::move(m_nn_factory->createLocalNeuralNet(layers));
+        m_neural_net = m_nn_factory->createLocalNeuralNet(layers);
 
         for (std::size_t i=0; i<nnet_json["signal_inputs"].array_items().size(); i++) {
             m_signal_inputs.push_back({

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -57,7 +57,7 @@ namespace geopm
 
         if (!file) {
             throw Exception("DomainNetMapImp::" + std::string(__func__) +
-                            ": Unable to open neural net file.",
+                            ": Unable to open neural net file: " + nn_path + ".",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -65,7 +65,7 @@ namespace geopm
         std::streampos length = file.tellg();
         file.seekg(0, std::ios::beg);
 
-        if (length >= M_MAX_NNET_SIZE) {
+        if (length >= M_MAX_NNET_SIZE_B) {
             throw Exception("DomainNetMapImp::" + std::string(__func__) +
                             ": Neural net file exceeds maximum size.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "DomainNetMap.hpp"
+
+#include <cmath>
+#include <fstream>
+
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm/PlatformIO.hpp"
+#include "DenseLayerImp.hpp"
+#include "LocalNeuralNetImp.hpp"
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+namespace geopm
+{
+    DomainNetMap::DomainNetMap(geopm::PlatformIO &plat_io, const int count)
+        : m_platform_io(plat_io)
+          , m_count(count)
+          , m_last_output(m_count)
+          , m_signal_inputs(m_count)
+          , m_delta_inputs(m_count)
+    {
+    }
+
+    std::shared_ptr<DenseLayer> DomainNetMap::json_to_DenseLayer(const json11::Json &obj) const {
+        if (!obj.is_array()) {
+            throw geopm::Exception("Neural network weights contains non-array-type.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (obj.array_items().size() != 2) {
+            throw geopm::Exception("Dense Layer weights must be an array of length exactly two.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        TensorTwoD weights = json_to_TensorTwoD(obj[0]);
+        TensorOneD biases = json_to_TensorOneD(obj[1]);
+        return std::make_shared<DenseLayerImp>(weights, biases);
+    }
+
+    TensorOneD DomainNetMap::json_to_TensorOneD(const json11::Json &obj) const {
+        if (!obj.is_array()) {
+            throw geopm::Exception("Neural network weights contains non-array-type.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (obj.array_items().empty()) {
+            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::size_t vec_size = obj.array_items().size();
+        std::vector<float> vals(vec_size);
+
+        for (std::size_t idx = 0; idx < vec_size; ++idx) {
+            if (!obj[idx].is_number()) {
+                throw geopm::Exception("Non-numeric type found in neural network weights.\n",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            vals[idx] = obj[idx].number_value();
+        }
+
+        return TensorOneD(vals);
+    }
+
+    TensorTwoD DomainNetMap::json_to_TensorTwoD(const json11::Json &obj) const {
+        if (!obj.is_array()){
+            throw geopm::Exception("Neural network weights is non-array-type.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (obj.array_items().size() == 0) {
+            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::vector<std::vector<float> > vals;
+        for (std::size_t ridx = 0; ridx < obj.array_items().size(); ++ridx) {
+            if(!obj[ridx].is_array()) {
+                throw geopm::Exception("Neural network weights is non-array-type.\n",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            std::size_t vec_size = obj[ridx].array_items().size();
+            std::vector<float> row(vec_size);
+
+            for (std::size_t cidx = 0; cidx < vec_size; ++cidx) {
+                if (!obj[ridx][cidx].is_number()) {
+                    throw geopm::Exception("Non-numeric type found in neural network weights.\n",
+                                           GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                }
+                row[cidx] = obj[ridx][cidx].number_value();
+            }
+
+            vals.push_back(row);
+        }
+
+        return TensorTwoD(vals);
+    }
+
+    void DomainNetMap::load_neural_net(char* nn_path, int domain_type)
+    {
+        std::ifstream file(nn_path);
+
+        if (!file) {
+            throw geopm::Exception("Unable to open neural net file.\n",
+                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        file.seekg(0, std::ios::end);
+        std::streampos length = file.tellg();
+        file.seekg(0, std::ios::beg);
+
+        if (length >= m_max_nnet_size) {
+            throw geopm::Exception("Neural net file exceeds maximum size.\n",
+                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::string buf, err;
+        buf.reserve(length);
+
+        std::getline(file, buf, '\0');
+
+        const json11::Json nnet_json = json11::Json::parse(buf, err);
+
+        if (! nnet_json["layers"].is_array()) {
+            throw geopm::Exception(
+                    "Neural net json must have a key \"layers\" whose value "
+                    "is an array.\n",
+                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (nnet_json["signal_inputs"].array_items().size() == 0 
+            && nnet_json["delta_inputs"].array_items().size() == 0) {
+            throw geopm::Exception(
+                    "Neural net json must contain at least one of "
+                    "\"signal_inputs\" and \"delta_inputs\" whose "
+                    "value is a non-empty array.\n",
+                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        
+        std::vector<std::shared_ptr<DenseLayer> > layers;
+        for (std::size_t layer_idx = 0; layer_idx < nnet_json["layers"].array_items().size(); ++layer_idx) {
+            layers.push_back(json_to_DenseLayer(nnet_json["layers"][layer_idx]));
+        }
+
+        m_neural_net = geopm::make_unique<LocalNeuralNetImp>(layers);
+
+        for (int domain_idx = 0; domain_idx < m_count; ++domain_idx) {
+            for (std::size_t i=0; i<nnet_json["signal_inputs"].array_items().size(); i++) {
+                m_signal_inputs[domain_idx].push_back({
+                        m_platform_io.push_signal(
+                                nnet_json["signal_inputs"][i][0].string_value(),
+                                domain_type,
+                                domain_idx),
+                        NAN});
+            }
+
+            for (std::size_t i=0; i<nnet_json["delta_inputs"].array_items().size(); i++) {
+                m_delta_inputs[domain_idx].push_back({
+                        m_platform_io.push_signal(
+                                nnet_json["delta_inputs"][i][0][0].string_value(),
+                                domain_type,
+                                domain_idx),
+                        m_platform_io.push_signal(
+                                nnet_json["delta_inputs"][i][1][0].string_value(),
+                                domain_type,
+                                domain_idx),
+                        NAN, NAN, NAN, NAN});
+            }
+        }
+
+        for (std::size_t i=0; i<nnet_json["trace_outputs"].array_items().size(); i++) {
+            m_trace_outputs.push_back(nnet_json["trace_outputs"][i].string_value());
+        }
+    }
+
+    void DomainNetMap::sample()
+    {
+        for (int idx=0; idx<m_count; ++idx) {
+            sample_one(idx);
+        }
+    }
+
+    void DomainNetMap::sample_one(int domain_index)
+    {
+        TensorOneD xs(m_signal_inputs[domain_index].size() + m_delta_inputs[domain_index].size());
+
+        // Collect latest signal values
+        for (std::size_t i=0; i<m_signal_inputs[domain_index].size(); i++) {
+            m_signal_inputs[domain_index][i].signal = m_platform_io.sample(m_signal_inputs[domain_index][i].batch_idx);
+            xs[i] = m_platform_io.sample(m_signal_inputs[domain_index][i].batch_idx);
+        }
+        for (std::size_t i=0; i<m_delta_inputs[domain_index].size(); i++) {
+            m_delta_inputs[domain_index][i].signal_num_last = m_delta_inputs[domain_index][i].signal_num;
+            m_delta_inputs[domain_index][i].signal_den_last = m_delta_inputs[domain_index][i].signal_den;
+            m_delta_inputs[domain_index][i].signal_num = m_platform_io.sample(m_delta_inputs[domain_index][i].batch_idx_num);
+            m_delta_inputs[domain_index][i].signal_den = m_platform_io.sample(m_delta_inputs[domain_index][i].batch_idx_den);
+            xs[m_signal_inputs[domain_index].size() + i] =
+                (m_delta_inputs[domain_index][i].signal_num - m_delta_inputs[domain_index][i].signal_num_last) /
+                (m_delta_inputs[domain_index][i].signal_den - m_delta_inputs[domain_index][i].signal_den_last);
+        }
+
+        m_last_output[domain_index] = m_neural_net->forward(xs);
+    }
+
+    std::vector<std::string> DomainNetMap::trace_names(std::string domain) const
+    {
+        std::vector<std::string> tracelist;
+        for (int domain_index=0; domain_index<m_count; ++domain_index) {
+            for (std::string col: m_trace_outputs) {
+                tracelist.push_back(col + "_" + domain + "_" + std::to_string(domain_index));
+            }
+        }
+        return tracelist;
+    }
+
+    std::vector<double> DomainNetMap::trace_values() const
+    {
+        std::vector<double> rval;
+
+        for (int domain_index=0; domain_index<m_count; ++domain_index) {
+            for (std::size_t idx=0; idx<m_last_output[domain_index].get_dim(); ++idx) {
+                rval.push_back(m_last_output[domain_index][idx]);
+            }
+        }
+
+        return rval;
+    }
+
+    std::map<std::string, float> DomainNetMap::last_output(int domain_index) const
+    {
+        std::map<std::string, float> rval;
+
+        for (std::size_t idx=0; idx<m_last_output[domain_index].get_dim(); ++idx) {
+            rval[m_trace_outputs.at(idx)] = m_last_output.at(domain_index)[idx];
+        }
+
+        return rval;
+    }
+}

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -140,7 +140,7 @@ namespace geopm
         }
 
         std::size_t vec_size = obj.array_items().size();
-        std::vector<float> vals(vec_size);
+        std::vector<double> vals(vec_size);
 
         for (std::size_t idx = 0; idx < vec_size; ++idx) {
             if (!obj[idx].is_number()) {
@@ -163,14 +163,14 @@ namespace geopm
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::vector<std::vector<float> > vals;
+        std::vector<std::vector<double> > vals;
         for (std::size_t ridx = 0; ridx < obj.array_items().size(); ++ridx) {
             if(!obj[ridx].is_array()) {
                 throw geopm::Exception("Neural network weights is non-array-type.\n",
                                        GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             std::size_t vec_size = obj[ridx].array_items().size();
-            std::vector<float> row(vec_size);
+            std::vector<double> row(vec_size);
 
             for (std::size_t cidx = 0; cidx < vec_size; ++cidx) {
                 if (!obj[ridx][cidx].is_number()) {
@@ -188,7 +188,7 @@ namespace geopm
 
     void DomainNetMapImp::sample()
     {
-        std::vector<float> xs;
+        std::vector<double> xs;
 
         // Collect latest signal values
         for (std::size_t i=0; i<m_signal_inputs.size(); i++) {
@@ -222,9 +222,9 @@ namespace geopm
         return rval;
     }
 
-    std::map<std::string, float> DomainNetMapImp::last_output() const
+    std::map<std::string, double> DomainNetMapImp::last_output() const
     {
-        std::map<std::string, float> rval;
+        std::map<std::string, double> rval;
 
         for (std::size_t idx=0; idx<m_last_output.get_dim(); ++idx) {
             rval[m_trace_outputs.at(idx)] = m_last_output[idx];

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -36,26 +36,25 @@ namespace geopm
         return std::make_shared<DomainNetMapImp>(nn_path, domain_type, domain_index);
     }
 
-    DomainNetMapImp::DomainNetMapImp(
-            const std::string &nn_path,
-            geopm_domain_e domain_type,
-            int domain_index)
+    DomainNetMapImp::DomainNetMapImp(const std::string &nn_path,
+                                     geopm_domain_e domain_type,
+                                     int domain_index)
         : DomainNetMapImp(nn_path, domain_type, domain_index, platform_io(),
-                          NNFactory::make_shared()) {
+                          NNFactory::make_shared())
+    {
     }
 
-    DomainNetMapImp::DomainNetMapImp(
-            const std::string &nn_path,
-            geopm_domain_e domain_type,
-            int domain_index,
-            PlatformIO &plat_io,
-            std::shared_ptr<NNFactory> nn_factory)
+    DomainNetMapImp::DomainNetMapImp(const std::string &nn_path,
+                                     geopm_domain_e domain_type,
+                                     int domain_index,
+                                     PlatformIO &plat_io,
+                                     std::shared_ptr<NNFactory> nn_factory)
         : m_platform_io(plat_io)
-          , m_nn_factory(nn_factory)
+        , m_nn_factory(nn_factory)
     {
         std::ifstream file(nn_path);
 
-        if (!file) {
+        if (!file.is_open()) {
             throw Exception("DomainNetMapImp::" + std::string(__func__) +
                             ": Unable to open neural net file: " + nn_path + ".",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -65,7 +64,7 @@ namespace geopm
         std::streampos length = file.tellg();
         file.seekg(0, std::ios::beg);
 
-        if (length >= M_MAX_NNET_SIZE_B) {
+        if (length >= M_MAX_NNET_SIZE) {
             throw Exception("DomainNetMapImp::" + std::string(__func__) +
                             ": Neural net file exceeds maximum size.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -140,7 +139,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         
-        std::vector<std::shared_ptr<DenseLayer>> layers;
+        std::vector<std::shared_ptr<DenseLayer> > layers;
         for (const auto &layer : nnet_json["layers"].array_items()) {
             layers.push_back(json_to_DenseLayer(layer));
         }
@@ -175,31 +174,26 @@ namespace geopm
                                 ": Neural net signal inputs must be strings.",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
-            m_signal_inputs.push_back({
-                    m_platform_io.push_signal(
-                            input.string_value(),
-                            domain_type,
-                            domain_index),
-                    NAN});
+            m_signal_inputs.push_back({m_platform_io.push_signal(input.string_value(),
+                                                                 domain_type,
+                                                                 domain_index),
+                                       NAN});
         }
 
         for (const auto &input : delta_it->second.array_items()) {
-            if (!input.is_array() || input.array_items().size() != 2
-                || !input[0].is_string() || !input[1].is_string()) {
+            if (!input.is_array() || input.array_items().size() != 2 ||
+                !input[0].is_string() || !input[1].is_string()) {
                 throw Exception("DomainNetMapImp::" + std::string(__func__) + 
                                 ": Neural net delta inputs must be tuples of strings.",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
-            m_delta_inputs.push_back({
-                    m_platform_io.push_signal(
-                            input[0].string_value(),
-                            domain_type,
-                            domain_index),
-                    m_platform_io.push_signal(
-                            input[1].string_value(),
-                            domain_type,
-                            domain_index),
-                    NAN, NAN, NAN, NAN});
+            m_delta_inputs.push_back({m_platform_io.push_signal(input[0].string_value(),
+                                                                domain_type,
+                                                                domain_index),
+                                      m_platform_io.push_signal(input[1].string_value(),
+                                                                domain_type,
+                                                                domain_index),
+                                      NAN, NAN, NAN, NAN});
         }
 
         for (const auto &output : nnet_json["trace_outputs"].array_items()) {
@@ -212,7 +206,8 @@ namespace geopm
         }
     }
 
-    std::shared_ptr<DenseLayer> DomainNetMapImp::json_to_DenseLayer(const json11::Json &obj) const {
+    std::shared_ptr<DenseLayer> DomainNetMapImp::json_to_DenseLayer(const json11::Json &obj) const
+    {
         if (!obj.is_array()) {
             throw Exception("DomainNetMapImp::" + std::string(__func__) +
                             ": Neural network weights contains non-array-type.",
@@ -230,7 +225,8 @@ namespace geopm
         return m_nn_factory->createDenseLayer(weights, biases);
     }
 
-    TensorOneD DomainNetMapImp::json_to_TensorOneD(const json11::Json &obj) const {
+    TensorOneD DomainNetMapImp::json_to_TensorOneD(const json11::Json &obj) const
+    {
         if (!obj.is_array()) {
             throw Exception("DomainNetMapImp::" + std::string(__func__) +
                             ": Neural network weights contains non-array-type.",
@@ -243,10 +239,10 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::size_t vec_size = obj.array_items().size();
+        size_t vec_size = obj.array_items().size();
         std::vector<double> vals(vec_size);
 
-        for (std::size_t idx = 0; idx < vec_size; ++idx) {
+        for (size_t idx = 0; idx < vec_size; ++idx) {
             if (!obj[idx].is_number()) {
                 throw Exception("DomainNetMapImp::" + std::string(__func__) +
                                 ": Non-numeric type found in neural network weights.",
@@ -258,7 +254,8 @@ namespace geopm
         return m_nn_factory->createTensorOneD(vals);
     }
 
-    TensorTwoD DomainNetMapImp::json_to_TensorTwoD(const json11::Json &obj) const {
+    TensorTwoD DomainNetMapImp::json_to_TensorTwoD(const json11::Json &obj) const
+    {
         if (!obj.is_array()){
             throw Exception("DomainNetMapImp::" + std::string(__func__) +
                             ": Neural network weights is non-array-type.",
@@ -271,16 +268,16 @@ namespace geopm
         }
 
         std::vector<std::vector<double> > vals;
-        for (std::size_t ridx = 0; ridx < obj.array_items().size(); ++ridx) {
+        for (size_t ridx = 0; ridx < obj.array_items().size(); ++ridx) {
             if (!obj[ridx].is_array()) {
                 throw Exception("DomainNetMapImp::" + std::string(__func__) +
                                 ": Neural network weights is non-array-type.",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
-            std::size_t vec_size = obj[ridx].array_items().size();
+            size_t vec_size = obj[ridx].array_items().size();
             std::vector<double> row(vec_size);
 
-            for (std::size_t cidx = 0; cidx < vec_size; ++cidx) {
+            for (size_t cidx = 0; cidx < vec_size; ++cidx) {
                 if (!obj[ridx][cidx].is_number()) {
                     throw Exception("DomainNetMapImp::" + std::string(__func__) +
                                     ": Non-numeric type found in neural network weights.",
@@ -309,10 +306,8 @@ namespace geopm
             input.signal_den_last = input.signal_den;
             input.signal_num = m_platform_io.sample(input.batch_idx_num);
             input.signal_den = m_platform_io.sample(input.batch_idx_den);
-            xs.push_back(
-                (input.signal_num - input.signal_num_last) /
-                (input.signal_den - input.signal_den_last)
-            );
+            xs.push_back((input.signal_num - input.signal_num_last) /
+                         (input.signal_den - input.signal_den_last));
         }
 
         m_last_output = m_neural_net->forward(m_nn_factory->createTensorOneD(xs));
@@ -325,9 +320,8 @@ namespace geopm
 
     std::vector<double> DomainNetMapImp::trace_values() const
     {
-        std::vector<double> rval(
-                m_last_output.get_data().begin(),
-                m_last_output.get_data().end());
+        std::vector<double> rval(m_last_output.get_data().begin(),
+                                 m_last_output.get_data().end());
         return rval;
     }
 
@@ -335,7 +329,7 @@ namespace geopm
     {
         std::map<std::string, double> rval;
 
-        for (std::size_t idx=0; idx<m_last_output.get_dim(); ++idx) {
+        for (size_t idx=0; idx<m_last_output.get_dim(); ++idx) {
             rval[m_trace_outputs.at(idx)] = m_last_output[idx];
         }
 

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -150,7 +150,7 @@ namespace geopm
 
         if (!nnet_json["trace_outputs"].is_array()) {
             throw Exception(
-                    "Neural net json must contain a key \"trace_outputs\" "
+                    "Neural net json must have a key \"trace_outputs\" "
                     "whose value is an array.\n",
                     GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
@@ -178,9 +178,10 @@ namespace geopm
         }
 
         for (const auto &input : delta_it->second.array_items()) {
-            if (!input.is_string()) {
+            if (!input.is_array() || input.array_items().size() != 2
+                || !input[0].is_string() || !input[1].is_string()) {
                 throw Exception(
-                    "Neural net delta inputs must be strings.\n",
+                    "Neural net delta inputs must be tuples of strings.\n",
                     GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             m_delta_inputs.push_back({

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
 #include "DomainNetMapImp.hpp"
 
 #include <cmath>

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -18,86 +18,8 @@
 
 namespace geopm
 {
-    DomainNetMap::DomainNetMap(geopm::PlatformIO &plat_io)
+    DomainNetMap::DomainNetMap(geopm::PlatformIO &plat_io, char* nn_path, geopm_domain_e domain_type, int domain_index)
         : m_platform_io(plat_io)
-    {
-    }
-
-    std::shared_ptr<DenseLayer> DomainNetMap::json_to_DenseLayer(const json11::Json &obj) const {
-        if (!obj.is_array()) {
-            throw geopm::Exception("Neural network weights contains non-array-type.\n",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-
-        if (obj.array_items().size() != 2) {
-            throw geopm::Exception("Dense Layer weights must be an array of length exactly two.\n",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-
-        TensorTwoD weights = json_to_TensorTwoD(obj[0]);
-        TensorOneD biases = json_to_TensorOneD(obj[1]);
-        return std::make_shared<DenseLayerImp>(weights, biases);
-    }
-
-    TensorOneD DomainNetMap::json_to_TensorOneD(const json11::Json &obj) const {
-        if (!obj.is_array()) {
-            throw geopm::Exception("Neural network weights contains non-array-type.\n",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-
-        if (obj.array_items().empty()) {
-            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-
-        std::size_t vec_size = obj.array_items().size();
-        std::vector<float> vals(vec_size);
-
-        for (std::size_t idx = 0; idx < vec_size; ++idx) {
-            if (!obj[idx].is_number()) {
-                throw geopm::Exception("Non-numeric type found in neural network weights.\n",
-                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-            }
-            vals[idx] = obj[idx].number_value();
-        }
-
-        return TensorOneD(vals);
-    }
-
-    TensorTwoD DomainNetMap::json_to_TensorTwoD(const json11::Json &obj) const {
-        if (!obj.is_array()){
-            throw geopm::Exception("Neural network weights is non-array-type.\n",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-        if (obj.array_items().size() == 0) {
-            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-
-        std::vector<std::vector<float> > vals;
-        for (std::size_t ridx = 0; ridx < obj.array_items().size(); ++ridx) {
-            if(!obj[ridx].is_array()) {
-                throw geopm::Exception("Neural network weights is non-array-type.\n",
-                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-            }
-            std::size_t vec_size = obj[ridx].array_items().size();
-            std::vector<float> row(vec_size);
-
-            for (std::size_t cidx = 0; cidx < vec_size; ++cidx) {
-                if (!obj[ridx][cidx].is_number()) {
-                    throw geopm::Exception("Non-numeric type found in neural network weights.\n",
-                                           GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-                }
-                row[cidx] = obj[ridx][cidx].number_value();
-            }
-
-            vals.push_back(row);
-        }
-
-        return TensorTwoD(vals);
-    }
-
-    void DomainNetMap::load_neural_net(char* nn_path, geopm_domain_e domain_type, int domain_index)
     {
         std::ifstream file(nn_path);
 
@@ -174,6 +96,80 @@ namespace geopm
         // TODO validate that trace_outputs == size of final layer in the net
         //      validate that signal_inputs + delta_inputs == size of initial layer
         //      if net is empty, ensure that these are equal to each other instead
+    }
+
+    std::shared_ptr<DenseLayer> DomainNetMap::json_to_DenseLayer(const json11::Json &obj) const {
+        if (!obj.is_array()) {
+            throw geopm::Exception("Neural network weights contains non-array-type.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (obj.array_items().size() != 2) {
+            throw geopm::Exception("Dense Layer weights must be an array of length exactly two.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        TensorTwoD weights = json_to_TensorTwoD(obj[0]);
+        TensorOneD biases = json_to_TensorOneD(obj[1]);
+        return std::make_shared<DenseLayerImp>(weights, biases);
+    }
+
+    TensorOneD DomainNetMap::json_to_TensorOneD(const json11::Json &obj) const {
+        if (!obj.is_array()) {
+            throw geopm::Exception("Neural network weights contains non-array-type.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        if (obj.array_items().empty()) {
+            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::size_t vec_size = obj.array_items().size();
+        std::vector<float> vals(vec_size);
+
+        for (std::size_t idx = 0; idx < vec_size; ++idx) {
+            if (!obj[idx].is_number()) {
+                throw geopm::Exception("Non-numeric type found in neural network weights.\n",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            vals[idx] = obj[idx].number_value();
+        }
+
+        return TensorOneD(vals);
+    }
+
+    TensorTwoD DomainNetMap::json_to_TensorTwoD(const json11::Json &obj) const {
+        if (!obj.is_array()){
+            throw geopm::Exception("Neural network weights is non-array-type.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        if (obj.array_items().size() == 0) {
+            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::vector<std::vector<float> > vals;
+        for (std::size_t ridx = 0; ridx < obj.array_items().size(); ++ridx) {
+            if(!obj[ridx].is_array()) {
+                throw geopm::Exception("Neural network weights is non-array-type.\n",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+            std::size_t vec_size = obj[ridx].array_items().size();
+            std::vector<float> row(vec_size);
+
+            for (std::size_t cidx = 0; cidx < vec_size; ++cidx) {
+                if (!obj[ridx][cidx].is_number()) {
+                    throw geopm::Exception("Non-numeric type found in neural network weights.\n",
+                                           GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                }
+                row[cidx] = obj[ridx][cidx].number_value();
+            }
+
+            vals.push_back(row);
+        }
+
+        return TensorTwoD(vals);
     }
 
     void DomainNetMap::sample()

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -11,7 +11,6 @@
 
 #include "geopm/Exception.hpp"
 #include "geopm/Helper.hpp"
-#include "geopm/PlatformIO.hpp"
 #include "DenseLayerImp.hpp"
 #include "LocalNeuralNetImp.hpp"
 #include "TensorOneD.hpp"
@@ -19,13 +18,13 @@
 
 namespace geopm
 {
-    std::unique_ptr<DomainNetMap> DomainNetMap::make_unique(PlatformIO &plat_io, const std::string nn_path, geopm_domain_e domain_type, int domain_index)
+    std::unique_ptr<DomainNetMap> DomainNetMap::make_unique(const std::string nn_path, geopm_domain_e domain_type, int domain_index)
     {
-        return geopm::make_unique<DomainNetMapImp>(plat_io, nn_path, domain_type, domain_index);
+        return geopm::make_unique<DomainNetMapImp>(nn_path, domain_type, domain_index);
     }
 
-    DomainNetMapImp::DomainNetMapImp(PlatformIO &plat_io, const std::string nn_path, geopm_domain_e domain_type, int domain_index)
-        : m_platform_io(plat_io)
+    DomainNetMapImp::DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index)
+        : m_platform_io(platform_io())
     {
         std::ifstream file(nn_path);
 

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "DomainNetMap.hpp"
+#include "DomainNetMapImp.hpp"
 
 #include <cmath>
 #include <fstream>
@@ -18,7 +19,12 @@
 
 namespace geopm
 {
-    DomainNetMap::DomainNetMap(geopm::PlatformIO &plat_io, char* nn_path, geopm_domain_e domain_type, int domain_index)
+    std::unique_ptr<DomainNetMap> DomainNetMap::make_unique(PlatformIO &plat_io, const std::string nn_path, geopm_domain_e domain_type, int domain_index)
+    {
+        return geopm::make_unique<DomainNetMapImp>(plat_io, nn_path, domain_type, domain_index);
+    }
+
+    DomainNetMapImp::DomainNetMapImp(PlatformIO &plat_io, const std::string nn_path, geopm_domain_e domain_type, int domain_index)
         : m_platform_io(plat_io)
     {
         std::ifstream file(nn_path);
@@ -98,7 +104,7 @@ namespace geopm
         //      if net is empty, ensure that these are equal to each other instead
     }
 
-    std::shared_ptr<DenseLayer> DomainNetMap::json_to_DenseLayer(const json11::Json &obj) const {
+    std::shared_ptr<DenseLayer> DomainNetMapImp::json_to_DenseLayer(const json11::Json &obj) const {
         if (!obj.is_array()) {
             throw geopm::Exception("Neural network weights contains non-array-type.\n",
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -114,7 +120,7 @@ namespace geopm
         return std::make_shared<DenseLayerImp>(weights, biases);
     }
 
-    TensorOneD DomainNetMap::json_to_TensorOneD(const json11::Json &obj) const {
+    TensorOneD DomainNetMapImp::json_to_TensorOneD(const json11::Json &obj) const {
         if (!obj.is_array()) {
             throw geopm::Exception("Neural network weights contains non-array-type.\n",
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -139,7 +145,7 @@ namespace geopm
         return TensorOneD(vals);
     }
 
-    TensorTwoD DomainNetMap::json_to_TensorTwoD(const json11::Json &obj) const {
+    TensorTwoD DomainNetMapImp::json_to_TensorTwoD(const json11::Json &obj) const {
         if (!obj.is_array()){
             throw geopm::Exception("Neural network weights is non-array-type.\n",
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -172,7 +178,7 @@ namespace geopm
         return TensorTwoD(vals);
     }
 
-    void DomainNetMap::sample()
+    void DomainNetMapImp::sample()
     {
         TensorOneD xs(m_signal_inputs.size() + m_delta_inputs.size());
 
@@ -194,12 +200,12 @@ namespace geopm
         m_last_output = m_neural_net->forward(xs);
     }
 
-    std::vector<std::string> DomainNetMap::trace_names() const
+    std::vector<std::string> DomainNetMapImp::trace_names() const
     {
         return m_trace_outputs;
     }
 
-    std::vector<double> DomainNetMap::trace_values() const
+    std::vector<double> DomainNetMapImp::trace_values() const
     {
         std::vector<double> rval(
                 m_last_output.get_data().begin(),
@@ -207,7 +213,7 @@ namespace geopm
         return rval;
     }
 
-    std::map<std::string, float> DomainNetMap::last_output() const
+    std::map<std::string, float> DomainNetMapImp::last_output() const
     {
         std::map<std::string, float> rval;
 

--- a/src/DomainNetMap.cpp
+++ b/src/DomainNetMap.cpp
@@ -56,7 +56,8 @@ namespace geopm
         std::ifstream file(nn_path);
 
         if (!file) {
-            throw Exception("Unable to open neural net file.\n",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                            ": Unable to open neural net file.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -65,7 +66,8 @@ namespace geopm
         file.seekg(0, std::ios::beg);
 
         if (length >= M_MAX_NNET_SIZE) {
-            throw Exception("Neural net file exceeds maximum size.\n",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                            ": Neural net file exceeds maximum size.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -77,12 +79,14 @@ namespace geopm
         const json11::Json nnet_json = json11::Json::parse(buf, err);
 
         if (!err.empty()) {
-            throw Exception("Neural net file format is incorrect: " + err + "\n.",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                            ": Neural net file format is incorrect: " + err + ".",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         if (nnet_json.is_null() || !nnet_json.is_object()) {
-            throw Exception("Neural net file format is incorrect: object expected\n.",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                            ": Neural net file format is incorrect: object expected.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -90,18 +94,18 @@ namespace geopm
         for (const auto &key : nnet_json.object_items()) {
             if (std::find(M_EXPECTED_KEYS.begin(), M_EXPECTED_KEYS.end(), key.first)
                 == M_EXPECTED_KEYS.end()) {
-                throw Exception(
-                        "Unexpected key in neural net json: " + key.first + "\n",
-                        GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                throw Exception("DomainNetMapImp::" + std::string(__func__) + 
+                                ": Unexpected key in neural net json: " + key.first,
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
         }
 
         // will check key exists, it's an array, and is not empty
         if (nnet_json["layers"].array_items().size() == 0) {
-            throw Exception(
-                    "Neural net must contain valid json and must have "
-                    "a key \"layers\" whose value is a non-empty array.\n",
-                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("DomainNetMapImp::" + std::string(__func__) + 
+                            ": Neural net must contain valid json and must have "
+                            "a key \"layers\" whose value is a non-empty array.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         const auto nnet_properties = nnet_json.object_items();
@@ -112,7 +116,8 @@ namespace geopm
 
         if (signal_it != nnet_properties.end()) {
             if (!signal_it->second.is_array()) {
-                throw Exception("Neural net \"signal_inputs\" must be an array.\n",
+                throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                                 ": Neural net \"signal_inputs\" must be an array.",
                                  GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             signal_inputs_size = signal_it->second.array_items().size();
@@ -120,18 +125,19 @@ namespace geopm
 
         if (delta_it != nnet_properties.end()) {
             if (!delta_it->second.is_array()) {
-                throw Exception("Neural net \"delta_inputs\" must be an array.\n",
+                throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                                ": Neural net \"delta_inputs\" must be an array.",
                                  GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             delta_inputs_size = delta_it->second.array_items().size();
         }
 
         if (signal_inputs_size == 0 && delta_inputs_size == 0) {
-            throw Exception(
-                    "Neural net json must contain at least one of "
-                    "\"signal_inputs\" and \"delta_inputs\" whose "
-                    "value is a non-empty array.\n",
-                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("DomainNetMapImp::" + std::string(__func__) + 
+                            ": Neural net json must contain at least one of "
+                            "\"signal_inputs\" and \"delta_inputs\" whose "
+                            "value is a non-empty array.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         
         std::vector<std::shared_ptr<DenseLayer>> layers;
@@ -142,32 +148,32 @@ namespace geopm
         m_neural_net = m_nn_factory->createLocalNeuralNet(layers);
 
         if (signal_inputs_size + delta_inputs_size != m_neural_net->get_input_dim()) {
-            throw Exception(
-                    "Neural net input dimension must match the number of "
-                    "signal and delta inputs.\n",
-                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("DomainNetMapImp::" + std::string(__func__) + 
+                            ": Neural net input dimension must match the number of "
+                            "signal and delta inputs.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         if (!nnet_json["trace_outputs"].is_array()) {
-            throw Exception(
-                    "Neural net json must have a key \"trace_outputs\" "
-                    "whose value is an array.\n",
-                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("DomainNetMapImp::" + std::string(__func__) + 
+                            ": Neural net json must have a key \"trace_outputs\" "
+                            "whose value is an array.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         if (nnet_json["trace_outputs"].array_items().size()
             != m_neural_net->get_output_dim()) {
-            throw Exception(
-                    "Neural net output dimension must match the number of "
-                    "trace outputs.\n",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) + 
+                            ": Neural net output dimension must match the number of "
+                            "trace outputs.",
                     GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         for (const auto &input : signal_it->second.array_items()) {
             if (!input.is_string()) {
-                throw Exception(
-                    "Neural net signal inputs must be strings.\n",
-                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                throw Exception("DomainNetMapImp::" + std::string(__func__) + 
+                                ": Neural net signal inputs must be strings.",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             m_signal_inputs.push_back({
                     m_platform_io.push_signal(
@@ -180,9 +186,9 @@ namespace geopm
         for (const auto &input : delta_it->second.array_items()) {
             if (!input.is_array() || input.array_items().size() != 2
                 || !input[0].is_string() || !input[1].is_string()) {
-                throw Exception(
-                    "Neural net delta inputs must be tuples of strings.\n",
-                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                throw Exception("DomainNetMapImp::" + std::string(__func__) + 
+                                ": Neural net delta inputs must be tuples of strings.",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             m_delta_inputs.push_back({
                     m_platform_io.push_signal(
@@ -198,9 +204,9 @@ namespace geopm
 
         for (const auto &output : nnet_json["trace_outputs"].array_items()) {
             if (!output.is_string()) {
-                throw Exception(
-                    "Neural net trace outputs must be strings.\n",
-                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                throw Exception("DomainNetMapImp::" + std::string(__func__) + 
+                                ": Neural net trace outputs must be strings.",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             m_trace_outputs.push_back(output.string_value());
         }
@@ -208,12 +214,14 @@ namespace geopm
 
     std::shared_ptr<DenseLayer> DomainNetMapImp::json_to_DenseLayer(const json11::Json &obj) const {
         if (!obj.is_array()) {
-            throw Exception("Neural network weights contains non-array-type.\n",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                            ": Neural network weights contains non-array-type.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         if (obj.array_items().size() != 2) {
-            throw Exception("Dense Layer weights must be an array of length exactly two.\n",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                            ": Dense Layer weights must be an array of length exactly two.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -224,12 +232,14 @@ namespace geopm
 
     TensorOneD DomainNetMapImp::json_to_TensorOneD(const json11::Json &obj) const {
         if (!obj.is_array()) {
-            throw Exception("Neural network weights contains non-array-type.\n",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                            ": Neural network weights contains non-array-type.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         if (obj.array_items().empty()) {
-            throw Exception("Empty array is invalid for neural network weights.\n",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                            ": Empty array is invalid for neural network weights.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -238,7 +248,8 @@ namespace geopm
 
         for (std::size_t idx = 0; idx < vec_size; ++idx) {
             if (!obj[idx].is_number()) {
-                throw Exception("Non-numeric type found in neural network weights.\n",
+                throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                                ": Non-numeric type found in neural network weights.",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             vals[idx] = obj[idx].number_value();
@@ -249,18 +260,21 @@ namespace geopm
 
     TensorTwoD DomainNetMapImp::json_to_TensorTwoD(const json11::Json &obj) const {
         if (!obj.is_array()){
-            throw Exception("Neural network weights is non-array-type.\n",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                            ": Neural network weights is non-array-type.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         if (obj.array_items().size() == 0) {
-            throw Exception("Empty array is invalid for neural network weights.\n",
+            throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                            ": Empty array is invalid for neural network weights.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         std::vector<std::vector<double> > vals;
         for (std::size_t ridx = 0; ridx < obj.array_items().size(); ++ridx) {
             if (!obj[ridx].is_array()) {
-                throw Exception("Neural network weights is non-array-type.\n",
+                throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                                ": Neural network weights is non-array-type.",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             std::size_t vec_size = obj[ridx].array_items().size();
@@ -268,7 +282,8 @@ namespace geopm
 
             for (std::size_t cidx = 0; cidx < vec_size; ++cidx) {
                 if (!obj[ridx][cidx].is_number()) {
-                    throw Exception("Non-numeric type found in neural network weights.\n",
+                    throw Exception("DomainNetMapImp::" + std::string(__func__) +
+                                    ": Non-numeric type found in neural network weights.",
                                     GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                 }
                 row[cidx] = obj[ridx][cidx].number_value();

--- a/src/DomainNetMap.hpp
+++ b/src/DomainNetMap.hpp
@@ -6,13 +6,12 @@
 #ifndef DOMAINNETMAP_HPP_INCLUDE
 #define DOMAINNETMAP_HPP_INCLUDE
 
-#include "geopm/PlatformTopo.hpp"
-
 #include <memory>
+
+#include "geopm/PlatformTopo.hpp"
 
 namespace geopm
 {
-    class PlatformIO;
 
     /// @brief Class to load neural net from file, sample signals specified in 
     ///        that file, feed those signals into the neural net, and manage 
@@ -32,11 +31,10 @@ namespace geopm
             /// @throws geopm::Exception if neural net file does not contain 
             ///         expected keys or arrays
             ///
-            /// @param [in] plat_io PlatformIO instance
             /// @param [in] nn_path Path to neural net
             /// @param [in] domain_type Domain type, defined by geopm_domain_e enum 
             /// @param [in] domain_index Index of the domain to be measured
-            static std::unique_ptr<DomainNetMap> make_unique(PlatformIO &plat_io, const std::string n_path, geopm_domain_e domain_type, int domain_index);
+            static std::unique_ptr<DomainNetMap> make_unique(const std::string n_path, geopm_domain_e domain_type, int domain_index);
 
             virtual ~DomainNetMap() = default;
             /// @brief Collects latest signals for a specific domain and applies the 

--- a/src/DomainNetMap.hpp
+++ b/src/DomainNetMap.hpp
@@ -24,16 +24,21 @@ namespace geopm
             ///        using the underlying implementation which loads neural
             ///        net for a specified domain from a json file.
             ///
+            /// @param [in] nn_path Path to neural net json
+            ///
+            /// @param [in] domain_type Domain type, defined by geopm_domain_e enum 
+            ///
+            /// @param [in] domain_index Index of the domain to be measured
+            ///
             /// @throws geopm::Exception if unable to open neural net file
             ///
             /// @throws geopm::Exception if neural net file exceeds max size  (currently 1024)
             ///
-            /// @throws geopm::Exception if neural net file does not contain 
-            ///         expected keys or arrays
+            /// @throws geopm::Exception if neural net file does not contain a key "layers"
+            ///         or if "layers" does not contain an array
             ///
-            /// @param [in] nn_path Path to neural net
-            /// @param [in] domain_type Domain type, defined by geopm_domain_e enum 
-            /// @param [in] domain_index Index of the domain to be measured
+            /// @throws geopm::Exception if neural net file does not contain either a non-empty 
+            ///         array "signal_inputs" or a non-empty array "delta_inputs"
             static std::unique_ptr<DomainNetMap> make_unique(const std::string n_path, geopm_domain_e domain_type, int domain_index);
 
             virtual ~DomainNetMap() = default;
@@ -44,14 +49,11 @@ namespace geopm
             virtual std::vector<std::string> trace_names() const = 0;
             /// @brief Populates trace values from last_output for each index within each domain type
             ///
-            /// @return A vector of doubles containing trace values
+            /// @return Returns a vector of doubles containing trace values
             virtual std::vector<double> trace_values() const = 0;
-            /// @brief Populates a map of region class name to probability for a given domain, 
-            ///        index from the latest evaluation of the neural net.
+            /// @brief Populates a map of trace names to the latest output from the neural net.
             ///
-            /// @param [in] domain_index
-            ///
-            /// @return A map of string, double containing region class and probabilities
+            /// @return A map of string, double containing trace names and latest nn output
             virtual std::map<std::string, double> last_output() const = 0;
     };
 }

--- a/src/DomainNetMap.hpp
+++ b/src/DomainNetMap.hpp
@@ -6,18 +6,14 @@
 #ifndef DOMAINNETMAP_HPP_INCLUDE
 #define DOMAINNETMAP_HPP_INCLUDE
 
-#include "geopm/json11.hpp"
 #include "geopm/PlatformTopo.hpp"
-
-#include "DenseLayer.hpp"
-#include "LocalNeuralNet.hpp"
 
 #include <memory>
 
 namespace geopm
 {
-    class PlatformTopo;
     class PlatformIO;
+
     /// @brief Class to load neural net from file, sample signals specified in 
     ///        that file, feed those signals into the neural net, and manage 
     ///        the output from the neural nets, i.e. the probabilities of each 
@@ -25,7 +21,9 @@ namespace geopm
     class DomainNetMap
     {
         public:
-            /// @brief Constructor which loads neural net for a specified domain from a json11 instance.
+            /// @brief Returns a unique_ptr to a concrete object constructed
+            ///        using the underlying implementation which loads neural
+            ///        net for a specified domain from a json file.
             ///
             /// @throws geopm::Exception if unable to open neural net file
             ///
@@ -38,62 +36,25 @@ namespace geopm
             /// @param [in] nn_path Path to neural net
             /// @param [in] domain_type Domain type, defined by geopm_domain_e enum 
             /// @param [in] domain_index Index of the domain to be measured
+            static std::unique_ptr<DomainNetMap> make_unique(PlatformIO &plat_io, const std::string n_path, geopm_domain_e domain_type, int domain_index);
 
-            DomainNetMap(geopm::PlatformIO &plat_io, char* nn_path, geopm_domain_e domain_type, int domain_index);
             virtual ~DomainNetMap() = default;
             /// @brief Collects latest signals for a specific domain and applies the 
             ///        resulting TensorOneD state to the neural net.
-            void sample();
+            virtual void sample() = 0;
             /// @brief generates the names for trace columns from the appropriate field in the neural net
-            std::vector<std::string> trace_names() const;
+            virtual std::vector<std::string> trace_names() const = 0;
             /// @brief Populates trace values from last_output for each index within each domain type
             ///
             /// @return A vector of doubles containing trace values
-            std::vector<double> trace_values() const;
+            virtual std::vector<double> trace_values() const = 0;
             /// @brief Populates a map of region class name to probability for a given domain, 
             ///        index from the latest evaluation of the neural net.
             ///
             /// @param [in] domain_index
             ///
             /// @return A map of string, float containing region class and probabilities
-            std::map<std::string, float> last_output() const;
-        private:
-            std::shared_ptr<DenseLayer> json_to_DenseLayer(const json11::Json &obj) const;
-            TensorOneD json_to_TensorOneD(const json11::Json &obj) const;
-            TensorTwoD json_to_TensorTwoD(const json11::Json &obj) const;
-
-            geopm::PlatformIO &m_platform_io;
-
-            struct signal
-            {
-                int batch_idx;
-                double signal;
-            };
-
-            struct delta_signal
-            {
-                int batch_idx_num;
-                int batch_idx_den;
-                double signal_num;
-                double signal_den;
-                double signal_num_last;
-                double signal_den_last;
-            };
-
-            struct trace_output
-            {
-                std::string trace_name;
-                double value;
-            };
-
-            int m_count;
-            static constexpr int m_max_nnet_size = 1024;
-            std::unique_ptr<LocalNeuralNet> m_neural_net;
-
-            TensorOneD m_last_output;
-            std::vector<signal> m_signal_inputs;
-            std::vector<delta_signal> m_delta_inputs;
-            std::vector<std::string> m_trace_outputs;
+            virtual std::map<std::string, float> last_output() const = 0;
     };
 }
 

--- a/src/DomainNetMap.hpp
+++ b/src/DomainNetMap.hpp
@@ -51,8 +51,8 @@ namespace geopm
             ///
             /// @param [in] domain_index
             ///
-            /// @return A map of string, float containing region class and probabilities
-            virtual std::map<std::string, float> last_output() const = 0;
+            /// @return A map of string, double containing region class and probabilities
+            virtual std::map<std::string, double> last_output() const = 0;
     };
 }
 

--- a/src/DomainNetMap.hpp
+++ b/src/DomainNetMap.hpp
@@ -25,12 +25,7 @@ namespace geopm
     class DomainNetMap
     {
         public:
-            DomainNetMap(geopm::PlatformIO &plat_io);
-            /// @brief Constructor with size specified 
-            ///
-            /// @param [in] n Size of 1D tensor
-            virtual ~DomainNetMap() = default;
-            /// @brief Loads neural net for a specified domain from a json11 instance.
+            /// @brief Constructor which loads neural net for a specified domain from a json11 instance.
             ///
             /// @throws geopm::Exception if unable to open neural net file
             ///
@@ -39,10 +34,13 @@ namespace geopm
             /// @throws geopm::Exception if neural net file does not contain 
             ///         expected keys or arrays
             ///
+            /// @param [in] plat_io PlatformIO instance
             /// @param [in] nn_path Path to neural net
             /// @param [in] domain_type Domain type, defined by geopm_domain_e enum 
             /// @param [in] domain_index Index of the domain to be measured
-            void load_neural_net(char* nn_path, geopm_domain_e domain_type, int domain_index);
+
+            DomainNetMap(geopm::PlatformIO &plat_io, char* nn_path, geopm_domain_e domain_type, int domain_index);
+            virtual ~DomainNetMap() = default;
             /// @brief Collects latest signals for a specific domain and applies the 
             ///        resulting TensorOneD state to the neural net.
             void sample();

--- a/src/DomainNetMap.hpp
+++ b/src/DomainNetMap.hpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef DOMAINNETMAP_HPP_INCLUDE
+#define DOMAINNETMAP_HPP_INCLUDE
+
+#include "geopm/json11.hpp"
+
+#include "DenseLayer.hpp"
+#include "LocalNeuralNet.hpp"
+
+#include <memory>
+
+namespace geopm
+{
+    class PlatformTopo;
+    class PlatformIO;
+    /// @brief Class to load neural net from file, sample signals specified in 
+    ///        that file, feed those signals into the neural net, and manage 
+    ///        the output from the neural nets, i.e. the probabilities of each 
+    ///        region class for each domain.
+    class DomainNetMap
+    {
+        public:
+            DomainNetMap(geopm::PlatformIO &plat_io, int count);
+            /// @brief Constructor with size specified 
+            ///
+            /// @param [in] n Size of 1D tensor
+            virtual ~DomainNetMap() = default;
+            /// @brief Loads neural net for a specified domain from a json11 instance.
+            ///
+            /// @throws geopm::Exception if unable to open neural net file
+            ///
+            /// @throws geopm::Exception if neural net file exceeds max size  (currently 1024)
+            ///
+            /// @throws geopm::Exception if neural net file does not contain 
+            ///         expected keys or arrays
+            ///
+            /// @param [in] nn_path Path to neural net
+            /// @param [in] domain_type Domain type, defined by geopm_domain_e enum 
+            void load_neural_net(char* nn_path, int domain_type);
+            /// @brief Calls sample_one for every domain index
+            void sample();
+            /// @brief Collects latest signals for a specific domain index and applies the 
+            ///        resulting TensorOneD state to the neural net.
+            ///
+            /// @param [in] domain_index
+            void sample_one(int index);
+            /// @brief generates the names for trace columns from the appropriate field in the neural net
+            ///
+            /// @param [in] domain String containing domain name. Must match neural net index
+            std::vector<std::string> trace_names(std::string domain) const;
+            /// @brief Populates trace values from last_output for each index within each domain type
+            ///
+            /// @return A vector of doubles containing trace values
+            std::vector<double> trace_values() const;
+            /// @brief Populates a map of region class name to probability for a given domain, 
+            ///        index from the latest evaluation of the neural net.
+            ///
+            /// @param [in] domain_index
+            ///
+            /// @return A map of string, float containing region class and probabilities
+            std::map<std::string, float> last_output(int index) const;
+        private:
+            std::shared_ptr<DenseLayer> json_to_DenseLayer(const json11::Json &obj) const;
+            TensorOneD json_to_TensorOneD(const json11::Json &obj) const;
+            TensorTwoD json_to_TensorTwoD(const json11::Json &obj) const;
+
+            geopm::PlatformIO &m_platform_io;
+
+            struct signal
+            {
+                int batch_idx;
+                double signal;
+            };
+
+            struct delta_signal
+            {
+                int batch_idx_num;
+                int batch_idx_den;
+                double signal_num;
+                double signal_den;
+                double signal_num_last;
+                double signal_den_last;
+            };
+
+            struct trace_output
+            {
+                std::string trace_name;
+                double value;
+            };
+
+            int m_count;
+            static constexpr int m_max_nnet_size = 1024;
+            std::unique_ptr<LocalNeuralNet> m_neural_net;
+
+            std::vector<TensorOneD> m_last_output;
+            std::vector<std::vector<signal> > m_signal_inputs;
+            std::vector<std::vector<delta_signal> > m_delta_inputs;
+            std::vector<std::string> m_trace_outputs;
+    };
+}
+
+#endif  /* DOMAINNETMAP_HPP_INCLUDE */

--- a/src/DomainNetMap.hpp
+++ b/src/DomainNetMap.hpp
@@ -7,6 +7,7 @@
 #define DOMAINNETMAP_HPP_INCLUDE
 
 #include "geopm/json11.hpp"
+#include "geopm/PlatformTopo.hpp"
 
 #include "DenseLayer.hpp"
 #include "LocalNeuralNet.hpp"
@@ -24,7 +25,7 @@ namespace geopm
     class DomainNetMap
     {
         public:
-            DomainNetMap(geopm::PlatformIO &plat_io, int count);
+            DomainNetMap(geopm::PlatformIO &plat_io);
             /// @brief Constructor with size specified 
             ///
             /// @param [in] n Size of 1D tensor
@@ -40,18 +41,13 @@ namespace geopm
             ///
             /// @param [in] nn_path Path to neural net
             /// @param [in] domain_type Domain type, defined by geopm_domain_e enum 
-            void load_neural_net(char* nn_path, int domain_type);
-            /// @brief Calls sample_one for every domain index
-            void sample();
-            /// @brief Collects latest signals for a specific domain index and applies the 
+            /// @param [in] domain_index Index of the domain to be measured
+            void load_neural_net(char* nn_path, geopm_domain_e domain_type, int domain_index);
+            /// @brief Collects latest signals for a specific domain and applies the 
             ///        resulting TensorOneD state to the neural net.
-            ///
-            /// @param [in] domain_index
-            void sample_one(int index);
+            void sample();
             /// @brief generates the names for trace columns from the appropriate field in the neural net
-            ///
-            /// @param [in] domain String containing domain name. Must match neural net index
-            std::vector<std::string> trace_names(std::string domain) const;
+            std::vector<std::string> trace_names() const;
             /// @brief Populates trace values from last_output for each index within each domain type
             ///
             /// @return A vector of doubles containing trace values
@@ -62,7 +58,7 @@ namespace geopm
             /// @param [in] domain_index
             ///
             /// @return A map of string, float containing region class and probabilities
-            std::map<std::string, float> last_output(int index) const;
+            std::map<std::string, float> last_output() const;
         private:
             std::shared_ptr<DenseLayer> json_to_DenseLayer(const json11::Json &obj) const;
             TensorOneD json_to_TensorOneD(const json11::Json &obj) const;
@@ -96,9 +92,9 @@ namespace geopm
             static constexpr int m_max_nnet_size = 1024;
             std::unique_ptr<LocalNeuralNet> m_neural_net;
 
-            std::vector<TensorOneD> m_last_output;
-            std::vector<std::vector<signal> > m_signal_inputs;
-            std::vector<std::vector<delta_signal> > m_delta_inputs;
+            TensorOneD m_last_output;
+            std::vector<signal> m_signal_inputs;
+            std::vector<delta_signal> m_delta_inputs;
             std::vector<std::string> m_trace_outputs;
     };
 }

--- a/src/DomainNetMap.hpp
+++ b/src/DomainNetMap.hpp
@@ -7,16 +7,17 @@
 #define DOMAINNETMAP_HPP_INCLUDE
 
 #include <memory>
+#include <vector>
+#include <map>
 
-#include "geopm/PlatformTopo.hpp"
+#include "geopm_topo.h"
 
 namespace geopm
 {
 
     /// @brief Class to load neural net from file, sample signals specified in 
-    ///        that file, feed those signals into the neural net, and manage 
-    ///        the output from the neural nets, i.e. the probabilities of each 
-    ///        region class for each domain.
+    ///        that file, feed those signals into the neural net and manage 
+    ///        the output from the neural nets.
     class DomainNetMap
     {
         public:
@@ -39,10 +40,34 @@ namespace geopm
             ///
             /// @throws geopm::Exception if neural net file does not contain either a non-empty 
             ///         array "signal_inputs" or a non-empty array "delta_inputs"
-            static std::unique_ptr<DomainNetMap> make_unique(const std::string n_path, geopm_domain_e domain_type, int domain_index);
+            static std::unique_ptr<DomainNetMap> make_unique(const std::string &nn_path,
+                                                             geopm_domain_e domain_type,
+                                                             int domain_index);
+            /// @brief Returns a shared_ptr to a concrete object constructed
+            ///        using the underlying implementation which loads neural
+            ///        net for a specified domain from a json file.
+            ///
+            /// @param [in] nn_path Path to neural net json
+            ///
+            /// @param [in] domain_type Domain type, defined by geopm_domain_e enum 
+            ///
+            /// @param [in] domain_index Index of the domain to be measured
+            ///
+            /// @throws geopm::Exception if unable to open neural net file
+            ///
+            /// @throws geopm::Exception if neural net file exceeds max size  (currently 1024)
+            ///
+            /// @throws geopm::Exception if neural net file does not contain a key "layers"
+            ///         or if "layers" does not contain an array
+            ///
+            /// @throws geopm::Exception if neural net file does not contain either a non-empty 
+            ///         array "signal_inputs" or a non-empty array "delta_inputs"
+            static std::shared_ptr<DomainNetMap> make_shared(const std::string &nn_path,
+                                                             geopm_domain_e domain_type,
+                                                             int domain_index);
 
             virtual ~DomainNetMap() = default;
-            /// @brief Collects latest signals for a specific domain and applies the 
+            /// @brief Samples latest signals for a specific domain and applies the 
             ///        resulting TensorOneD state to the neural net.
             virtual void sample() = 0;
             /// @brief generates the names for trace columns from the appropriate field in the neural net

--- a/src/DomainNetMapImp.hpp
+++ b/src/DomainNetMapImp.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef DOMAINNETMAPIMP_HPP_INCLUDE
+#define DOMAINNETMAPIMP_HPP_INCLUDE
+
+#include "DomainNetMap.hpp"
+
+#include <memory>
+
+#include "geopm/json11.hpp"
+
+#include "DenseLayer.hpp"
+#include "LocalNeuralNet.hpp"
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+namespace geopm
+{
+    class DomainNetMapImp : public DomainNetMap
+    {
+        public:
+            DomainNetMapImp(PlatformIO &plat_io, const std::string nn_path, geopm_domain_e domain_type, int domain_index);
+
+            /// @brief Collects latest signals for a specific domain and applies the 
+            ///        resulting TensorOneD state to the neural net.
+            void sample() override;
+
+            /// @brief generates the names for trace columns from the appropriate field in the neural net
+            std::vector<std::string> trace_names() const override;
+
+            /// @brief Populates trace values from last_output for each index within each domain type
+            ///
+            /// @return A vector of doubles containing trace values
+            std::vector<double> trace_values() const override;
+
+            /// @brief Populates a map of region class name to probability for a given domain, 
+            ///        index from the latest evaluation of the neural net.
+            ///
+            /// @param [in] domain_index
+            ///
+            /// @return A map of string, float containing region class and probabilities
+            std::map<std::string, float> last_output() const override;
+
+        private:
+            std::shared_ptr<DenseLayer> json_to_DenseLayer(const json11::Json &obj) const;
+            TensorOneD json_to_TensorOneD(const json11::Json &obj) const;
+            TensorTwoD json_to_TensorTwoD(const json11::Json &obj) const;
+
+            geopm::PlatformIO &m_platform_io;
+
+            struct signal
+            {
+                int batch_idx;
+                double signal;
+            };
+
+            struct delta_signal
+            {
+                int batch_idx_num;
+                int batch_idx_den;
+                double signal_num;
+                double signal_den;
+                double signal_num_last;
+                double signal_den_last;
+            };
+
+            struct trace_output
+            {
+                std::string trace_name;
+                double value;
+            };
+
+            static constexpr int m_max_nnet_size = 1024;
+            std::unique_ptr<LocalNeuralNet> m_neural_net;
+
+            TensorOneD m_last_output;
+            std::vector<signal> m_signal_inputs;
+            std::vector<delta_signal> m_delta_inputs;
+            std::vector<std::string> m_trace_outputs;
+    };
+}
+
+#endif /* DOMAINNETMAPIMP_HPP_INCLUDE */

--- a/src/DomainNetMapImp.hpp
+++ b/src/DomainNetMapImp.hpp
@@ -26,7 +26,7 @@ namespace geopm
         public:
             DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index);
 
-            DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index, std::shared_ptr<NNFactory> nn_factory);
+            DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index, PlatformIO &plat_io, std::shared_ptr<NNFactory> nn_factory);
 
             /// @brief Collects latest signals for a specific domain and applies the 
             ///        resulting TensorOneD state to the neural net.
@@ -53,7 +53,7 @@ namespace geopm
             TensorOneD json_to_TensorOneD(const json11::Json &obj) const;
             TensorTwoD json_to_TensorTwoD(const json11::Json &obj) const;
 
-            geopm::PlatformIO &m_platform_io;
+            PlatformIO &m_platform_io;
             std::shared_ptr<NNFactory> m_nn_factory;
 
             struct signal
@@ -79,7 +79,7 @@ namespace geopm
             };
 
             static constexpr int m_max_nnet_size = 1024;
-            std::unique_ptr<LocalNeuralNet> m_neural_net;
+            std::shared_ptr<LocalNeuralNet> m_neural_net;
 
             TensorOneD m_last_output;
             std::vector<signal> m_signal_inputs;

--- a/src/DomainNetMapImp.hpp
+++ b/src/DomainNetMapImp.hpp
@@ -11,7 +11,6 @@
 #include <memory>
 
 #include "geopm/json11.hpp"
-#include "geopm/PlatformIO.hpp"
 
 #include "DenseLayer.hpp"
 #include "LocalNeuralNet.hpp"
@@ -21,25 +20,30 @@
 
 namespace geopm
 {
+    class PlatformIO;
+
     class DomainNetMapImp : public DomainNetMap
     {
         public:
-            DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index);
+            DomainNetMapImp(const std::string &nn_path, geopm_domain_e domain_type,
+                            int domain_index);
 
-            DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index, PlatformIO &plat_io, std::shared_ptr<NNFactory> nn_factory);
+            DomainNetMapImp(const std::string &nn_path, geopm_domain_e domain_type,
+                            int domain_index, PlatformIO &plat_io,
+                            std::shared_ptr<NNFactory> nn_factory);
 
             void sample() override;
             /// @brief Generates the names for trace columns from the appropriate field in the neural net.
             //         In this case, region classification names annotated with domain type and index. 
             std::vector<std::string> trace_names() const override;
             /// @brief Populates trace values from last_output for each index within each domain type.
-            ///        In this case, region classification probabilities. 
+            ///        In this case, region classification logits. 
             /// @return Returns a vector of doubles containing trace values
             std::vector<double> trace_values() const override;
             /// @brief Populates a map of trace names to the latest output from the neural net.
-            ///        In this case, region classification names to their respective probabilities.
+            ///        In this case, region classification names to their respective logits.
             ///
-            /// @return A map of string, double containing region class and probabilities.
+            /// @return A map of string, double containing region class and logits.
             std::map<std::string, double> last_output() const override;
 
         private:
@@ -72,7 +76,8 @@ namespace geopm
                 double value;
             };
 
-            static constexpr int m_max_nnet_size = 1024;
+            static const std::vector<std::string> M_EXPECTED_KEYS;
+            static constexpr int M_MAX_NNET_SIZE = 1024;
             std::shared_ptr<LocalNeuralNet> m_neural_net;
 
             TensorOneD m_last_output;

--- a/src/DomainNetMapImp.hpp
+++ b/src/DomainNetMapImp.hpp
@@ -17,6 +17,7 @@
 #include "LocalNeuralNet.hpp"
 #include "TensorOneD.hpp"
 #include "TensorTwoD.hpp"
+#include "NNFactory.hpp"
 
 namespace geopm
 {
@@ -24,6 +25,8 @@ namespace geopm
     {
         public:
             DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index);
+
+            DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index, std::shared_ptr<NNFactory> nn_factory);
 
             /// @brief Collects latest signals for a specific domain and applies the 
             ///        resulting TensorOneD state to the neural net.
@@ -51,6 +54,7 @@ namespace geopm
             TensorTwoD json_to_TensorTwoD(const json11::Json &obj) const;
 
             geopm::PlatformIO &m_platform_io;
+            std::shared_ptr<NNFactory> m_nn_factory;
 
             struct signal
             {

--- a/src/DomainNetMapImp.hpp
+++ b/src/DomainNetMapImp.hpp
@@ -54,13 +54,13 @@ namespace geopm
             PlatformIO &m_platform_io;
             std::shared_ptr<NNFactory> m_nn_factory;
 
-            struct signal_s
+            struct m_signal_s
             {
                 int batch_idx;
                 double signal;
             };
 
-            struct delta_signal_s
+            struct m_delta_signal_s
             {
                 int batch_idx_num;
                 int batch_idx_den;
@@ -71,12 +71,13 @@ namespace geopm
             };
 
             static const std::vector<std::string> M_EXPECTED_KEYS;
-            static constexpr int M_MAX_NNET_SIZE_B = 1024 * 1024;
+            // Size in bytes
+            static constexpr int M_MAX_NNET_SIZE = 1024 * 1024;
             std::shared_ptr<LocalNeuralNet> m_neural_net;
 
             TensorOneD m_last_output;
-            std::vector<signal_s> m_signal_inputs;
-            std::vector<delta_signal_s> m_delta_inputs;
+            std::vector<m_signal_s> m_signal_inputs;
+            std::vector<m_delta_signal_s> m_delta_inputs;
             std::vector<std::string> m_trace_outputs;
     };
 }

--- a/src/DomainNetMapImp.hpp
+++ b/src/DomainNetMapImp.hpp
@@ -29,8 +29,17 @@ namespace geopm
             DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index, PlatformIO &plat_io, std::shared_ptr<NNFactory> nn_factory);
 
             void sample() override;
+            /// @brief Generates the names for trace columns from the appropriate field in the neural net.
+            //         In this case, region classification names annotated with domain type and index. 
             std::vector<std::string> trace_names() const override;
+            /// @brief Populates trace values from last_output for each index within each domain type.
+            ///        In this case, region classification probabilities. 
+            /// @return Returns a vector of doubles containing trace values
             std::vector<double> trace_values() const override;
+            /// @brief Populates a map of trace names to the latest output from the neural net.
+            ///        In this case, region classification names to their respective probabilities.
+            ///
+            /// @return A map of string, double containing region class and probabilities.
             std::map<std::string, double> last_output() const override;
 
         private:

--- a/src/DomainNetMapImp.hpp
+++ b/src/DomainNetMapImp.hpp
@@ -28,25 +28,10 @@ namespace geopm
 
             DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index, PlatformIO &plat_io, std::shared_ptr<NNFactory> nn_factory);
 
-            /// @brief Collects latest signals for a specific domain and applies the 
-            ///        resulting TensorOneD state to the neural net.
             void sample() override;
-
-            /// @brief generates the names for trace columns from the appropriate field in the neural net
             std::vector<std::string> trace_names() const override;
-
-            /// @brief Populates trace values from last_output for each index within each domain type
-            ///
-            /// @return A vector of doubles containing trace values
             std::vector<double> trace_values() const override;
-
-            /// @brief Populates a map of region class name to probability for a given domain, 
-            ///        index from the latest evaluation of the neural net.
-            ///
-            /// @param [in] domain_index
-            ///
-            /// @return A map of string, float containing region class and probabilities
-            std::map<std::string, float> last_output() const override;
+            std::map<std::string, double> last_output() const override;
 
         private:
             std::shared_ptr<DenseLayer> json_to_DenseLayer(const json11::Json &obj) const;

--- a/src/DomainNetMapImp.hpp
+++ b/src/DomainNetMapImp.hpp
@@ -54,13 +54,13 @@ namespace geopm
             PlatformIO &m_platform_io;
             std::shared_ptr<NNFactory> m_nn_factory;
 
-            struct signal
+            struct signal_s
             {
                 int batch_idx;
                 double signal;
             };
 
-            struct delta_signal
+            struct delta_signal_s
             {
                 int batch_idx_num;
                 int batch_idx_den;
@@ -70,19 +70,13 @@ namespace geopm
                 double signal_den_last;
             };
 
-            struct trace_output
-            {
-                std::string trace_name;
-                double value;
-            };
-
             static const std::vector<std::string> M_EXPECTED_KEYS;
             static constexpr int M_MAX_NNET_SIZE = 1024;
             std::shared_ptr<LocalNeuralNet> m_neural_net;
 
             TensorOneD m_last_output;
-            std::vector<signal> m_signal_inputs;
-            std::vector<delta_signal> m_delta_inputs;
+            std::vector<signal_s> m_signal_inputs;
+            std::vector<delta_signal_s> m_delta_inputs;
             std::vector<std::string> m_trace_outputs;
     };
 }

--- a/src/DomainNetMapImp.hpp
+++ b/src/DomainNetMapImp.hpp
@@ -71,7 +71,7 @@ namespace geopm
             };
 
             static const std::vector<std::string> M_EXPECTED_KEYS;
-            static constexpr int M_MAX_NNET_SIZE = 1024;
+            static constexpr int M_MAX_NNET_SIZE_B = 1024 * 1024;
             std::shared_ptr<LocalNeuralNet> m_neural_net;
 
             TensorOneD m_last_output;

--- a/src/DomainNetMapImp.hpp
+++ b/src/DomainNetMapImp.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include "geopm/json11.hpp"
+#include "geopm/PlatformIO.hpp"
 
 #include "DenseLayer.hpp"
 #include "LocalNeuralNet.hpp"
@@ -22,7 +23,7 @@ namespace geopm
     class DomainNetMapImp : public DomainNetMap
     {
         public:
-            DomainNetMapImp(PlatformIO &plat_io, const std::string nn_path, geopm_domain_e domain_type, int domain_index);
+            DomainNetMapImp(const std::string nn_path, geopm_domain_e domain_type, int domain_index);
 
             /// @brief Collects latest signals for a specific domain and applies the 
             ///        resulting TensorOneD state to the neural net.

--- a/src/FFNetAgent.cpp
+++ b/src/FFNetAgent.cpp
@@ -116,7 +116,6 @@ namespace geopm
         //Loading neural nets
         for (const m_domain_key_s domain_key : m_domains) {
             m_net_map[domain_key] = DomainNetMap::make_unique(
-                            m_platform_io,
                             getenv(nnet_envname.at(domain_key.type)),
                             domain_key.type,
                             domain_key.index);

--- a/src/FFNetAgent.cpp
+++ b/src/FFNetAgent.cpp
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "FFNetAgent.hpp"
+
+#include <sstream>
+#include <cmath>
+#include <iostream>
+#include <cassert>
+#include <algorithm>
+#include <fstream>
+
+#include "PlatformIOProf.hpp"
+#include "geopm/PluginFactory.hpp"
+#include "geopm/PlatformIO.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm/Exception.hpp"
+#include "geopm/Agg.hpp"
+
+#include <string>
+
+using geopm::Agent;
+using geopm::PlatformIO;
+using geopm::PlatformTopo;
+
+namespace geopm
+{
+    FFNetAgent::FFNetAgent()
+        : FFNetAgent(geopm::platform_io(), geopm::platform_topo())
+    {
+
+    }
+
+    FFNetAgent::FFNetAgent(geopm::PlatformIO &plat_io, const geopm::PlatformTopo &topo)
+        : m_platform_io(plat_io)
+          , m_platform_topo(topo)
+          , m_last_wait{{0, 0}}
+          , M_WAIT_SEC(0.050) // 50ms Wait
+          , m_phi_idx(0)
+    {
+        geopm_time(&m_last_wait);
+
+        m_domain_types.push_back(GEOPM_DOMAIN_PACKAGE);
+        m_domain_types.push_back(GEOPM_DOMAIN_GPU);
+
+        for (int domain_type : m_domain_types) {
+            m_net_map[domain_type] = geopm::make_unique<DomainNetMap>(
+                            m_platform_io,
+                            m_platform_topo.num_domain(domain_type));
+
+            m_freq_recommender[domain_type] = geopm::make_unique<RegionHintRecommender>();
+        }
+
+        m_has_gpus = m_platform_topo.num_domain(GEOPM_DOMAIN_GPU) > 0;
+    }
+
+    std::string FFNetAgent::plugin_name(void)
+    {
+        return "ffnet";
+    }
+
+    // Name used for registration with the Agent factory
+    std::unique_ptr<Agent> FFNetAgent::make_plugin(void)
+    {
+        return geopm::make_unique<FFNetAgent>();
+    }
+
+    // Push signals and controls for future batch read/write
+    void FFNetAgent::init(int level, const std::vector<int> &fan_in, bool is_level_root)
+    {
+        //Loading neural nets
+        m_net_map[GEOPM_DOMAIN_PACKAGE]->load_neural_net(getenv("GEOPM_CPU_NN_PATH"), GEOPM_DOMAIN_PACKAGE);
+        m_net_map[GEOPM_DOMAIN_GPU]->load_neural_net(getenv("GEOPM_GPU_NN_PATH"), GEOPM_DOMAIN_GPU);
+
+        //Loading frequency map
+        m_freq_recommender[GEOPM_DOMAIN_PACKAGE]->load_freqmap(getenv("GEOPM_CPU_FMAP_PATH"));
+        m_freq_recommender[GEOPM_DOMAIN_GPU]->load_freqmap(getenv("GEOPM_GPU_FMAP_PATH"));
+
+        m_freq_recommender[GEOPM_DOMAIN_PACKAGE]->set_max_freq(
+                        m_platform_io.read_signal(
+                                "CPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD, 0)
+                        );
+        m_freq_recommender[GEOPM_DOMAIN_PACKAGE]->set_min_freq(
+                        m_platform_io.read_signal(
+                                "CPU_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD, 0)
+                        );
+
+        if (m_has_gpus) {
+            m_freq_recommender[GEOPM_DOMAIN_GPU]->set_max_freq(
+                            m_platform_io.read_signal(
+                                    "GPU_CORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD, 0)
+                            );
+            m_freq_recommender[GEOPM_DOMAIN_GPU]->set_min_freq(
+                            m_platform_io.read_signal(
+                                    "GPU_CORE_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD, 0)
+                            );
+        }
+
+        for (int idx=0; idx<m_platform_topo.num_domain(GEOPM_DOMAIN_PACKAGE); ++idx) {
+            m_freq_control[GEOPM_DOMAIN_PACKAGE].push_back(m_platform_io.push_control("CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_PACKAGE, idx));
+        }
+
+        for (int idx=0; idx<m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++idx) {
+            m_freq_control[GEOPM_DOMAIN_GPU].push_back(m_platform_io.push_control("GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU, idx));
+        }
+
+        m_platform_io.write_control("MSR::PQR_ASSOC:RMID", GEOPM_DOMAIN_BOARD, 0, 0);
+        m_platform_io.write_control("MSR::QM_EVTSEL:RMID", GEOPM_DOMAIN_BOARD, 0, 0);
+        m_platform_io.write_control("MSR::QM_EVTSEL:EVENT_ID", GEOPM_DOMAIN_BOARD, 0, 2);
+    }
+
+    // Validate incoming policy and configure default policy requests.
+    void FFNetAgent::validate_policy(std::vector<double> &in_policy) const
+    {
+    }
+
+    // Distribute incoming policy to children
+    void FFNetAgent::split_policy(const std::vector<double>& in_policy,
+            std::vector<std::vector<double> >& out_policy)
+    {
+        for (auto &child_pol : out_policy) {
+            child_pol = in_policy;
+        }
+    }
+
+    // Indicate whether to send the policy down to children
+    bool FFNetAgent::do_send_policy(void) const
+    {
+        return true;
+    }
+
+    void FFNetAgent::aggregate_sample(const std::vector<std::vector<double> > &in_sample,
+            std::vector<double>& out_sample)
+    {
+
+    }
+
+    // Indicate whether to send samples up to the parent
+    bool FFNetAgent::do_send_sample(void) const
+    {
+        return false;
+    }
+
+    void FFNetAgent::adjust_platform(const std::vector<double>& in_policy)
+    {
+        if (!std::isnan(in_policy[M_POLICY_PHI])) {
+            m_phi_idx = (int)in_policy[M_POLICY_PHI];
+            if (m_phi_idx < 0) {
+                m_phi_idx = 0;
+            }
+            if (m_phi_idx > 10) {
+                m_phi_idx = 10;
+            }
+        }
+        m_do_write_batch = false;
+
+        for (int domain_type : m_domain_types) {
+            for (int idx=0; idx<m_platform_topo.num_domain(domain_type); ++idx) {
+                double new_freq = m_freq_recommender[domain_type]->recommend_frequency(
+                        m_net_map[domain_type]->last_output(idx),
+                        m_phi_idx
+                        );
+                if (!std::isnan(new_freq)) {
+                    m_platform_io.adjust(
+                            m_freq_control[domain_type][idx],
+                            new_freq
+                            );
+                    m_do_write_batch = true;
+                }
+            }
+        }
+    }
+
+    // If controls have a valid updated value write them.
+    bool FFNetAgent::do_write_batch(void) const
+    {
+        return m_do_write_batch;
+    }
+
+    // Read signals from the platform and calculate samples to be sent up
+    void FFNetAgent::sample_platform(std::vector<double> &out_sample)
+    {
+        m_sample ++;
+
+        for (int domain_type : m_domain_types) {
+            m_net_map[domain_type]->sample();
+        }
+    }
+
+    // Wait for the remaining cycle time to keep Controller loop cadence
+    void FFNetAgent::wait(void)
+    {
+        geopm_time_s current_time;
+        do {
+            geopm_time(&current_time);
+        }
+        while(geopm_time_diff(&m_last_wait, &current_time) < M_WAIT_SEC);
+        geopm_time(&m_last_wait);
+    }
+
+    // Describes expected policies to be provided by the resource manager or user
+    std::vector<std::string> FFNetAgent::policy_names(void)
+    {
+        return {"CPU_PHI"};
+    }
+    // Describes samples to be provided to the resource manager or user
+    std::vector<std::string> FFNetAgent::sample_names(void)
+    {
+        return {};
+    }
+
+    // Adds the wait time to the top of the report
+    std::vector<std::pair<std::string, std::string> > FFNetAgent::report_header(void) const
+    {
+        return {{"Wait time (sec)", std::to_string(M_WAIT_SEC)}};
+    }
+
+    std::vector<std::pair<std::string, std::string> > FFNetAgent::report_host(void) const
+    {
+        std::vector<std::pair<std::string, std::string> > result;
+        return result;
+    }
+
+    // This Agent does not add any per-region details
+    std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > FFNetAgent::report_region(void) const
+    {
+        return {};
+    }
+
+    // Adds trace columns signals of interest
+    std::vector<std::string> FFNetAgent::trace_names(void) const
+    {
+        std::vector<std::string> tracelist;
+        for (int domain_type : m_domain_types) {
+            std::vector<std::string> domain_tracenames = m_net_map.at(domain_type)->trace_names(std::to_string(domain_type));
+            tracelist.insert(tracelist.end(), domain_tracenames.begin(), domain_tracenames.end());
+        }
+        return tracelist;
+    }
+
+    std::vector<std::function<std::string(double)> > FFNetAgent::trace_formats(void) const
+    {
+        return {};
+    }
+
+    // Updates the trace with values for signals from this Agent
+    void FFNetAgent::trace_values(std::vector<double> &values)
+    {
+        int vidx = 0;
+        for (int domain_type : m_domain_types) {
+            std::vector<double> domain_row = m_net_map[domain_type]->trace_values();
+            for (std::size_t idx=0; idx < domain_row.size(); ++vidx, ++idx) {
+                values[vidx] = domain_row[idx];
+            }
+        }
+    }
+
+    void FFNetAgent::enforce_policy(const std::vector<double> &policy) const
+    {
+    }
+}

--- a/src/FFNetAgent.cpp
+++ b/src/FFNetAgent.cpp
@@ -83,7 +83,7 @@ namespace geopm
             )
         : m_platform_io(plat_io)
           , m_last_wait{{0, 0}}
-          , M_WAIT_SEC(0.050) // 50ms Wait
+          , M_WAIT_SEC(0.020) // 20ms Wait
           , m_phi(0)
     {
         geopm_time(&m_last_wait);
@@ -299,7 +299,7 @@ namespace geopm
     // Describes expected policies to be provided by the resource manager or user
     std::vector<std::string> FFNetAgent::policy_names(void)
     {
-        return {"CPU_PHI"};
+        return {"PERF_ENERGY_BIAS"};
     }
     // Describes samples to be provided to the resource manager or user
     std::vector<std::string> FFNetAgent::sample_names(void)

--- a/src/FFNetAgent.cpp
+++ b/src/FFNetAgent.cpp
@@ -91,7 +91,7 @@ namespace geopm
 
         //Loading neural nets
         for (const m_domain_key_s domain_key : m_domains) {
-            m_net_map[domain_key] = geopm::make_unique<DomainNetMap>(
+            m_net_map[domain_key] = DomainNetMap::make_unique(
                             m_platform_io,
                             getenv(nnet_envname.at(domain_key.type)),
                             domain_key.type,
@@ -99,7 +99,7 @@ namespace geopm
         }
 
         for (geopm_domain_e domain_type : m_domain_types) {
-            m_freq_recommender[domain_type] = geopm::make_unique<RegionHintRecommender>(
+            m_freq_recommender[domain_type] = RegionHintRecommender::make_unique(
                     getenv(freqmap_envname.at(domain_type)),
                     m_platform_io.read_signal(
                         min_freq_signal_name.at(domain_type),
@@ -147,7 +147,7 @@ namespace geopm
 
     // Distribute incoming policy to children
     void FFNetAgent::split_policy(const std::vector<double>& in_policy,
-            std::vector<std::vector<double> >& out_policy)
+                                  std::vector<std::vector<double> >& out_policy)
     {
         for (auto &child_pol : out_policy) {
             child_pol = in_policy;
@@ -161,7 +161,7 @@ namespace geopm
     }
 
     void FFNetAgent::aggregate_sample(const std::vector<std::vector<double> > &in_sample,
-            std::vector<double>& out_sample)
+                                      std::vector<double>& out_sample)
     {
 
     }
@@ -209,7 +209,7 @@ namespace geopm
     // Read signals from the platform and calculate samples to be sent up
     void FFNetAgent::sample_platform(std::vector<double> &out_sample)
     {
-        m_sample ++;
+        ++m_sample;
 
         for (const m_domain_key_s domain_key : m_domains) {
             m_net_map[domain_key]->sample();
@@ -223,7 +223,7 @@ namespace geopm
         do {
             geopm_time(&current_time);
         }
-        while(geopm_time_diff(&m_last_wait, &current_time) < M_WAIT_SEC);
+        while (geopm_time_diff(&m_last_wait, &current_time) < M_WAIT_SEC);
         geopm_time(&m_last_wait);
     }
 

--- a/src/FFNetAgent.cpp
+++ b/src/FFNetAgent.cpp
@@ -279,7 +279,7 @@ namespace geopm
     {
         std::vector<std::string> tracelist;
         for (const m_domain_key_s domain_key : m_domains) {
-            for (const std::string trace_name : m_net_map.at(domain_key)->trace_names()) {
+            for (const std::string& trace_name : m_net_map.at(domain_key)->trace_names()) {
                 tracelist.push_back(
                         trace_name
                         + trace_suffix.at(domain_key.type)

--- a/src/FFNetAgent.cpp
+++ b/src/FFNetAgent.cpp
@@ -112,7 +112,7 @@ namespace geopm
         }
 
         if (net_map.empty()) {
-            for (const m_domain_key_s domain_key : m_domains) {
+            for (const domain_key_s domain_key : m_domains) {
                 m_net_map[domain_key] = DomainNetMap::make_shared(
                                 getenv(M_NNET_ENVNAME.at(domain_key.type)),
                                 domain_key.type,
@@ -120,7 +120,7 @@ namespace geopm
             }
         }
         else {
-            for (const m_domain_key_s domain_key : m_domains) {
+            for (const domain_key_s domain_key : m_domains) {
                 m_net_map[domain_key] = net_map.at(
                         std::make_pair(
                             domain_key.type,
@@ -158,7 +158,7 @@ namespace geopm
     // Push signals and controls for future batch read/write
     void FFNetAgent::init(int level, const std::vector<int> &fan_in, bool is_level_root)
     {
-        for (const m_domain_key_s domain_key : m_domains) {
+        for (const domain_key_s domain_key : m_domains) {
             m_freq_control[domain_key].min_idx = 
                     m_platform_io.push_control(
                         M_MIN_FREQ_CONTROL_NAME.at(domain_key.type),
@@ -237,7 +237,7 @@ namespace geopm
         }
         m_do_write_batch = false;
 
-        for (const m_domain_key_s domain_key : m_domains) {
+        for (const domain_key_s domain_key : m_domains) {
             double new_freq = m_freq_recommender[domain_key.type]->recommend_frequency(
                     m_net_map[domain_key]->last_output(),
                     m_perf_energy_bias
@@ -309,7 +309,8 @@ namespace geopm
     }
 
     // This Agent does not add any per-region details
-    std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > FFNetAgent::report_region(void) const
+    std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >
+            FFNetAgent::report_region(void) const
     {
         return {};
     }
@@ -318,7 +319,7 @@ namespace geopm
     std::vector<std::string> FFNetAgent::trace_names(void) const
     {
         std::vector<std::string> tracelist;
-        for (const m_domain_key_s domain_key : m_domains) {
+        for (const domain_key_s domain_key : m_domains) {
             for (const std::string& trace_name : m_net_map.at(domain_key)->trace_names()) {
                 tracelist.push_back(
                         trace_name
@@ -339,7 +340,6 @@ namespace geopm
     {
         int vidx = 0;
         for (const auto &kv : m_net_map) {
-        //for (const m_domain_key_s domain_key : m_domains) {
             std::vector<double> domain_row = kv.second->trace_values();
             for (std::size_t idx=0; idx < domain_row.size(); ++vidx, ++idx) {
                 values[vidx] = domain_row[idx];

--- a/src/FFNetAgent.cpp
+++ b/src/FFNetAgent.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
 #include "FFNetAgent.hpp"
 
 #include <sstream>

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -6,8 +6,10 @@
 #ifndef FFNETAGENT_HPP_INCLUDE
 #define FFNETAGENT_HPP_INCLUDE
 
+#include <cstdint>
 #include <vector>
 #include <string>
+#include <utility>
 
 #include "Agent.hpp"
 #include "geopm_time.h"
@@ -34,13 +36,10 @@ namespace geopm
             };
 
             FFNetAgent();
-            FFNetAgent(
-                    PlatformIO &plat_io,
-                    const PlatformTopo &topo,
-                    const std::map<std::pair<geopm_domain_e, int>, std::shared_ptr<DomainNetMap> >
-                        &net_map,
-                    const std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> >
-                        &freq_recommender
+            FFNetAgent(PlatformIO &plat_io,
+                       const PlatformTopo &topo,
+                       const std::map<std::pair<geopm_domain_e, int>, std::shared_ptr<DomainNetMap> > &net_map,
+                       const std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> > &freq_recommender
             );
             virtual ~FFNetAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
@@ -70,14 +69,14 @@ namespace geopm
             static std::vector<std::string> sample_names(void);
 
         private:
-            struct domain_key_s {
+            struct m_domain_key_s {
                 geopm_domain_e type;
                 int index;
-                bool operator<(const domain_key_s &other) const {
+                bool operator<(const m_domain_key_s &other) const; /*{
                     return type < other.type || (type == other.type && index < other.index);
-                }
+                }*/
             };
-            struct control_s {
+            struct m_control_s {
                 int max_idx;
                 int min_idx;
                 double last_value;
@@ -96,12 +95,12 @@ namespace geopm
 
             double m_perf_energy_bias;
             int m_sample;
-            std::map<domain_key_s, std::shared_ptr<DomainNetMap> > m_net_map;
+            std::map<m_domain_key_s, std::shared_ptr<DomainNetMap> > m_net_map;
             std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> > m_freq_recommender;
 
-            std::map<domain_key_s, control_s> m_freq_control;
+            std::map<m_domain_key_s, m_control_s> m_freq_control;
             std::vector<geopm_domain_e> m_domain_types;
-            std::vector<domain_key_s> m_domains;
+            std::vector<m_domain_key_s> m_domains;
 
             static const std::map<geopm_domain_e, std::string> M_NNET_ENVNAME;
             static const std::map<geopm_domain_e, std::string> M_FREQMAP_ENVNAME;

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -12,6 +12,7 @@
 #include "geopm_time.h"
 #include "DomainNetMap.hpp"
 #include "RegionHintRecommender.hpp"
+#include "geopm/PlatformTopo.hpp"
 
 namespace geopm
 {
@@ -60,6 +61,14 @@ namespace geopm
             static std::vector<std::string> policy_names(void);
             static std::vector<std::string> sample_names(void);
         private:
+            struct m_domain_key_s {
+                geopm_domain_e type;
+                int index;
+                bool operator<(const m_domain_key_s &other) const {
+                    return type < other.type || (type == other.type && index < other.index);
+                }
+            };
+
             geopm::PlatformIO &m_platform_io;
             const geopm::PlatformTopo &m_platform_topo;
             geopm_time_s m_last_wait;
@@ -70,13 +79,19 @@ namespace geopm
 
             int m_phi_idx;
             int m_sample;
-            bool m_has_gpus;
-            std::map<int, std::unique_ptr<DomainNetMap> > m_net_map;
-            std::map<int, std::unique_ptr<RegionHintRecommender> > m_freq_recommender;
+            std::map<m_domain_key_s, std::unique_ptr<DomainNetMap> > m_net_map;
+            std::map<geopm_domain_e, std::unique_ptr<RegionHintRecommender> > m_freq_recommender;
 
             // m_freq_control[domain type][domain index] = platform io control index
-            std::map<int, std::vector<int> > m_freq_control;
-            std::vector<int> m_domain_types;
+            std::map<m_domain_key_s, int> m_freq_control;
+            std::vector<geopm_domain_e> m_domain_types;
+            std::vector<m_domain_key_s> m_domains;
+
+            const static std::map<geopm_domain_e, const char *> nnet_envname;
+            const static std::map<geopm_domain_e, const char *> freqmap_envname;
+            const static std::map<geopm_domain_e, std::string> max_freq_signal_name;
+            const static std::map<geopm_domain_e, std::string> min_freq_signal_name;
+            const static std::map<geopm_domain_e, std::string> trace_suffix;
     };
 }
 #endif  /* FFNETAGENT_HPP_INCLUDE */

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -56,7 +56,8 @@ namespace geopm
             void wait(void) override;
             std::vector<std::pair<std::string, std::string> > report_header(void) const override;
             std::vector<std::pair<std::string, std::string> > report_host(void) const override;
-            std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > report_region(void) const override;
+            std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >
+                    report_region(void) const override;
             std::vector<std::string> trace_names(void) const override;
             std::vector<std::function<std::string(double)> > trace_formats(void) const override;
             void trace_values(std::vector<double> &values) override;
@@ -68,14 +69,14 @@ namespace geopm
             static std::vector<std::string> sample_names(void);
 
         private:
-            struct m_domain_key_s {
+            struct domain_key_s {
                 geopm_domain_e type;
                 int index;
-                bool operator<(const m_domain_key_s &other) const {
+                bool operator<(const domain_key_s &other) const {
                     return type < other.type || (type == other.type && index < other.index);
                 }
             };
-            struct m_control_s {
+            struct control_s {
                 int max_idx;
                 int min_idx;
                 double last_value;
@@ -93,12 +94,12 @@ namespace geopm
 
             double m_perf_energy_bias;
             int m_sample;
-            std::map<m_domain_key_s, std::shared_ptr<DomainNetMap> > m_net_map;
+            std::map<domain_key_s, std::shared_ptr<DomainNetMap> > m_net_map;
             std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> > m_freq_recommender;
 
-            std::map<m_domain_key_s, m_control_s> m_freq_control;
+            std::map<domain_key_s, control_s> m_freq_control;
             std::vector<geopm_domain_e> m_domain_types;
-            std::vector<m_domain_key_s> m_domains;
+            std::vector<domain_key_s> m_domains;
 
             static const std::map<geopm_domain_e, const char *> M_NNET_ENVNAME;
             static const std::map<geopm_domain_e, const char *> M_FREQMAP_ENVNAME;

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -68,6 +68,7 @@ namespace geopm
                     return type < other.type || (type == other.type && index < other.index);
                 }
             };
+            static bool is_all_nan(const std::vector<double> &vec);
 
             PlatformIO &m_platform_io;
             const PlatformTopo &m_platform_topo;

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -34,6 +34,12 @@ namespace geopm
             };
 
             FFNetAgent();
+            FFNetAgent(
+                    PlatformIO &plat_io,
+                    const PlatformTopo &topo,
+                    std::map<std::pair<geopm_domain_e, int>, std::unique_ptr<DomainNetMap> > &net_map,
+                    std::map<geopm_domain_e, std::unique_ptr<RegionHintRecommender> > &freq_recommender
+            );
             FFNetAgent(PlatformIO &plat_io, const PlatformTopo &topo);
             virtual ~FFNetAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
@@ -68,10 +74,15 @@ namespace geopm
                     return type < other.type || (type == other.type && index < other.index);
                 }
             };
+            struct m_control_s {
+                int max_idx;
+                int min_idx;
+                double last_value;
+            };
+
             static bool is_all_nan(const std::vector<double> &vec);
 
             PlatformIO &m_platform_io;
-            const PlatformTopo &m_platform_topo;
             geopm_time_s m_last_wait;
             const double M_WAIT_SEC;
             bool m_do_write_batch;
@@ -83,17 +94,19 @@ namespace geopm
             std::map<m_domain_key_s, std::unique_ptr<DomainNetMap> > m_net_map;
             std::map<geopm_domain_e, std::unique_ptr<RegionHintRecommender> > m_freq_recommender;
 
-            // m_freq_control[domain type][domain index] = platform io control index
-            std::map<m_domain_key_s, int> m_freq_control;
+            std::map<m_domain_key_s, m_control_s> m_freq_control;
             std::vector<geopm_domain_e> m_domain_types;
             std::vector<m_domain_key_s> m_domains;
 
-            const static std::map<geopm_domain_e, const char *> nnet_envname;
-            const static std::map<geopm_domain_e, const char *> freqmap_envname;
-            const static std::map<geopm_domain_e, std::string> max_freq_signal_name;
-            const static std::map<geopm_domain_e, std::string> min_freq_signal_name;
-            const static std::map<geopm_domain_e, std::string> max_freq_control_name;
-            const static std::map<geopm_domain_e, std::string> trace_suffix;
+            static const std::map<geopm_domain_e, const char *> nnet_envname;
+            static const std::map<geopm_domain_e, const char *> freqmap_envname;
+            static const std::map<geopm_domain_e, std::string> max_freq_signal_name;
+            static const std::map<geopm_domain_e, std::string> min_freq_signal_name;
+            static const std::map<geopm_domain_e, std::string> max_freq_control_name;
+            static const std::map<geopm_domain_e, std::string> min_freq_control_name;
+            static const std::map<geopm_domain_e, std::string> trace_suffix;
+
+            void init_domain_indices(const geopm::PlatformTopo &topo);
     };
 }
 #endif  /* FFNETAGENT_HPP_INCLUDE */

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -12,6 +12,8 @@
 #include "geopm_time.h"
 #include "DomainNetMap.hpp"
 #include "RegionHintRecommender.hpp"
+#include "DomainNetMapImp.hpp"
+#include "RegionHintRecommenderImp.hpp"
 #include "geopm/PlatformTopo.hpp"
 
 namespace geopm
@@ -37,8 +39,8 @@ namespace geopm
             FFNetAgent(
                     PlatformIO &plat_io,
                     const PlatformTopo &topo,
-                    std::map<std::pair<geopm_domain_e, int>, std::unique_ptr<DomainNetMap> > &net_map,
-                    std::map<geopm_domain_e, std::unique_ptr<RegionHintRecommender> > &freq_recommender
+                    std::map<std::pair<geopm_domain_e, int>, std::shared_ptr<DomainNetMap> > &net_map,
+                    std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> > &freq_recommender
             );
             FFNetAgent(PlatformIO &plat_io, const PlatformTopo &topo);
             virtual ~FFNetAgent() = default;
@@ -91,8 +93,8 @@ namespace geopm
 
             double m_phi;
             int m_sample;
-            std::map<m_domain_key_s, std::unique_ptr<DomainNetMap> > m_net_map;
-            std::map<geopm_domain_e, std::unique_ptr<RegionHintRecommender> > m_freq_recommender;
+            std::map<m_domain_key_s, std::shared_ptr<DomainNetMap> > m_net_map;
+            std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> > m_freq_recommender;
 
             std::map<m_domain_key_s, m_control_s> m_freq_control;
             std::vector<geopm_domain_e> m_domain_types;

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -12,9 +12,6 @@
 #include "geopm_time.h"
 #include "DomainNetMap.hpp"
 #include "RegionHintRecommender.hpp"
-#include "DomainNetMapImp.hpp"
-#include "RegionHintRecommenderImp.hpp"
-#include "geopm/PlatformTopo.hpp"
 
 namespace geopm
 {
@@ -39,18 +36,19 @@ namespace geopm
             FFNetAgent(
                     PlatformIO &plat_io,
                     const PlatformTopo &topo,
-                    std::map<std::pair<geopm_domain_e, int>, std::shared_ptr<DomainNetMap> > &net_map,
-                    std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> > &freq_recommender
+                    const std::map<std::pair<geopm_domain_e, int>, std::shared_ptr<DomainNetMap> >
+                        &net_map,
+                    const std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> >
+                        &freq_recommender
             );
-            FFNetAgent(PlatformIO &plat_io, const PlatformTopo &topo);
             virtual ~FFNetAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
             void validate_policy(std::vector<double> &in_policy) const override;
             void split_policy(const std::vector<double> &in_policy,
-                    std::vector<std::vector<double> > &out_policy) override;
+                              std::vector<std::vector<double> > &out_policy) override;
             bool do_send_policy(void) const override;
             void aggregate_sample(const std::vector<std::vector<double> > &in_sample,
-                    std::vector<double> &out_sample) override;
+                                  std::vector<double> &out_sample) override;
             bool do_send_sample(void) const override;
             void adjust_platform(const std::vector<double> &in_policy) override;
             bool do_write_batch(void) const override;
@@ -68,6 +66,7 @@ namespace geopm
             static std::unique_ptr<Agent> make_plugin(void);
             static std::vector<std::string> policy_names(void);
             static std::vector<std::string> sample_names(void);
+
         private:
             struct m_domain_key_s {
                 geopm_domain_e type;
@@ -83,10 +82,11 @@ namespace geopm
             };
 
             static bool is_all_nan(const std::vector<double> &vec);
+            void init_domain_indices(const PlatformTopo &topo);
 
             PlatformIO &m_platform_io;
             geopm_time_s m_last_wait;
-            const double M_WAIT_SEC;
+            static constexpr double M_WAIT_SEC = 0.020;
             bool m_do_write_batch;
 
             std::map<std::string, double> m_policy_available;
@@ -100,15 +100,13 @@ namespace geopm
             std::vector<geopm_domain_e> m_domain_types;
             std::vector<m_domain_key_s> m_domains;
 
-            static const std::map<geopm_domain_e, const char *> nnet_envname;
-            static const std::map<geopm_domain_e, const char *> freqmap_envname;
-            static const std::map<geopm_domain_e, std::string> max_freq_signal_name;
-            static const std::map<geopm_domain_e, std::string> min_freq_signal_name;
-            static const std::map<geopm_domain_e, std::string> max_freq_control_name;
-            static const std::map<geopm_domain_e, std::string> min_freq_control_name;
-            static const std::map<geopm_domain_e, std::string> trace_suffix;
-
-            void init_domain_indices(const geopm::PlatformTopo &topo);
+            static const std::map<geopm_domain_e, const char *> M_NNET_ENVNAME;
+            static const std::map<geopm_domain_e, const char *> M_FREQMAP_ENVNAME;
+            static const std::map<geopm_domain_e, std::string> M_MAX_FREQ_SIGNAL_NAME;
+            static const std::map<geopm_domain_e, std::string> M_MIN_FREQ_SIGNAL_NAME;
+            static const std::map<geopm_domain_e, std::string> M_MAX_FREQ_CONTROL_NAME;
+            static const std::map<geopm_domain_e, std::string> M_MIN_FREQ_CONTROL_NAME;
+            static const std::map<geopm_domain_e, std::string> M_TRACE_SUFFIX;
     };
 }
 #endif  /* FFNETAGENT_HPP_INCLUDE */

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -7,6 +7,7 @@
 #define FFNETAGENT_HPP_INCLUDE
 
 #include <vector>
+#include <string>
 
 #include "Agent.hpp"
 #include "geopm_time.h"
@@ -83,6 +84,7 @@ namespace geopm
             };
 
             static bool is_all_nan(const std::vector<double> &vec);
+            static std::string get_env_value(const std::string &env_var);
             void init_domain_indices(const PlatformTopo &topo);
 
             PlatformIO &m_platform_io;
@@ -101,8 +103,8 @@ namespace geopm
             std::vector<geopm_domain_e> m_domain_types;
             std::vector<domain_key_s> m_domains;
 
-            static const std::map<geopm_domain_e, const char *> M_NNET_ENVNAME;
-            static const std::map<geopm_domain_e, const char *> M_FREQMAP_ENVNAME;
+            static const std::map<geopm_domain_e, std::string> M_NNET_ENVNAME;
+            static const std::map<geopm_domain_e, std::string> M_FREQMAP_ENVNAME;
             static const std::map<geopm_domain_e, std::string> M_MAX_FREQ_SIGNAL_NAME;
             static const std::map<geopm_domain_e, std::string> M_MIN_FREQ_SIGNAL_NAME;
             static const std::map<geopm_domain_e, std::string> M_MAX_FREQ_CONTROL_NAME;

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -77,7 +77,7 @@ namespace geopm
 
             std::map<std::string, double> m_policy_available;
 
-            int m_phi_idx;
+            double m_phi;
             int m_sample;
             std::map<m_domain_key_s, std::unique_ptr<DomainNetMap> > m_net_map;
             std::map<geopm_domain_e, std::unique_ptr<RegionHintRecommender> > m_freq_recommender;
@@ -91,6 +91,7 @@ namespace geopm
             const static std::map<geopm_domain_e, const char *> freqmap_envname;
             const static std::map<geopm_domain_e, std::string> max_freq_signal_name;
             const static std::map<geopm_domain_e, std::string> min_freq_signal_name;
+            const static std::map<geopm_domain_e, std::string> max_freq_control_name;
             const static std::map<geopm_domain_e, std::string> trace_suffix;
     };
 }

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FFNETAGENT_HPP_INCLUDE
+#define FFNETAGENT_HPP_INCLUDE
+
+#include <vector>
+
+#include "Agent.hpp"
+#include "geopm_time.h"
+#include "DomainNetMap.hpp"
+#include "RegionHintRecommender.hpp"
+
+namespace geopm
+{
+    class PlatformTopo;
+    class PlatformIO;
+
+    /// @brief Agent
+    class FFNetAgent : public geopm::Agent
+    {
+        public:
+            enum m_policy_e {
+                /// @brief Phi represents the user's desire to trade off
+                ///        performance for energy efficiency. A value of
+                ///        0 indicates an extreme preference for
+                ///        performance and a value of 10 indicates an
+                ///        extreme preference for energy efficiency.
+                M_POLICY_PHI,
+                M_NUM_POLICY,
+            };
+
+            FFNetAgent();
+            FFNetAgent(geopm::PlatformIO &plat_io, const geopm::PlatformTopo &topo);
+            virtual ~FFNetAgent() = default;
+            void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
+            void validate_policy(std::vector<double> &in_policy) const override;
+            void split_policy(const std::vector<double> &in_policy,
+                    std::vector<std::vector<double> > &out_policy) override;
+            bool do_send_policy(void) const override;
+            void aggregate_sample(const std::vector<std::vector<double> > &in_sample,
+                    std::vector<double> &out_sample) override;
+            bool do_send_sample(void) const override;
+            void adjust_platform(const std::vector<double> &in_policy) override;
+            bool do_write_batch(void) const override;
+            void sample_platform(std::vector<double> &out_sample) override;
+            void wait(void) override;
+            std::vector<std::pair<std::string, std::string> > report_header(void) const override;
+            std::vector<std::pair<std::string, std::string> > report_host(void) const override;
+            std::map<uint64_t, std::vector<std::pair<std::string, std::string> > > report_region(void) const override;
+            std::vector<std::string> trace_names(void) const override;
+            std::vector<std::function<std::string(double)> > trace_formats(void) const override;
+            void trace_values(std::vector<double> &values) override;
+            void enforce_policy(const std::vector<double> &policy) const override;
+
+            static std::string plugin_name(void);
+            static std::unique_ptr<geopm::Agent> make_plugin(void);
+            static std::vector<std::string> policy_names(void);
+            static std::vector<std::string> sample_names(void);
+        private:
+            geopm::PlatformIO &m_platform_io;
+            const geopm::PlatformTopo &m_platform_topo;
+            geopm_time_s m_last_wait;
+            const double M_WAIT_SEC;
+            bool m_do_write_batch;
+
+            std::map<std::string, double> m_policy_available;
+
+            int m_phi_idx;
+            int m_sample;
+            bool m_has_gpus;
+            std::map<int, std::unique_ptr<DomainNetMap> > m_net_map;
+            std::map<int, std::unique_ptr<RegionHintRecommender> > m_freq_recommender;
+
+            // m_freq_control[domain type][domain index] = platform io control index
+            std::map<int, std::vector<int> > m_freq_control;
+            std::vector<int> m_domain_types;
+    };
+}
+#endif  /* FFNETAGENT_HPP_INCLUDE */

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -20,7 +20,7 @@ namespace geopm
     class PlatformIO;
 
     /// @brief Agent
-    class FFNetAgent : public geopm::Agent
+    class FFNetAgent : public Agent
     {
         public:
             enum m_policy_e {
@@ -34,7 +34,7 @@ namespace geopm
             };
 
             FFNetAgent();
-            FFNetAgent(geopm::PlatformIO &plat_io, const geopm::PlatformTopo &topo);
+            FFNetAgent(PlatformIO &plat_io, const PlatformTopo &topo);
             virtual ~FFNetAgent() = default;
             void init(int level, const std::vector<int> &fan_in, bool is_level_root) override;
             void validate_policy(std::vector<double> &in_policy) const override;
@@ -57,7 +57,7 @@ namespace geopm
             void enforce_policy(const std::vector<double> &policy) const override;
 
             static std::string plugin_name(void);
-            static std::unique_ptr<geopm::Agent> make_plugin(void);
+            static std::unique_ptr<Agent> make_plugin(void);
             static std::vector<std::string> policy_names(void);
             static std::vector<std::string> sample_names(void);
         private:
@@ -69,8 +69,8 @@ namespace geopm
                 }
             };
 
-            geopm::PlatformIO &m_platform_io;
-            const geopm::PlatformTopo &m_platform_topo;
+            PlatformIO &m_platform_io;
+            const PlatformTopo &m_platform_topo;
             geopm_time_s m_last_wait;
             const double M_WAIT_SEC;
             bool m_do_write_batch;

--- a/src/FFNetAgent.hpp
+++ b/src/FFNetAgent.hpp
@@ -21,17 +21,17 @@ namespace geopm
     class PlatformTopo;
     class PlatformIO;
 
-    /// @brief Agent
+    /// @brief Feed Forward Net Agent
     class FFNetAgent : public Agent
     {
         public:
             enum m_policy_e {
-                /// @brief Phi represents the user's desire to trade off
-                ///        performance for energy efficiency. A value of
-                ///        0 indicates an extreme preference for
-                ///        performance and a value of 10 indicates an
+                /// @brief Perf-energy-bias represents the user's desire 
+                ///        to trade off performance for energy efficiency. 
+                ///        A value of 0 indicates an extreme preference for
+                ///        performance and a value of 1 indicates an
                 ///        extreme preference for energy efficiency.
-                M_POLICY_PHI,
+                M_POLICY_PERF_ENERGY_BIAS,
                 M_NUM_POLICY,
             };
 
@@ -91,7 +91,7 @@ namespace geopm
 
             std::map<std::string, double> m_policy_available;
 
-            double m_phi;
+            double m_perf_energy_bias;
             int m_sample;
             std::map<m_domain_key_s, std::shared_ptr<DomainNetMap> > m_net_map;
             std::map<geopm_domain_e, std::shared_ptr<RegionHintRecommender> > m_freq_recommender;

--- a/src/LocalNeuralNet.cpp
+++ b/src/LocalNeuralNet.cpp
@@ -6,11 +6,9 @@
 
 #include "config.h"
 
-#include "TensorMath.hpp"
 #include "TensorOneD.hpp"
 #include "TensorTwoD.hpp"
 #include "DenseLayer.hpp"
-#include "LocalNeuralNet.hpp"
 #include "LocalNeuralNetImp.hpp"
 
 #include "geopm/Exception.hpp"
@@ -18,17 +16,23 @@
 
 namespace geopm
 {
-    std::unique_ptr<LocalNeuralNet> LocalNeuralNet::make_unique(std::vector<std::shared_ptr<DenseLayer> > layers)
+    std::unique_ptr<LocalNeuralNet> LocalNeuralNet::make_unique(
+            std::vector<std::shared_ptr<DenseLayer> > layers)
     {
         return geopm::make_unique<LocalNeuralNetImp>(layers);
     }
 
     LocalNeuralNetImp::LocalNeuralNetImp(std::vector<std::shared_ptr<DenseLayer> > layers)
     {
-        for (std::size_t idx=1; idx < layers.size(); ++idx) {
-            if (layers[idx]->get_input_dim() != layers[idx-1]->get_output_dim()) {
-                throw geopm::Exception("Incompatible dimensions for consecutive layers.",
-                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        if (layers.empty()) {
+            throw Exception("Empty layers found.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        for (std::size_t idx = 1; idx < layers.size(); ++idx) {
+            if (layers[idx]->get_input_dim() != layers[idx - 1]->get_output_dim()) {
+                throw Exception("Incompatible dimensions for consecutive layers.",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
         }
 
@@ -38,8 +42,8 @@ namespace geopm
     TensorOneD LocalNeuralNetImp::forward(const TensorOneD &inp) const
     {
         if (inp.get_dim() != m_layers[0]->get_input_dim()) {
-            throw geopm::Exception("Input vector dimension is incompatible with network.\n",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("Input vector dimension is incompatible with network.\n",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         TensorOneD tmp = inp;

--- a/src/LocalNeuralNet.cpp
+++ b/src/LocalNeuralNet.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#include "config.h"
+
+#include "TensorMath.hpp"
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+#include "DenseLayer.hpp"
+#include "LocalNeuralNet.hpp"
+#include "LocalNeuralNetImp.hpp"
+
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+
+namespace geopm
+{
+    std::unique_ptr<LocalNeuralNet> LocalNeuralNet::make_unique(std::vector<std::shared_ptr<DenseLayer> > layers)
+    {
+        return geopm::make_unique<LocalNeuralNetImp>(layers);
+    }
+
+    LocalNeuralNetImp::LocalNeuralNetImp(std::vector<std::shared_ptr<DenseLayer> > layers)
+    {
+        for (std::size_t idx=1; idx < layers.size(); ++idx) {
+            if (layers[idx]->get_input_dim() != layers[idx-1]->get_output_dim()) {
+                throw geopm::Exception("Incompatible dimensions for consecutive layers.",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+        }
+
+        m_layers = layers;
+    }
+
+    TensorOneD LocalNeuralNetImp::forward(const TensorOneD &inp) const
+    {
+        if (inp.get_dim() != m_layers[0]->get_input_dim()) {
+            throw geopm::Exception("Input vector dimension is incompatible with network.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        TensorOneD tmp = inp;
+
+        for (std::size_t idx = 0; idx < m_layers.size(); ++idx) {
+            tmp = m_layers[idx]->forward(tmp);
+
+            // Apply a sigmoid on all but the last layer
+            if (idx != m_layers.size() - 1) {
+                tmp = tmp.sigmoid();
+            }
+        }
+
+        return tmp;
+    }
+}

--- a/src/LocalNeuralNet.cpp
+++ b/src/LocalNeuralNet.cpp
@@ -30,7 +30,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        for (std::size_t idx = 1; idx < layers.size(); ++idx) {
+        for (size_t idx = 1; idx < layers.size(); ++idx) {
             if (layers[idx]->get_input_dim() != layers[idx - 1]->get_output_dim()) {
                 throw Exception("LocalNeuralNetImp::" + std::string(__func__) +
                                 ": Incompatible dimensions for consecutive layers.",
@@ -51,7 +51,7 @@ namespace geopm
 
         TensorOneD tmp = inp;
 
-        for (std::size_t idx = 0; idx < m_layers.size(); ++idx) {
+        for (size_t idx = 0; idx < m_layers.size(); ++idx) {
             tmp = m_layers[idx]->forward(tmp);
 
             // Apply a sigmoid on all but the last layer
@@ -69,5 +69,10 @@ namespace geopm
 
     size_t LocalNeuralNetImp::get_output_dim() const {
         return m_layers[m_layers.size() - 1]->get_output_dim();
+    }
+
+    TensorOneD LocalNeuralNet::operator()(const TensorOneD &input) const
+    {
+        return forward(input);
     }
 }

--- a/src/LocalNeuralNet.cpp
+++ b/src/LocalNeuralNet.cpp
@@ -25,13 +25,15 @@ namespace geopm
     LocalNeuralNetImp::LocalNeuralNetImp(std::vector<std::shared_ptr<DenseLayer> > layers)
     {
         if (layers.empty()) {
-            throw Exception("Empty layers found.",
+            throw Exception("LocalNeuralNetImp::" + std::string(__func__) +
+                            ": Empty layers found.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         for (std::size_t idx = 1; idx < layers.size(); ++idx) {
             if (layers[idx]->get_input_dim() != layers[idx - 1]->get_output_dim()) {
-                throw Exception("Incompatible dimensions for consecutive layers.",
+                throw Exception("LocalNeuralNetImp::" + std::string(__func__) +
+                                ": Incompatible dimensions for consecutive layers.",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
         }
@@ -42,7 +44,8 @@ namespace geopm
     TensorOneD LocalNeuralNetImp::forward(const TensorOneD &inp) const
     {
         if (inp.get_dim() != m_layers[0]->get_input_dim()) {
-            throw Exception("Input vector dimension is incompatible with network.\n",
+            throw Exception("LocalNeuralNetImp::" + std::string(__func__) +
+                            ": Input vector dimension is incompatible with network.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 

--- a/src/LocalNeuralNet.cpp
+++ b/src/LocalNeuralNet.cpp
@@ -55,4 +55,12 @@ namespace geopm
 
         return tmp;
     }
+
+    size_t LocalNeuralNetImp::get_input_dim() const {
+        return m_layers[0]->get_input_dim();
+    }
+
+    size_t LocalNeuralNetImp::get_output_dim() const {
+        return m_layers[m_layers.size() - 1]->get_output_dim();
+    }
 }

--- a/src/LocalNeuralNet.hpp
+++ b/src/LocalNeuralNet.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef LOCALNEURALNET_HPP_INCLUDE
+#define LOCALNEURALNET_HPP_INCLUDE
+
+#include "DenseLayer.hpp"
+#include "TensorOneD.hpp"
+
+namespace geopm
+{
+    class TensorTwoD;
+
+    ///  @brief Class to manage data and operations of feed forward neural nets
+    ///         required for neural net inference.
+
+    class LocalNeuralNet
+    {
+        public:
+            virtual ~LocalNeuralNet() = default;
+            /// @brief Returns a unique_ptr to a concrete object
+            ///        constructed using the underlying implementation
+            ///        from a vector of DenseLayers
+            /// 
+            /// @param [in] Vector of DenseLayers
+            static std::unique_ptr<LocalNeuralNet> make_unique(std::vector<std::shared_ptr<DenseLayer> > layers);
+            /// @brief Perform inference using the instance weights and biases.
+            /// 
+            /// @param [in] TensorOneD vector of input signals.
+            ///
+            /// @return Returns a TensorOneD vector of output values.
+            ///
+            /// @throws geopm::Exception if input dimension is incompatible
+            /// with network.
+            virtual TensorOneD forward(const TensorOneD &inp) const = 0;
+
+            TensorOneD operator()(const TensorOneD &input) const {
+                return forward(input);
+            }
+    };
+}
+
+#endif  /* LOCALNEURALNET_HPP_INCLUDE */

--- a/src/LocalNeuralNet.hpp
+++ b/src/LocalNeuralNet.hpp
@@ -25,7 +25,8 @@ namespace geopm
             ///        from a vector of DenseLayers
             /// 
             /// @param [in] Vector of DenseLayers
-            static std::unique_ptr<LocalNeuralNet> make_unique(std::vector<std::shared_ptr<DenseLayer> > layers);
+            static std::unique_ptr<LocalNeuralNet> make_unique(
+                    std::vector<std::shared_ptr<DenseLayer> > layers);
             /// @brief Perform inference using the instance weights and biases.
             /// 
             /// @param [in] TensorOneD vector of input signals.

--- a/src/LocalNeuralNet.hpp
+++ b/src/LocalNeuralNet.hpp
@@ -25,8 +25,7 @@ namespace geopm
             ///        from a vector of DenseLayers
             /// 
             /// @param [in] Vector of DenseLayers
-            static std::unique_ptr<LocalNeuralNet> make_unique(
-                    std::vector<std::shared_ptr<DenseLayer> > layers);
+            static std::unique_ptr<LocalNeuralNet> make_unique(std::vector<std::shared_ptr<DenseLayer> > layers);
             /// @brief Perform inference using the instance weights and biases.
             /// 
             /// @param [in] TensorOneD vector of input signals.
@@ -45,9 +44,7 @@ namespace geopm
             /// @return Returns a size_t equal to the number of rows of weights 
             virtual size_t get_output_dim() const = 0;
 
-            TensorOneD operator()(const TensorOneD &input) const {
-                return forward(input);
-            }
+            TensorOneD operator()(const TensorOneD &input) const;
     };
 }
 

--- a/src/LocalNeuralNet.hpp
+++ b/src/LocalNeuralNet.hpp
@@ -30,10 +30,10 @@ namespace geopm
             /// 
             /// @param [in] TensorOneD vector of input signals.
             ///
-            /// @return Returns a TensorOneD vector of output values.
-            ///
             /// @throws geopm::Exception if input dimension is incompatible
             /// with network.
+            ///
+            /// @return Returns a TensorOneD vector of output values.
             virtual TensorOneD forward(const TensorOneD &inp) const = 0;
 
             TensorOneD operator()(const TensorOneD &input) const {

--- a/src/LocalNeuralNet.hpp
+++ b/src/LocalNeuralNet.hpp
@@ -35,6 +35,14 @@ namespace geopm
             ///
             /// @return Returns a TensorOneD vector of output values.
             virtual TensorOneD forward(const TensorOneD &inp) const = 0;
+            /// @brief Get the dimension required for the input TensorOneD
+            /// 
+            /// @return Returns a size_t equal to the number of columns of weights
+            virtual size_t get_input_dim() const = 0;
+            /// @brief Get the dimension of the resulting TensorOneD
+            /// 
+            /// @return Returns a size_t equal to the number of rows of weights 
+            virtual size_t get_output_dim() const = 0;
 
             TensorOneD operator()(const TensorOneD &input) const {
                 return forward(input);

--- a/src/LocalNeuralNetImp.hpp
+++ b/src/LocalNeuralNetImp.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef LOCALNEURALNETIMP_HPP_INCLUDE
+#define LOCALNEURALNETIMP_HPP_INCLUDE
+
+#include "LocalNeuralNet.hpp"
+
+namespace geopm
+{
+    class LocalNeuralNetImp : public LocalNeuralNet
+    {
+        public:
+            /// @brief Constructor input from a vector of DenseLayers
+            ///
+            /// @param [in] input layers
+            ///
+            /// @throws geopm::Exception if consecutive layer sizes are
+            /// incompatible
+            LocalNeuralNetImp(const std::vector<std::shared_ptr<DenseLayer> > layers);
+            /// @brief Perform inference using the instance weights and biases.
+            /// 
+            /// @param [in] TensorOneD vector of input signals.
+            ///
+            /// @return Returns a TensorOneD vector of output values.
+            ///
+            /// @throws geopm::Exception if input dimension is incompatible
+            /// with network.
+            TensorOneD forward(const TensorOneD &inp) const override;
+
+        private:
+            std::vector<std::shared_ptr<DenseLayer> > m_layers;
+    };
+}
+
+#endif  /* LOCALNEURALNETIMP_HPP_INCLUDE */

--- a/src/LocalNeuralNetImp.hpp
+++ b/src/LocalNeuralNetImp.hpp
@@ -24,10 +24,10 @@ namespace geopm
             /// 
             /// @param [in] TensorOneD vector of input signals.
             ///
-            /// @return Returns a TensorOneD vector of output values.
-            ///
             /// @throws geopm::Exception if input dimension is incompatible
             /// with network.
+            ///
+            /// @return Returns a TensorOneD vector of output values.
             TensorOneD forward(const TensorOneD &inp) const override;
 
         private:

--- a/src/LocalNeuralNetImp.hpp
+++ b/src/LocalNeuralNetImp.hpp
@@ -29,6 +29,14 @@ namespace geopm
             ///
             /// @return Returns a TensorOneD vector of output values.
             TensorOneD forward(const TensorOneD &inp) const override;
+            /// @brief Get the dimension required for the input TensorOneD
+            /// 
+            /// @return Returns a size_t equal to the number of columns of weights
+            size_t get_input_dim() const override;
+            /// @brief Get the dimension of the resulting TensorOneD
+            /// 
+            /// @return Returns a size_t equal to the number of rows of weights 
+            size_t get_output_dim() const override;
 
         private:
             std::vector<std::shared_ptr<DenseLayer> > m_layers;

--- a/src/NNFactory.cpp
+++ b/src/NNFactory.cpp
@@ -8,13 +8,17 @@
 
 #include "DenseLayerImp.hpp"
 #include "LocalNeuralNetImp.hpp"
-#include "NNFactory.hpp"
 #include "NNFactoryImp.hpp"
 
 namespace geopm {
     std::unique_ptr<NNFactory> NNFactory::make_unique()
     {
         return geopm::make_unique<NNFactoryImp>();
+    }
+
+    std::shared_ptr<NNFactory> NNFactory::make_shared()
+    {
+        return std::make_shared<NNFactoryImp>();
     }
 
     std::shared_ptr<LocalNeuralNet> NNFactoryImp::createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const

--- a/src/NNFactory.cpp
+++ b/src/NNFactory.cpp
@@ -21,17 +21,19 @@ namespace geopm {
         return std::make_shared<NNFactoryImp>();
     }
 
-    std::shared_ptr<LocalNeuralNet> NNFactoryImp::createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const
+    std::shared_ptr<LocalNeuralNet> NNFactoryImp::createLocalNeuralNet(
+            const std::vector<std::shared_ptr<DenseLayer> > &layers) const
     {
         return std::make_shared<LocalNeuralNetImp>(layers);
     }
 
-    std::shared_ptr<DenseLayer> NNFactoryImp::createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const
+    std::shared_ptr<DenseLayer> NNFactoryImp::createDenseLayer(const TensorTwoD &weights,
+                                                               const TensorOneD &biases) const
     {
         return std::make_shared<DenseLayerImp>(weights, biases);
     }
 
-    TensorTwoD NNFactoryImp::createTensorTwoD(const std::vector<std::vector<double>> &vals) const
+    TensorTwoD NNFactoryImp::createTensorTwoD(const std::vector<std::vector<double> > &vals) const
     {
         return TensorTwoD(vals);
     }

--- a/src/NNFactory.cpp
+++ b/src/NNFactory.cpp
@@ -27,12 +27,12 @@ namespace geopm {
         return std::make_shared<DenseLayerImp>(weights, biases);
     }
 
-    TensorTwoD NNFactoryImp::createTensorTwoD(const std::vector<std::vector<float>> &vals) const
+    TensorTwoD NNFactoryImp::createTensorTwoD(const std::vector<std::vector<double>> &vals) const
     {
         return TensorTwoD(vals);
     }
 
-    TensorOneD NNFactoryImp::createTensorOneD(const std::vector<float> &vals) const
+    TensorOneD NNFactoryImp::createTensorOneD(const std::vector<double> &vals) const
     {
         return TensorOneD(vals);
     }

--- a/src/NNFactory.cpp
+++ b/src/NNFactory.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+
+#include "DenseLayerImp.hpp"
+#include "NNFactory.hpp"
+#include "NNFactoryImp.hpp"
+
+namespace geopm {
+    std::unique_ptr<NNFactory> NNFactory::make_unique()
+    {
+        return geopm::make_unique<NNFactoryImp>();
+    }
+
+    std::unique_ptr<LocalNeuralNet> NNFactoryImp::createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const
+    {
+        return LocalNeuralNet::make_unique(layers);
+    }
+
+    std::shared_ptr<DenseLayer> NNFactoryImp::createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const
+    {
+        return std::make_shared<DenseLayerImp>(weights, biases);
+    }
+
+    TensorTwoD NNFactoryImp::createTensorTwoD(const std::vector<std::vector<float>> &vals) const
+    {
+        return TensorTwoD(vals);
+    }
+
+    TensorOneD NNFactoryImp::createTensorOneD(const std::vector<float> &vals) const
+    {
+        return TensorOneD(vals);
+    }
+}

--- a/src/NNFactory.cpp
+++ b/src/NNFactory.cpp
@@ -7,6 +7,7 @@
 #include "geopm/Helper.hpp"
 
 #include "DenseLayerImp.hpp"
+#include "LocalNeuralNetImp.hpp"
 #include "NNFactory.hpp"
 #include "NNFactoryImp.hpp"
 
@@ -16,9 +17,9 @@ namespace geopm {
         return geopm::make_unique<NNFactoryImp>();
     }
 
-    std::unique_ptr<LocalNeuralNet> NNFactoryImp::createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const
+    std::shared_ptr<LocalNeuralNet> NNFactoryImp::createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const
     {
-        return LocalNeuralNet::make_unique(layers);
+        return std::make_shared<LocalNeuralNetImp>(layers);
     }
 
     std::shared_ptr<DenseLayer> NNFactoryImp::createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const

--- a/src/NNFactory.cpp
+++ b/src/NNFactory.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
 #include "geopm/Exception.hpp"
 #include "geopm/Helper.hpp"
 

--- a/src/NNFactory.hpp
+++ b/src/NNFactory.hpp
@@ -16,14 +16,39 @@
 
 namespace geopm
 {
+    /// @brief Class to generate objects related to feed-forward neural nets,
+    ///        i.e. TensorOneD, TensorTwoD, DenseLayer, and LocalNeuralNet objects.
     class NNFactory {
         public:
+            /// @brief Returns a unique pointer to a conrete object constructed
+            ///        using the underlying implementation.
             static std::unique_ptr<NNFactory> make_unique();
             virtual ~NNFactory() = default;
-
+            /// @brief Create a LocalNeuralNet
+            ///
+            /// @param [in] layers A shared pointer to a vector of DenseLayers
+            ///
+            /// @return Returns a shared pointer to a LocalNeuralNet instance
             virtual std::shared_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const = 0;
+            /// @brief Create a Dense Layer
+            ///
+            /// @param [in] weights TensorTwoD instance (matrix)
+            ///
+            /// @param [in] biases TensorOneD instance (vector)
+            ///
+            /// @return Returns a shared pointer to the DenseLayer instance
             virtual std::shared_ptr<DenseLayer> createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const = 0;
+            /// @brief Create a TensorTwoD object.
+            ///
+            /// @param [in] vals Matrix doubles to fill TensorTwoD object
+            ///
+            /// @return Returns a TensorTwoD instance
             virtual TensorTwoD createTensorTwoD(const std::vector<std::vector<double>> &vals) const = 0;
+            /// @brief Create a TensorOneD object.
+            ///
+            /// @param [in] vals Vector of doubles to fill TensorOneD object
+            ///
+            /// @return Returns a TensorOneD instance
             virtual TensorOneD createTensorOneD(const std::vector<double> &vals) const = 0;
     };
 }

--- a/src/NNFactory.hpp
+++ b/src/NNFactory.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef NNFACTORY_HPP_INCLUDE
+#define NNFACTORY_HPP_INCLUDE
+
+#include <memory>
+#include <vector>
+
+#include "DenseLayer.hpp"
+#include "LocalNeuralNet.hpp"
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+namespace geopm
+{
+    class NNFactory {
+        public:
+            static std::unique_ptr<NNFactory> make_unique();
+            virtual ~NNFactory() = default;
+
+            virtual std::unique_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const = 0;
+            virtual std::shared_ptr<DenseLayer> createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const = 0;
+            virtual TensorTwoD createTensorTwoD(const std::vector<std::vector<float>> &vals) const = 0;
+            virtual TensorOneD createTensorOneD(const std::vector<float> &vals) const = 0;
+    };
+}
+
+#endif  // NNFACTORY_HPP_INCLUDE

--- a/src/NNFactory.hpp
+++ b/src/NNFactory.hpp
@@ -23,8 +23,8 @@ namespace geopm
 
             virtual std::shared_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const = 0;
             virtual std::shared_ptr<DenseLayer> createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const = 0;
-            virtual TensorTwoD createTensorTwoD(const std::vector<std::vector<float>> &vals) const = 0;
-            virtual TensorOneD createTensorOneD(const std::vector<float> &vals) const = 0;
+            virtual TensorTwoD createTensorTwoD(const std::vector<std::vector<double>> &vals) const = 0;
+            virtual TensorOneD createTensorOneD(const std::vector<double> &vals) const = 0;
     };
 }
 

--- a/src/NNFactory.hpp
+++ b/src/NNFactory.hpp
@@ -21,7 +21,7 @@ namespace geopm
             static std::unique_ptr<NNFactory> make_unique();
             virtual ~NNFactory() = default;
 
-            virtual std::unique_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const = 0;
+            virtual std::shared_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const = 0;
             virtual std::shared_ptr<DenseLayer> createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const = 0;
             virtual TensorTwoD createTensorTwoD(const std::vector<std::vector<float>> &vals) const = 0;
             virtual TensorOneD createTensorOneD(const std::vector<float> &vals) const = 0;

--- a/src/NNFactory.hpp
+++ b/src/NNFactory.hpp
@@ -23,6 +23,9 @@ namespace geopm
             /// @brief Returns a unique pointer to a concrete object constructed
             ///        using the underlying implementation.
             static std::unique_ptr<NNFactory> make_unique();
+            /// @brief Returns a shared pointer to a concrete object constructed
+            ///        using the underlying implementation.
+            static std::shared_ptr<NNFactory> make_shared();
             virtual ~NNFactory() = default;
             /// @brief Create a LocalNeuralNet
             ///

--- a/src/NNFactory.hpp
+++ b/src/NNFactory.hpp
@@ -32,7 +32,7 @@ namespace geopm
             /// @param [in] layers A shared pointer to a vector of DenseLayers
             ///
             /// @return Returns a shared pointer to a LocalNeuralNet instance
-            virtual std::shared_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const = 0;
+            virtual std::shared_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer> > &layers) const = 0;
             /// @brief Create a Dense Layer
             ///
             /// @param [in] weights TensorTwoD instance (matrix)
@@ -46,7 +46,7 @@ namespace geopm
             /// @param [in] vals Matrix doubles to fill TensorTwoD object
             ///
             /// @return Returns a TensorTwoD instance
-            virtual TensorTwoD createTensorTwoD(const std::vector<std::vector<double>> &vals) const = 0;
+            virtual TensorTwoD createTensorTwoD(const std::vector<std::vector<double> > &vals) const = 0;
             /// @brief Create a TensorOneD object.
             ///
             /// @param [in] vals Vector of doubles to fill TensorOneD object

--- a/src/NNFactory.hpp
+++ b/src/NNFactory.hpp
@@ -20,7 +20,7 @@ namespace geopm
     ///        i.e. TensorOneD, TensorTwoD, DenseLayer, and LocalNeuralNet objects.
     class NNFactory {
         public:
-            /// @brief Returns a unique pointer to a conrete object constructed
+            /// @brief Returns a unique pointer to a concrete object constructed
             ///        using the underlying implementation.
             static std::unique_ptr<NNFactory> make_unique();
             virtual ~NNFactory() = default;

--- a/src/NNFactoryImp.hpp
+++ b/src/NNFactoryImp.hpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef NNFACTORYIMP_HPP_INCLUDE
+#define NNFACTORYIMP_HPP_INCLUDE
+
+#include "NNFactory.hpp"
+
+namespace geopm
+{
+    class NNFactoryImp : public NNFactory {
+        public:
+            NNFactoryImp() = default;
+            virtual ~NNFactoryImp() = default;
+
+            std::unique_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const override;
+            std::shared_ptr<DenseLayer> createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const override;
+            TensorTwoD createTensorTwoD(const std::vector<std::vector<float>> &vals) const override;
+            TensorOneD createTensorOneD(const std::vector<float> &vals) const override;
+    };
+}
+
+#endif  // NNFACTORYIMP_HPP_INCLUDE

--- a/src/NNFactoryImp.hpp
+++ b/src/NNFactoryImp.hpp
@@ -15,7 +15,7 @@ namespace geopm
             NNFactoryImp() = default;
             virtual ~NNFactoryImp() = default;
 
-            std::unique_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const override;
+            std::shared_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const override;
             std::shared_ptr<DenseLayer> createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const override;
             TensorTwoD createTensorTwoD(const std::vector<std::vector<float>> &vals) const override;
             TensorOneD createTensorOneD(const std::vector<float> &vals) const override;

--- a/src/NNFactoryImp.hpp
+++ b/src/NNFactoryImp.hpp
@@ -17,8 +17,8 @@ namespace geopm
 
             std::shared_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const override;
             std::shared_ptr<DenseLayer> createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const override;
-            TensorTwoD createTensorTwoD(const std::vector<std::vector<float>> &vals) const override;
-            TensorOneD createTensorOneD(const std::vector<float> &vals) const override;
+            TensorTwoD createTensorTwoD(const std::vector<std::vector<double>> &vals) const override;
+            TensorOneD createTensorOneD(const std::vector<double> &vals) const override;
     };
 }
 

--- a/src/NNFactoryImp.hpp
+++ b/src/NNFactoryImp.hpp
@@ -15,9 +15,12 @@ namespace geopm
             NNFactoryImp() = default;
             virtual ~NNFactoryImp() = default;
 
-            std::shared_ptr<LocalNeuralNet> createLocalNeuralNet(const std::vector<std::shared_ptr<DenseLayer>> &layers) const override;
-            std::shared_ptr<DenseLayer> createDenseLayer(const TensorTwoD &weights, const TensorOneD &biases) const override;
-            TensorTwoD createTensorTwoD(const std::vector<std::vector<double>> &vals) const override;
+            std::shared_ptr<LocalNeuralNet> createLocalNeuralNet(
+                    const std::vector<std::shared_ptr<DenseLayer> > &layers) const override;
+            std::shared_ptr<DenseLayer> createDenseLayer(const TensorTwoD &weights,
+                                                         const TensorOneD &biases) const override;
+            TensorTwoD createTensorTwoD(const std::vector<std::vector<double> > &vals)
+                    const override;
             TensorOneD createTensorOneD(const std::vector<double> &vals) const override;
     };
 }

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -40,7 +40,7 @@ namespace geopm
         std::ifstream ffile(fmap_path);
         if (!ffile) {
             throw Exception("RegionHintRecommenderImp::" + std::string(__func__) +
-                            ": Unable to open frequency map file.",
+                            ": Unable to open frequency map file: " + fmap_path + ".",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -59,7 +59,7 @@ namespace geopm
         }
     }
 
-    double RegionHintRecommenderImp::recommend_frequency(std::map<std::string, float> region_class, double phi) const {
+    double RegionHintRecommenderImp::recommend_frequency(std::map<std::string, double> region_class, double phi) const {
         for (const auto & [region_name, probability] : region_class) {
             if (std::isnan(probability)) {
                 return NAN;

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -12,7 +12,9 @@
 
 namespace geopm
 {
-    void RegionHintRecommender::load_freqmap(char* fmap_path)
+    RegionHintRecommender::RegionHintRecommender(char* fmap_path, int min_freq, int max_freq)
+        : m_min_freq(min_freq)
+          , m_max_freq(max_freq)
     {
         std::string buf, err;
 
@@ -41,17 +43,7 @@ namespace geopm
         }
     }
 
-    void RegionHintRecommender::set_max_freq(int max_freq)
-    {
-        m_max_freq = max_freq;
-    }
-
-    void RegionHintRecommender::set_min_freq(int min_freq)
-    {
-        m_min_freq = min_freq;
-    }
-
-    double RegionHintRecommender::recommend_frequency(std::map<std::string, float> region_class, int phi)
+    double RegionHintRecommender::recommend_frequency(std::map<std::string, float> region_class, double phi)
     {
         for (const auto & [region_name, probability] : region_class) {
             if (std::isnan(probability)) {
@@ -62,7 +54,8 @@ namespace geopm
         double ZZ = 0;
         double freq = 0;
         for (const auto & [region_name, probability] : region_class) {
-            freq += exp(probability) * m_freq_map[region_name][phi];
+            int phi_idx = (int)(phi * (m_freq_map[region_name].size() - 1));
+            freq += exp(probability) * m_freq_map[region_name].at(phi_idx);
             ZZ += exp(probability);
         }
         freq = freq / ZZ;

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -39,7 +39,8 @@ namespace geopm
 
         std::ifstream ffile(fmap_path);
         if (!ffile) {
-            throw Exception("Unable to open frequency map file.\n",
+            throw Exception("RegionHintRecommenderImp::" + std::string(__func__) +
+                            ": Unable to open frequency map file.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -55,26 +56,30 @@ namespace geopm
         json11::Json fmap_json = json11::Json::parse(fbuf, err);
         
         if (!err.empty()) {
-            throw Exception("Frequency map file format is incorrect: " + err + ".\n",
+            throw Exception("RegionHintRecommenderImp::" + std::string(__func__) +
+                            ": Frequency map file format is incorrect: " + err + ".",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         if (fmap_json.is_null() || !fmap_json.is_object()) {
-            throw Exception("Frequency map file format is incorrect: object expected.\n",
+            throw Exception("RegionHintRecommenderImp::" + std::string(__func__) +
+                            ": Frequency map file format is incorrect: object expected.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         for (const auto &row : fmap_json.object_items()) {
             if (!row.second.is_array() || row.second.array_items().size() == 0) {
-                throw Exception("Frequency map file format is incorrect: region keys "
-                                "must contain an array of numbers.\n",
+                throw Exception("RegionHintRecommenderImp::" + std::string(__func__) +
+                                ": Frequency map file format is incorrect: region keys "
+                                "must contain an array of numbers.",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
             m_freq_map[row.first].resize(row.second.array_items().size());
             for (size_t idx = 0; idx < m_freq_map[row.first].size(); ++idx) {
                 if (!row.second[idx].is_number()) {
-                    throw Exception("Non-numeric value found in frequencies for "
-                                    "region: \"" + row.first + "\".\n",
+                    throw Exception("RegionHintRecommenderImp::" + std::string(__func__) +
+                                    ": Non-numeric value found in frequencies for "
+                                    "region: \"" + row.first + "\".",
                                     GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                 }
                 m_freq_map[row.first][idx] = row.second[idx].number_value();
@@ -82,7 +87,8 @@ namespace geopm
         }
 
         if (m_freq_map.empty()) {
-            throw Exception("Frequency map file must contain a frequency map",
+            throw Exception("RegionHintRecommenderImp::" + std::string(__func__) +
+                            ": Frequency map file must contain a frequency map.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
     }

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -49,7 +49,7 @@ namespace geopm
         }
 
         for (const auto &row : fmap_json.object_items()) {
-            if (! row.second.is_array()) {
+            if (! row.second.is_array() || row.second.array_items().size() == 0) {
                 throw geopm::Exception("Frequency map file format is incorrect.\n",
                                        GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -12,6 +12,7 @@
 #include "geopm/Exception.hpp"
 #include "geopm/Helper.hpp"
 
+//TODO: Change from logits to probabilities
 namespace geopm
 {
     std::unique_ptr<RegionHintRecommender> RegionHintRecommender::make_unique(const std::string fmap_path, int min_freq, int max_freq)
@@ -59,8 +60,8 @@ namespace geopm
         }
     }
 
-    double RegionHintRecommenderImp::recommend_frequency(std::map<std::string, double> region_class, double phi) const {
-        for (const auto & [region_name, probability] : region_class) {
+    double RegionHintRecommenderImp::recommend_frequency(std::map<std::string, double> nn_output, double phi) const {
+        for (const auto & [region_name, probability] : nn_output ) {
             if (std::isnan(probability)) {
                 return NAN;
             }
@@ -68,7 +69,7 @@ namespace geopm
 
         double ZZ = 0;
         double freq = 0;
-        for (const auto & [region_name, probability] : region_class) {
+        for (const auto & [region_name, probability] : nn_output) {
             int phi_idx = (int)(phi * (m_freq_map.at(region_name).size() - 1));
             freq += exp(probability) * m_freq_map.at(region_name).at(phi_idx);
             ZZ += exp(probability);

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -4,15 +4,22 @@
  */
 
 #include "RegionHintRecommender.hpp"
+#include "RegionHintRecommenderImp.hpp"
 
 #include <cmath>
 #include <fstream>
 
 #include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
 
 namespace geopm
 {
-    RegionHintRecommender::RegionHintRecommender(char* fmap_path, int min_freq, int max_freq)
+    std::unique_ptr<RegionHintRecommender> RegionHintRecommender::make_unique(const std::string fmap_path, int min_freq, int max_freq)
+    {
+        return geopm::make_unique<RegionHintRecommenderImp>(fmap_path, min_freq, max_freq);
+    }
+
+    RegionHintRecommenderImp::RegionHintRecommenderImp(const std::string fmap_path, int min_freq, int max_freq)
         : m_min_freq(min_freq)
           , m_max_freq(max_freq)
     {
@@ -34,8 +41,13 @@ namespace geopm
         std::getline(ffile, fbuf, '\0');
 
         json11::Json fmap_json = json11::Json::parse(fbuf, err);
+        
 
         for (const auto &row : fmap_json.object_items()) {
+            if (! row.second.is_array()) {
+                throw geopm::Exception("Frequency map file format is incorrect.\n",
+                                       GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
             m_freq_map[row.first].resize(row.second.array_items().size());
             for (int idx=0; idx < (int)m_freq_map[row.first].size(); idx++) {
                 m_freq_map[row.first][idx] = row.second[idx].number_value();
@@ -43,8 +55,7 @@ namespace geopm
         }
     }
 
-    double RegionHintRecommender::recommend_frequency(std::map<std::string, float> region_class, double phi)
-    {
+    double RegionHintRecommenderImp::recommend_frequency(std::map<std::string, float> region_class, double phi) const {
         for (const auto & [region_name, probability] : region_class) {
             if (std::isnan(probability)) {
                 return NAN;
@@ -54,8 +65,8 @@ namespace geopm
         double ZZ = 0;
         double freq = 0;
         for (const auto & [region_name, probability] : region_class) {
-            int phi_idx = (int)(phi * (m_freq_map[region_name].size() - 1));
-            freq += exp(probability) * m_freq_map[region_name].at(phi_idx);
+            int phi_idx = (int)(phi * (m_freq_map.at(region_name).size() - 1));
+            freq += exp(probability) * m_freq_map.at(region_name).at(phi_idx);
             ZZ += exp(probability);
         }
         freq = freq / ZZ;

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -3,10 +3,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
+
 #include "RegionHintRecommenderImp.hpp"
 
 #include <cmath>
 #include <fstream>
+
+#ifdef GEOPM_DEBUG
+#include <iostream>
+#endif
 
 #include "geopm/json11.hpp"
 #include "geopm/Exception.hpp"
@@ -107,7 +113,16 @@ namespace geopm
             freq += exp(probability) * m_freq_map.at(region_name).at(phi_idx);
             zz += exp(probability);
         }
-        freq = freq / zz;
+        //If something goes terribly wrong with probabilities, set frequency to max
+        if (zz == 0) {
+#ifdef GEOPM_DEBUG
+            std::cerr << "Warning: <geopm> Unexpected neural net normalization factor of 0.\n";
+#endif
+            freq = m_max_freq;
+        }
+        else {
+            freq = freq / zz;
+        }
 
         if (std::isnan(freq)) {
             freq = m_max_freq;
@@ -120,6 +135,6 @@ namespace geopm
             freq = m_min_freq;
         }
 
-        return freq * 1e8;
+        return freq;
     }
 }

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -80,6 +80,11 @@ namespace geopm
                 m_freq_map[row.first][idx] = row.second[idx].number_value();
             }
         }
+
+        if (m_freq_map.empty()) {
+            throw Exception("Frequency map file must contain a frequency map",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
     }
 
     double RegionHintRecommenderImp::recommend_frequency(

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -3,29 +3,27 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "RegionHintRecommender.hpp"
 #include "RegionHintRecommenderImp.hpp"
 
 #include <cmath>
 #include <fstream>
 
+#include "geopm/json11.hpp"
 #include "geopm/Exception.hpp"
 #include "geopm/Helper.hpp"
 
 namespace geopm
 {
-    std::unique_ptr<RegionHintRecommender> RegionHintRecommender::make_unique(
-            const std::string &fmap_path,
-            int min_freq,
-            int max_freq)
+    std::unique_ptr<RegionHintRecommender> RegionHintRecommender::make_unique(const std::string &fmap_path,
+                                                                              int min_freq,
+                                                                              int max_freq)
     {
         return geopm::make_unique<RegionHintRecommenderImp>(fmap_path, min_freq, max_freq);
     }
 
-    std::shared_ptr<RegionHintRecommender> RegionHintRecommender::make_shared(
-            const std::string &fmap_path,
-            int min_freq,
-            int max_freq)
+    std::shared_ptr<RegionHintRecommender> RegionHintRecommender::make_shared(const std::string &fmap_path,
+                                                                              int min_freq,
+                                                                              int max_freq)
     {
         return std::make_shared<RegionHintRecommenderImp>(fmap_path, min_freq, max_freq);
     }
@@ -33,12 +31,12 @@ namespace geopm
     RegionHintRecommenderImp::RegionHintRecommenderImp(const std::string &fmap_path, int min_freq,
                                                        int max_freq)
         : m_min_freq(min_freq)
-          , m_max_freq(max_freq)
+        , m_max_freq(max_freq)
     {
         std::string buf, err;
 
         std::ifstream ffile(fmap_path);
-        if (!ffile) {
+        if (!ffile.is_open()) {
             throw Exception("RegionHintRecommenderImp::" + std::string(__func__) +
                             ": Unable to open frequency map file: " + fmap_path + ".",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -93,9 +91,8 @@ namespace geopm
         }
     }
 
-    double RegionHintRecommenderImp::recommend_frequency(
-            const std::map<std::string, double> &nn_output,
-            double phi) const {
+    double RegionHintRecommenderImp::recommend_frequency(const std::map<std::string, double> &nn_output,
+                                                         double phi) const {
         for (const auto &kv : nn_output ) {
             if (std::isnan(kv.second)) {
                 return NAN;
@@ -105,8 +102,8 @@ namespace geopm
         double zz = 0;
         double freq = 0;
         for (const auto &[region_name, probability] : nn_output) {
-            size_t phi_idx = static_cast<size_t>(
-                                std::floor(phi * (m_freq_map.at(region_name).size() - 1)));
+            size_t phi_idx =
+                static_cast<size_t>(std::floor(phi * (m_freq_map.at(region_name).size() - 1)));
             freq += exp(probability) * m_freq_map.at(region_name).at(phi_idx);
             zz += exp(probability);
         }

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "RegionHintRecommender.hpp"
+
+#include <cmath>
+#include <fstream>
+
+#include "geopm/Exception.hpp"
+
+namespace geopm
+{
+    void RegionHintRecommender::load_freqmap(char* fmap_path)
+    {
+        std::string buf, err;
+
+        std::ifstream ffile(fmap_path);
+        if (!ffile) {
+            throw geopm::Exception("Unable to open frequency map file.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        ffile.seekg(0, std::ios::end);
+        std::streampos length = ffile.tellg();
+        ffile.seekg(0, std::ios::beg);
+
+        std::string fbuf;
+        fbuf.reserve(length);
+
+        std::getline(ffile, fbuf, '\0');
+
+        json11::Json fmap_json = json11::Json::parse(fbuf, err);
+
+        for (const auto &row : fmap_json.object_items()) {
+            m_freq_map[row.first].resize(row.second.array_items().size());
+            for (int idx=0; idx < (int)m_freq_map[row.first].size(); idx++) {
+                m_freq_map[row.first][idx] = row.second[idx].number_value();
+            }
+        }
+    }
+
+    void RegionHintRecommender::set_max_freq(int max_freq)
+    {
+        m_max_freq = max_freq;
+    }
+
+    void RegionHintRecommender::set_min_freq(int min_freq)
+    {
+        m_min_freq = min_freq;
+    }
+
+    double RegionHintRecommender::recommend_frequency(std::map<std::string, float> region_class, int phi)
+    {
+        for (const auto & [region_name, probability] : region_class) {
+            if (std::isnan(probability)) {
+                return NAN;
+            }
+        }
+
+        double ZZ = 0;
+        double freq = 0;
+        for (const auto & [region_name, probability] : region_class) {
+            freq += exp(probability) * m_freq_map[region_name][phi];
+            ZZ += exp(probability);
+        }
+        freq = freq / ZZ;
+
+        if (std::isnan(freq)) {
+            freq = m_max_freq;
+        }
+
+        if (freq > m_max_freq) {
+            freq = m_max_freq;
+        }
+        if (freq < m_min_freq) {
+            freq = m_min_freq;
+        }
+
+        return freq*1e8;
+    }
+}

--- a/src/RegionHintRecommender.cpp
+++ b/src/RegionHintRecommender.cpp
@@ -42,6 +42,10 @@ namespace geopm
 
         json11::Json fmap_json = json11::Json::parse(fbuf, err);
         
+        if (fmap_json.is_null() || !fmap_json.is_object()) {
+            throw geopm::Exception("Frequency map file format is incorrect.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
 
         for (const auto &row : fmap_json.object_items()) {
             if (! row.second.is_array()) {

--- a/src/RegionHintRecommender.hpp
+++ b/src/RegionHintRecommender.hpp
@@ -28,6 +28,7 @@ namespace geopm
             /// @param [in] max_freq integer containing maximum frequency
             static std::unique_ptr<RegionHintRecommender> make_unique(const std::string fmap_path, int min_freq, int max_freq);
 
+            virtual ~RegionHintRecommender() = default;
             /// @brief Recommends frequency based on region classification probabilities
             ///
             /// @param [in] region_class List of region classification names and

--- a/src/RegionHintRecommender.hpp
+++ b/src/RegionHintRecommender.hpp
@@ -16,24 +16,21 @@ namespace geopm
     class RegionHintRecommender
     {
         public:
-            /// @brief Loads frequency map file from json11 into a std::map
-            ///        of region class string to double
+            /// @brief Constructor loads frequency map file from json11 into
+            ///        a std::map of region class string to double, and sets
+            ///        both min and max frequency recommendations.
             ///
             /// @param [in] fmap_path string containing path to freq map json
-            void load_freqmap(char* fmap_path);
-            /// @brief Set maximum frequency to recommend
-            ///
-            /// @param [in] max_freq integer containing maximum frequency
-            void set_max_freq(int max_freq);
-            /// @brief Set minimum frequency to recommend
             /// @param [in] min_freq integer containing minimum frequency
-            void set_min_freq(int min_freq);
+            /// @param [in] max_freq integer containing maximum frequency
+            RegionHintRecommender(char* fmap_path, int min_freq, int max_freq);
+
             /// @brief Recommends frequency based on region classification probabilities
             ///
             /// @param [in] region_class List of region classification names and
             ///             probabilities output from region class neural net
             /// @param [in] phi User-input energy-perf bias
-            double recommend_frequency(std::map<std::string, float> region_class, int phi);
+            double recommend_frequency(std::map<std::string, float> region_class, double phi);
 
         private:
             int m_max_freq;

--- a/src/RegionHintRecommender.hpp
+++ b/src/RegionHintRecommender.hpp
@@ -8,6 +8,8 @@
 
 #include <memory>
 #include <map>
+#include <string>
+#include <vector>
 
 namespace geopm
 {

--- a/src/RegionHintRecommender.hpp
+++ b/src/RegionHintRecommender.hpp
@@ -11,9 +11,9 @@
 
 namespace geopm
 {
-    /// @brief Class ingesting region classification probabilities and
+    /// @brief Class ingesting the output from a DomainNetMap and
     ///        a frequency map json file and determining a recommended 
-    ///        frequency decisions.
+    ///        frequency decision.
     class RegionHintRecommender
     {
         public:
@@ -29,12 +29,12 @@ namespace geopm
             static std::unique_ptr<RegionHintRecommender> make_unique(const std::string fmap_path, int min_freq, int max_freq);
 
             virtual ~RegionHintRecommender() = default;
-            /// @brief Recommends frequency based on region classification probabilities
+            /// @brief Recommends frequency based on the output from a DomainNetMap neural net evaluation
             ///
-            /// @param [in] region_class List of region classification names and
-            ///             probabilities output from region class neural net
-            /// @param [in] phi User-input energy-perf bias
-            virtual double recommend_frequency(std::map<std::string, double> region_class, double phi) const = 0;
+            /// @param [in] nn_output Output from the DomainNetMap neural net evaluation, as a map from
+            ///             trace names to doubles.
+            /// @param [in] phi User-input perf-energy bias
+            virtual double recommend_frequency(std::map<std::string, double> nn_output, double phi) const = 0;
     };
 }
 

--- a/src/RegionHintRecommender.hpp
+++ b/src/RegionHintRecommender.hpp
@@ -34,7 +34,7 @@ namespace geopm
             /// @param [in] region_class List of region classification names and
             ///             probabilities output from region class neural net
             /// @param [in] phi User-input energy-perf bias
-            virtual double recommend_frequency(std::map<std::string, float> region_class, double phi) const = 0;
+            virtual double recommend_frequency(std::map<std::string, double> region_class, double phi) const = 0;
     };
 }
 

--- a/src/RegionHintRecommender.hpp
+++ b/src/RegionHintRecommender.hpp
@@ -49,6 +49,8 @@ namespace geopm
             /// @param [in] nn_output Output from the DomainNetMap neural net evaluation, as a
             ///             map from trace names to doubles.
             /// @param [in] phi User-input perf-energy bias
+            ///
+            /// @return Returns frequency, double in Hertz
             virtual double recommend_frequency(const std::map<std::string, double> &nn_output,
                                                double phi) const = 0;
     };

--- a/src/RegionHintRecommender.hpp
+++ b/src/RegionHintRecommender.hpp
@@ -26,15 +26,29 @@ namespace geopm
             /// @param [in] fmap_path string containing path to freq map json
             /// @param [in] min_freq integer containing minimum frequency
             /// @param [in] max_freq integer containing maximum frequency
-            static std::unique_ptr<RegionHintRecommender> make_unique(const std::string fmap_path, int min_freq, int max_freq);
+            static std::unique_ptr<RegionHintRecommender> make_unique(const std::string &fmap_path,
+                                                                      int min_freq, int max_freq);
+            /// @brief Returns a shared_ptr to a concrete object constructed
+            ///        using the underlying implementation, which loads a
+            ///        frequency map file into a std::map of region class
+            ///        string to double, and sets both min and max frequency
+            ///        recommendations.
+            ///
+            /// @param [in] fmap_path string containing path to freq map json
+            /// @param [in] min_freq integer containing minimum frequency
+            /// @param [in] max_freq integer containing maximum frequency
+            static std::shared_ptr<RegionHintRecommender> make_shared(const std::string &fmap_path,
+                                                                      int min_freq, int max_freq);
 
             virtual ~RegionHintRecommender() = default;
-            /// @brief Recommends frequency based on the output from a DomainNetMap neural net evaluation
+            /// @brief Recommends frequency based on the output from a DomainNetMap neural net
+            ///        evaluation
             ///
-            /// @param [in] nn_output Output from the DomainNetMap neural net evaluation, as a map from
-            ///             trace names to doubles.
+            /// @param [in] nn_output Output from the DomainNetMap neural net evaluation, as a
+            ///             map from trace names to doubles.
             /// @param [in] phi User-input perf-energy bias
-            virtual double recommend_frequency(std::map<std::string, double> nn_output, double phi) const = 0;
+            virtual double recommend_frequency(const std::map<std::string, double> &nn_output,
+                                               double phi) const = 0;
     };
 }
 

--- a/src/RegionHintRecommender.hpp
+++ b/src/RegionHintRecommender.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef REGIONHINTRECOMMENDER_HPP_INCLUDE
+#define REGIONHINTRECOMMENDER_HPP_INCLUDE
+
+#include "geopm/json11.hpp"
+
+namespace geopm
+{
+    /// @brief Class ingesting region classification probabilities and
+    ///        a frequency map json11 file and determining a recommended 
+    ///        frequency decisions.
+    class RegionHintRecommender
+    {
+        public:
+            /// @brief Loads frequency map file from json11 into a std::map
+            ///        of region class string to double
+            ///
+            /// @param [in] fmap_path string containing path to freq map json
+            void load_freqmap(char* fmap_path);
+            /// @brief Set maximum frequency to recommend
+            ///
+            /// @param [in] max_freq integer containing maximum frequency
+            void set_max_freq(int max_freq);
+            /// @brief Set minimum frequency to recommend
+            /// @param [in] min_freq integer containing minimum frequency
+            void set_min_freq(int min_freq);
+            /// @brief Recommends frequency based on region classification probabilities
+            ///
+            /// @param [in] region_class List of region classification names and
+            ///             probabilities output from region class neural net
+            /// @param [in] phi User-input energy-perf bias
+            double recommend_frequency(std::map<std::string, float> region_class, int phi);
+
+        private:
+            int m_max_freq;
+            int m_min_freq;
+            std::map<std::string, std::vector<double> > m_freq_map;
+            std::vector<int> m_freq_control;
+    };
+}
+
+#endif  /* REGIONHINTRECOMMENDER_HPP_INCLUDE */

--- a/src/RegionHintRecommender.hpp
+++ b/src/RegionHintRecommender.hpp
@@ -39,7 +39,6 @@ namespace geopm
             int m_max_freq;
             int m_min_freq;
             std::map<std::string, std::vector<double> > m_freq_map;
-            std::vector<int> m_freq_control;
     };
 }
 

--- a/src/RegionHintRecommender.hpp
+++ b/src/RegionHintRecommender.hpp
@@ -6,36 +6,34 @@
 #ifndef REGIONHINTRECOMMENDER_HPP_INCLUDE
 #define REGIONHINTRECOMMENDER_HPP_INCLUDE
 
-#include "geopm/json11.hpp"
+#include <memory>
+#include <map>
 
 namespace geopm
 {
     /// @brief Class ingesting region classification probabilities and
-    ///        a frequency map json11 file and determining a recommended 
+    ///        a frequency map json file and determining a recommended 
     ///        frequency decisions.
     class RegionHintRecommender
     {
         public:
-            /// @brief Constructor loads frequency map file from json11 into
-            ///        a std::map of region class string to double, and sets
-            ///        both min and max frequency recommendations.
+            /// @brief Returns a unique_ptr to a concrete object constructed
+            ///        using the underlying implementation, which loads a
+            ///        frequency map file into a std::map of region class
+            ///        string to double, and sets both min and max frequency
+            ///        recommendations.
             ///
             /// @param [in] fmap_path string containing path to freq map json
             /// @param [in] min_freq integer containing minimum frequency
             /// @param [in] max_freq integer containing maximum frequency
-            RegionHintRecommender(char* fmap_path, int min_freq, int max_freq);
+            static std::unique_ptr<RegionHintRecommender> make_unique(const std::string fmap_path, int min_freq, int max_freq);
 
             /// @brief Recommends frequency based on region classification probabilities
             ///
             /// @param [in] region_class List of region classification names and
             ///             probabilities output from region class neural net
             /// @param [in] phi User-input energy-perf bias
-            double recommend_frequency(std::map<std::string, float> region_class, double phi);
-
-        private:
-            int m_max_freq;
-            int m_min_freq;
-            std::map<std::string, std::vector<double> > m_freq_map;
+            virtual double recommend_frequency(std::map<std::string, float> region_class, double phi) const = 0;
     };
 }
 

--- a/src/RegionHintRecommenderImp.hpp
+++ b/src/RegionHintRecommenderImp.hpp
@@ -14,7 +14,7 @@ namespace geopm
     {
         public:
             RegionHintRecommenderImp(const std::string fmap_path, int min_freq, int max_freq);
-            double recommend_frequency(std::map<std::string, float> region_class, double phi) const override;
+            double recommend_frequency(std::map<std::string, double> region_class, double phi) const override;
 
         private:
             int m_min_freq;

--- a/src/RegionHintRecommenderImp.hpp
+++ b/src/RegionHintRecommenderImp.hpp
@@ -17,8 +17,8 @@ namespace geopm
             double recommend_frequency(std::map<std::string, float> region_class, double phi) const override;
 
         private:
-            int m_max_freq;
             int m_min_freq;
+            int m_max_freq;
             std::map<std::string, std::vector<double> > m_freq_map;
     };
 }

--- a/src/RegionHintRecommenderImp.hpp
+++ b/src/RegionHintRecommenderImp.hpp
@@ -22,6 +22,8 @@ namespace geopm
             /// @param [in] nn_output List of region classification names and
             ///             logits output from region class neural net
             /// @param [in] phi User-input perf-energy bias
+            ///
+            /// @return Returns a frequency, double in Hertz
             double recommend_frequency(const std::map<std::string, double> &nn_output, double phi)
                     const override;
 

--- a/src/RegionHintRecommenderImp.hpp
+++ b/src/RegionHintRecommenderImp.hpp
@@ -6,7 +6,7 @@
 #ifndef REGIONHINTRECOMMENDERIMP_HPP_INCLUDE
 #define REGIONHINTRECOMMENDERIMP_HPP_INCLUDE
 
-#include "geopm/json11.hpp"
+#include "RegionHintRecommender.hpp"
 
 namespace geopm
 {

--- a/src/RegionHintRecommenderImp.hpp
+++ b/src/RegionHintRecommenderImp.hpp
@@ -10,11 +10,19 @@
 
 namespace geopm
 {
+    /// @brief Class ingesting region classification probabilities and
+    ///        a frequency map json file and determining a recommended 
+    ///        frequency decision.
     class RegionHintRecommenderImp : public RegionHintRecommender
     {
         public:
             RegionHintRecommenderImp(const std::string fmap_path, int min_freq, int max_freq);
-            double recommend_frequency(std::map<std::string, double> region_class, double phi) const override;
+            /// @brief Recommends frequency based on region classification probabilities
+            ///
+            /// @param [in] nn_output List of region classification names and
+            ///             probabilities output from region class neural net
+            /// @param [in] phi User-input perf-energy bias
+            double recommend_frequency(std::map<std::string, double> nn_output, double phi) const override;
 
         private:
             int m_min_freq;

--- a/src/RegionHintRecommenderImp.hpp
+++ b/src/RegionHintRecommenderImp.hpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef REGIONHINTRECOMMENDERIMP_HPP_INCLUDE
+#define REGIONHINTRECOMMENDERIMP_HPP_INCLUDE
+
+#include "geopm/json11.hpp"
+
+namespace geopm
+{
+    class RegionHintRecommenderImp : public RegionHintRecommender
+    {
+        public:
+            RegionHintRecommenderImp(const std::string fmap_path, int min_freq, int max_freq);
+            double recommend_frequency(std::map<std::string, float> region_class, double phi) const override;
+
+        private:
+            int m_max_freq;
+            int m_min_freq;
+            std::map<std::string, std::vector<double> > m_freq_map;
+    };
+}
+
+
+#endif  /* REGIONHINTRECOMMENDERIMP_HPP_INCLUDE */

--- a/src/RegionHintRecommenderImp.hpp
+++ b/src/RegionHintRecommenderImp.hpp
@@ -10,19 +10,20 @@
 
 namespace geopm
 {
-    /// @brief Class ingesting region classification probabilities and
+    /// @brief Class ingesting region classification logits and
     ///        a frequency map json file and determining a recommended 
     ///        frequency decision.
     class RegionHintRecommenderImp : public RegionHintRecommender
     {
         public:
-            RegionHintRecommenderImp(const std::string fmap_path, int min_freq, int max_freq);
-            /// @brief Recommends frequency based on region classification probabilities
+            RegionHintRecommenderImp(const std::string &fmap_path, int min_freq, int max_freq);
+            /// @brief Recommends frequency based on region classification logits 
             ///
             /// @param [in] nn_output List of region classification names and
-            ///             probabilities output from region class neural net
+            ///             logits output from region class neural net
             /// @param [in] phi User-input perf-energy bias
-            double recommend_frequency(std::map<std::string, double> nn_output, double phi) const override;
+            double recommend_frequency(const std::map<std::string, double> &nn_output, double phi)
+                    const override;
 
         private:
             int m_min_freq;

--- a/src/TensorMath.cpp
+++ b/src/TensorMath.cpp
@@ -83,7 +83,7 @@ namespace geopm
     TensorOneD TensorMathImp::sigmoid(const TensorOneD &tensor) const
     {
         TensorOneD rval(tensor.get_dim());
-        for (std::size_t idx = 0; idx < tensor.get_dim(); ++idx) {
+        for (size_t idx = 0; idx < tensor.get_dim(); ++idx) {
             rval[idx] = 1/(1 + expf(-tensor[idx]));
         }
         return rval;

--- a/src/TensorMath.cpp
+++ b/src/TensorMath.cpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <numeric>
 #include <utility>
+#include <cerrno>
 
 #include "geopm/Exception.hpp"
 
@@ -84,7 +85,16 @@ namespace geopm
     {
         TensorOneD rval(tensor.get_dim());
         for (size_t idx = 0; idx < tensor.get_dim(); ++idx) {
-            rval[idx] = 1/(1 + expf(-tensor[idx]));
+            // Note that a divide by zero error is impossible because denominator is 1+e^-x
+            double retval = exp(-tensor[idx]);
+
+            if (retval == HUGE_VAL) {
+                errno = 0;
+                rval[idx] = 0;
+            }
+            else {
+                rval[idx] = 1/(1 + retval);
+            }
         }
         return rval;
     }

--- a/src/TensorMath.cpp
+++ b/src/TensorMath.cpp
@@ -28,7 +28,8 @@ namespace geopm
     TensorOneD TensorMathImp::add(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const
     {
         if (tensor_a.get_dim() != tensor_b.get_dim()) {
-            throw Exception("Adding vectors of mismatched dimensions.",
+            throw Exception("TensorMathImp::" + std::string(__func__) +
+                            ": Adding vectors of mismatched dimensions.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -47,7 +48,8 @@ namespace geopm
     TensorOneD TensorMathImp::subtract(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const
     {
         if (tensor_a.get_dim() != tensor_b.get_dim()) {
-            throw Exception("Subtracting vectors of mismatched dimensions.",
+            throw Exception("TensorMathImp::" + std::string(__func__) +
+                            ": Subtracting vectors of mismatched dimensions.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -66,7 +68,8 @@ namespace geopm
     double TensorMathImp::inner_product(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const
     {
         if (tensor_a.get_dim() != tensor_b.get_dim()) {
-            throw Exception("Inner product of vectors of mismatched dimensions.",
+            throw Exception("TensorMathImp::" + std::string(__func__) +
+                            ": Inner product of vectors of mismatched dimensions.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -89,7 +92,8 @@ namespace geopm
     TensorOneD TensorMathImp::multiply(const TensorTwoD &tensor_a, const TensorOneD &tensor_b) const
     {
         if (tensor_a.get_cols() != tensor_b.get_dim()) {
-            throw Exception("Attempted to multiply matrix and vector with incompatible dimensions.",
+            throw Exception("TensorMathImp::" + std::string(__func__) +
+                            ": Attempted to multiply matrix and vector with incompatible dimensions.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 

--- a/src/TensorMath.cpp
+++ b/src/TensorMath.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#include "config.h"
+
+#include "TensorMath.hpp"
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+#include <cmath>
+#include <algorithm>
+#include <functional>
+#include <numeric>
+#include <utility>
+
+#include "geopm/Exception.hpp"
+
+namespace geopm
+{
+    TensorOneD TensorMathImp::add(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const
+    {
+        if (tensor_a.get_dim() != tensor_b.get_dim()) {
+            throw geopm::Exception("Adding vectors of mismatched dimensions.",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::vector<float> rval(tensor_a.get_dim());
+        const auto &vec_a = tensor_a.get_data();
+        const auto &vec_b = tensor_b.get_data();
+        std::transform(vec_a.begin(),
+                       vec_a.end(),
+                       vec_b.begin(),
+                       rval.begin(),
+                       std::plus<float>());
+
+        return TensorOneD(rval);
+    }
+
+    TensorOneD TensorMathImp::subtract(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const
+    {
+        if (tensor_a.get_dim() != tensor_b.get_dim()) {
+            throw geopm::Exception("Subtracting vectors of mismatched dimensions.",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::vector<float> rval(tensor_a.get_dim());
+        const auto &vec_a = tensor_a.get_data();
+        const auto &vec_b = tensor_b.get_data();
+        std::transform(vec_a.begin(),
+                       vec_a.end(),
+                       vec_b.begin(),
+                       rval.begin(),
+                       std::minus<float>());
+
+        return TensorOneD(rval);
+    }
+
+    float TensorMathImp::inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const
+    {
+        if (tensor_a.get_dim() != tensor_b.get_dim()) {
+            throw geopm::Exception("Inner product of vectors of mismatched dimensions.",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::vector<float> rval(tensor_a.get_dim());
+        const auto &vec_a = tensor_a.get_data();
+        const auto &vec_b = tensor_b.get_data();
+
+        return std::inner_product(vec_a.begin(), vec_a.end(), vec_b.begin(), 0);
+    }
+
+    TensorOneD TensorMathImp::sigmoid(const TensorOneD& tensor) const
+    {
+        TensorOneD rval(tensor.get_dim());
+        for(std::size_t idx = 0; idx < tensor.get_dim(); idx++) {
+            rval[idx] = 1/(1 + expf(-tensor[idx]));
+        }
+        return rval;
+    }
+
+    TensorOneD TensorMathImp::multiply(const TensorTwoD& tensor_a, const TensorOneD& tensor_b) const
+    {
+        if (tensor_a.get_cols() != tensor_b.get_dim()) {
+            throw geopm::Exception("Attempted to multiply matrix and vector with incompatible dimensions.",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        const auto &mat = tensor_a.get_data();
+
+        TensorOneD rval(tensor_a.get_rows());
+
+        for (size_t idx = 0; idx < tensor_a.get_rows(); ++idx) {
+            rval[idx] = mat[idx] * tensor_b;
+        }
+        return rval;
+    }
+}

--- a/src/TensorMath.cpp
+++ b/src/TensorMath.cpp
@@ -27,14 +27,14 @@ namespace geopm
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::vector<float> rval(tensor_a.get_dim());
+        std::vector<double> rval(tensor_a.get_dim());
         const auto &vec_a = tensor_a.get_data();
         const auto &vec_b = tensor_b.get_data();
         std::transform(vec_a.begin(),
                        vec_a.end(),
                        vec_b.begin(),
                        rval.begin(),
-                       std::plus<float>());
+                       std::plus<double>());
 
         return TensorOneD(rval);
     }
@@ -46,26 +46,26 @@ namespace geopm
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::vector<float> rval(tensor_a.get_dim());
+        std::vector<double> rval(tensor_a.get_dim());
         const auto &vec_a = tensor_a.get_data();
         const auto &vec_b = tensor_b.get_data();
         std::transform(vec_a.begin(),
                        vec_a.end(),
                        vec_b.begin(),
                        rval.begin(),
-                       std::minus<float>());
+                       std::minus<double>());
 
         return TensorOneD(rval);
     }
 
-    float TensorMathImp::inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const
+    double TensorMathImp::inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const
     {
         if (tensor_a.get_dim() != tensor_b.get_dim()) {
             throw geopm::Exception("Inner product of vectors of mismatched dimensions.",
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::vector<float> rval(tensor_a.get_dim());
+        std::vector<double> rval(tensor_a.get_dim());
         const auto &vec_a = tensor_a.get_data();
         const auto &vec_b = tensor_b.get_data();
 

--- a/src/TensorMath.cpp
+++ b/src/TensorMath.cpp
@@ -20,11 +20,16 @@
 
 namespace geopm
 {
-    TensorOneD TensorMathImp::add(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const
+    std::shared_ptr<TensorMath> TensorMath::make_shared()
+    {
+        return std::make_shared<TensorMathImp>();
+    }
+
+    TensorOneD TensorMathImp::add(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const
     {
         if (tensor_a.get_dim() != tensor_b.get_dim()) {
-            throw geopm::Exception("Adding vectors of mismatched dimensions.",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("Adding vectors of mismatched dimensions.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         std::vector<double> rval(tensor_a.get_dim());
@@ -39,11 +44,11 @@ namespace geopm
         return TensorOneD(rval);
     }
 
-    TensorOneD TensorMathImp::subtract(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const
+    TensorOneD TensorMathImp::subtract(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const
     {
         if (tensor_a.get_dim() != tensor_b.get_dim()) {
-            throw geopm::Exception("Subtracting vectors of mismatched dimensions.",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("Subtracting vectors of mismatched dimensions.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         std::vector<double> rval(tensor_a.get_dim());
@@ -58,11 +63,11 @@ namespace geopm
         return TensorOneD(rval);
     }
 
-    double TensorMathImp::inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const
+    double TensorMathImp::inner_product(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const
     {
         if (tensor_a.get_dim() != tensor_b.get_dim()) {
-            throw geopm::Exception("Inner product of vectors of mismatched dimensions.",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("Inner product of vectors of mismatched dimensions.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         std::vector<double> rval(tensor_a.get_dim());
@@ -72,28 +77,28 @@ namespace geopm
         return std::inner_product(vec_a.begin(), vec_a.end(), vec_b.begin(), 0);
     }
 
-    TensorOneD TensorMathImp::sigmoid(const TensorOneD& tensor) const
+    TensorOneD TensorMathImp::sigmoid(const TensorOneD &tensor) const
     {
         TensorOneD rval(tensor.get_dim());
-        for(std::size_t idx = 0; idx < tensor.get_dim(); idx++) {
+        for (std::size_t idx = 0; idx < tensor.get_dim(); ++idx) {
             rval[idx] = 1/(1 + expf(-tensor[idx]));
         }
         return rval;
     }
 
-    TensorOneD TensorMathImp::multiply(const TensorTwoD& tensor_a, const TensorOneD& tensor_b) const
+    TensorOneD TensorMathImp::multiply(const TensorTwoD &tensor_a, const TensorOneD &tensor_b) const
     {
         if (tensor_a.get_cols() != tensor_b.get_dim()) {
-            throw geopm::Exception("Attempted to multiply matrix and vector with incompatible dimensions.",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("Attempted to multiply matrix and vector with incompatible dimensions.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        const auto &mat = tensor_a.get_data();
+        const auto &MAT = tensor_a.get_data();
 
         TensorOneD rval(tensor_a.get_rows());
 
         for (size_t idx = 0; idx < tensor_a.get_rows(); ++idx) {
-            rval[idx] = mat[idx] * tensor_b;
+            rval[idx] = MAT[idx] * tensor_b;
         }
         return rval;
     }

--- a/src/TensorMath.hpp
+++ b/src/TensorMath.hpp
@@ -21,9 +21,7 @@ namespace geopm
         public:
             virtual ~TensorMath() = default;
 
-            /// @brief Add two 1D tensors, element-wise
-            ///
-            /// The tensors need to be the same length. 
+            /// @brief Add two 1D tensors of the same length, element-wise
             ///
             /// @throws geopm::Exception if the lengths do not match.
             ///
@@ -31,7 +29,7 @@ namespace geopm
             ///
             /// @return Returns a 1D tensor, the sum of two 1D tensors
             virtual TensorOneD add(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const = 0;
-            /// @brief Subtract two 1D tensors, element-wise
+            /// @brief Subtract two 1D tensors of the same length, element-wise
             ///
             /// @throws geopm::Exception if the lengths do not match.
             ///
@@ -54,10 +52,11 @@ namespace geopm
             /// @brief Multiply a 2D tensor by a 1D tensor
             /// 
             /// @param [in] TensorTwoD& Reference to the 2D multiplicand
+            ///
             /// @param [in] TensorOneD& Reference to the 1D multiplicand
             /// 
             /// @throws geopm::Exception if the sizes are incompatible, i.e. if 2D
-            /// tensor number of columns is unequal to 1D tensor number of rows
+            ///         tensor number of columns is unequal to 1D tensor number of rows
             virtual TensorOneD multiply(const TensorTwoD&, const TensorOneD&) const = 0;
     };
 

--- a/src/TensorMath.hpp
+++ b/src/TensorMath.hpp
@@ -6,6 +6,7 @@
 #ifndef TENSORMATH_HPP_INCLUDE
 #define TENSORMATH_HPP_INCLUDE
 
+#include <memory>
 #include <vector>
 
 namespace geopm
@@ -19,6 +20,10 @@ namespace geopm
     class TensorMath
     {
         public:
+            /// @brief Returns a shared_ptr to a concrete object constructed
+            ///        using the underlying implementation.
+            static std::shared_ptr<TensorMath> make_shared();
+
             virtual ~TensorMath() = default;
 
             /// @brief Add two 1D tensors of the same length, element-wise
@@ -28,7 +33,7 @@ namespace geopm
             /// @param [in] other The summand
             ///
             /// @return Returns a 1D tensor, the sum of two 1D tensors
-            virtual TensorOneD add(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const = 0;
+            virtual TensorOneD add(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const = 0;
             /// @brief Subtract two 1D tensors of the same length, element-wise
             ///
             /// @throws geopm::Exception if the lengths do not match.
@@ -36,7 +41,7 @@ namespace geopm
             /// @param [in] other The subtrahend
             ///
             /// @return A 1D tensor, the difference of two 1D tensors.
-            virtual TensorOneD subtract(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const = 0;
+            virtual TensorOneD subtract(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const = 0;
             /// @brief Multiply two 1D tensors, element-wise, and sum the result.
             ///
             /// @throws geopm::Exception if the lengths do not match.
@@ -44,10 +49,10 @@ namespace geopm
             /// @param [in] other The multiplicand
             ///
             /// @return Returns a 1D tensor, the product of two 1D tensors
-            virtual double inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const = 0;
+            virtual double inner_product(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const = 0;
             /// @brief Compute logistic sigmoid function of 1D Tensor
 
-            virtual TensorOneD sigmoid(const TensorOneD& tensor) const = 0;
+            virtual TensorOneD sigmoid(const TensorOneD &tensor) const = 0;
 
             /// @brief Multiply a 2D tensor by a 1D tensor
             /// 
@@ -57,7 +62,7 @@ namespace geopm
             /// 
             /// @throws geopm::Exception if the sizes are incompatible, i.e. if 2D
             ///         tensor number of columns is unequal to 1D tensor number of rows
-            virtual TensorOneD multiply(const TensorTwoD&, const TensorOneD&) const = 0;
+            virtual TensorOneD multiply(const TensorTwoD &, const TensorOneD &) const = 0;
     };
 
     class TensorMathImp : public TensorMath
@@ -65,11 +70,11 @@ namespace geopm
         public:
             TensorMathImp() = default;
             virtual ~TensorMathImp() = default;
-            TensorOneD add(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const override;
-            TensorOneD subtract(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const override;
-            double inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const override;
-            TensorOneD sigmoid(const TensorOneD& tensor) const override;
-            TensorOneD multiply(const TensorTwoD&, const TensorOneD&) const override;
+            TensorOneD add(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const override;
+            TensorOneD subtract(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const override;
+            double inner_product(const TensorOneD &tensor_a, const TensorOneD &tensor_b) const override;
+            TensorOneD sigmoid(const TensorOneD &tensor) const override;
+            TensorOneD multiply(const TensorTwoD &, const TensorOneD &) const override;
     };
 }
 #endif /* TENSORMATH_HPP_INCLUDE */

--- a/src/TensorMath.hpp
+++ b/src/TensorMath.hpp
@@ -46,7 +46,7 @@ namespace geopm
             /// @param [in] other The multiplicand
             ///
             /// @return Returns a 1D tensor, the product of two 1D tensors
-            virtual float inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const = 0;
+            virtual double inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const = 0;
             /// @brief Compute logistic sigmoid function of 1D Tensor
 
             virtual TensorOneD sigmoid(const TensorOneD& tensor) const = 0;
@@ -68,7 +68,7 @@ namespace geopm
             virtual ~TensorMathImp() = default;
             TensorOneD add(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const override;
             TensorOneD subtract(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const override;
-            float inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const override;
+            double inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const override;
             TensorOneD sigmoid(const TensorOneD& tensor) const override;
             TensorOneD multiply(const TensorTwoD&, const TensorOneD&) const override;
     };

--- a/src/TensorMath.hpp
+++ b/src/TensorMath.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TENSORMATH_HPP_INCLUDE
+#define TENSORMATH_HPP_INCLUDE
+
+#include <vector>
+
+namespace geopm
+{
+    class TensorOneD;
+    class TensorTwoD;
+
+    /// @brief Class to perform operations on 1D and 2D Tensors,
+    ///        aka vectors and matrices, suitable for use in
+    ///        feed-forward neural networks.
+    class TensorMath
+    {
+        public:
+            virtual ~TensorMath() = default;
+
+            /// @brief Add two 1D tensors, element-wise
+            ///
+            /// The tensors need to be the same length. 
+            ///
+            /// @throws geopm::Exception if the lengths do not match.
+            ///
+            /// @param [in] other The summand
+            ///
+            /// @return Returns a 1D tensor, the sum of two 1D tensors
+            virtual TensorOneD add(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const = 0;
+            /// @brief Subtract two 1D tensors, element-wise
+            ///
+            /// @throws geopm::Exception if the lengths do not match.
+            ///
+            /// @param [in] other The subtrahend
+            ///
+            /// @return A 1D tensor, the difference of two 1D tensors.
+            virtual TensorOneD subtract(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const = 0;
+            /// @brief Multiply two 1D tensors, element-wise, and sum the result.
+            ///
+            /// @throws geopm::Exception if the lengths do not match.
+            ///
+            /// @param [in] other The multiplicand
+            ///
+            /// @return Returns a 1D tensor, the product of two 1D tensors
+            virtual float inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const = 0;
+            /// @brief Compute logistic sigmoid function of 1D Tensor
+
+            virtual TensorOneD sigmoid(const TensorOneD& tensor) const = 0;
+
+            /// @brief Multiply a 2D tensor by a 1D tensor
+            /// 
+            /// @param [in] TensorTwoD& Reference to the 2D multiplicand
+            /// @param [in] TensorOneD& Reference to the 1D multiplicand
+            /// 
+            /// @throws geopm::Exception if the sizes are incompatible, i.e. if 2D
+            /// tensor number of columns is unequal to 1D tensor number of rows
+            virtual TensorOneD multiply(const TensorTwoD&, const TensorOneD&) const = 0;
+    };
+
+    class TensorMathImp : public TensorMath
+    {
+        public:
+            TensorMathImp() = default;
+            virtual ~TensorMathImp() = default;
+            TensorOneD add(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const override;
+            TensorOneD subtract(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const override;
+            float inner_product(const TensorOneD& tensor_a, const TensorOneD& tensor_b) const override;
+            TensorOneD sigmoid(const TensorOneD& tensor) const override;
+            TensorOneD multiply(const TensorTwoD&, const TensorOneD&) const override;
+    };
+}
+#endif /* TENSORMATH_HPP_INCLUDE */

--- a/src/TensorOneD.cpp
+++ b/src/TensorOneD.cpp
@@ -29,8 +29,8 @@ namespace geopm
     }
 
     TensorOneD::TensorOneD(TensorOneD &&other)
-        : TensorOneD(std::move(other.m_vec), std::move(other.m_math))
     {
+        *this = std::move(other);
     }
 
     TensorOneD::TensorOneD(std::vector<float> input)
@@ -38,7 +38,7 @@ namespace geopm
     {
     }
 
-    TensorOneD::TensorOneD(std::vector<float> input, std::shared_ptr<TensorMath> math)
+    TensorOneD::TensorOneD(const std::vector<float> &input, std::shared_ptr<TensorMath> math)
     {
         m_vec = input;
         m_math = math;
@@ -57,6 +57,7 @@ namespace geopm
     TensorOneD& TensorOneD::operator=(const TensorOneD &other)
     {
         m_vec = other.m_vec;
+        m_math = other.m_math;
         return *this;
     }
 
@@ -67,6 +68,7 @@ namespace geopm
         }
 
         m_vec = std::move(other.m_vec);
+        m_math = std::move(other.m_math);
         return *this;
     }
 

--- a/src/TensorOneD.cpp
+++ b/src/TensorOneD.cpp
@@ -34,8 +34,8 @@ namespace geopm
         m_math = std::move(other.m_math);
     }
 
-    TensorOneD::TensorOneD(std::vector<double> input)
-        : TensorOneD(input, std::make_shared<TensorMathImp>())
+    TensorOneD::TensorOneD(const std::vector<double> &input)
+        : TensorOneD(input, TensorMath::make_shared())
     {
     }
 
@@ -78,12 +78,12 @@ namespace geopm
         return m_vec == other.m_vec;
     }
 
-    double& TensorOneD::operator[] (size_t idx)
+    double& TensorOneD::operator[](size_t idx)
     {
         return m_vec.at(idx);
     }
 
-    double TensorOneD::operator[] (size_t idx) const
+    double TensorOneD::operator[](size_t idx) const
     {
         return m_vec.at(idx);
     }

--- a/src/TensorOneD.cpp
+++ b/src/TensorOneD.cpp
@@ -19,7 +19,7 @@ namespace geopm
     }
 
     TensorOneD::TensorOneD(size_t dim)
-        : TensorOneD(std::vector<float>(dim))
+        : TensorOneD(std::vector<double>(dim))
     {
     }
 
@@ -34,12 +34,12 @@ namespace geopm
         m_math = std::move(other.m_math);
     }
 
-    TensorOneD::TensorOneD(std::vector<float> input)
+    TensorOneD::TensorOneD(std::vector<double> input)
         : TensorOneD(input, std::make_shared<TensorMathImp>())
     {
     }
 
-    TensorOneD::TensorOneD(const std::vector<float> &input, std::shared_ptr<TensorMath> math)
+    TensorOneD::TensorOneD(const std::vector<double> &input, std::shared_ptr<TensorMath> math)
     {
         m_vec = input;
         m_math = math;
@@ -78,17 +78,17 @@ namespace geopm
         return m_vec == other.m_vec;
     }
 
-    float& TensorOneD::operator[] (size_t idx)
+    double& TensorOneD::operator[] (size_t idx)
     {
         return m_vec.at(idx);
     }
 
-    float TensorOneD::operator[] (size_t idx) const
+    double TensorOneD::operator[] (size_t idx) const
     {
         return m_vec.at(idx);
     }
 
-    const std::vector<float> &TensorOneD::get_data() const
+    const std::vector<double> &TensorOneD::get_data() const
     {
         return m_vec;
     }
@@ -103,7 +103,7 @@ namespace geopm
         return m_math->subtract(*this, other);
     }
 
-    float TensorOneD::operator*(const TensorOneD &other) const
+    double TensorOneD::operator*(const TensorOneD &other) const
     {
         return m_math->inner_product(*this, other);
     }

--- a/src/TensorOneD.cpp
+++ b/src/TensorOneD.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#include "config.h"
+
+#include "TensorMath.hpp"
+#include "TensorOneD.hpp"
+
+#include "geopm/Exception.hpp"
+
+namespace geopm
+{
+    TensorOneD::TensorOneD()
+        : TensorOneD(0)
+    {
+    }
+
+    TensorOneD::TensorOneD(size_t dim)
+        : TensorOneD(std::vector<float>(dim))
+    {
+    }
+
+    TensorOneD::TensorOneD(const TensorOneD &other)
+        : TensorOneD(other.m_vec)
+    {
+    }
+
+    TensorOneD::TensorOneD(TensorOneD &&other)
+        : TensorOneD(std::move(other.m_vec))
+    {
+    }
+
+    TensorOneD::TensorOneD(std::vector<float> input)
+        : TensorOneD(input, std::make_shared<TensorMathImp>())
+    {
+    }
+
+    TensorOneD::TensorOneD(std::vector<float> input, std::shared_ptr<TensorMath> math)
+    {
+        m_vec = input;
+        m_math = math;
+    }
+
+    void TensorOneD::set_dim(size_t dim)
+    {
+        m_vec.resize(dim, 0);
+    }
+
+    size_t TensorOneD::get_dim() const
+    {
+        return m_vec.size();
+    }
+
+    TensorOneD& TensorOneD::operator=(const TensorOneD &other)
+    {
+        m_vec = other.m_vec;
+        return *this;
+    }
+
+    TensorOneD& TensorOneD::operator=(TensorOneD &&other)
+    {
+        if (&other == this) {
+            return *this;
+        }
+
+        m_vec = std::move(other.m_vec);
+        return *this;
+    }
+
+    bool TensorOneD::operator==(const TensorOneD &other) const
+    {
+        return m_vec == other.m_vec;
+    }
+
+    float& TensorOneD::operator[] (size_t idx)
+    {
+        return m_vec.at(idx);
+    }
+
+    float TensorOneD::operator[] (size_t idx) const
+    {
+        return m_vec.at(idx);
+    }
+
+    const std::vector<float> &TensorOneD::get_data() const
+    {
+        return m_vec;
+    }
+
+    TensorOneD TensorOneD::operator+(const TensorOneD &other) const
+    {
+        return m_math->add(*this, other);
+    }
+
+    TensorOneD TensorOneD::operator-(const TensorOneD &other) const
+    {
+        return m_math->subtract(*this, other);
+    }
+
+    float TensorOneD::operator*(const TensorOneD &other) const
+    {
+        return m_math->inner_product(*this, other);
+    }
+
+    TensorOneD TensorOneD::sigmoid() const
+    {
+        return m_math->sigmoid(*this);
+    }
+}

--- a/src/TensorOneD.cpp
+++ b/src/TensorOneD.cpp
@@ -24,12 +24,12 @@ namespace geopm
     }
 
     TensorOneD::TensorOneD(const TensorOneD &other)
-        : TensorOneD(other.m_vec)
+        : TensorOneD(other.m_vec, other.m_math)
     {
     }
 
     TensorOneD::TensorOneD(TensorOneD &&other)
-        : TensorOneD(std::move(other.m_vec))
+        : TensorOneD(std::move(other.m_vec), std::move(other.m_math))
     {
     }
 

--- a/src/TensorOneD.cpp
+++ b/src/TensorOneD.cpp
@@ -30,7 +30,8 @@ namespace geopm
 
     TensorOneD::TensorOneD(TensorOneD &&other)
     {
-        *this = std::move(other);
+        m_vec = std::move(other.m_vec);
+        m_math = std::move(other.m_math);
     }
 
     TensorOneD::TensorOneD(std::vector<float> input)

--- a/src/TensorOneD.hpp
+++ b/src/TensorOneD.hpp
@@ -95,6 +95,7 @@ namespace geopm
             /// @return Returns the contents of the tensor.
             const std::vector<float> &get_data() const;
 
+	    virtual ~TensorOneD() = default;
         private:
             std::vector<float> m_vec;
             std::shared_ptr<TensorMath> m_math;

--- a/src/TensorOneD.hpp
+++ b/src/TensorOneD.hpp
@@ -36,7 +36,7 @@ namespace geopm
             /// @param [in] input  The values to store in the 1D tensor.
             ///
             /// @throws geopm::Exception if input is empty.
-            TensorOneD(std::vector<float> input);
+            TensorOneD(std::vector<double> input);
 
             /// @brief Test constructor
             ///
@@ -44,7 +44,7 @@ namespace geopm
             /// @param [in] math  TensorMath instance
             ///
             /// @throws geopm::Exception if input is empty.
-            TensorOneD(const std::vector<float> &input, std::shared_ptr<TensorMath> math);
+            TensorOneD(const std::vector<double> &input, std::shared_ptr<TensorMath> math);
 
             /// @brief Set length of 1D tensor
             ///
@@ -61,7 +61,7 @@ namespace geopm
 
             TensorOneD operator+(const TensorOneD &other) const;
             TensorOneD operator-(const TensorOneD &other) const;
-            float operator*(const TensorOneD &other) const;
+            double operator*(const TensorOneD &other) const;
             /// @brief Overload = operator with an in-place deep copy
             ///
             /// @param [in] other The assignee (tensor to be copied)
@@ -80,24 +80,24 @@ namespace geopm
             /// @param [in] idx The index at which to look for the value
             ///
             /// @return Returns a reference to the 1D tensor at idx
-            float &operator[](size_t idx);
+            double &operator[](size_t idx);
             /// @brief Value access of 1D Tensor value at idx.
             ///
             /// @param [in] idx The index at which to look for the value
             ///
             /// @return Returns the value of the 1D tensor at idx
-            float operator[](size_t idx) const;
+            double operator[](size_t idx) const;
 
             TensorOneD sigmoid() const;
 
-            /// @brief Return the tensor as a vector of floats.
+            /// @brief Return the tensor as a vector of doubles.
             ///
             /// @return Returns the contents of the tensor.
-            const std::vector<float> &get_data() const;
+            const std::vector<double> &get_data() const;
 
 	    virtual ~TensorOneD() = default;
         private:
-            std::vector<float> m_vec;
+            std::vector<double> m_vec;
             std::shared_ptr<TensorMath> m_math;
     };
 }

--- a/src/TensorOneD.hpp
+++ b/src/TensorOneD.hpp
@@ -28,7 +28,7 @@ namespace geopm
             /// @brief Constructs a deep copy of the argument
             ///
             /// @param [in] TensorOneD Tensor to copy
-            TensorOneD(const TensorOneD&);
+            TensorOneD(const TensorOneD &);
 
             TensorOneD(TensorOneD &&other);
             /// @brief Constructor from vector of values
@@ -36,7 +36,7 @@ namespace geopm
             /// @param [in] input  The values to store in the 1D tensor.
             ///
             /// @throws geopm::Exception if input is empty.
-            TensorOneD(std::vector<double> input);
+            TensorOneD(const std::vector<double> &input);
 
             /// @brief Test constructor
             ///
@@ -65,7 +65,7 @@ namespace geopm
             /// @brief Overload = operator with an in-place deep copy
             ///
             /// @param [in] other The assignee (tensor to be copied)
-            TensorOneD& operator=(const TensorOneD& other);
+            TensorOneD& operator=(const TensorOneD &other);
 
             TensorOneD& operator=(TensorOneD &&other);
 

--- a/src/TensorOneD.hpp
+++ b/src/TensorOneD.hpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TENSORONED_HPP_INCLUDE
+#define TENSORONED_HPP_INCLUDE
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace geopm
+{
+    class TensorMath;
+
+    /// @brief Class to store and perform operations on 1D Tensors,
+    ///        aka vectors, suitable for use in feed-forward neural
+    ///        networks.
+    class TensorOneD
+    {
+        public:
+            TensorOneD();
+            /// @brief Constructor with size specified 
+            ///
+            /// @param [in] n Size of 1D tensor
+            TensorOneD(size_t n);
+            /// @brief Constructs a deep copy of the argument
+            ///
+            /// @param [in] TensorOneD Tensor to copy
+            TensorOneD(const TensorOneD&);
+
+            TensorOneD(TensorOneD &&other);
+            /// @brief Constructor from vector of values
+            ///
+            /// @param [in] input  The values to store in the 1D tensor.
+            ///
+            /// @throws geopm::Exception if input is empty.
+            TensorOneD(std::vector<float> input);
+
+            /// @brief Test constructor
+            ///
+            /// @param [in] input  The values to store in the 1D tensor.
+            /// @param [in] math  TensorMath instance
+            ///
+            /// @throws geopm::Exception if input is empty.
+            TensorOneD(std::vector<float> input, std::shared_ptr<TensorMath> math);
+
+            /// @brief Set length of 1D tensor
+            ///
+            /// If the instance has more than n elements, it will
+            /// be truncated. If it has fewer than n elements, the
+            /// tensor will be expanded to a total size of n, uninitialized.
+            ///
+            /// @param [in] n Resulting size of 1D tensor
+            void set_dim(size_t dim);
+            /// @brief Get the length of the 1D tensor
+            ///
+            /// @return Returns the length of the 1D tensor
+            size_t get_dim() const;
+
+            TensorOneD operator+(const TensorOneD &other) const;
+            TensorOneD operator-(const TensorOneD &other) const;
+            float operator*(const TensorOneD &other) const;
+            /// @brief Overload = operator with an in-place deep copy
+            ///
+            /// @param [in] other The assignee (tensor to be copied)
+            TensorOneD& operator=(const TensorOneD& other);
+
+            TensorOneD& operator=(TensorOneD &&other);
+
+            /// @brief Overload == operator to do comparison of the underlying
+            //         data
+            ///
+            /// @param [in] other The tensor to compare against
+            bool operator==(const TensorOneD &other) const;
+
+            /// @brief Reference indexing of 1D tensor value at idx
+            ///
+            /// @param [in] idx The index at which to look for the value
+            ///
+            /// @return Returns a reference to the 1D tensor at idx
+            float &operator[](size_t idx);
+            /// @brief Value access of 1D Tensor value at idx.
+            ///
+            /// @param [in] idx The index at which to look for the value
+            ///
+            /// @return Returns the value of the 1D tensor at idx
+            float operator[](size_t idx) const;
+
+            TensorOneD sigmoid() const;
+
+            /// @brief Return the tensor as a vector of floats.
+            ///
+            /// @return Returns the contents of the tensor.
+            const std::vector<float> &get_data() const;
+
+        private:
+            std::vector<float> m_vec;
+            std::shared_ptr<TensorMath> m_math;
+    };
+}
+#endif /* TENSORONED_HPP_INCLUDE */

--- a/src/TensorOneD.hpp
+++ b/src/TensorOneD.hpp
@@ -6,7 +6,7 @@
 #ifndef TENSORONED_HPP_INCLUDE
 #define TENSORONED_HPP_INCLUDE
 
-#include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <vector>
 

--- a/src/TensorOneD.hpp
+++ b/src/TensorOneD.hpp
@@ -44,7 +44,7 @@ namespace geopm
             /// @param [in] math  TensorMath instance
             ///
             /// @throws geopm::Exception if input is empty.
-            TensorOneD(std::vector<float> input, std::shared_ptr<TensorMath> math);
+            TensorOneD(const std::vector<float> &input, std::shared_ptr<TensorMath> math);
 
             /// @brief Set length of 1D tensor
             ///

--- a/src/TensorTwoD.cpp
+++ b/src/TensorTwoD.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#include "config.h"
+
+#include "TensorMath.hpp"
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+#include "geopm/Exception.hpp"
+
+#include <iostream>
+
+namespace geopm
+{
+    TensorTwoD::TensorTwoD()
+        : TensorTwoD(0, 0)
+    {
+    }
+
+    TensorTwoD::TensorTwoD(size_t rows, size_t cols)
+        : TensorTwoD(rows, cols, std::make_shared<TensorMathImp>())
+    {
+    }
+
+    TensorTwoD::TensorTwoD(size_t rows,
+                           size_t cols,
+                           std::shared_ptr<TensorMath> math)
+    {
+        set_dim(rows, cols);
+        m_math = math;
+    }
+
+    TensorTwoD::TensorTwoD(const TensorTwoD &other)
+        : m_mat(other.m_mat)
+    {
+    }
+
+    TensorTwoD::TensorTwoD(TensorTwoD &&other)
+        : TensorTwoD(std::move(other.m_mat))
+    {
+    }
+
+    TensorTwoD::TensorTwoD(std::vector<TensorOneD> input)
+        : TensorTwoD(input, std::make_shared<TensorMathImp>())
+    {
+    }
+
+    TensorTwoD::TensorTwoD(std::vector<TensorOneD> input,
+                           std::shared_ptr<TensorMath> math)
+    {
+        set_data(input);
+        m_math = math;
+    }
+
+    TensorTwoD::TensorTwoD(std::vector<std::vector<float> > input)
+    {
+        std::cerr << "init 61" << std::endl;
+        std::cout << "init 62" << std::endl;
+
+        if (input.size() == 0) {
+            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::cout << "init 69" << std::endl;
+
+        size_t rows = input.size();
+        std::cout << "rows = " << rows << std::endl;
+        std::vector<TensorOneD> tensor_vec(rows);
+        for (size_t idx = 0; idx < rows; ++idx) {
+            tensor_vec[idx] = TensorOneD(input[idx]);
+            std::cout << "cols[" << idx << "] = " << tensor_vec[idx].get_dim() << std::endl;
+            std::cout << "from " << input[idx].size() << std::endl;
+        }
+
+        set_data(tensor_vec);
+        m_math = std::make_shared<TensorMathImp>();
+    }
+
+    size_t TensorTwoD::get_rows() const
+    {
+        return m_mat.size();
+    }
+
+    size_t TensorTwoD::get_cols() const
+    {
+        if (m_mat.size() == 0) {
+            return 0;
+        }
+        return m_mat[0].get_dim();
+    }
+
+    void TensorTwoD::set_dim(size_t rows, size_t cols)
+    {
+        if ((rows == 0 && cols > 0) || (rows > 0 && cols == 0)) {
+            throw geopm::Exception("Tried to allocate degenerate matrix.",
+                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        m_mat.resize(rows);
+        for (auto &row : m_mat) {
+            row.set_dim(cols);
+        }
+    }
+
+    TensorOneD TensorTwoD::operator*(const TensorOneD& other) const
+    {
+        return m_math->multiply(*this, other);
+    }
+
+    TensorOneD& TensorTwoD::operator[](size_t idx)
+    {
+        return m_mat.at(idx);
+    }
+
+    TensorOneD TensorTwoD::operator[](size_t idx) const
+    {
+        return m_mat.at(idx);
+    }
+
+    TensorTwoD& TensorTwoD::operator=(const TensorTwoD &other)
+    {
+        m_mat = other.m_mat;
+
+        return *this;
+    }
+
+    bool TensorTwoD::operator==(const TensorTwoD &other) const
+    {
+        return m_mat == other.m_mat;
+    }
+
+    const std::vector<TensorOneD> &TensorTwoD::get_data() const
+    {
+        return m_mat;
+    }
+
+    void TensorTwoD::set_data(const std::vector<TensorOneD> data)
+    {
+        m_mat = data;
+        size_t rows = data.size();
+        if (rows > 1) {
+            std::cout << "hi" << std::endl;
+            size_t cols = data[0].get_dim();
+            for (size_t idx = 1; idx < rows; ++idx) {
+                std::cout << idx << data[idx].get_dim() << "=?" << cols << std::endl;
+                if (data[idx].get_dim() != cols) {
+                    throw geopm::Exception("Attempt to load non-rectangular matrix.",
+                                           GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                }
+            }
+        }
+    }
+}

--- a/src/TensorTwoD.cpp
+++ b/src/TensorTwoD.cpp
@@ -64,7 +64,8 @@ namespace geopm
         : m_math(math)
     {
         if (input.size() == 0) {
-            throw Exception("Empty array is invalid for neural network weights.\n",
+            throw Exception("TensorTwoD::" + std::string(__func__) +
+                            ": Empty array is invalid for neural network weights.",
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -93,8 +94,9 @@ namespace geopm
     void TensorTwoD::set_dim(size_t rows, size_t cols)
     {
         if ((rows == 0 && cols > 0) || (rows > 0 && cols == 0)) {
-            throw Exception("Tried to allocate degenerate matrix.",
-                                   GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            throw Exception("TensorTwoD::" + std::string(__func__) +
+                            ": Tried to allocate degenerate matrix.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
         m_mat.resize(rows);
@@ -144,8 +146,9 @@ namespace geopm
             size_t cols = data[0].get_dim();
             for (size_t idx = 1; idx < rows; ++idx) {
                 if (data[idx].get_dim() != cols) {
-                    throw Exception("Attempt to load non-rectangular matrix.",
-                                           GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                    throw Exception("TensorTwoD::" + std::string(__func__) +
+                                    ": Attempt to load non-rectangular matrix.",
+                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                 }
             }
         }

--- a/src/TensorTwoD.cpp
+++ b/src/TensorTwoD.cpp
@@ -54,12 +54,12 @@ namespace geopm
         set_data(input);
     }
 
-    TensorTwoD::TensorTwoD(std::vector<std::vector<float> > input)
+    TensorTwoD::TensorTwoD(std::vector<std::vector<double>> input)
         : TensorTwoD(input, std::make_shared<TensorMathImp>())
     {
     }
 
-    TensorTwoD::TensorTwoD(std::vector<std::vector<float> > input,
+    TensorTwoD::TensorTwoD(std::vector<std::vector<double>> input,
                            std::shared_ptr<TensorMath> math)
         : m_math(math)
     {

--- a/src/TensorTwoD.cpp
+++ b/src/TensorTwoD.cpp
@@ -20,7 +20,7 @@ namespace geopm
     }
 
     TensorTwoD::TensorTwoD(size_t rows, size_t cols)
-        : TensorTwoD(rows, cols, std::make_shared<TensorMathImp>())
+        : TensorTwoD(rows, cols, TensorMath::make_shared())
     {
     }
 
@@ -42,29 +42,29 @@ namespace geopm
     {
     }
 
-    TensorTwoD::TensorTwoD(std::vector<TensorOneD> input)
-        : TensorTwoD(input, std::make_shared<TensorMathImp>())
+    TensorTwoD::TensorTwoD(const std::vector<TensorOneD> &input)
+        : TensorTwoD(input, TensorMath::make_shared())
     {
     }
 
-    TensorTwoD::TensorTwoD(std::vector<TensorOneD> input,
+    TensorTwoD::TensorTwoD(const std::vector<TensorOneD> &input,
                            std::shared_ptr<TensorMath> math)
         : m_math(math)
     {
         set_data(input);
     }
 
-    TensorTwoD::TensorTwoD(std::vector<std::vector<double>> input)
-        : TensorTwoD(input, std::make_shared<TensorMathImp>())
+    TensorTwoD::TensorTwoD(const std::vector<std::vector<double>> &input)
+        : TensorTwoD(input, TensorMath::make_shared())
     {
     }
 
-    TensorTwoD::TensorTwoD(std::vector<std::vector<double>> input,
+    TensorTwoD::TensorTwoD(const std::vector<std::vector<double>> &input,
                            std::shared_ptr<TensorMath> math)
         : m_math(math)
     {
         if (input.size() == 0) {
-            throw geopm::Exception("Empty array is invalid for neural network weights.\n",
+            throw Exception("Empty array is invalid for neural network weights.\n",
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -93,7 +93,7 @@ namespace geopm
     void TensorTwoD::set_dim(size_t rows, size_t cols)
     {
         if ((rows == 0 && cols > 0) || (rows > 0 && cols == 0)) {
-            throw geopm::Exception("Tried to allocate degenerate matrix.",
+            throw Exception("Tried to allocate degenerate matrix.",
                                    GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -103,7 +103,7 @@ namespace geopm
         }
     }
 
-    TensorOneD TensorTwoD::operator*(const TensorOneD& other) const
+    TensorOneD TensorTwoD::operator*(const TensorOneD &other) const
     {
         return m_math->multiply(*this, other);
     }
@@ -136,7 +136,7 @@ namespace geopm
         return m_mat;
     }
 
-    void TensorTwoD::set_data(const std::vector<TensorOneD> data)
+    void TensorTwoD::set_data(const std::vector<TensorOneD> &data)
     {
         m_mat = data;
         size_t rows = data.size();
@@ -144,7 +144,7 @@ namespace geopm
             size_t cols = data[0].get_dim();
             for (size_t idx = 1; idx < rows; ++idx) {
                 if (data[idx].get_dim() != cols) {
-                    throw geopm::Exception("Attempt to load non-rectangular matrix.",
+                    throw Exception("Attempt to load non-rectangular matrix.",
                                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                 }
             }

--- a/src/TensorTwoD.cpp
+++ b/src/TensorTwoD.cpp
@@ -54,12 +54,12 @@ namespace geopm
         set_data(input);
     }
 
-    TensorTwoD::TensorTwoD(const std::vector<std::vector<double>> &input)
+    TensorTwoD::TensorTwoD(const std::vector<std::vector<double> > &input)
         : TensorTwoD(input, TensorMath::make_shared())
     {
     }
 
-    TensorTwoD::TensorTwoD(const std::vector<std::vector<double>> &input,
+    TensorTwoD::TensorTwoD(const std::vector<std::vector<double> > &input,
                            std::shared_ptr<TensorMath> math)
         : m_math(math)
     {

--- a/src/TensorTwoD.cpp
+++ b/src/TensorTwoD.cpp
@@ -33,7 +33,7 @@ namespace geopm
     }
 
     TensorTwoD::TensorTwoD(const TensorTwoD &other)
-        : m_mat(other.m_mat), m_math(other.m_math)
+        : TensorTwoD(other.m_mat, other.m_math)
     {
     }
 
@@ -121,6 +121,7 @@ namespace geopm
     TensorTwoD& TensorTwoD::operator=(const TensorTwoD &other)
     {
         m_mat = other.m_mat;
+        m_math = other.m_math;
 
         return *this;
     }

--- a/src/TensorTwoD.hpp
+++ b/src/TensorTwoD.hpp
@@ -29,7 +29,7 @@ namespace geopm
             /// @brief Copy constructor using a deep copy
             ///
             /// @param [in] TensorTwoD& 2D Tensor to copy
-            TensorTwoD(const TensorTwoD&);
+            TensorTwoD(const TensorTwoD &);
 
             TensorTwoD(TensorTwoD &&other);
             /// @brief Constructor input from a vector of vectors of values.
@@ -38,7 +38,7 @@ namespace geopm
             ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
-            TensorTwoD(std::vector<std::vector<double>> input);
+            TensorTwoD(const std::vector<std::vector<double>> &input);
             /// @brief Constructor input from a vector of vectors of values.
             ///
             /// @param [in] input std::vector<std::vector<double>> instance
@@ -46,14 +46,15 @@ namespace geopm
             ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
-            TensorTwoD(std::vector<std::vector<double>> input, std::shared_ptr<TensorMath> math);
+            TensorTwoD(const std::vector<std::vector<double>> &input,
+                       std::shared_ptr<TensorMath> math);
             /// @brief Constructor input from a vector of 1D tensors.
             ///
             /// @param [in] input std::vector<TensorOneD> instance
             ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
-            TensorTwoD(std::vector<TensorOneD> input);
+            TensorTwoD(const std::vector<TensorOneD> &input);
             /// @brief Test constructor
             ///
             /// @param [in] input std::vector<TensorOneD> instance
@@ -61,7 +62,7 @@ namespace geopm
             ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
-            TensorTwoD(std::vector<TensorOneD> input, std::shared_ptr<TensorMath> math);
+            TensorTwoD(const std::vector<TensorOneD> &input, std::shared_ptr<TensorMath> math);
             /// @brief Get number of rows in the 2D tensor
             ///
             /// @return Number of rows of the 2D tensor
@@ -89,7 +90,7 @@ namespace geopm
             ///
             /// @throws geopm::Exception if the sizes are incompatible, i.e. if 2D tensor
             /// number of columns is unequal to 1D tensor number of rows
-            TensorOneD operator*(const TensorOneD&) const;
+            TensorOneD operator*(const TensorOneD &) const;
             /// @brief Reference indexing of 1D Tensor at idx of the 2D Tensor
             ///
             /// @param [in] idx The index at which to look for the value
@@ -105,7 +106,7 @@ namespace geopm
             /// @brief Oerload = operator with an in-place deep copy
             ///
             /// @param [in] TensorTwoD& Reference to the 2D Tensor to copy
-            TensorTwoD& operator=(const TensorTwoD&);
+            TensorTwoD& operator=(const TensorTwoD &);
             /// @brief Overload == operator to do comparison of the underlying
             //         data
             ///
@@ -118,7 +119,7 @@ namespace geopm
             const std::vector<TensorOneD> &get_data() const;
 
             /// @brief Set the contents as a vector of tensors.
-            void set_data(const std::vector<TensorOneD>);
+            void set_data(const std::vector<TensorOneD> &);
 
 	    virtual ~TensorTwoD() = default;
         private:

--- a/src/TensorTwoD.hpp
+++ b/src/TensorTwoD.hpp
@@ -17,7 +17,7 @@ namespace geopm
     class TensorMath;
 
     ///  @brief Class to manage data and operations related to 2D Tensors
-    ///         required for neural net inference.  
+    ///         required for neural net inference.
     class TensorTwoD
     {
         public:
@@ -27,75 +27,83 @@ namespace geopm
             /// @brief Test constructor
             TensorTwoD(std::size_t rows, std::size_t cols, std::shared_ptr<TensorMath> math);
             /// @brief Copy constructor using a deep copy
-            /// 
+            ///
             /// @param [in] TensorTwoD& 2D Tensor to copy
             TensorTwoD(const TensorTwoD&);
 
             TensorTwoD(TensorTwoD &&other);
             /// @brief Constructor input from a vector of vectors of values.
-            /// 
+            ///
             /// @param [in] input std::vector<std::vector<float> > instance
-            /// 
+            ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
             TensorTwoD(std::vector<std::vector<float> > input);
+            /// @brief Constructor input from a vector of vectors of values.
+            ///
+            /// @param [in] input std::vector<std::vector<float> > instance
+            /// @param [in] math  TensorMath instance
+            ///
+            /// @throws geopm::Exception if input is not rectangular or
+            /// if input is empty.
+            TensorTwoD(std::vector<std::vector<float> > input, std::shared_ptr<TensorMath> math);
             /// @brief Constructor input from a vector of 1D tensors.
-            /// 
+            ///
             /// @param [in] input std::vector<TensorOneD> instance
-            /// 
+            ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
             TensorTwoD(std::vector<TensorOneD> input);
             /// @brief Test constructor
-            /// 
+            ///
             /// @param [in] input std::vector<TensorOneD> instance
             /// @param [in] math  TensorMath instance
-            /// 
+            ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
             TensorTwoD(std::vector<TensorOneD> input, std::shared_ptr<TensorMath> math);
             /// @brief Get number of rows in the 2D tensor
-            /// 
+            ///
             /// @return Number of rows of the 2D tensor
             std::size_t get_rows() const;
             /// @brief get number of columns in 2D tensor
-            /// 
+            ///
             /// @return Number of columns in the 2D tensor
             std::size_t get_cols() const;
             /// @brief Set dimensions of 2D tensor
-            /// 
+            ///
             /// @param [in] rows The number of "rows" or 1D tensors
             /// @param [in] cols The number of "cols" or the size of each 1D tensor
-            /// 
+            ///
             /// If the instance contains more than \p rows 1D tensors,
             /// it will be truncated. If the instance contains fewer
             /// than \p rows 1D tensors, it will be expanded to a total
             /// number of rows, uninitialized. The individual 1D tensors
-            /// will be managed similarly. 
-            /// 
+            /// will be managed similarly.
+            ///
             /// @throws geopm::Exception if \p rows = 0 and \p cols > 0
             void set_dim(std::size_t rows, std::size_t cols);
             /// @brief Multiply a 2D tensor by a 1D tensor
-            /// 
+            ///
             /// @param [in] TensorOneD& Reference to the multiplicand
-            /// 
+            ///
             /// @throws geopm::Exception if the sizes are incompatible, i.e. if 2D tensor
             /// number of columns is unequal to 1D tensor number of rows
             TensorOneD operator*(const TensorOneD&) const;
             /// @brief Reference indexing of 1D Tensor at idx of the 2D Tensor
-            /// 
+            ///
             /// @param [in] idx The index at which to look for the value
-            /// 
+            ///
             /// @return Returns a reference to the 1D Tensor at idx
             TensorOneD &operator[](size_t idx);
             /// @brief Value access of 1D Tensor value at idx
-            /// 
+            ///
             /// @pram [in] idx The index at which to look for the value
-            /// 
+            ///
             /// @return Returns the values of 1D Tensors at idx
             TensorOneD operator[](size_t idx) const;
             /// @brief Oerload = operator with an in-place deep copy
-            /// 
+            ///
             /// @param [in] TensorTwoD& Reference to the 2D Tensor to copy
             TensorTwoD& operator=(const TensorTwoD&);
             /// @brief Overload == operator to do comparison of the underlying

--- a/src/TensorTwoD.hpp
+++ b/src/TensorTwoD.hpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TENSORTWOD_HPP_INCLUDE
+#define TENSORTWOD_HPP_INCLUDE
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "TensorOneD.hpp"
+
+namespace geopm
+{
+    class TensorMath;
+
+    ///  @brief Class to manage data and operations related to 2D Tensors
+    ///         required for neural net inference.  
+    class TensorTwoD
+    {
+        public:
+            TensorTwoD();
+            /// @brief Constructor setting dimensions
+            TensorTwoD(std::size_t rows, std::size_t cols);
+            /// @brief Test constructor
+            TensorTwoD(std::size_t rows, std::size_t cols, std::shared_ptr<TensorMath> math);
+            /// @brief Copy constructor using a deep copy
+            /// 
+            /// @param [in] TensorTwoD& 2D Tensor to copy
+            TensorTwoD(const TensorTwoD&);
+
+            TensorTwoD(TensorTwoD &&other);
+            /// @brief Constructor input from a vector of vectors of values.
+            /// 
+            /// @param [in] input std::vector<std::vector<float> > instance
+            /// 
+            /// @throws geopm::Exception if input is not rectangular or
+            /// if input is empty.
+            TensorTwoD(std::vector<std::vector<float> > input);
+            /// @brief Constructor input from a vector of 1D tensors.
+            /// 
+            /// @param [in] input std::vector<TensorOneD> instance
+            /// 
+            /// @throws geopm::Exception if input is not rectangular or
+            /// if input is empty.
+            TensorTwoD(std::vector<TensorOneD> input);
+            /// @brief Test constructor
+            /// 
+            /// @param [in] input std::vector<TensorOneD> instance
+            /// @param [in] math  TensorMath instance
+            /// 
+            /// @throws geopm::Exception if input is not rectangular or
+            /// if input is empty.
+            TensorTwoD(std::vector<TensorOneD> input, std::shared_ptr<TensorMath> math);
+            /// @brief Get number of rows in the 2D tensor
+            /// 
+            /// @return Number of rows of the 2D tensor
+            std::size_t get_rows() const;
+            /// @brief get number of columns in 2D tensor
+            /// 
+            /// @return Number of columns in the 2D tensor
+            std::size_t get_cols() const;
+            /// @brief Set dimensions of 2D tensor
+            /// 
+            /// @param [in] rows The number of "rows" or 1D tensors
+            /// @param [in] cols The number of "cols" or the size of each 1D tensor
+            /// 
+            /// If the instance contains more than \p rows 1D tensors,
+            /// it will be truncated. If the instance contains fewer
+            /// than \p rows 1D tensors, it will be expanded to a total
+            /// number of rows, uninitialized. The individual 1D tensors
+            /// will be managed similarly. 
+            /// 
+            /// @throws geopm::Exception if \p rows = 0 and \p cols > 0
+            void set_dim(std::size_t rows, std::size_t cols);
+            /// @brief Multiply a 2D tensor by a 1D tensor
+            /// 
+            /// @param [in] TensorOneD& Reference to the multiplicand
+            /// 
+            /// @throws geopm::Exception if the sizes are incompatible, i.e. if 2D tensor
+            /// number of columns is unequal to 1D tensor number of rows
+            TensorOneD operator*(const TensorOneD&) const;
+            /// @brief Reference indexing of 1D Tensor at idx of the 2D Tensor
+            /// 
+            /// @param [in] idx The index at which to look for the value
+            /// 
+            /// @return Returns a reference to the 1D Tensor at idx
+            TensorOneD &operator[](size_t idx);
+            /// @brief Value access of 1D Tensor value at idx
+            /// 
+            /// @pram [in] idx The index at which to look for the value
+            /// 
+            /// @return Returns the values of 1D Tensors at idx
+            TensorOneD operator[](size_t idx) const;
+            /// @brief Oerload = operator with an in-place deep copy
+            /// 
+            /// @param [in] TensorTwoD& Reference to the 2D Tensor to copy
+            TensorTwoD& operator=(const TensorTwoD&);
+            /// @brief Overload == operator to do comparison of the underlying
+            //         data
+            ///
+            /// @param [in] other The tensor to compare against
+            bool operator==(const TensorTwoD &other) const;
+
+            /// @brief Return the tensor as a vector of tensors.
+            ///
+            /// @return Returns the contents of the tensor.
+            const std::vector<TensorOneD> &get_data() const;
+
+            /// @brief Set the contents as a vector of tensors.
+            void set_data(const std::vector<TensorOneD>);
+
+        private:
+            std::vector<TensorOneD> m_mat;
+            std::shared_ptr<TensorMath> m_math;
+    };
+}
+#endif

--- a/src/TensorTwoD.hpp
+++ b/src/TensorTwoD.hpp
@@ -23,9 +23,9 @@ namespace geopm
         public:
             TensorTwoD();
             /// @brief Constructor setting dimensions
-            TensorTwoD(std::size_t rows, std::size_t cols);
+            TensorTwoD(size_t rows, size_t cols);
             /// @brief Test constructor
-            TensorTwoD(std::size_t rows, std::size_t cols, std::shared_ptr<TensorMath> math);
+            TensorTwoD(size_t rows, size_t cols, std::shared_ptr<TensorMath> math);
             /// @brief Copy constructor using a deep copy
             ///
             /// @param [in] TensorTwoD& 2D Tensor to copy
@@ -34,19 +34,19 @@ namespace geopm
             TensorTwoD(TensorTwoD &&other);
             /// @brief Constructor input from a vector of vectors of values.
             ///
-            /// @param [in] input std::vector<std::vector<double>> instance
+            /// @param [in] input std::vector<std::vector<double> > instance
             ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
-            TensorTwoD(const std::vector<std::vector<double>> &input);
+            TensorTwoD(const std::vector<std::vector<double> > &input);
             /// @brief Constructor input from a vector of vectors of values.
             ///
-            /// @param [in] input std::vector<std::vector<double>> instance
+            /// @param [in] input std::vector<std::vector<double> > instance
             /// @param [in] math  TensorMath instance
             ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
-            TensorTwoD(const std::vector<std::vector<double>> &input,
+            TensorTwoD(const std::vector<std::vector<double> > &input,
                        std::shared_ptr<TensorMath> math);
             /// @brief Constructor input from a vector of 1D tensors.
             ///
@@ -66,11 +66,11 @@ namespace geopm
             /// @brief Get number of rows in the 2D tensor
             ///
             /// @return Number of rows of the 2D tensor
-            std::size_t get_rows() const;
+            size_t get_rows() const;
             /// @brief get number of columns in 2D tensor
             ///
             /// @return Number of columns in the 2D tensor
-            std::size_t get_cols() const;
+            size_t get_cols() const;
             /// @brief Set dimensions of 2D tensor
             ///
             /// @param [in] rows The number of "rows" or 1D tensors
@@ -83,7 +83,7 @@ namespace geopm
             /// will be managed similarly.
             ///
             /// @throws geopm::Exception if \p rows = 0 and \p cols > 0
-            void set_dim(std::size_t rows, std::size_t cols);
+            void set_dim(size_t rows, size_t cols);
             /// @brief Multiply a 2D tensor by a 1D tensor
             ///
             /// @param [in] TensorOneD& Reference to the multiplicand

--- a/src/TensorTwoD.hpp
+++ b/src/TensorTwoD.hpp
@@ -120,6 +120,7 @@ namespace geopm
             /// @brief Set the contents as a vector of tensors.
             void set_data(const std::vector<TensorOneD>);
 
+	    virtual ~TensorTwoD() = default;
         private:
             std::vector<TensorOneD> m_mat;
             std::shared_ptr<TensorMath> m_math;

--- a/src/TensorTwoD.hpp
+++ b/src/TensorTwoD.hpp
@@ -34,19 +34,19 @@ namespace geopm
             TensorTwoD(TensorTwoD &&other);
             /// @brief Constructor input from a vector of vectors of values.
             ///
-            /// @param [in] input std::vector<std::vector<float> > instance
+            /// @param [in] input std::vector<std::vector<double>> instance
             ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
-            TensorTwoD(std::vector<std::vector<float> > input);
+            TensorTwoD(std::vector<std::vector<double>> input);
             /// @brief Constructor input from a vector of vectors of values.
             ///
-            /// @param [in] input std::vector<std::vector<float> > instance
+            /// @param [in] input std::vector<std::vector<double>> instance
             /// @param [in] math  TensorMath instance
             ///
             /// @throws geopm::Exception if input is not rectangular or
             /// if input is empty.
-            TensorTwoD(std::vector<std::vector<float> > input, std::shared_ptr<TensorMath> math);
+            TensorTwoD(std::vector<std::vector<double>> input, std::shared_ptr<TensorMath> math);
             /// @brief Constructor input from a vector of 1D tensors.
             ///
             /// @param [in] input std::vector<TensorOneD> instance

--- a/test/DenseLayerTest.cpp
+++ b/test/DenseLayerTest.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "geopm/Exception.hpp"

--- a/test/DenseLayerTest.cpp
+++ b/test/DenseLayerTest.cpp
@@ -17,13 +17,14 @@
 #include "TensorOneDMatcher.hpp"
 #include "TensorTwoDMatcher.hpp"
 
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::_;
+
 using geopm::TensorOneD;
 using geopm::TensorTwoD;
 using geopm::DenseLayer;
 using geopm::DenseLayerImp;
-using ::testing::Mock;
-using ::testing::Return;
-using ::testing::_;
 
 class DenseLayerTest : public ::testing::Test
 {

--- a/test/DenseLayerTest.cpp
+++ b/test/DenseLayerTest.cpp
@@ -29,102 +29,52 @@ class DenseLayerTest : public ::testing::Test
 {
     protected:
         void SetUp() override;
+        std::shared_ptr<MockTensorMath> fake_math;
+        TensorTwoD weights;
+        TensorOneD biases, tmp1, tmp2, inp3, inp4;
 };
 
 void DenseLayerTest::SetUp()
 {
+    fake_math = std::make_shared<MockTensorMath>();
+    weights = TensorTwoD({{1, 2, 3}, {4, 5, 6}}, fake_math);
+    biases = TensorOneD({7, 8}, fake_math);
+    tmp1 = TensorOneD({3, 8, 9, 30}, fake_math);
+    tmp2 = TensorOneD({10, 8, -1}, fake_math);
+    inp3 = TensorOneD({1, 2, 3}, fake_math);
+    inp4 = TensorOneD({1, 2, 3, 4}, fake_math);
 }
 
 TEST_F(DenseLayerTest, test_inference) {
-    auto fake_math = std::make_shared<MockTensorMath>();
-
-    TensorTwoD weights(
-            std::vector<std::vector<double> >(
-                {{1, 2, 3}, {4, 5, 6}}
-                ),
-            fake_math
-            );
-
-    TensorOneD biases(
-            std::vector<double>(
-                {7, 8}
-                ),
-            fake_math
-            );
-
     DenseLayerImp layer(weights, biases);
 
-    TensorOneD inp(
-            std::vector<double>(
-                {1, 2, 3}
-                ),
-            fake_math
-            );
-
-    TensorOneD tmp1(
-            std::vector<double>(
-                {3, 8, 9, 30}
-                ),
-	    fake_math
-            );
-
-    TensorOneD tmp2(
-            std::vector<double>(
-                {10, 8, -1}
-                ),
-	    fake_math
-            );
-
     EXPECT_CALL(*fake_math,
-                multiply(TensorTwoDEqualTo(weights),
-                         TensorOneDEqualTo(inp)))
-	    .WillOnce(Return(tmp1));
+            multiply(TensorTwoDEqualTo(weights),
+                TensorOneDEqualTo(inp3)))
+        .WillOnce(Return(tmp1));
     EXPECT_CALL(*fake_math,
-                add(TensorOneDEqualTo(biases),
-                    TensorOneDEqualTo(tmp1)))
-	    .WillOnce(Return(tmp2));
+            add(TensorOneDEqualTo(biases),
+                TensorOneDEqualTo(tmp1)))
+        .WillOnce(Return(tmp2));
 
     EXPECT_EQ(3u, layer.get_input_dim());
     EXPECT_EQ(2u, layer.get_output_dim());
 
-    TensorOneD out = layer.forward(inp);
+    EXPECT_THAT(layer.forward(inp3), TensorOneDEqualTo(tmp2));
 }
 
 TEST_F(DenseLayerTest, test_bad_dimensions) {
-    auto fake_math = std::make_shared<MockTensorMath>();
-
-    TensorTwoD weights(
-            std::vector<std::vector<double> >(
-                {{1, 2, 3}, {4, 5, 6}}
-                ),
-            fake_math
-            );
-
-    TensorOneD biases(
-            std::vector<double>(
-                {7, 8}
-                ),
-            fake_math
-            );
-
     DenseLayerImp layer(weights, biases);
 
-    TensorOneD inp(
-            std::vector<double>(
-                {1, 2, 3, 4}
-                ),
-            fake_math
-            );
-
-    GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(TensorTwoD(), inp),
+    GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(TensorTwoD(), inp3),
                                GEOPM_ERROR_INVALID,
                                "Empty array is invalid for neural network weights.");
 
-    GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(weights, inp),
+    GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(weights, inp4),
                                GEOPM_ERROR_INVALID,
                                "Incompatible dimensions for weights and biases.");
 
-    GEOPM_EXPECT_THROW_MESSAGE(layer.forward(inp),
+    GEOPM_EXPECT_THROW_MESSAGE(layer.forward(inp4),
                                GEOPM_ERROR_INVALID,
                                "Input vector dimension is incompatible with network");
 }

--- a/test/DenseLayerTest.cpp
+++ b/test/DenseLayerTest.cpp
@@ -42,14 +42,14 @@ TEST_F(DenseLayerTest, test_inference) {
             std::vector<std::vector<float> >(
                 {{1, 2, 3}, {4, 5, 6}}
                 ),
-	    fake_math
+            fake_math
             );
 
     TensorOneD biases(
             std::vector<float>(
                 {7, 8}
                 ),
-	    fake_math
+            fake_math
             );
 
     DenseLayerImp layer(weights, biases);
@@ -58,8 +58,8 @@ TEST_F(DenseLayerTest, test_inference) {
             std::vector<float>(
                 {1, 2, 3}
                 ),
-	    fake_math
-	    );
+            fake_math
+            );
 
     // We can't use fake_math here because ON_CALL will leak
     // the mock instance.
@@ -67,23 +67,23 @@ TEST_F(DenseLayerTest, test_inference) {
             std::vector<float>(
                 {3, 8, 9, 30}
                 )
-	    );
+            );
 
     TensorOneD tmp2(
             std::vector<float>(
                 {10, 8, -1}
                 )
-	    );
+            );
 
     ON_CALL(*fake_math, multiply(_, _)).WillByDefault(Return(tmp1));
     ON_CALL(*fake_math, add(_, _)).WillByDefault(Return(tmp2));
 
     EXPECT_CALL(*fake_math,
-		multiply(TensorTwoDEqualTo(weights),
-			 TensorOneDEqualTo(inp))).Times(1);
+                multiply(TensorTwoDEqualTo(weights),
+                         TensorOneDEqualTo(inp))).Times(1);
     EXPECT_CALL(*fake_math,
-		add(TensorOneDEqualTo(biases),
-		    TensorOneDEqualTo(tmp1))).Times(1);
+                add(TensorOneDEqualTo(biases),
+                    TensorOneDEqualTo(tmp1))).Times(1);
 
     EXPECT_EQ(3u, layer.get_input_dim());
     EXPECT_EQ(2u, layer.get_output_dim());
@@ -100,14 +100,14 @@ TEST_F(DenseLayerTest, test_bad_dimensions) {
             std::vector<std::vector<float> >(
                 {{1, 2, 3}, {4, 5, 6}}
                 ),
-	    fake_math
+            fake_math
             );
 
     TensorOneD biases(
             std::vector<float>(
                 {7, 8}
                 ),
-	    fake_math
+            fake_math
             );
 
     DenseLayerImp layer(weights, biases);
@@ -116,18 +116,18 @@ TEST_F(DenseLayerTest, test_bad_dimensions) {
             std::vector<float>(
                 {1, 2, 3, 4}
                 ),
-	    fake_math
-	    );
+            fake_math
+            );
 
     GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(TensorTwoD(), inp),
-			       GEOPM_ERROR_INVALID,
-			       "Empty array is invalid for neural network weights.");
+                               GEOPM_ERROR_INVALID,
+                               "Empty array is invalid for neural network weights.");
 
     GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(weights, inp),
-			       GEOPM_ERROR_INVALID,
-			       "Incompatible dimensions for weights and biases.");
+                               GEOPM_ERROR_INVALID,
+                               "Incompatible dimensions for weights and biases.");
 
     GEOPM_EXPECT_THROW_MESSAGE(layer.forward(inp),
-			       GEOPM_ERROR_INVALID,
-			       "Input vector dimension is incompatible with network");
+                               GEOPM_ERROR_INVALID,
+                               "Input vector dimension is incompatible with network");
 }

--- a/test/DenseLayerTest.cpp
+++ b/test/DenseLayerTest.cpp
@@ -39,14 +39,14 @@ TEST_F(DenseLayerTest, test_inference) {
     auto fake_math = std::make_shared<MockTensorMath>();
 
     TensorTwoD weights(
-            std::vector<std::vector<float> >(
+            std::vector<std::vector<double> >(
                 {{1, 2, 3}, {4, 5, 6}}
                 ),
             fake_math
             );
 
     TensorOneD biases(
-            std::vector<float>(
+            std::vector<double>(
                 {7, 8}
                 ),
             fake_math
@@ -55,21 +55,21 @@ TEST_F(DenseLayerTest, test_inference) {
     DenseLayerImp layer(weights, biases);
 
     TensorOneD inp(
-            std::vector<float>(
+            std::vector<double>(
                 {1, 2, 3}
                 ),
             fake_math
             );
 
     TensorOneD tmp1(
-            std::vector<float>(
+            std::vector<double>(
                 {3, 8, 9, 30}
                 ),
 	    fake_math
             );
 
     TensorOneD tmp2(
-            std::vector<float>(
+            std::vector<double>(
                 {10, 8, -1}
                 ),
 	    fake_math
@@ -94,14 +94,14 @@ TEST_F(DenseLayerTest, test_bad_dimensions) {
     auto fake_math = std::make_shared<MockTensorMath>();
 
     TensorTwoD weights(
-            std::vector<std::vector<float> >(
+            std::vector<std::vector<double> >(
                 {{1, 2, 3}, {4, 5, 6}}
                 ),
             fake_math
             );
 
     TensorOneD biases(
-            std::vector<float>(
+            std::vector<double>(
                 {7, 8}
                 ),
             fake_math
@@ -110,7 +110,7 @@ TEST_F(DenseLayerTest, test_bad_dimensions) {
     DenseLayerImp layer(weights, biases);
 
     TensorOneD inp(
-            std::vector<float>(
+            std::vector<double>(
                 {1, 2, 3, 4}
                 ),
             fake_math

--- a/test/DenseLayerTest.cpp
+++ b/test/DenseLayerTest.cpp
@@ -29,52 +29,52 @@ class DenseLayerTest : public ::testing::Test
 {
     protected:
         void SetUp() override;
-        std::shared_ptr<MockTensorMath> fake_math;
-        TensorTwoD weights;
-        TensorOneD biases, tmp1, tmp2, inp3, inp4;
+        std::shared_ptr<MockTensorMath> m_fake_math;
+        TensorTwoD m_weights;
+        TensorOneD m_biases, m_tmp1, m_tmp2, m_inp3, m_inp4;
 };
 
 void DenseLayerTest::SetUp()
 {
-    fake_math = std::make_shared<MockTensorMath>();
-    weights = TensorTwoD({{1, 2, 3}, {4, 5, 6}}, fake_math);
-    biases = TensorOneD({7, 8}, fake_math);
-    tmp1 = TensorOneD({3, 8, 9, 30}, fake_math);
-    tmp2 = TensorOneD({10, 8, -1}, fake_math);
-    inp3 = TensorOneD({1, 2, 3}, fake_math);
-    inp4 = TensorOneD({1, 2, 3, 4}, fake_math);
+    m_fake_math = std::make_shared<MockTensorMath>();
+    m_weights = TensorTwoD({{1, 2, 3}, {4, 5, 6}}, m_fake_math);
+    m_biases = TensorOneD({7, 8}, m_fake_math);
+    m_tmp1 = TensorOneD({3, 8, 9, 30}, m_fake_math);
+    m_tmp2 = TensorOneD({10, 8, -1}, m_fake_math);
+    m_inp3 = TensorOneD({1, 2, 3}, m_fake_math);
+    m_inp4 = TensorOneD({1, 2, 3, 4}, m_fake_math);
 }
 
 TEST_F(DenseLayerTest, test_inference) {
-    DenseLayerImp layer(weights, biases);
+    DenseLayerImp layer(m_weights, m_biases);
 
-    EXPECT_CALL(*fake_math,
-            multiply(TensorTwoDEqualTo(weights),
-                TensorOneDEqualTo(inp3)))
-        .WillOnce(Return(tmp1));
-    EXPECT_CALL(*fake_math,
-            add(TensorOneDEqualTo(biases),
-                TensorOneDEqualTo(tmp1)))
-        .WillOnce(Return(tmp2));
+    EXPECT_CALL(*m_fake_math,
+            multiply(TensorTwoDEqualTo(m_weights),
+                TensorOneDEqualTo(m_inp3)))
+        .WillOnce(Return(m_tmp1));
+    EXPECT_CALL(*m_fake_math,
+            add(TensorOneDEqualTo(m_biases),
+                TensorOneDEqualTo(m_tmp1)))
+        .WillOnce(Return(m_tmp2));
 
     EXPECT_EQ(3u, layer.get_input_dim());
     EXPECT_EQ(2u, layer.get_output_dim());
 
-    EXPECT_THAT(layer.forward(inp3), TensorOneDEqualTo(tmp2));
+    EXPECT_THAT(layer.forward(m_inp3), TensorOneDEqualTo(m_tmp2));
 }
 
 TEST_F(DenseLayerTest, test_bad_dimensions) {
-    DenseLayerImp layer(weights, biases);
+    DenseLayerImp layer(m_weights, m_biases);
 
-    GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(TensorTwoD(), inp3),
+    GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(TensorTwoD(), m_inp3),
                                GEOPM_ERROR_INVALID,
                                "Empty array is invalid for neural network weights.");
 
-    GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(weights, inp4),
+    GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(m_weights, m_inp4),
                                GEOPM_ERROR_INVALID,
                                "Incompatible dimensions for weights and biases.");
 
-    GEOPM_EXPECT_THROW_MESSAGE(layer.forward(inp4),
+    GEOPM_EXPECT_THROW_MESSAGE(layer.forward(m_inp4),
                                GEOPM_ERROR_INVALID,
                                "Input vector dimension is incompatible with network");
 }

--- a/test/DenseLayerTest.cpp
+++ b/test/DenseLayerTest.cpp
@@ -61,36 +61,33 @@ TEST_F(DenseLayerTest, test_inference) {
             fake_math
             );
 
-    // We can't use fake_math here because ON_CALL will leak
-    // the mock instance.
     TensorOneD tmp1(
             std::vector<float>(
                 {3, 8, 9, 30}
-                )
+                ),
+	    fake_math
             );
 
     TensorOneD tmp2(
             std::vector<float>(
                 {10, 8, -1}
-                )
+                ),
+	    fake_math
             );
-
-    ON_CALL(*fake_math, multiply(_, _)).WillByDefault(Return(tmp1));
-    ON_CALL(*fake_math, add(_, _)).WillByDefault(Return(tmp2));
 
     EXPECT_CALL(*fake_math,
                 multiply(TensorTwoDEqualTo(weights),
-                         TensorOneDEqualTo(inp))).Times(1);
+                         TensorOneDEqualTo(inp)))
+	    .WillOnce(Return(tmp1));
     EXPECT_CALL(*fake_math,
                 add(TensorOneDEqualTo(biases),
-                    TensorOneDEqualTo(tmp1))).Times(1);
+                    TensorOneDEqualTo(tmp1)))
+	    .WillOnce(Return(tmp2));
 
     EXPECT_EQ(3u, layer.get_input_dim());
     EXPECT_EQ(2u, layer.get_output_dim());
 
     TensorOneD out = layer.forward(inp);
-
-    Mock::VerifyAndClearExpectations(fake_math.get());
 }
 
 TEST_F(DenseLayerTest, test_bad_dimensions) {

--- a/test/DenseLayerTest.cpp
+++ b/test/DenseLayerTest.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm/Exception.hpp"
+#include "geopm_test.hpp"
+
+#include "DenseLayer.hpp"
+#include "DenseLayerImp.hpp"
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+#include "MockTensorMath.hpp"
+#include "TensorOneDMatcher.hpp"
+#include "TensorTwoDMatcher.hpp"
+
+using geopm::TensorOneD;
+using geopm::TensorTwoD;
+using geopm::DenseLayer;
+using geopm::DenseLayerImp;
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::_;
+
+class DenseLayerTest : public ::testing::Test
+{
+    protected:
+        void SetUp() override;
+};
+
+void DenseLayerTest::SetUp()
+{
+}
+
+TEST_F(DenseLayerTest, test_inference) {
+    auto fake_math = std::make_shared<MockTensorMath>();
+
+    TensorTwoD weights(
+            std::vector<std::vector<float> >(
+                {{1, 2, 3}, {4, 5, 6}}
+                ),
+	    fake_math
+            );
+
+    TensorOneD biases(
+            std::vector<float>(
+                {7, 8}
+                ),
+	    fake_math
+            );
+
+    DenseLayerImp layer(weights, biases);
+
+    TensorOneD inp(
+            std::vector<float>(
+                {1, 2, 3}
+                ),
+	    fake_math
+	    );
+
+    // We can't use fake_math here because ON_CALL will leak
+    // the mock instance.
+    TensorOneD tmp1(
+            std::vector<float>(
+                {3, 8, 9, 30}
+                )
+	    );
+
+    TensorOneD tmp2(
+            std::vector<float>(
+                {10, 8, -1}
+                )
+	    );
+
+    ON_CALL(*fake_math, multiply(_, _)).WillByDefault(Return(tmp1));
+    ON_CALL(*fake_math, add(_, _)).WillByDefault(Return(tmp2));
+
+    EXPECT_CALL(*fake_math,
+		multiply(TensorTwoDEqualTo(weights),
+			 TensorOneDEqualTo(inp))).Times(1);
+    EXPECT_CALL(*fake_math,
+		add(TensorOneDEqualTo(biases),
+		    TensorOneDEqualTo(tmp1))).Times(1);
+
+    EXPECT_EQ(3u, layer.get_input_dim());
+    EXPECT_EQ(2u, layer.get_output_dim());
+
+    TensorOneD out = layer.forward(inp);
+
+    Mock::VerifyAndClearExpectations(fake_math.get());
+}
+
+TEST_F(DenseLayerTest, test_bad_dimensions) {
+    auto fake_math = std::make_shared<MockTensorMath>();
+
+    TensorTwoD weights(
+            std::vector<std::vector<float> >(
+                {{1, 2, 3}, {4, 5, 6}}
+                ),
+	    fake_math
+            );
+
+    TensorOneD biases(
+            std::vector<float>(
+                {7, 8}
+                ),
+	    fake_math
+            );
+
+    DenseLayerImp layer(weights, biases);
+
+    TensorOneD inp(
+            std::vector<float>(
+                {1, 2, 3, 4}
+                ),
+	    fake_math
+	    );
+
+    GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(TensorTwoD(), inp),
+			       GEOPM_ERROR_INVALID,
+			       "Empty array is invalid for neural network weights.");
+
+    GEOPM_EXPECT_THROW_MESSAGE(DenseLayerImp(weights, inp),
+			       GEOPM_ERROR_INVALID,
+			       "Incompatible dimensions for weights and biases.");
+
+    GEOPM_EXPECT_THROW_MESSAGE(layer.forward(inp),
+			       GEOPM_ERROR_INVALID,
+			       "Input vector dimension is incompatible with network");
+}

--- a/test/DomainNetMapTest.cpp
+++ b/test/DomainNetMapTest.cpp
@@ -24,9 +24,6 @@
 
 using geopm::DomainNetMap;
 using geopm::DomainNetMapImp;
-using geopm::MockDenseLayer;
-using geopm::MockLocalNeuralNet;
-using geopm::MockNNFactory;
 using ::testing::ByMove;
 using ::testing::ElementsAre;
 using ::testing::Mock;

--- a/test/DomainNetMapTest.cpp
+++ b/test/DomainNetMapTest.cpp
@@ -34,8 +34,6 @@ using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::_;
 
-//TODO: Change from logits to probabilities
-
 class DomainNetMapTest : public ::testing::Test
 {
     protected:

--- a/test/DomainNetMapTest.cpp
+++ b/test/DomainNetMapTest.cpp
@@ -33,6 +33,8 @@ using ::testing::Mock;
 using ::testing::Return;
 using ::testing::_;
 
+//TODO: Change from logits to probabilities
+
 class DomainNetMapTest : public ::testing::Test
 {
     protected:

--- a/test/DomainNetMapTest.cpp
+++ b/test/DomainNetMapTest.cpp
@@ -100,26 +100,26 @@ TEST_F(DomainNetMapTest, test_plumbing)
     MockPlatformIO fake_plat_io;
     auto fake_nn_factory = std::make_shared<MockNNFactory>();
     std::shared_ptr<MockLocalNeuralNet> fake_nn = std::make_shared<MockLocalNeuralNet>();
-    std::vector<std::vector<float> > weight_vals(
+    std::vector<std::vector<double> > weight_vals(
                 {{1, 2, 3}, {4, 5, 6}});
     TensorTwoD weights(weight_vals, fake_math);
 
     TensorOneD biases(
-            std::vector<float>(
+            std::vector<double>(
                 {7, 8}
                 ),
             fake_math
             );
 
     TensorOneD tmp1(
-            std::vector<float>(
+            std::vector<double>(
                 {4, 3, -1, 0, 2}
                 ),
             fake_math
             );
 
     TensorOneD tmp2(
-            std::vector<float>(
+            std::vector<double>(
                 {0, 2, -4}
                 ),
             fake_math
@@ -183,6 +183,6 @@ TEST_F(DomainNetMapTest, test_plumbing)
     EXPECT_EQ(std::vector<std::string>({"GEO", "PM", "@", "INTEL", "2023"}),
               net_map.trace_names());
     EXPECT_EQ(std::vector<double>({4, 3, -1, 0, 2}), net_map.trace_values());
-    std::map<std::string, float> expected_output({{"GEO", 4}, {"PM", 3}, {"@", -1}, {"INTEL", 0}, {"2023", 2}});
+    std::map<std::string, double> expected_output({{"GEO", 4}, {"PM", 3}, {"@", -1}, {"INTEL", 0}, {"2023", 2}});
     EXPECT_EQ(expected_output, net_map.last_output());
 }

--- a/test/DomainNetMapTest.cpp
+++ b/test/DomainNetMapTest.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm/Exception.hpp"
+#include "geopm_test.hpp"
+
+#include "DomainNetMap.hpp"
+#include "DomainNetMapImp.hpp"
+
+#include "MockDenseLayer.hpp"
+#include "MockLocalNeuralNet.hpp"
+#include "MockNNFactory.hpp"
+#include "MockPlatformIO.hpp"
+#include "MockTensorMath.hpp"
+#include "TensorOneDMatcher.hpp"
+#include "TensorTwoDMatcher.hpp"
+
+using geopm::DomainNetMap;
+using geopm::DomainNetMapImp;
+using geopm::MockDenseLayer;
+using geopm::MockLocalNeuralNet;
+using geopm::MockNNFactory;
+using ::testing::ByMove;
+using ::testing::ElementsAre;
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::_;
+
+class DomainNetMapTest : public ::testing::Test
+{
+    protected:
+        std::string m_filename = "domain_net_map_test.json";
+        void TearDown() override
+        {
+            std::remove(m_filename.c_str());
+        }
+};
+
+TEST_F(DomainNetMapTest, test_json_parsing)
+{
+    {
+        std::ofstream bad_json(m_filename);
+        bad_json << "{[\"test\"]" << std::endl;
+        bad_json.close();
+
+        MockPlatformIO fake_plat_io;
+        auto fake_nn_factory = std::make_shared<MockNNFactory>();
+        GEOPM_EXPECT_THROW_MESSAGE(
+                        DomainNetMapImp(m_filename,
+                                        GEOPM_DOMAIN_PACKAGE,
+                                        0,
+                                        fake_plat_io,
+                                        fake_nn_factory),
+                        GEOPM_ERROR_INVALID,
+                        "Neural net must contain valid json");
+    }
+
+    {
+        std::ofstream bad_json(m_filename);
+        bad_json << "{\"layers\": 15}" << std::endl;
+        bad_json.close();
+
+        MockPlatformIO fake_plat_io;
+        auto fake_nn_factory = std::make_shared<MockNNFactory>();
+        GEOPM_EXPECT_THROW_MESSAGE(
+                        DomainNetMapImp(m_filename,
+                                        GEOPM_DOMAIN_PACKAGE,
+                                        0,
+                                        fake_plat_io,
+                                        fake_nn_factory),
+                        GEOPM_ERROR_INVALID,
+                        "must have a key \"layers\" whose value is an array");
+    }
+}
+
+TEST_F(DomainNetMapTest, test_plumbing)
+{
+    auto fake_math = std::make_shared<MockTensorMath>();
+
+    std::ofstream good_json(m_filename);
+    good_json << 
+        "{\"layers\": ["
+        "[[[1, 2, 3], [4, 5, 6]], [7, 8]]"
+        "],"
+        "\"signal_inputs\": [[\"A\", 1, 0]],"
+        "\"delta_inputs\": ["
+            "[[\"B\", 1, 0], [\"C\", 1, 0]],"
+            "[[\"D\", 1, 0], [\"E\", 1, 0]]"
+        "],"
+        "\"trace_outputs\": [\"GEO\", \"PM\", \"@\", \"INTEL\", \"2023\"]}" << std::endl;
+    good_json.close();
+
+    MockPlatformIO fake_plat_io;
+    auto fake_nn_factory = std::make_shared<MockNNFactory>();
+    std::shared_ptr<MockLocalNeuralNet> fake_nn = std::make_shared<MockLocalNeuralNet>();
+    std::vector<std::vector<float> > weight_vals(
+                {{1, 2, 3}, {4, 5, 6}});
+    TensorTwoD weights(weight_vals, fake_math);
+
+    TensorOneD biases(
+            std::vector<float>(
+                {7, 8}
+                ),
+            fake_math
+            );
+
+    TensorOneD tmp1(
+            std::vector<float>(
+                {4, 3, -1, 0, 2}
+                ),
+            fake_math
+            );
+
+    TensorOneD tmp2(
+            std::vector<float>(
+                {0, 2, -4}
+                ),
+            fake_math
+            );
+
+
+    std::shared_ptr<MockDenseLayer> fake_layer = std::make_shared<MockDenseLayer>();
+
+    ON_CALL(*fake_nn_factory, createTensorOneD(_))
+        .WillByDefault(Return(biases));
+    ON_CALL(*fake_nn_factory, createTensorTwoD(_))
+        .WillByDefault(Return(weights));
+    ON_CALL(*fake_nn_factory, createDenseLayer(_, _))
+        .WillByDefault(Return(fake_layer));
+    ON_CALL(*fake_nn_factory, createLocalNeuralNet(_))
+        .WillByDefault(Return(fake_nn));
+    ON_CALL(fake_plat_io, push_signal("A", _, _))
+        .WillByDefault(Return(0));
+    ON_CALL(fake_plat_io, push_signal("B", _, _))
+        .WillByDefault(Return(1));
+    ON_CALL(fake_plat_io, push_signal("C", _, _))
+        .WillByDefault(Return(2));
+    ON_CALL(fake_plat_io, push_signal("D", _, _))
+        .WillByDefault(Return(3));
+    ON_CALL(fake_plat_io, push_signal("E", _, _))
+        .WillByDefault(Return(4));
+
+    EXPECT_CALL(*fake_nn_factory, createTensorOneD(_))
+        .Times(2);
+    EXPECT_CALL(*fake_nn_factory, createTensorOneD(ElementsAre(0, 2, -4)))
+        .Times(1);
+    EXPECT_CALL(*fake_nn_factory, createTensorTwoD(weight_vals))
+        .Times(1);
+    EXPECT_CALL(*fake_nn_factory, createDenseLayer(TensorTwoDEqualTo(weights), TensorOneDEqualTo(biases)))
+        .Times(1);
+    EXPECT_CALL(*fake_nn_factory, createLocalNeuralNet(ElementsAre(fake_layer)))
+        .Times(1);
+
+    EXPECT_CALL(fake_plat_io, push_signal("A", _, _)).Times(1);
+    EXPECT_CALL(fake_plat_io, push_signal("B", _, _)).Times(1);
+    EXPECT_CALL(fake_plat_io, push_signal("C", _, _)).Times(1);
+    EXPECT_CALL(fake_plat_io, push_signal("D", _, _)).Times(1);
+    EXPECT_CALL(fake_plat_io, push_signal("E", _, _)).Times(1);
+    EXPECT_CALL(fake_plat_io, sample(0)).WillOnce(Return(1)).WillOnce(Return(0));
+    EXPECT_CALL(fake_plat_io, sample(1)).WillOnce(Return(2)).WillOnce(Return(4));
+    EXPECT_CALL(fake_plat_io, sample(2)).WillOnce(Return(3)).WillOnce(Return(4));
+    EXPECT_CALL(fake_plat_io, sample(3)).WillOnce(Return(4)).WillOnce(Return(0));
+    EXPECT_CALL(fake_plat_io, sample(4)).WillOnce(Return(5)).WillOnce(Return(6));
+
+    DomainNetMapImp net_map(m_filename,
+                            GEOPM_DOMAIN_PACKAGE,
+                            0,
+                            fake_plat_io,
+                            fake_nn_factory);
+
+    ON_CALL(*fake_nn, forward(_)).WillByDefault(Return(tmp1));
+    EXPECT_CALL(*fake_nn, forward(_)).Times(2);
+
+    net_map.sample();
+    net_map.sample();
+    EXPECT_EQ(std::vector<std::string>({"GEO", "PM", "@", "INTEL", "2023"}),
+              net_map.trace_names());
+    EXPECT_EQ(std::vector<double>({4, 3, -1, 0, 2}), net_map.trace_values());
+    std::map<std::string, float> expected_output({{"GEO", 4}, {"PM", 3}, {"@", -1}, {"INTEL", 0}, {"2023", 2}});
+    EXPECT_EQ(expected_output, net_map.last_output());
+}

--- a/test/DomainNetMapTest.cpp
+++ b/test/DomainNetMapTest.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
+
 #include <fstream>
 #include <string>
 

--- a/test/DomainNetMapTest.cpp
+++ b/test/DomainNetMapTest.cpp
@@ -30,7 +30,6 @@ using geopm::MockNNFactory;
 using ::testing::ByMove;
 using ::testing::ElementsAre;
 using ::testing::Mock;
-using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::_;
 
@@ -41,7 +40,7 @@ class DomainNetMapTest : public ::testing::Test
         void TearDown() override;
 
         const std::string M_FILENAME = "domain_net_map_test.json";
-        std::shared_ptr<NiceMock<MockNNFactory>> m_fake_nn_factory;
+        std::shared_ptr<MockNNFactory> m_fake_nn_factory;
         MockPlatformIO m_fake_plat_io;
         std::shared_ptr<MockTensorMath> m_fake_math;
         std::shared_ptr<MockLocalNeuralNet> m_fake_nn;
@@ -54,7 +53,7 @@ class DomainNetMapTest : public ::testing::Test
 
 void DomainNetMapTest::SetUp()
 {
-    m_fake_nn_factory = std::make_shared<NiceMock<MockNNFactory>>();
+    m_fake_nn_factory = std::make_shared<MockNNFactory>();
     m_fake_math = std::make_shared<MockTensorMath>();
     m_fake_nn = std::make_shared<MockLocalNeuralNet>();
 
@@ -261,6 +260,17 @@ TEST_F(DomainNetMapTest, test_json_parsing)
         EXPECT_CALL(*m_fake_nn, get_input_dim()).Times(1);
         EXPECT_CALL(*m_fake_nn, get_output_dim()).Times(0);
 
+        EXPECT_CALL(*m_fake_nn_factory, createTensorTwoD(m_weight_vals))
+            .WillOnce(Return(m_weights));
+        EXPECT_CALL(*m_fake_nn_factory, createTensorOneD(_))
+            .WillOnce(Return(m_biases));
+        EXPECT_CALL(*m_fake_nn_factory,
+                createDenseLayer(TensorTwoDEqualTo(m_weights),
+                    TensorOneDEqualTo(m_biases)))
+            .WillOnce(Return(m_fake_layer));
+        EXPECT_CALL(*m_fake_nn_factory, createLocalNeuralNet(ElementsAre(m_fake_layer)))
+            .WillOnce(Return(m_fake_nn));
+
         GEOPM_EXPECT_THROW_MESSAGE(
                 DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
@@ -269,6 +279,9 @@ TEST_F(DomainNetMapTest, test_json_parsing)
                     m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "must have a key \"trace_outputs\" whose value is an array");
+
+        // reset the mock
+        Mock::VerifyAndClearExpectations(m_fake_nn_factory.get());
     }
 
     // mismatched input dimensions
@@ -283,6 +296,17 @@ TEST_F(DomainNetMapTest, test_json_parsing)
 
 	EXPECT_CALL(*m_fake_nn, get_input_dim()).Times(1);
 
+        EXPECT_CALL(*m_fake_nn_factory, createTensorTwoD(m_weight_vals))
+            .WillOnce(Return(m_weights));
+        EXPECT_CALL(*m_fake_nn_factory, createTensorOneD(_))
+            .WillOnce(Return(m_biases));
+        EXPECT_CALL(*m_fake_nn_factory,
+                createDenseLayer(TensorTwoDEqualTo(m_weights),
+                    TensorOneDEqualTo(m_biases)))
+            .WillOnce(Return(m_fake_layer));
+        EXPECT_CALL(*m_fake_nn_factory, createLocalNeuralNet(ElementsAre(m_fake_layer)))
+            .WillOnce(Return(m_fake_nn));
+
         GEOPM_EXPECT_THROW_MESSAGE(
                 DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
@@ -291,6 +315,7 @@ TEST_F(DomainNetMapTest, test_json_parsing)
                     m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "input dimension must match the number of signal and delta inputs");
+        Mock::VerifyAndClearExpectations(m_fake_nn_factory.get());
     }
 
     // mismatched output dimensions
@@ -306,6 +331,17 @@ TEST_F(DomainNetMapTest, test_json_parsing)
         EXPECT_CALL(*m_fake_nn, get_input_dim()).WillOnce(Return(3));
         EXPECT_CALL(*m_fake_nn, get_output_dim()).WillOnce(Return(2));
 
+        EXPECT_CALL(*m_fake_nn_factory, createTensorTwoD(m_weight_vals))
+            .WillOnce(Return(m_weights));
+        EXPECT_CALL(*m_fake_nn_factory, createTensorOneD(_))
+            .WillOnce(Return(m_biases));
+        EXPECT_CALL(*m_fake_nn_factory,
+                createDenseLayer(TensorTwoDEqualTo(m_weights),
+                    TensorOneDEqualTo(m_biases)))
+            .WillOnce(Return(m_fake_layer));
+        EXPECT_CALL(*m_fake_nn_factory, createLocalNeuralNet(ElementsAre(m_fake_layer)))
+            .WillOnce(Return(m_fake_nn));
+
         GEOPM_EXPECT_THROW_MESSAGE(
                 DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
@@ -314,6 +350,7 @@ TEST_F(DomainNetMapTest, test_json_parsing)
                     m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "output dimension must match the number of trace outputs");
+        Mock::VerifyAndClearExpectations(m_fake_nn_factory.get());
     }
 
     // invalid signal_inputs values
@@ -334,6 +371,17 @@ TEST_F(DomainNetMapTest, test_json_parsing)
         EXPECT_CALL(*m_fake_nn, get_input_dim()).WillOnce(Return(3));
         EXPECT_CALL(*m_fake_nn, get_output_dim()).WillOnce(Return(5));
 
+        EXPECT_CALL(*m_fake_nn_factory, createTensorTwoD(m_weight_vals))
+            .WillOnce(Return(m_weights));
+        EXPECT_CALL(*m_fake_nn_factory, createTensorOneD(_))
+            .WillOnce(Return(m_biases));
+        EXPECT_CALL(*m_fake_nn_factory,
+                createDenseLayer(TensorTwoDEqualTo(m_weights),
+                    TensorOneDEqualTo(m_biases)))
+            .WillOnce(Return(m_fake_layer));
+        EXPECT_CALL(*m_fake_nn_factory, createLocalNeuralNet(ElementsAre(m_fake_layer)))
+            .WillOnce(Return(m_fake_nn));
+
         GEOPM_EXPECT_THROW_MESSAGE(
                 DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
@@ -342,6 +390,7 @@ TEST_F(DomainNetMapTest, test_json_parsing)
                     m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "signal inputs must be strings");
+        Mock::VerifyAndClearExpectations(m_fake_nn_factory.get());
     }
 
     // invalid delta_inputs values
@@ -363,6 +412,17 @@ TEST_F(DomainNetMapTest, test_json_parsing)
         EXPECT_CALL(*m_fake_nn, get_output_dim()).WillOnce(Return(5));
         EXPECT_CALL(m_fake_plat_io, push_signal("A", _, _)).WillOnce(Return(0));
 
+        EXPECT_CALL(*m_fake_nn_factory, createTensorTwoD(m_weight_vals))
+            .WillOnce(Return(m_weights));
+        EXPECT_CALL(*m_fake_nn_factory, createTensorOneD(_))
+            .WillOnce(Return(m_biases));
+        EXPECT_CALL(*m_fake_nn_factory,
+                createDenseLayer(TensorTwoDEqualTo(m_weights),
+                    TensorOneDEqualTo(m_biases)))
+            .WillOnce(Return(m_fake_layer));
+        EXPECT_CALL(*m_fake_nn_factory, createLocalNeuralNet(ElementsAre(m_fake_layer)))
+            .WillOnce(Return(m_fake_nn));
+
         GEOPM_EXPECT_THROW_MESSAGE(
                 DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
@@ -371,6 +431,7 @@ TEST_F(DomainNetMapTest, test_json_parsing)
                     m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "delta inputs must be tuples of strings");
+        Mock::VerifyAndClearExpectations(m_fake_nn_factory.get());
     }
     
     // invalid delta_inputs values
@@ -392,6 +453,17 @@ TEST_F(DomainNetMapTest, test_json_parsing)
         EXPECT_CALL(*m_fake_nn, get_output_dim()).WillOnce(Return(5));
         EXPECT_CALL(m_fake_plat_io, push_signal("A", _, _)).WillOnce(Return(0));
 
+        EXPECT_CALL(*m_fake_nn_factory, createTensorTwoD(m_weight_vals))
+            .WillOnce(Return(m_weights));
+        EXPECT_CALL(*m_fake_nn_factory, createTensorOneD(_))
+            .WillOnce(Return(m_biases));
+        EXPECT_CALL(*m_fake_nn_factory,
+                createDenseLayer(TensorTwoDEqualTo(m_weights),
+                    TensorOneDEqualTo(m_biases)))
+            .WillOnce(Return(m_fake_layer));
+        EXPECT_CALL(*m_fake_nn_factory, createLocalNeuralNet(ElementsAre(m_fake_layer)))
+            .WillOnce(Return(m_fake_nn));
+
         GEOPM_EXPECT_THROW_MESSAGE(
                 DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
@@ -400,6 +472,7 @@ TEST_F(DomainNetMapTest, test_json_parsing)
                     m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "delta inputs must be tuples of strings");
+        Mock::VerifyAndClearExpectations(m_fake_nn_factory.get());
     }
 
     // invalid trace_outputs values
@@ -425,6 +498,17 @@ TEST_F(DomainNetMapTest, test_json_parsing)
         EXPECT_CALL(m_fake_plat_io, push_signal("D", _, _)).WillOnce(Return(3));
         EXPECT_CALL(m_fake_plat_io, push_signal("E", _, _)).WillOnce(Return(4));
 
+        EXPECT_CALL(*m_fake_nn_factory, createTensorTwoD(m_weight_vals))
+            .WillOnce(Return(m_weights));
+        EXPECT_CALL(*m_fake_nn_factory, createTensorOneD(_))
+            .WillOnce(Return(m_biases));
+        EXPECT_CALL(*m_fake_nn_factory,
+                createDenseLayer(TensorTwoDEqualTo(m_weights),
+                    TensorOneDEqualTo(m_biases)))
+            .WillOnce(Return(m_fake_layer));
+        EXPECT_CALL(*m_fake_nn_factory, createLocalNeuralNet(ElementsAre(m_fake_layer)))
+            .WillOnce(Return(m_fake_nn));
+
         GEOPM_EXPECT_THROW_MESSAGE(
                 DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
@@ -433,6 +517,7 @@ TEST_F(DomainNetMapTest, test_json_parsing)
                     m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "trace outputs must be strings");
+        Mock::VerifyAndClearExpectations(m_fake_nn_factory.get());
     }
 }
 

--- a/test/DomainNetMapTest.cpp
+++ b/test/DomainNetMapTest.cpp
@@ -40,115 +40,115 @@ class DomainNetMapTest : public ::testing::Test
         void SetUp() override;
         void TearDown() override;
 
-        std::string m_filename = "domain_net_map_test.json";
-        std::shared_ptr<NiceMock<MockNNFactory>> fake_nn_factory;
-        MockPlatformIO fake_plat_io;
-        std::shared_ptr<MockTensorMath> fake_math;
-        std::shared_ptr<MockLocalNeuralNet> fake_nn;
-        std::shared_ptr<MockDenseLayer> fake_layer;
-        std::vector<std::vector<double>> weight_vals;
-        TensorTwoD weights;
-        TensorOneD biases;
-        TensorOneD tmp1, tmp2;
+        const std::string M_FILENAME = "domain_net_map_test.json";
+        std::shared_ptr<NiceMock<MockNNFactory>> m_fake_nn_factory;
+        MockPlatformIO m_fake_plat_io;
+        std::shared_ptr<MockTensorMath> m_fake_math;
+        std::shared_ptr<MockLocalNeuralNet> m_fake_nn;
+        std::shared_ptr<MockDenseLayer> m_fake_layer;
+        std::vector<std::vector<double>> m_weight_vals;
+        TensorTwoD m_weights;
+        TensorOneD m_biases;
+        TensorOneD m_tmp1, m_tmp2;
 };
 
 void DomainNetMapTest::SetUp()
 {
-    fake_nn_factory = std::make_shared<NiceMock<MockNNFactory>>();
-    fake_math = std::make_shared<MockTensorMath>();
-    fake_nn = std::make_shared<MockLocalNeuralNet>();
+    m_fake_nn_factory = std::make_shared<NiceMock<MockNNFactory>>();
+    m_fake_math = std::make_shared<MockTensorMath>();
+    m_fake_nn = std::make_shared<MockLocalNeuralNet>();
 
-    weight_vals = {{1, 2, 3}, {4, 5, 6}};
-    weights = TensorTwoD(weight_vals, fake_math);
-    biases = TensorOneD({7, 8}, fake_math);
-    tmp1 = TensorOneD({4, 3, -1, 0, 2}, fake_math);
-    tmp2 = TensorOneD({0, 2, -4}, fake_math);
+    m_weight_vals = {{1, 2, 3}, {4, 5, 6}};
+    m_weights = TensorTwoD(m_weight_vals, m_fake_math);
+    m_biases = TensorOneD({7, 8}, m_fake_math);
+    m_tmp1 = TensorOneD({4, 3, -1, 0, 2}, m_fake_math);
+    m_tmp2 = TensorOneD({0, 2, -4}, m_fake_math);
 
-    fake_layer = std::make_shared<MockDenseLayer>();
+    m_fake_layer = std::make_shared<MockDenseLayer>();
 
-    ON_CALL(*fake_nn_factory, createLocalNeuralNet(_))
-        .WillByDefault(Return(fake_nn));
+    ON_CALL(*m_fake_nn_factory, createLocalNeuralNet(_))
+        .WillByDefault(Return(m_fake_nn));
 
-    ON_CALL(*fake_nn, get_input_dim()).WillByDefault(Return(1));
-    ON_CALL(*fake_nn, get_output_dim()).WillByDefault(Return(1));
+    ON_CALL(*m_fake_nn, get_input_dim()).WillByDefault(Return(1));
+    ON_CALL(*m_fake_nn, get_output_dim()).WillByDefault(Return(1));
 }
 
 void DomainNetMapTest::TearDown()
 {
-    remove(m_filename.c_str());
+    remove(M_FILENAME.c_str());
 }
 
 TEST_F(DomainNetMapTest, test_json_parsing)
 {
     // malformed json
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "{[\"test\"]" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "Neural net file format is incorrect");
     }
 
     // empty file
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "Neural net file format is incorrect");
     }
     
     // empty json
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "{ }" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "must have a key \"layers\" whose value is a non-empty array");
     }
 
     // layers missing
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"signal_inputs\": [\"A\"],"
             "\"trace_outputs\": [\"B\"]}" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "must have a key \"layers\" whose value is a non-empty array");
     }
 
     // layers are not actual layers
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": 15,"
             "\"signal_inputs\": [\"A\"],"
@@ -156,18 +156,18 @@ TEST_F(DomainNetMapTest, test_json_parsing)
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "must have a key \"layers\" whose value is a non-empty array");
     }
 
     // extraneous keys
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": [[[[1, 2, 3], [4, 5, 6]], [7, 8]]],"
             "\"signal_inputs\": [\"A\"],"
@@ -176,36 +176,36 @@ TEST_F(DomainNetMapTest, test_json_parsing)
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "Unexpected key");
     }
 
     // missing both signal_inputs and delta_inputs
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": [[[[1, 2, 3], [4, 5, 6]], [7, 8]]],"
             "\"trace_outputs\": [\"B\"]}" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "must contain at least one of \"signal_inputs\" and \"delta_inputs\"");
     }
 
     // valid signal_inputs, invalid delta_inputs 
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": ["
             "[[[1, 2, 3], [4, 5, 6]], [7, 8]]"
@@ -216,18 +216,18 @@ TEST_F(DomainNetMapTest, test_json_parsing)
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "\"delta_inputs\" must be an array");
     }
 
     // valid delta_inputs, invalid signal_inputs 
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": ["
             "[[[1, 2, 3], [4, 5, 6]], [7, 8]]"
@@ -241,39 +241,39 @@ TEST_F(DomainNetMapTest, test_json_parsing)
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "\"signal_inputs\" must be an array");
     }
 
     // missing trace_outputs
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": [[[[1, 2, 3], [4, 5, 6]], [7, 8]]],"
             "\"signal_inputs\": [\"A\"]}" << std::endl;
         bad_json.close();
 
-        EXPECT_CALL(*fake_nn, get_input_dim()).Times(1);
-        EXPECT_CALL(*fake_nn, get_output_dim()).Times(0);
+        EXPECT_CALL(*m_fake_nn, get_input_dim()).Times(1);
+        EXPECT_CALL(*m_fake_nn, get_output_dim()).Times(0);
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "must have a key \"trace_outputs\" whose value is an array");
     }
 
     // mismatched input dimensions
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": [[[[1, 2, 3], [4, 5, 6]], [7, 8]]],"
             "\"signal_inputs\": [\"A\"],"
@@ -281,21 +281,21 @@ TEST_F(DomainNetMapTest, test_json_parsing)
             "\"trace_outputs\": [\"D\", \"E\"]}" << std::endl;
         bad_json.close();
 
-	EXPECT_CALL(*fake_nn, get_input_dim()).Times(1);
+	EXPECT_CALL(*m_fake_nn, get_input_dim()).Times(1);
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "input dimension must match the number of signal and delta inputs");
     }
 
     // mismatched output dimensions
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": [[[[1, 2, 3], [4, 5, 6]], [7, 8]]],"
             "\"signal_inputs\": [\"A\"],"
@@ -303,22 +303,22 @@ TEST_F(DomainNetMapTest, test_json_parsing)
             "\"trace_outputs\": [\"F\", \"G\", \"H\"]}" << std::endl;
         bad_json.close();
 
-        EXPECT_CALL(*fake_nn, get_input_dim()).WillOnce(Return(3));
-        EXPECT_CALL(*fake_nn, get_output_dim()).WillOnce(Return(2));
+        EXPECT_CALL(*m_fake_nn, get_input_dim()).WillOnce(Return(3));
+        EXPECT_CALL(*m_fake_nn, get_output_dim()).WillOnce(Return(2));
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "output dimension must match the number of trace outputs");
     }
 
     // invalid signal_inputs values
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": ["
             "[[[1, 2, 3], [4, 5, 6]], [7, 8]]"
@@ -331,22 +331,22 @@ TEST_F(DomainNetMapTest, test_json_parsing)
             "\"trace_outputs\": [\"GEO\", \"PM\", \"@\", \"INTEL\", \"2023\"]}" << std::endl;
         bad_json.close();
         
-        EXPECT_CALL(*fake_nn, get_input_dim()).WillOnce(Return(3));
-        EXPECT_CALL(*fake_nn, get_output_dim()).WillOnce(Return(5));
+        EXPECT_CALL(*m_fake_nn, get_input_dim()).WillOnce(Return(3));
+        EXPECT_CALL(*m_fake_nn, get_output_dim()).WillOnce(Return(5));
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "signal inputs must be strings");
     }
 
     // invalid delta_inputs values
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": ["
             "[[[1, 2, 3], [4, 5, 6]], [7, 8]]"
@@ -359,23 +359,23 @@ TEST_F(DomainNetMapTest, test_json_parsing)
             "\"trace_outputs\": [\"GEO\", \"PM\", \"@\", \"INTEL\", \"2023\"]}" << std::endl;
         bad_json.close();
 
-        EXPECT_CALL(*fake_nn, get_input_dim()).WillOnce(Return(3));
-        EXPECT_CALL(*fake_nn, get_output_dim()).WillOnce(Return(5));
-        EXPECT_CALL(fake_plat_io, push_signal("A", _, _)).WillOnce(Return(0));
+        EXPECT_CALL(*m_fake_nn, get_input_dim()).WillOnce(Return(3));
+        EXPECT_CALL(*m_fake_nn, get_output_dim()).WillOnce(Return(5));
+        EXPECT_CALL(m_fake_plat_io, push_signal("A", _, _)).WillOnce(Return(0));
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "delta inputs must be tuples of strings");
     }
     
     // invalid delta_inputs values
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": ["
             "[[[1, 2, 3], [4, 5, 6]], [7, 8]]"
@@ -388,23 +388,23 @@ TEST_F(DomainNetMapTest, test_json_parsing)
             "\"trace_outputs\": [\"GEO\", \"PM\", \"@\", \"INTEL\", \"2023\"]}" << std::endl;
         bad_json.close();
 
-        EXPECT_CALL(*fake_nn, get_input_dim()).WillOnce(Return(3));
-        EXPECT_CALL(*fake_nn, get_output_dim()).WillOnce(Return(5));
-        EXPECT_CALL(fake_plat_io, push_signal("A", _, _)).WillOnce(Return(0));
+        EXPECT_CALL(*m_fake_nn, get_input_dim()).WillOnce(Return(3));
+        EXPECT_CALL(*m_fake_nn, get_output_dim()).WillOnce(Return(5));
+        EXPECT_CALL(m_fake_plat_io, push_signal("A", _, _)).WillOnce(Return(0));
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "delta inputs must be tuples of strings");
     }
 
     // invalid trace_outputs values
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << 
             "{\"layers\": ["
             "[[[1, 2, 3], [4, 5, 6]], [7, 8]]"
@@ -417,20 +417,20 @@ TEST_F(DomainNetMapTest, test_json_parsing)
             "\"trace_outputs\": [1, 2, 3, 4, 2023]}" << std::endl;
         bad_json.close();
 
-        EXPECT_CALL(*fake_nn, get_input_dim()).WillOnce(Return(3));
-        EXPECT_CALL(*fake_nn, get_output_dim()).WillOnce(Return(5));
-        EXPECT_CALL(fake_plat_io, push_signal("A", _, _)).WillOnce(Return(0));
-        EXPECT_CALL(fake_plat_io, push_signal("B", _, _)).WillOnce(Return(1));
-        EXPECT_CALL(fake_plat_io, push_signal("C", _, _)).WillOnce(Return(2));
-        EXPECT_CALL(fake_plat_io, push_signal("D", _, _)).WillOnce(Return(3));
-        EXPECT_CALL(fake_plat_io, push_signal("E", _, _)).WillOnce(Return(4));
+        EXPECT_CALL(*m_fake_nn, get_input_dim()).WillOnce(Return(3));
+        EXPECT_CALL(*m_fake_nn, get_output_dim()).WillOnce(Return(5));
+        EXPECT_CALL(m_fake_plat_io, push_signal("A", _, _)).WillOnce(Return(0));
+        EXPECT_CALL(m_fake_plat_io, push_signal("B", _, _)).WillOnce(Return(1));
+        EXPECT_CALL(m_fake_plat_io, push_signal("C", _, _)).WillOnce(Return(2));
+        EXPECT_CALL(m_fake_plat_io, push_signal("D", _, _)).WillOnce(Return(3));
+        EXPECT_CALL(m_fake_plat_io, push_signal("E", _, _)).WillOnce(Return(4));
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                DomainNetMapImp(m_filename,
+                DomainNetMapImp(M_FILENAME,
                     GEOPM_DOMAIN_PACKAGE,
                     0,
-                    fake_plat_io,
-                    fake_nn_factory),
+                    m_fake_plat_io,
+                    m_fake_nn_factory),
                 GEOPM_ERROR_INVALID,
                 "trace outputs must be strings");
     }
@@ -438,7 +438,7 @@ TEST_F(DomainNetMapTest, test_json_parsing)
 
 TEST_F(DomainNetMapTest, test_plumbing)
 {
-    std::ofstream good_json(m_filename);
+    std::ofstream good_json(M_FILENAME);
     good_json << 
         "{\"layers\": ["
         "[[[1, 2, 3], [4, 5, 6]], [7, 8]]"
@@ -451,42 +451,42 @@ TEST_F(DomainNetMapTest, test_plumbing)
         "\"trace_outputs\": [\"GEO\", \"PM\", \"@\", \"INTEL\", \"2023\"]}" << std::endl;
     good_json.close();
 
-    EXPECT_CALL(*fake_nn_factory, createTensorOneD(_))
-        .WillOnce(Return(biases))
-        .WillOnce(Return(tmp1));
-    EXPECT_CALL(*fake_nn_factory, createTensorOneD(ElementsAre(0, 2, -4)))
-        .WillOnce(Return(biases));
-    EXPECT_CALL(*fake_nn_factory, createTensorTwoD(weight_vals))
-        .WillOnce(Return(weights));
-    EXPECT_CALL(*fake_nn_factory,
-            createDenseLayer(TensorTwoDEqualTo(weights),
-                TensorOneDEqualTo(biases)))
-        .WillOnce(Return(fake_layer));
-    EXPECT_CALL(*fake_nn_factory, createLocalNeuralNet(ElementsAre(fake_layer)))
-        .WillOnce(Return(fake_nn));
+    EXPECT_CALL(*m_fake_nn_factory, createTensorOneD(_))
+        .WillOnce(Return(m_biases))
+        .WillOnce(Return(m_tmp1));
+    EXPECT_CALL(*m_fake_nn_factory, createTensorOneD(ElementsAre(0, 2, -4)))
+        .WillOnce(Return(m_biases));
+    EXPECT_CALL(*m_fake_nn_factory, createTensorTwoD(m_weight_vals))
+        .WillOnce(Return(m_weights));
+    EXPECT_CALL(*m_fake_nn_factory,
+            createDenseLayer(TensorTwoDEqualTo(m_weights),
+                TensorOneDEqualTo(m_biases)))
+        .WillOnce(Return(m_fake_layer));
+    EXPECT_CALL(*m_fake_nn_factory, createLocalNeuralNet(ElementsAre(m_fake_layer)))
+        .WillOnce(Return(m_fake_nn));
 
-    EXPECT_CALL(*fake_nn, get_input_dim()).WillRepeatedly(Return(3));
-    EXPECT_CALL(*fake_nn, get_output_dim()).WillRepeatedly(Return(5));
+    EXPECT_CALL(*m_fake_nn, get_input_dim()).WillRepeatedly(Return(3));
+    EXPECT_CALL(*m_fake_nn, get_output_dim()).WillRepeatedly(Return(5));
 
-    EXPECT_CALL(fake_plat_io, push_signal("A", _, _)).WillOnce(Return(0));
-    EXPECT_CALL(fake_plat_io, push_signal("B", _, _)).WillOnce(Return(1));
-    EXPECT_CALL(fake_plat_io, push_signal("C", _, _)).WillOnce(Return(2));
-    EXPECT_CALL(fake_plat_io, push_signal("D", _, _)).WillOnce(Return(3));
-    EXPECT_CALL(fake_plat_io, push_signal("E", _, _)).WillOnce(Return(4));
+    EXPECT_CALL(m_fake_plat_io, push_signal("A", _, _)).WillOnce(Return(0));
+    EXPECT_CALL(m_fake_plat_io, push_signal("B", _, _)).WillOnce(Return(1));
+    EXPECT_CALL(m_fake_plat_io, push_signal("C", _, _)).WillOnce(Return(2));
+    EXPECT_CALL(m_fake_plat_io, push_signal("D", _, _)).WillOnce(Return(3));
+    EXPECT_CALL(m_fake_plat_io, push_signal("E", _, _)).WillOnce(Return(4));
 
-    EXPECT_CALL(fake_plat_io, sample(0)).WillOnce(Return(1)).WillOnce(Return(0));
-    EXPECT_CALL(fake_plat_io, sample(1)).WillOnce(Return(2)).WillOnce(Return(4));
-    EXPECT_CALL(fake_plat_io, sample(2)).WillOnce(Return(3)).WillOnce(Return(4));
-    EXPECT_CALL(fake_plat_io, sample(3)).WillOnce(Return(4)).WillOnce(Return(0));
-    EXPECT_CALL(fake_plat_io, sample(4)).WillOnce(Return(5)).WillOnce(Return(6));
+    EXPECT_CALL(m_fake_plat_io, sample(0)).WillOnce(Return(1)).WillOnce(Return(0));
+    EXPECT_CALL(m_fake_plat_io, sample(1)).WillOnce(Return(2)).WillOnce(Return(4));
+    EXPECT_CALL(m_fake_plat_io, sample(2)).WillOnce(Return(3)).WillOnce(Return(4));
+    EXPECT_CALL(m_fake_plat_io, sample(3)).WillOnce(Return(4)).WillOnce(Return(0));
+    EXPECT_CALL(m_fake_plat_io, sample(4)).WillOnce(Return(5)).WillOnce(Return(6));
 
-    DomainNetMapImp net_map(m_filename,
+    DomainNetMapImp net_map(M_FILENAME,
             GEOPM_DOMAIN_PACKAGE,
             0,
-            fake_plat_io,
-            fake_nn_factory);
+            m_fake_plat_io,
+            m_fake_nn_factory);
 
-    EXPECT_CALL(*fake_nn, forward(_)).WillRepeatedly(Return(tmp1));
+    EXPECT_CALL(*m_fake_nn, forward(_)).WillRepeatedly(Return(m_tmp1));
 
     net_map.sample();
     net_map.sample();

--- a/test/FFNetAgentTest.cpp
+++ b/test/FFNetAgentTest.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <memory>
+
+#include "geopm/json11.hpp"
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm_agent.h"
+#include "geopm_hint.h"
+#include "geopm_hash.h"
+
+#include "Agent.hpp"
+#include "FFNetAgent.hpp"
+#include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm/Agg.hpp"
+#include "MockPlatformIO.hpp"
+#include "MockPlatformTopo.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm_prof.h"
+#include "geopm_test.hpp"
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Sequence;
+using ::testing::Return;
+using ::testing::AtLeast;
+using geopm::FrequencyMapAgent;
+using geopm::PlatformTopo;
+using testing::Throw;
+using json11::Json;
+
+class FFNetAgentTest: public :: testing :: Test
+{
+    protected:
+        enum mock_pio_idx_e {
+            CPU_FREQ_CTL_IDX,
+            GPU_FREQ_MIN_CTL_IDX,
+            GPU_FREQ_MAX_CTL_IDX
+        };
+        enum policy_idx_e {
+            PHI
+        };
+
+        void SetUp(); 
+        void setup_gpu(bool m_do_gpu);
+        void TearDown();
+        static const int M_NUM_PKG = 2;
+        static const int M_NUM_GPU = 6;
+        bool m_do_gpu = true;
+        double m_cpu_freq_min = 1800000000.0;
+        double m_cpu_freq_max = 2200000000.0;
+        double m_gpu_freq_min = 800000000.0;
+        double m_gpu_freq_max = 1600000000.0;
+    
+
+        std::unique_ptr<FFNetAgent> m_agent;
+        std::unique_ptr<MockPlatformIO> m_platform_io;
+        std::unique_ptr<MockPlatformTopo> m_platform_topo;
+        //TODO: Add DomainNetMap and RegionHintRecommender mocks
+
+};
+
+void FFNetAgentTest::SetUp()
+{
+    m_platform_io = geopm::make_unique<MockPlatformIO>();
+    m_platform_topo = geopm::make_unique<MockPlatformTopo>();
+
+
+    //Platform Topo Calls
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .WillByDefault(Return(M_NUM_PKG));
+    
+    //Platform IO Calls
+    ON_CALL(*m_platform_io, read_signal("CPU_FREQUENCY_MAX_AVAIL", _, _))
+        .Times(M_NUM_PKG)
+        .WillRepeatedly(Return(m_cpu_freq_max));
+    ON_CALL(*m_platform_io, read_signal("CPU_FREQUENCY_MIN_AVAIL", _, _))
+        .Times(M_NUM_PKG)
+        .WillRepeatedly(Return(m_cpu_freq_min));
+
+    //Test init: getting CPU freq range
+    EXPECT_CALL(*m_platform_io, read_signal("CPU_FREQUENCY_MIN_AVAIL", _, _));
+    EXPECT_CALL(*m_platform_io, read_signal("CPU_FREQUENCY_MAX_AVAIL", _, _));
+    //Test init: push controls for CPU
+    EXPECT_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MIN_CONTROL", _, _));
+    EXPECT_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MAX_CONTROL", _, _));
+    //Test init: init controls for signals needed for nn
+    EXPECT_CALL(*m_platform_io, write_control("MSR::PQR_ASSOC:RMID", _, _, 0));
+    EXPECT_CALL(*m_platform_io, write_control("MSR::QM_EVTSEL:RMID", _, _, 0));
+    EXPECT_CALL(*m_platform_io, write_control("MSR::QM_EVTSEL:EVENT_ID", _, _, 0));
+}
+
+void FFNetAgentTest::setup_gpu(bool do_gpu)
+{
+    std::set<std::string> control_names = {
+        "CPU_FREQUENCY_MAX_CONTROL"
+    };
+
+    if (do_gpu) {
+        //Platform Topo Calls
+        ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_GPU))
+            .WillByDefault(Return(M_NUM_GPU));
+        //Platform IO Calls
+        ON_CALL(*m_platform_io, control_domain_type("GPU_CORE_FREQUENCY_MAX_CONTROL"))
+            .WillByDefault(Return(GEOPM_DOMAIN_GPU));
+        control_names.insert({
+            "GPU_CORE_FREQUENCY_MAX_CONTROL",
+            "GPU_CORE_FREQUENCY_MIN_CONTROL"});
+        ON_CALL(*m_platform_io, read_signal("GPU_FREQUENCY_MAX_AVAIL", _, _))
+            .Times(M_NUM_GPU)
+            .WillRepeatedly(Return(m_gpu_freq_max));
+        ON_CALL(*m_platform_io, read_signal("GPU_FREQUENCY_MIN_AVAIL", _, _))
+            .Times(M_NUM_GPU)
+            .WillRepeatedly(Return(m_gpu_freq_min));
+    }
+    //TODO: Fix
+    else {
+        //Platform Topo Calls
+        ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_GPU))
+            .WillByDefault(Return(0));
+        //Platform IO Calls
+        ON_CALL(*m_platform_io, control_domain_type("GPU_CORE_FREQUENCY_MAX_CONTROL"))
+            .WillByDefault(Return(GEOPM_DOMAIN_INVALID));
+    }
+
+    //GPU Push Controls
+    ON_CALL(*m_platform_io, control_names())
+        .WillByDefault(Return(control_names));
+    ON_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_GPU, 0))
+        .WillByDefault(Return(GPU_FREQ_MIN_CONTROL_IDX));
+    ON_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU, 0))
+        .WillByDefault(Return(GPU_FREQ_MAX_CONTROL_IDX));
+
+    //GPU Signals - frequency range
+    ON_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_GPU, 0))
+        .WillByDefault(Return(m_freq_gpu_min));
+    ON_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU, 0))
+        .WillByDefault(Return(m_freq_gpu_max));
+
+    //GPU Signals = default frequency settings
+    ON_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_GPU, 0))
+        .WillByDefault(Return(m_freq_gpu_min));
+    ON_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU, 0))
+        .WillByDefault(Return(m_freq_gpu_max));
+
+    EXPECT_CALL(*m_platform_io, control_names());
+
+    if (do_gpu) {
+        //Test init: getting GPU freq range when do_gpu=True
+        //Test init: GPU range is not queried when do_gpu=False [implicit]
+        EXPECT_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MIN_AVAIL", _, _))
+            .Times(M_NUM_GPU);
+        EXPECT_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MAX_AVAIL", _, _))
+            .Times(M_NUM_GPU);
+        //Test init: push controls for GPU when do_gpu=True
+        //Test init: GPU controls are not pushed when do_gpu=False [implicit]
+        EXPECT_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MIN_CONTROL", _, _))
+            .Times(M_NUM_GPU);
+        EXPECT_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MAX_CONTROL", _, _))
+            .Times(M_NUM_GPU);
+    
+    }
+}
+
+
+//TODO Tests
+
+//Test validate_policy: Error if size != 1
+//Test validate_policy: Accept all-nan policy
+//Test validate_policy: Error if phi < 0 or phi > 1
+//Test validate_policy: All good if phi [0,1]
+
+//These tests require mocks of DomainNetMap and RegionHintRecommender
+//Test adjust_platform: New cpu freq recommendation means cpu freq is set
+//Test adjust_platform: New gpu freq recommendation means gpu freq is set when do_gpu=True
+//Test adjust_platform: NAN cpu and gpu freq recommendation = m_write_batch=false
+//Test adjust_platform: Do not get gpu freq recommendation when do_gpu=False
+
+//Test sample_platform: All CPU signals are queried
+//Test sample_platform: All GPU signals are queried when do_gpu=True
+//Test sample_platform: No GPU signals are queried when do_gpu=False
+
+//TODO: Test trace_names

--- a/test/FFNetAgentTest.cpp
+++ b/test/FFNetAgentTest.cpp
@@ -177,6 +177,25 @@ int FFNetAgentTest::construct_and_init(bool do_gpu)
     return num_gpu;
 }
 
+TEST_F(FFNetAgentTest, agent_name)
+{
+    construct_and_init(true);
+    EXPECT_EQ("ffnet", m_agent->plugin_name());
+    EXPECT_NE("bad_string", m_agent->plugin_name());
+}
+
+TEST_F(FFNetAgentTest, policy_names)
+{
+    std::vector<std::string> policy_names;
+
+    construct_and_init(true);
+    policy_names = m_agent->policy_names();
+    EXPECT_EQ((std::size_t)1, policy_names.size());
+    EXPECT_EQ("PERF_ENERGY_BIAS", policy_names.at(0));
+
+}
+
+
 // Test validate_policy: Accept all-nan policy
 TEST_F(FFNetAgentTest, validate_empty_policy)
 {

--- a/test/FFNetAgentTest.cpp
+++ b/test/FFNetAgentTest.cpp
@@ -44,12 +44,10 @@ using geopm::FFNetAgent;
 using geopm::PlatformTopo;
 using geopm::DomainNetMap;
 using geopm::RegionHintRecommender;
-using geopm::MockDomainNetMap;
-using geopm::MockRegionHintRecommender;
 using testing::Throw;
 using json11::Json;
 
-class FFNetAgentTest: public :: testing :: Test
+class FFNetAgentTest : public ::testing::Test
 {
     protected:
         enum mock_pio_idx_e {
@@ -71,7 +69,7 @@ class FFNetAgentTest: public :: testing :: Test
 
         std::vector<double> m_default_policy = {0.5};
         const std::map<std::string, double> M_REGION_CLASS = {{"dgemm", 0.75},
-                                                              {"stream",0.25}};
+                                                              {"stream", 0.25}};
     
         std::unique_ptr<FFNetAgent> m_agent;
         std::unique_ptr<MockPlatformIO> m_platform_io;

--- a/test/FFNetAgentTest.cpp
+++ b/test/FFNetAgentTest.cpp
@@ -66,16 +66,12 @@ class FFNetAgentTest: public :: testing :: Test
         int init(bool m_do_gpu);
         void construct();
         int construct_and_init(bool m_do_gpu);
-        static const int M_NUM_PKG = 2;
-        static const int M_NUM_GPU = 6;
-        double m_cpu_freq_min = 1800000000.0;
-        double m_cpu_freq_max = 2200000000.0;
-        double m_gpu_freq_min = 800000000.0;
-        double m_gpu_freq_max = 1600000000.0;
+        static constexpr int M_NUM_PKG = 2;
+        static constexpr int M_NUM_GPU = 6;
 
         std::vector<double> m_default_policy = {0.5};
-        std::map<std::string, double> m_region_class 
-            = {{"dgemm", 0.75},{"stream",0.25}};
+        const std::map<std::string, double> M_REGION_CLASS = {{"dgemm", 0.75},
+                                                              {"stream",0.25}};
     
         std::unique_ptr<FFNetAgent> m_agent;
         std::unique_ptr<MockPlatformIO> m_platform_io;
@@ -89,7 +85,7 @@ int FFNetAgentTest::init(bool do_gpu)
 {
     int num_gpu = do_gpu ? M_NUM_GPU : 0;
 
-    //Set up mocks
+    // Set up mocks
     m_platform_io = geopm::make_unique<MockPlatformIO>();
     m_platform_topo = geopm::make_unique<MockPlatformTopo>();
 
@@ -109,32 +105,32 @@ int FFNetAgentTest::init(bool do_gpu)
             = std::make_shared<MockRegionHintRecommender>();
     }
 
-    //Platform Topo Calls
+    // Platform Topo Calls
     ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
         .WillByDefault(Return(M_NUM_PKG));
     ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_GPU))
         .WillByDefault(Return(num_gpu));
 
-    //Platform IO Calls
+    // Platform IO Calls
     ON_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_PACKAGE, _))
         .WillByDefault(Return(CPU_FREQ_MIN_CTL_IDX));
     ON_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_PACKAGE, _))
         .WillByDefault(Return(CPU_FREQ_MAX_CTL_IDX));
 
-    if(do_gpu) {
+    if (do_gpu) {
         ON_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_GPU, _))
             .WillByDefault(Return(GPU_FREQ_MIN_CTL_IDX));
         ON_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU, _))
             .WillByDefault(Return(GPU_FREQ_MAX_CTL_IDX));
     }
     
-    //Test init: ask for number of domains
+    // Test init: ask for number of domains
     EXPECT_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
         .Times(1);
     EXPECT_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_GPU))
         .Times(do_gpu ? 2 : 1);
 
-    //Test init: push controls 
+    // Test init: push controls 
     EXPECT_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_PACKAGE, _))
         .Times(M_NUM_PKG);
     EXPECT_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_PACKAGE, _))
@@ -144,7 +140,7 @@ int FFNetAgentTest::init(bool do_gpu)
     EXPECT_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MIN_CONTROL", _, _))
         .Times(num_gpu);
 
-    //Test init: Initializing MSRs that require it
+    // Test init: Initializing MSRs that require it
     EXPECT_CALL(*m_platform_io, write_control("MSR::PQR_ASSOC:RMID", _, _, 0));
     EXPECT_CALL(*m_platform_io, write_control("MSR::QM_EVTSEL:RMID", _, _, 0));
     EXPECT_CALL(*m_platform_io, write_control("MSR::QM_EVTSEL:EVENT_ID", _, _, 2));
@@ -181,7 +177,7 @@ int FFNetAgentTest::construct_and_init(bool do_gpu)
     return num_gpu;
 }
 
-//Test validate_policy: Accept all-nan policy
+// Test validate_policy: Accept all-nan policy
 TEST_F(FFNetAgentTest, validate_empty_policy)
 {
     construct_and_init(true);
@@ -191,7 +187,7 @@ TEST_F(FFNetAgentTest, validate_empty_policy)
     EXPECT_EQ(0, empty_policy[POLICY_PHI]);
 }
 
-//Test validate_policy: Error if size != NUM_POLICY
+// Test validate_policy: Error if size != NUM_POLICY
 TEST_F(FFNetAgentTest, validate_badsize_policy)
 {
     construct_and_init(true);
@@ -201,7 +197,7 @@ TEST_F(FFNetAgentTest, validate_badsize_policy)
                                "policy vector not correctly sized.");
 }
 
-//Test validate_policy: Error if phi < 0 or phi > 1
+// Test validate_policy: Error if phi < 0 or phi > 1
 TEST_F(FFNetAgentTest, validate_badphi_policy)
 {
     construct_and_init(true);
@@ -216,7 +212,8 @@ TEST_F(FFNetAgentTest, validate_badphi_policy)
                                "PERF_ENERGY_BIAS is out of range (should be 0-1).");
                                
 }
-//Test validate_policy: All good if phi [0,1]
+
+// Test validate_policy: All good if phi [0,1]
 TEST_F(FFNetAgentTest, validate_good_policy)
 {
     construct_and_init(true);
@@ -225,38 +222,41 @@ TEST_F(FFNetAgentTest, validate_good_policy)
     ASSERT_EQ(NUM_POLICY, m_default_policy.size());
 }
 
-//Test adjust_platform: NAN cpu and gpu freq recommendation = m_write_batch=false
+// Test adjust_platform: NAN cpu and gpu freq recommendation = m_write_batch=false
 TEST_F(FFNetAgentTest, adjust_platform_nans)
 {
     int num_gpu = construct_and_init(true);
     int ncalls = 0;
 
-    //Call to DomainNetMap to get regions
+    // Call to DomainNetMap to get regions
     for (const auto &net_map_pair : m_net_map) {
         ON_CALL(*net_map_pair.second, last_output())
-            .WillByDefault(Return(m_region_class));
+            .WillByDefault(Return(M_REGION_CLASS));
         EXPECT_CALL(*net_map_pair.second, last_output());
     }
-    //Call to RegionHintRecommender to get NAN recommended freq
+    // Call to RegionHintRecommender to get NAN recommended freq
     for (const auto &freq_rec_pair : m_freq_recommender) {
-        ON_CALL(*freq_rec_pair.second, recommend_frequency(m_region_class, m_default_policy[POLICY_PHI]))
+        ON_CALL(*freq_rec_pair.second,
+                recommend_frequency(M_REGION_CLASS, m_default_policy[POLICY_PHI]))
             .WillByDefault(Return(NAN));
         //Get number of expected calls based on domain type
-        if(freq_rec_pair.first == GEOPM_DOMAIN_PACKAGE){
+        if (freq_rec_pair.first == GEOPM_DOMAIN_PACKAGE) {
             ncalls = M_NUM_PKG;
         }
-        else if(freq_rec_pair.first == GEOPM_DOMAIN_GPU){
+        else if (freq_rec_pair.first == GEOPM_DOMAIN_GPU) {
             ncalls = num_gpu;
         }
 
-        EXPECT_CALL(*freq_rec_pair.second, recommend_frequency(m_region_class, m_default_policy[POLICY_PHI]))
+        EXPECT_CALL(*freq_rec_pair.second,
+                    recommend_frequency(M_REGION_CLASS, m_default_policy[POLICY_PHI]))
             .Times(ncalls);
     }
 
     m_agent->adjust_platform(m_default_policy);
     EXPECT_FALSE(m_agent->do_write_batch());
 }
-//Test adjust_platform: New cpu freq recommendation means cpu freq is set
+
+// Test adjust_platform: New cpu freq recommendation means cpu freq is set
 TEST_F(FFNetAgentTest, adjust_platform_all)
 {
     int num_gpu = construct_and_init(true);
@@ -264,27 +264,30 @@ TEST_F(FFNetAgentTest, adjust_platform_all)
     int gpu_req = 1.0e9;
     int ncalls = 0;
 
-    //Call to DomainNetMap to get regions
+    // Call to DomainNetMap to get regions
     for (const auto &net_map_pair : m_net_map) {
         ON_CALL(*net_map_pair.second, last_output())
-            .WillByDefault(Return(m_region_class));
+            .WillByDefault(Return(M_REGION_CLASS));
         EXPECT_CALL(*net_map_pair.second, last_output())
             .Times(1);
     }
-    //Call to RegionHintRecommender to get recommended freq
+    // Call to RegionHintRecommender to get recommended freq
     for (const auto &freq_rec_pair : m_freq_recommender) {
-        if(freq_rec_pair.first == GEOPM_DOMAIN_PACKAGE){
+        if (freq_rec_pair.first == GEOPM_DOMAIN_PACKAGE) {
             ncalls = M_NUM_PKG;
-            ON_CALL(*freq_rec_pair.second, recommend_frequency(m_region_class, m_default_policy[POLICY_PHI]))
+            ON_CALL(*freq_rec_pair.second,
+                    recommend_frequency(M_REGION_CLASS, m_default_policy[POLICY_PHI]))
                 .WillByDefault(Return(cpu_req));
         }
-        else if(freq_rec_pair.first == GEOPM_DOMAIN_GPU){
+        else if (freq_rec_pair.first == GEOPM_DOMAIN_GPU) {
             ncalls = num_gpu;
-            ON_CALL(*freq_rec_pair.second, recommend_frequency(m_region_class, m_default_policy[POLICY_PHI]))
+            ON_CALL(*freq_rec_pair.second,
+                    recommend_frequency(M_REGION_CLASS, m_default_policy[POLICY_PHI]))
                 .WillByDefault(Return(gpu_req));
         }
 
-        EXPECT_CALL(*freq_rec_pair.second, recommend_frequency(m_region_class, m_default_policy[POLICY_PHI]))
+        EXPECT_CALL(*freq_rec_pair.second,
+                    recommend_frequency(M_REGION_CLASS, m_default_policy[POLICY_PHI]))
             .Times(ncalls);
     }
 
@@ -303,27 +306,29 @@ TEST_F(FFNetAgentTest, adjust_platform_all)
 
 }
 
-//Test adjust_platform: Do not get gpu freq recommendation when do_gpu=False
+// Test adjust_platform: Do not get gpu freq recommendation when do_gpu=False
 TEST_F(FFNetAgentTest, adjust_platform_no_gpu)
 {
     int num_gpu = construct_and_init(false);
     int cpu_req = 1.2e9;
     int gpu_req = 1.0e9;
 
-    //Call to DomainNetMap to get regions
+    // Call to DomainNetMap to get regions
     for (const auto &net_map_pair : m_net_map) {
-        if(net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE){
+        if (net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE) {
             ON_CALL(*net_map_pair.second, last_output())
-                .WillByDefault(Return(m_region_class));
+                .WillByDefault(Return(M_REGION_CLASS));
             EXPECT_CALL(*net_map_pair.second, last_output());
         }
     }
-    //Call to RegionHintRecommender to get recommended freq
+    // Call to RegionHintRecommender to get recommended freq
     for (const auto &freq_rec_pair : m_freq_recommender) {
-        if(freq_rec_pair.first == GEOPM_DOMAIN_PACKAGE){
-            ON_CALL(*freq_rec_pair.second, recommend_frequency(m_region_class, m_default_policy[POLICY_PHI]))
+        if (freq_rec_pair.first == GEOPM_DOMAIN_PACKAGE) {
+            ON_CALL(*freq_rec_pair.second,
+                    recommend_frequency(M_REGION_CLASS, m_default_policy[POLICY_PHI]))
                 .WillByDefault(Return(cpu_req));
-            EXPECT_CALL(*freq_rec_pair.second, recommend_frequency(m_region_class, m_default_policy[POLICY_PHI]))
+            EXPECT_CALL(*freq_rec_pair.second,
+                        recommend_frequency(M_REGION_CLASS, m_default_policy[POLICY_PHI]))
                 .Times(M_NUM_PKG);
         }
     }
@@ -343,7 +348,7 @@ TEST_F(FFNetAgentTest, adjust_platform_no_gpu)
 
 }
 
-//Test sample_platform: All signals are queried when do_gpu=True
+// Test sample_platform: All signals are queried when do_gpu=True
 TEST_F(FFNetAgentTest, sample_platform)
 {
     construct_and_init(true);
@@ -356,17 +361,17 @@ TEST_F(FFNetAgentTest, sample_platform)
     m_agent->sample_platform(tmp);
 }
 
-//Test sample_platform: No GPU signals are queried when do_gpu=False
+// Test sample_platform: No GPU signals are queried when do_gpu=False
 TEST_F(FFNetAgentTest, sample_platform_no_gpu)
 {
     construct_and_init(false);
 
     for (const auto &net_map_pair : m_net_map) {
-        if(net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE){
+        if (net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE) {
             EXPECT_CALL(*net_map_pair.second, sample())
                 .Times(1);
         }
-        else if(net_map_pair.first.first == GEOPM_DOMAIN_GPU){
+        else if (net_map_pair.first.first == GEOPM_DOMAIN_GPU) {
             EXPECT_CALL(*net_map_pair.second, sample())
                 .Times(0);
         }
@@ -376,7 +381,7 @@ TEST_F(FFNetAgentTest, sample_platform_no_gpu)
     m_agent->sample_platform(tmp);
 }
 
-//Test trace_names 
+// Test trace_names 
 TEST_F(FFNetAgentTest, trace_names)
 {
     construct_and_init(true);
@@ -389,11 +394,11 @@ TEST_F(FFNetAgentTest, trace_names)
                                            "parres_gpu_3", "parres_gpu_4", "parres_gpu_5"};
 
     for (const auto &net_map_pair : m_net_map) {
-        if(net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE){
+        if (net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE) {
             ON_CALL(*net_map_pair.second, trace_names())
                 .WillByDefault(Return(cpu_region_names));
         }
-        else if(net_map_pair.first.first == GEOPM_DOMAIN_GPU){
+        else if (net_map_pair.first.first == GEOPM_DOMAIN_GPU) {
             ON_CALL(*net_map_pair.second, trace_names())
                 .WillByDefault(Return(gpu_region_names));
         }
@@ -405,12 +410,12 @@ TEST_F(FFNetAgentTest, trace_names)
 
     EXPECT_EQ(expect_val.size(), retval.size());
 
-    for(std::size_t idx = 0; idx < expect_val.size() ; idx++) {
+    for (std::size_t idx = 0; idx < expect_val.size() ; idx++) {
         EXPECT_EQ(retval.at(idx), expect_val.at(idx));
     }
 }
 
-//Test trace_names no GPU
+// Test trace_names no GPU
 TEST_F(FFNetAgentTest, trace_names_no_gpu)
 {
     construct_and_init(false);
@@ -421,12 +426,12 @@ TEST_F(FFNetAgentTest, trace_names_no_gpu)
     std::vector<std::string> expect_val = {"aib_cpu_0", "stream_cpu_0", "aib_cpu_1", "stream_cpu_1"};
 
     for (const auto &net_map_pair : m_net_map) {
-        if(net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE) {
+        if (net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE) {
             ON_CALL(*net_map_pair.second, trace_names())
                 .WillByDefault(Return(cpu_region_names));
             EXPECT_CALL(*net_map_pair.second, trace_names());
         }
-        else if(net_map_pair.first.first == GEOPM_DOMAIN_GPU) {
+        else if (net_map_pair.first.first == GEOPM_DOMAIN_GPU) {
             ON_CALL(*net_map_pair.second, trace_names())
                 .WillByDefault(Return(gpu_region_names));
             EXPECT_CALL(*net_map_pair.second, trace_names())
@@ -439,11 +444,12 @@ TEST_F(FFNetAgentTest, trace_names_no_gpu)
 
     EXPECT_EQ(expect_val.size(), retval.size());
 
-    for(std::size_t idx = 0; idx < expect_val.size() ; idx++) {
+    for (std::size_t idx = 0; idx < expect_val.size() ; idx++) {
         EXPECT_EQ(retval.at(idx), expect_val.at(idx));
     }
 }
-//Test trace_values
+
+// Test trace_values
 TEST_F(FFNetAgentTest, trace_values)
 {
     size_t num_gpu = construct_and_init(true);
@@ -451,24 +457,24 @@ TEST_F(FFNetAgentTest, trace_values)
     std::vector<std::vector<double>> gpu_probs;
     std::vector<double> expect_val;
 
-    for(size_t idx=0; idx<M_NUM_PKG; ++idx) {
+    for (size_t idx = 0; idx < M_NUM_PKG; ++idx) {
         cpu_probs.push_back(std::vector<double>({1+(double)idx, 2}));
         expect_val.push_back(1+(double)idx);
         expect_val.push_back(2);
 
         
     }
-    for(size_t idx=0; idx<num_gpu; ++idx) {
+    for (size_t idx = 0; idx < num_gpu; ++idx) {
         gpu_probs.push_back(std::vector<double>({(double)idx}));
         expect_val.push_back((double)idx);
     }
 
     for (const auto &net_map_pair : m_net_map) {
-        if(net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE) {
+        if (net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE) {
             ON_CALL(*net_map_pair.second, trace_values())
                 .WillByDefault(Return(cpu_probs.at(net_map_pair.first.second)));
         }
-        if(net_map_pair.first.first == GEOPM_DOMAIN_GPU) {
+        if (net_map_pair.first.first == GEOPM_DOMAIN_GPU) {
             ON_CALL(*net_map_pair.second, trace_values())
                 .WillByDefault(Return(gpu_probs.at(net_map_pair.first.second)));
         }
@@ -479,30 +485,31 @@ TEST_F(FFNetAgentTest, trace_values)
     std::vector<double> retval(expect_val.size());
     m_agent->trace_values(retval);
 
-    for(std::size_t idx = 0; idx < expect_val.size() ; idx++) {
+    for (std::size_t idx = 0; idx < expect_val.size() ; idx++) {
         EXPECT_EQ(retval.at(idx), expect_val.at(idx));
     }
 }
-//Test trace_values no gpu
+
+// Test trace_values no gpu
 TEST_F(FFNetAgentTest, trace_values_no_gpu)
 {
     construct_and_init(false);
     std::vector<std::vector<double>> cpu_probs;
     std::vector<double> expect_val;
 
-    for(size_t idx=0; idx<M_NUM_PKG; ++idx) {
+    for (size_t idx = 0; idx < M_NUM_PKG; ++idx) {
         cpu_probs.push_back(std::vector<double>({1+(double)idx, 2}));
         expect_val.push_back(1+(double)idx);
         expect_val.push_back(2);
     }
 
     for (const auto &net_map_pair : m_net_map) {
-        if(net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE) {
+        if (net_map_pair.first.first == GEOPM_DOMAIN_PACKAGE) {
             ON_CALL(*net_map_pair.second, trace_values())
                 .WillByDefault(Return(cpu_probs.at(net_map_pair.first.second)));
             EXPECT_CALL(*net_map_pair.second, trace_values());
         }
-        if(net_map_pair.first.first == GEOPM_DOMAIN_GPU) {
+        if (net_map_pair.first.first == GEOPM_DOMAIN_GPU) {
             ON_CALL(*net_map_pair.second, trace_values())
                 .WillByDefault(Return(std::vector<double>({0})));
             EXPECT_CALL(*net_map_pair.second, trace_values())
@@ -513,7 +520,7 @@ TEST_F(FFNetAgentTest, trace_values_no_gpu)
     std::vector<double> retval(expect_val.size());
     m_agent->trace_values(retval);
 
-    for(std::size_t idx = 0; idx < expect_val.size() ; idx++) {
+    for (std::size_t idx = 0; idx < expect_val.size() ; idx++) {
         EXPECT_EQ(retval.at(idx), expect_val.at(idx));
     }
 }

--- a/test/FFNetAgentTest.cpp
+++ b/test/FFNetAgentTest.cpp
@@ -74,7 +74,7 @@ class FFNetAgentTest: public :: testing :: Test
         double m_gpu_freq_max = 1600000000.0;
 
         std::vector<double> m_default_policy = {0.5};
-        std::map<std::string, float> m_region_class 
+        std::map<std::string, double> m_region_class 
             = {{"dgemm", 0.75},{"stream",0.25}};
     
         std::unique_ptr<FFNetAgent> m_agent;

--- a/test/FFNetAgentTest.cpp
+++ b/test/FFNetAgentTest.cpp
@@ -209,11 +209,11 @@ TEST_F(FFNetAgentTest, validate_badphi_policy)
 
     policy[POLICY_PHI] = 1.5;
     GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
-                               "CPU_PHI is out of range (should be 0-1).");
+                               "PERF_ENERGY_BIAS is out of range (should be 0-1).");
 
     policy[POLICY_PHI] = -2.0;
     GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
-                               "CPU_PHI is out of range (should be 0-1).");
+                               "PERF_ENERGY_BIAS is out of range (should be 0-1).");
                                
 }
 //Test validate_policy: All good if phi [0,1]

--- a/test/FFNetAgentTest.cpp
+++ b/test/FFNetAgentTest.cpp
@@ -225,7 +225,6 @@ TEST_F(FFNetAgentTest, test_validate_good_policy)
 TEST_F(FFNetAgentTest, test_adjust_platform_nans)
 {
     init(m_do_gpu);
-    double new_freq = NAN;
 
     //Call to DomainNetMap to get regions
     for (const auto &net_map_pair : m_net_map) {

--- a/test/FFNetAgentTest.cpp
+++ b/test/FFNetAgentTest.cpp
@@ -20,22 +20,32 @@
 
 #include "Agent.hpp"
 #include "FFNetAgent.hpp"
+#include "DomainNetMap.hpp"
+#include "RegionHintRecommender.hpp"
 #include "geopm/Exception.hpp"
 #include "geopm/Helper.hpp"
 #include "geopm/Agg.hpp"
 #include "MockPlatformIO.hpp"
 #include "MockPlatformTopo.hpp"
+#include "MockDomainNetMap.hpp"
+#include "MockRegionHintRecommender.hpp"
 #include "geopm/PlatformTopo.hpp"
 #include "geopm_prof.h"
 #include "geopm_test.hpp"
 
+using ::testing::Mock;
+using ::testing::Return;
 using ::testing::_;
 using ::testing::Invoke;
 using ::testing::Sequence;
 using ::testing::Return;
 using ::testing::AtLeast;
-using geopm::FrequencyMapAgent;
+using geopm::FFNetAgent;
 using geopm::PlatformTopo;
+using geopm::DomainNetMap;
+using geopm::RegionHintRecommender;
+using geopm::MockDomainNetMap;
+using geopm::MockRegionHintRecommender;
 using testing::Throw;
 using json11::Json;
 
@@ -48,12 +58,11 @@ class FFNetAgentTest: public :: testing :: Test
             GPU_FREQ_MAX_CTL_IDX
         };
         enum policy_idx_e {
-            PHI
+            POLICY_PHI,
+            NUM_POLICY
         };
 
-        void SetUp(); 
-        void setup_gpu(bool m_do_gpu);
-        void TearDown();
+        void construct_and_init(bool m_do_gpu);
         static const int M_NUM_PKG = 2;
         static const int M_NUM_GPU = 6;
         bool m_do_gpu = true;
@@ -62,128 +71,130 @@ class FFNetAgentTest: public :: testing :: Test
         double m_gpu_freq_min = 800000000.0;
         double m_gpu_freq_max = 1600000000.0;
     
-
         std::unique_ptr<FFNetAgent> m_agent;
         std::unique_ptr<MockPlatformIO> m_platform_io;
         std::unique_ptr<MockPlatformTopo> m_platform_topo;
-        //TODO: Add DomainNetMap and RegionHintRecommender mocks
 
+        std::map<std::pair<geopm_domain_e, int>, std::unique_ptr<DomainNetMap> > m_net_map;
+        std::map<geopm_domain_e, std::unique_ptr<RegionHintRecommender> > m_freq_recommender;
 };
 
-void FFNetAgentTest::SetUp()
+void FFNetAgentTest::construct_and_init(bool do_gpu)
 {
+    int num_gpu = do_gpu ? M_NUM_GPU : 0;
+
+    //Set up mocks
     m_platform_io = geopm::make_unique<MockPlatformIO>();
     m_platform_topo = geopm::make_unique<MockPlatformTopo>();
 
+    for (int idx = 0; idx < M_NUM_PKG; ++idx) {
+        m_net_map[std::make_pair(GEOPM_DOMAIN_PACKAGE, idx)]
+            = geopm::make_unique<MockDomainNetMap>();
+    }
+    for (int idx = 0; idx < num_gpu; ++idx) {
+        m_net_map[std::make_pair(GEOPM_DOMAIN_GPU, idx)]
+            = geopm::make_unique<MockDomainNetMap>();
+    }
+
+    m_freq_recommender[GEOPM_DOMAIN_PACKAGE]
+        = geopm::make_unique<MockRegionHintRecommender>();
+    if (do_gpu) {
+        m_freq_recommender[GEOPM_DOMAIN_GPU]
+            = geopm::make_unique<MockRegionHintRecommender>();
+    }
 
     //Platform Topo Calls
     ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
         .WillByDefault(Return(M_NUM_PKG));
-    
-    //Platform IO Calls
-    ON_CALL(*m_platform_io, read_signal("CPU_FREQUENCY_MAX_AVAIL", _, _))
-        .Times(M_NUM_PKG)
-        .WillRepeatedly(Return(m_cpu_freq_max));
-    ON_CALL(*m_platform_io, read_signal("CPU_FREQUENCY_MIN_AVAIL", _, _))
-        .Times(M_NUM_PKG)
-        .WillRepeatedly(Return(m_cpu_freq_min));
+    ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_GPU))
+        .WillByDefault(Return(num_gpu));
+   
 
-    //Test init: getting CPU freq range
-    EXPECT_CALL(*m_platform_io, read_signal("CPU_FREQUENCY_MIN_AVAIL", _, _));
-    EXPECT_CALL(*m_platform_io, read_signal("CPU_FREQUENCY_MAX_AVAIL", _, _));
-    //Test init: push controls for CPU
-    EXPECT_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MIN_CONTROL", _, _));
-    EXPECT_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MAX_CONTROL", _, _));
-    //Test init: init controls for signals needed for nn
+    //Test init: ask for number of domains
+    EXPECT_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .Times(1);
+    EXPECT_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_GPU))
+        .Times(2);
+
+    //Test init: push controls 
+    EXPECT_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_PACKAGE, _))
+        .Times(M_NUM_PKG);
+    EXPECT_CALL(*m_platform_io, push_control("CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_PACKAGE, _))
+        .Times(M_NUM_PKG);
+    EXPECT_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MAX_CONTROL", _, _))
+        .Times(num_gpu);
+    EXPECT_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MIN_CONTROL", _, _))
+        .Times(num_gpu);
+
+    //Test init: Initializing MSRs that require it
     EXPECT_CALL(*m_platform_io, write_control("MSR::PQR_ASSOC:RMID", _, _, 0));
     EXPECT_CALL(*m_platform_io, write_control("MSR::QM_EVTSEL:RMID", _, _, 0));
-    EXPECT_CALL(*m_platform_io, write_control("MSR::QM_EVTSEL:EVENT_ID", _, _, 0));
+    EXPECT_CALL(*m_platform_io, write_control("MSR::QM_EVTSEL:EVENT_ID", _, _, 2));
+
+    m_agent = geopm::make_unique<FFNetAgent>(
+            *m_platform_io,
+            *m_platform_topo,
+            m_net_map,
+            m_freq_recommender
+            );
+    m_agent->init(0, {}, false); 
 }
 
-void FFNetAgentTest::setup_gpu(bool do_gpu)
+//Test validate_policy: Accept all-nan policy
+TEST_F(FFNetAgentTest, test_validate_empty_policy)
 {
-    std::set<std::string> control_names = {
-        "CPU_FREQUENCY_MAX_CONTROL"
-    };
+    construct_and_init(true);
+    std::vector<double> empty_policy(NUM_POLICY, NAN);
 
-    if (do_gpu) {
-        //Platform Topo Calls
-        ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_GPU))
-            .WillByDefault(Return(M_NUM_GPU));
-        //Platform IO Calls
-        ON_CALL(*m_platform_io, control_domain_type("GPU_CORE_FREQUENCY_MAX_CONTROL"))
-            .WillByDefault(Return(GEOPM_DOMAIN_GPU));
-        control_names.insert({
-            "GPU_CORE_FREQUENCY_MAX_CONTROL",
-            "GPU_CORE_FREQUENCY_MIN_CONTROL"});
-        ON_CALL(*m_platform_io, read_signal("GPU_FREQUENCY_MAX_AVAIL", _, _))
-            .Times(M_NUM_GPU)
-            .WillRepeatedly(Return(m_gpu_freq_max));
-        ON_CALL(*m_platform_io, read_signal("GPU_FREQUENCY_MIN_AVAIL", _, _))
-            .Times(M_NUM_GPU)
-            .WillRepeatedly(Return(m_gpu_freq_min));
-    }
-    //TODO: Fix
-    else {
-        //Platform Topo Calls
-        ON_CALL(*m_platform_topo, num_domain(GEOPM_DOMAIN_GPU))
-            .WillByDefault(Return(0));
-        //Platform IO Calls
-        ON_CALL(*m_platform_io, control_domain_type("GPU_CORE_FREQUENCY_MAX_CONTROL"))
-            .WillByDefault(Return(GEOPM_DOMAIN_INVALID));
-    }
+    m_agent->validate_policy(empty_policy);
+    EXPECT_EQ(0, empty_policy[POLICY_PHI]);
+}
 
-    //GPU Push Controls
-    ON_CALL(*m_platform_io, control_names())
-        .WillByDefault(Return(control_names));
-    ON_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_GPU, 0))
-        .WillByDefault(Return(GPU_FREQ_MIN_CONTROL_IDX));
-    ON_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU, 0))
-        .WillByDefault(Return(GPU_FREQ_MAX_CONTROL_IDX));
+//Test validate_policy: Error if size != NUM_POLICY
+TEST_F(FFNetAgentTest, test_validate_badsize_policy)
+{
+    construct_and_init(m_do_gpu);
+    std::vector<double> policy(NUM_POLICY+3, 0);
 
-    //GPU Signals - frequency range
-    ON_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_GPU, 0))
-        .WillByDefault(Return(m_freq_gpu_min));
-    ON_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_GPU, 0))
-        .WillByDefault(Return(m_freq_gpu_max));
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "policy vector not correctly sized.");
+}
 
-    //GPU Signals = default frequency settings
-    ON_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_GPU, 0))
-        .WillByDefault(Return(m_freq_gpu_min));
-    ON_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU, 0))
-        .WillByDefault(Return(m_freq_gpu_max));
+//Test validate_policy: Error if phi < 0 or phi > 1
+TEST_F(FFNetAgentTest, test_validate_badphi_policy)
+{
+    construct_and_init(m_do_gpu);
+    std::vector<double> policy(NUM_POLICY, NAN);
 
-    EXPECT_CALL(*m_platform_io, control_names());
+    policy[POLICY_PHI] = 1.5;
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "CPU_PHI is out of range (should be 0-1).");
 
-    if (do_gpu) {
-        //Test init: getting GPU freq range when do_gpu=True
-        //Test init: GPU range is not queried when do_gpu=False [implicit]
-        EXPECT_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MIN_AVAIL", _, _))
-            .Times(M_NUM_GPU);
-        EXPECT_CALL(*m_platform_io, read_signal("GPU_CORE_FREQUENCY_MAX_AVAIL", _, _))
-            .Times(M_NUM_GPU);
-        //Test init: push controls for GPU when do_gpu=True
-        //Test init: GPU controls are not pushed when do_gpu=False [implicit]
-        EXPECT_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MIN_CONTROL", _, _))
-            .Times(M_NUM_GPU);
-        EXPECT_CALL(*m_platform_io, push_control("GPU_CORE_FREQUENCY_MAX_CONTROL", _, _))
-            .Times(M_NUM_GPU);
-    
-    }
+    policy[POLICY_PHI] = -2.0;
+    GEOPM_EXPECT_THROW_MESSAGE(m_agent->validate_policy(policy), GEOPM_ERROR_INVALID,
+                               "CPU_PHI is out of range (should be 0-1).");
+                               
+}
+//Test validate_policy: All good if phi [0,1]
+TEST_F(FFNetAgentTest, test_validate_good_policy)
+{
+    construct_and_init(m_do_gpu);
+    std::vector<double> policy(NUM_POLICY, NAN);
+
+    policy[POLICY_PHI] = 0.25;
+    m_agent->validate_policy(policy);
+    ASSERT_EQ(NUM_POLICY, policy.size());
+    EXPECT_EQ(0.25, policy[POLICY_PHI]);
+
 }
 
 
 //TODO Tests
 
-//Test validate_policy: Error if size != 1
-//Test validate_policy: Accept all-nan policy
-//Test validate_policy: Error if phi < 0 or phi > 1
-//Test validate_policy: All good if phi [0,1]
 
-//These tests require mocks of DomainNetMap and RegionHintRecommender
+//Test adjust_platform: NAN cpu and gpu freq recommendation = m_write_batch=false
 //Test adjust_platform: New cpu freq recommendation means cpu freq is set
 //Test adjust_platform: New gpu freq recommendation means gpu freq is set when do_gpu=True
-//Test adjust_platform: NAN cpu and gpu freq recommendation = m_write_batch=false
 //Test adjust_platform: Do not get gpu freq recommendation when do_gpu=False
 
 //Test sample_platform: All CPU signals are queried

--- a/test/LocalNeuralNetTest.cpp
+++ b/test/LocalNeuralNetTest.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "geopm/Exception.hpp"

--- a/test/LocalNeuralNetTest.cpp
+++ b/test/LocalNeuralNetTest.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm/Exception.hpp"
+#include "geopm_test.hpp"
+
+#include "LocalNeuralNet.hpp"
+#include "LocalNeuralNetImp.hpp"
+#include "DenseLayer.hpp"
+#include "TensorOneD.hpp"
+
+#include "MockDenseLayer.hpp"
+#include "MockTensorMath.hpp"
+#include "TensorOneDMatcher.hpp"
+
+using geopm::TensorOneD;
+using geopm::DenseLayer;
+using geopm::LocalNeuralNet;
+using geopm::LocalNeuralNetImp;
+using geopm::MockDenseLayer;
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::_;
+
+class LocalNeuralNetTest : public ::testing::Test
+{
+    protected:
+        void SetUp() override;
+};
+
+void LocalNeuralNetTest::SetUp()
+{
+}
+
+TEST_F(LocalNeuralNetTest, test_inference) {
+    auto fake_math = std::make_shared<MockTensorMath>();
+
+    std::shared_ptr<MockDenseLayer> fake_layer1, fake_layer2;
+
+    fake_layer1 = std::make_shared<MockDenseLayer>();
+    fake_layer2 = std::make_shared<MockDenseLayer>();
+
+    TensorOneD inp2(
+            std::vector<float>(
+                {1, 2}
+                ),
+            fake_math
+            );
+
+    TensorOneD inp3(
+            std::vector<float>(
+                {1, 2, 3}
+                ),
+            fake_math
+            );
+
+    TensorOneD inp4(
+            std::vector<float>(
+                {1, 2, 3, 4}
+                ),
+            fake_math
+            );
+
+    TensorOneD inp4s(
+            std::vector<float>(
+                {4, 0, 3, 1}
+                ),
+            fake_math
+            );
+
+    ON_CALL(*fake_layer1, get_input_dim()).WillByDefault(Return(2u));
+    ON_CALL(*fake_layer1, get_output_dim()).WillByDefault(Return(4u));
+    ON_CALL(*fake_layer2, get_input_dim()).WillByDefault(Return(4u));
+    ON_CALL(*fake_layer2, get_output_dim()).WillByDefault(Return(3u));
+
+    EXPECT_CALL(*fake_layer1, get_input_dim()).Times(1);
+    EXPECT_CALL(*fake_layer1, get_output_dim()).Times(1);
+    EXPECT_CALL(*fake_layer2, get_input_dim()).Times(1);
+    EXPECT_CALL(*fake_layer2, get_output_dim()).Times(0);
+
+    LocalNeuralNetImp net({fake_layer1, fake_layer2});
+
+    EXPECT_CALL(*fake_layer1, forward(TensorOneDEqualTo(inp2))).WillOnce(Return(inp4));
+    EXPECT_CALL(*fake_layer2, forward(TensorOneDEqualTo(inp4s))).WillOnce(Return(inp3));
+
+    EXPECT_CALL(*fake_math, sigmoid(TensorOneDEqualTo(inp4))).WillOnce(Return(inp4s));
+
+    EXPECT_THAT(net.forward(inp2), TensorOneDEqualTo(inp3));
+}
+
+TEST_F(LocalNeuralNetTest, test_bad_dimensions) {
+    auto fake_math = std::make_shared<MockTensorMath>();
+
+    std::shared_ptr<MockDenseLayer> fake_layer1, fake_layer2;
+
+    fake_layer1 = std::make_shared<MockDenseLayer>();
+    fake_layer2 = std::make_shared<MockDenseLayer>();
+
+    TensorOneD inp2(
+            std::vector<float>(
+                {1, 2}
+                ),
+            fake_math
+            );
+
+    TensorOneD inp3(
+            std::vector<float>(
+                {1, 2, 3}
+                ),
+            fake_math
+            );
+
+    TensorOneD inp4(
+            std::vector<float>(
+                {1, 2, 3, 4}
+                ),
+            fake_math
+            );
+
+    {
+        ON_CALL(*fake_layer1, get_input_dim()).WillByDefault(Return(3u));
+        ON_CALL(*fake_layer1, get_output_dim()).WillByDefault(Return(3u));
+        ON_CALL(*fake_layer2, get_input_dim()).WillByDefault(Return(2u));
+        ON_CALL(*fake_layer2, get_output_dim()).WillByDefault(Return(3u));
+
+        EXPECT_CALL(*fake_layer1, get_input_dim()).Times(0);
+        EXPECT_CALL(*fake_layer1, get_output_dim()).Times(1);
+        EXPECT_CALL(*fake_layer2, get_input_dim()).Times(1);
+        EXPECT_CALL(*fake_layer2, get_output_dim()).Times(0);
+
+        GEOPM_EXPECT_THROW_MESSAGE(LocalNeuralNetImp({fake_layer1, fake_layer2}),
+                                   GEOPM_ERROR_INVALID,
+                                   "Incompatible dimensions for consecutive layers.");
+
+        Mock::VerifyAndClearExpectations(fake_layer1.get());
+        Mock::VerifyAndClearExpectations(fake_layer2.get());
+    }
+
+    {
+        ON_CALL(*fake_layer1, get_input_dim()).WillByDefault(Return(2u));
+        ON_CALL(*fake_layer1, get_output_dim()).WillByDefault(Return(4u));
+        ON_CALL(*fake_layer2, get_input_dim()).WillByDefault(Return(4u));
+        ON_CALL(*fake_layer2, get_output_dim()).WillByDefault(Return(3u));
+
+        EXPECT_CALL(*fake_layer1, get_input_dim()).Times(1);
+        EXPECT_CALL(*fake_layer1, get_output_dim()).Times(1);
+        EXPECT_CALL(*fake_layer2, get_input_dim()).Times(1);
+        EXPECT_CALL(*fake_layer2, get_output_dim()).Times(0);
+
+        LocalNeuralNetImp net({fake_layer1, fake_layer2});
+
+        GEOPM_EXPECT_THROW_MESSAGE(net.forward(inp4),
+                                   GEOPM_ERROR_INVALID,
+                                   "Input vector dimension is incompatible");
+
+        Mock::VerifyAndClearExpectations(fake_layer1.get());
+        Mock::VerifyAndClearExpectations(fake_layer2.get());
+    }
+}

--- a/test/LocalNeuralNetTest.cpp
+++ b/test/LocalNeuralNetTest.cpp
@@ -45,28 +45,28 @@ TEST_F(LocalNeuralNetTest, test_inference) {
     fake_layer2 = std::make_shared<MockDenseLayer>();
 
     TensorOneD inp2(
-            std::vector<float>(
+            std::vector<double>(
                 {1, 2}
                 ),
             fake_math
             );
 
     TensorOneD inp3(
-            std::vector<float>(
+            std::vector<double>(
                 {1, 2, 3}
                 ),
             fake_math
             );
 
     TensorOneD inp4(
-            std::vector<float>(
+            std::vector<double>(
                 {1, 2, 3, 4}
                 ),
             fake_math
             );
 
     TensorOneD inp4s(
-            std::vector<float>(
+            std::vector<double>(
                 {4, 0, 3, 1}
                 ),
             fake_math
@@ -101,21 +101,21 @@ TEST_F(LocalNeuralNetTest, test_bad_dimensions) {
     fake_layer2 = std::make_shared<MockDenseLayer>();
 
     TensorOneD inp2(
-            std::vector<float>(
+            std::vector<double>(
                 {1, 2}
                 ),
             fake_math
             );
 
     TensorOneD inp3(
-            std::vector<float>(
+            std::vector<double>(
                 {1, 2, 3}
                 ),
             fake_math
             );
 
     TensorOneD inp4(
-            std::vector<float>(
+            std::vector<double>(
                 {1, 2, 3, 4}
                 ),
             fake_math

--- a/test/LocalNeuralNetTest.cpp
+++ b/test/LocalNeuralNetTest.cpp
@@ -66,6 +66,12 @@ TEST_F(LocalNeuralNetTest, test_inference) {
 
 TEST_F(LocalNeuralNetTest, test_bad_dimensions) {
     {
+        GEOPM_EXPECT_THROW_MESSAGE(LocalNeuralNetImp({}),
+                                   GEOPM_ERROR_INVALID,
+                                   "Empty layers");
+    }
+
+    {
         GEOPM_EXPECT_THROW_MESSAGE(LocalNeuralNetImp({fake_layer2, fake_layer1}),
                                    GEOPM_ERROR_INVALID,
                                    "Incompatible dimensions for consecutive layers.");

--- a/test/LocalNeuralNetTest.cpp
+++ b/test/LocalNeuralNetTest.cpp
@@ -21,7 +21,6 @@ using geopm::TensorOneD;
 using geopm::DenseLayer;
 using geopm::LocalNeuralNet;
 using geopm::LocalNeuralNetImp;
-using geopm::MockDenseLayer;
 using ::testing::Mock;
 using ::testing::Return;
 using ::testing::_;

--- a/test/LocalNeuralNetTest.cpp
+++ b/test/LocalNeuralNetTest.cpp
@@ -30,41 +30,43 @@ class LocalNeuralNetTest : public ::testing::Test
 {
     protected:
         void SetUp() override;
-	std::shared_ptr<MockTensorMath> fake_math;
-	std::shared_ptr<MockDenseLayer> fake_layer1, fake_layer2;
-	TensorOneD inp2, inp3, inp4, inp4s;
+	std::shared_ptr<MockTensorMath> m_fake_math;
+	std::shared_ptr<MockDenseLayer> m_fake_layer1, m_fake_layer2;
+	TensorOneD m_inp2, m_inp3, m_inp4, m_inp4s;
 };
 
 void LocalNeuralNetTest::SetUp()
 {
-    fake_math = std::make_shared<MockTensorMath>();
+    m_fake_math = std::make_shared<MockTensorMath>();
 
-    inp2 = TensorOneD({1, 2}, fake_math);
-    inp3 = TensorOneD({1, 2, 3}, fake_math);
-    inp4 = TensorOneD({1, 2, 3, 4}, fake_math);
-    inp4s = TensorOneD({4, 0, 3, 1}, fake_math);
+    m_inp2 = TensorOneD({1, 2}, m_fake_math);
+    m_inp3 = TensorOneD({1, 2, 3}, m_fake_math);
+    m_inp4 = TensorOneD({1, 2, 3, 4}, m_fake_math);
+    m_inp4s = TensorOneD({4, 0, 3, 1}, m_fake_math);
 
-    fake_layer1 = std::make_shared<MockDenseLayer>();
-    fake_layer2 = std::make_shared<MockDenseLayer>();
+    m_fake_layer1 = std::make_shared<MockDenseLayer>();
+    m_fake_layer2 = std::make_shared<MockDenseLayer>();
 
-    EXPECT_CALL(*fake_layer1, get_input_dim()).WillRepeatedly(Return(2u));
-    EXPECT_CALL(*fake_layer1, get_output_dim()).WillRepeatedly(Return(4u));
-    EXPECT_CALL(*fake_layer2, get_input_dim()).WillRepeatedly(Return(4u));
-    EXPECT_CALL(*fake_layer2, get_output_dim()).WillRepeatedly(Return(3u));
+    EXPECT_CALL(*m_fake_layer1, get_input_dim()).WillRepeatedly(Return(2u));
+    EXPECT_CALL(*m_fake_layer1, get_output_dim()).WillRepeatedly(Return(4u));
+    EXPECT_CALL(*m_fake_layer2, get_input_dim()).WillRepeatedly(Return(4u));
+    EXPECT_CALL(*m_fake_layer2, get_output_dim()).WillRepeatedly(Return(3u));
 }
 
-TEST_F(LocalNeuralNetTest, test_inference) {
-    LocalNeuralNetImp net({fake_layer1, fake_layer2});
+TEST_F(LocalNeuralNetTest, test_inference)
+{
+    LocalNeuralNetImp net({m_fake_layer1, m_fake_layer2});
 
-    EXPECT_CALL(*fake_layer1, forward(TensorOneDEqualTo(inp2))).WillOnce(Return(inp4));
-    EXPECT_CALL(*fake_layer2, forward(TensorOneDEqualTo(inp4s))).WillOnce(Return(inp3));
+    EXPECT_CALL(*m_fake_layer1, forward(TensorOneDEqualTo(m_inp2))).WillOnce(Return(m_inp4));
+    EXPECT_CALL(*m_fake_layer2, forward(TensorOneDEqualTo(m_inp4s))).WillOnce(Return(m_inp3));
 
-    EXPECT_CALL(*fake_math, sigmoid(TensorOneDEqualTo(inp4))).WillOnce(Return(inp4s));
+    EXPECT_CALL(*m_fake_math, sigmoid(TensorOneDEqualTo(m_inp4))).WillOnce(Return(m_inp4s));
 
-    EXPECT_THAT(net.forward(inp2), TensorOneDEqualTo(inp3));
+    EXPECT_THAT(net.forward(m_inp2), TensorOneDEqualTo(m_inp3));
 }
 
-TEST_F(LocalNeuralNetTest, test_bad_dimensions) {
+TEST_F(LocalNeuralNetTest, test_bad_dimensions)
+{
     {
         GEOPM_EXPECT_THROW_MESSAGE(LocalNeuralNetImp({}),
                                    GEOPM_ERROR_INVALID,
@@ -72,15 +74,15 @@ TEST_F(LocalNeuralNetTest, test_bad_dimensions) {
     }
 
     {
-        GEOPM_EXPECT_THROW_MESSAGE(LocalNeuralNetImp({fake_layer2, fake_layer1}),
+        GEOPM_EXPECT_THROW_MESSAGE(LocalNeuralNetImp({m_fake_layer2, m_fake_layer1}),
                                    GEOPM_ERROR_INVALID,
                                    "Incompatible dimensions for consecutive layers.");
     }
 
     {
-        LocalNeuralNetImp net({fake_layer1, fake_layer2});
+        LocalNeuralNetImp net({m_fake_layer1, m_fake_layer2});
 
-        GEOPM_EXPECT_THROW_MESSAGE(net.forward(inp4),
+        GEOPM_EXPECT_THROW_MESSAGE(net.forward(m_inp4),
                                    GEOPM_ERROR_INVALID,
                                    "Input vector dimension is incompatible");
     }

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -309,9 +309,13 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/TensorMathTest.test_sigmoid \
               test/gtest_links/TensorMathTest.test_bad_dimensions \
               test/gtest_links/TensorMathTest.test_mat_prod \
-              test/gtest_links/TensorOneDTest.test_sum \
               test/gtest_links/TensorOneDTest.test_copy \
+              test/gtest_links/TensorOneDTest.test_diff \
               test/gtest_links/TensorOneDTest.test_input \
+              test/gtest_links/TensorOneDTest.test_equivalent \
+              test/gtest_links/TensorOneDTest.test_prod \
+              test/gtest_links/TensorOneDTest.test_sigmoid \
+              test/gtest_links/TensorOneDTest.test_sum \
               test/gtest_links/TensorOneDIntegrationTest.test_bad_dimensions \
               test/gtest_links/TensorOneDIntegrationTest.test_copy \
               test/gtest_links/TensorOneDIntegrationTest.test_diff \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -301,18 +301,18 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/SSTFrequencyLimitDetectorTest.detects_nearest_license_level_limit_bucket_0 \
               test/gtest_links/SSTFrequencyLimitDetectorTest.detects_nearest_license_level_limit_bucket_1 \
               test/gtest_links/SSTFrequencyLimitDetectorTest.limits_license_level_search_if_frequency_capped \
-              test/gtest_links/TensorMathTest.test_sum \
-              test/gtest_links/TensorMathTest.test_self_sum \
-              test/gtest_links/TensorMathTest.test_diff \
-              test/gtest_links/TensorMathTest.test_self_diff \
-              test/gtest_links/TensorMathTest.test_dot \
-              test/gtest_links/TensorMathTest.test_sigmoid \
               test/gtest_links/TensorMathTest.test_bad_dimensions \
+              test/gtest_links/TensorMathTest.test_diff \
+              test/gtest_links/TensorMathTest.test_dot \
               test/gtest_links/TensorMathTest.test_mat_prod \
+              test/gtest_links/TensorMathTest.test_self_sum \
+              test/gtest_links/TensorMathTest.test_self_diff \
+              test/gtest_links/TensorMathTest.test_sigmoid \
+              test/gtest_links/TensorMathTest.test_sum \
               test/gtest_links/TensorOneDTest.test_copy \
               test/gtest_links/TensorOneDTest.test_diff \
-              test/gtest_links/TensorOneDTest.test_input \
               test/gtest_links/TensorOneDTest.test_equivalent \
+              test/gtest_links/TensorOneDTest.test_input \
               test/gtest_links/TensorOneDTest.test_prod \
               test/gtest_links/TensorOneDTest.test_sigmoid \
               test/gtest_links/TensorOneDTest.test_sum \
@@ -321,21 +321,22 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/TensorOneDIntegrationTest.test_diff \
               test/gtest_links/TensorOneDIntegrationTest.test_dot \
               test/gtest_links/TensorOneDIntegrationTest.test_input \
-              test/gtest_links/TensorOneDIntegrationTest.test_sigmoid \
               test/gtest_links/TensorOneDIntegrationTest.test_self_diff \
               test/gtest_links/TensorOneDIntegrationTest.test_self_sum \
+              test/gtest_links/TensorOneDIntegrationTest.test_sigmoid \
               test/gtest_links/TensorOneDIntegrationTest.test_sum \
-              test/gtest_links/TensorTwoDTest.test_vector_product \
-              test/gtest_links/TensorTwoDTest.test_bad_dimensions \
-              test/gtest_links/TensorTwoDTest.test_empty_weights \
-              test/gtest_links/TensorTwoDTest.test_copy_constructor \
               test/gtest_links/TensorTwoDTest.test_array_overload \
-              test/gtest_links/TensorTwoDTest.test_input \
+              test/gtest_links/TensorTwoDTest.test_bad_dimensions \
+              test/gtest_links/TensorTwoDTest.test_copy_constructor \
+              test/gtest_links/TensorTwoDTest.test_copy \
               test/gtest_links/TensorTwoDTest.test_degenerate_size \
-              test/gtest_links/TensorTwoDTest.test_set_data \
+              test/gtest_links/TensorTwoDTest.test_empty_weights \
               test/gtest_links/TensorTwoDTest.test_equality \
-              test/gtest_links/TensorTwoDIntegrationTest.test_mat_prod \
+              test/gtest_links/TensorTwoDTest.test_input \
+              test/gtest_links/TensorTwoDTest.test_set_data \
+              test/gtest_links/TensorTwoDTest.test_vector_product \
               test/gtest_links/TensorTwoDIntegrationTest.test_bad_dimensions \
+              test/gtest_links/TensorTwoDIntegrationTest.test_mat_prod \
               test/gtest_links/TracerTest.columns \
               test/gtest_links/TracerTest.region_entry_exit \
               test/gtest_links/TracerTest.update_samples \
@@ -393,10 +394,10 @@ if ENABLE_BETA
                    test/gtest_links/FFNetAgentTest.trace_names_no_gpu \
                    test/gtest_links/FFNetAgentTest.trace_values \
                    test/gtest_links/FFNetAgentTest.trace_values_no_gpu \
-                   test/gtest_links/FFNetAgentTest.validate_badsize_policy \
                    test/gtest_links/FFNetAgentTest.validate_badphi_policy\
-                   test/gtest_links/FFNetAgentTest.validate_good_policy\
+                   test/gtest_links/FFNetAgentTest.validate_badsize_policy \
                    test/gtest_links/FFNetAgentTest.validate_empty_policy \
+                   test/gtest_links/FFNetAgentTest.validate_good_policy\
                    test/gtest_links/GPUActivityAgentTest.name \
                    test/gtest_links/GPUActivityAgentTest.validate_policy \
                    test/gtest_links/GPUActivityAgentTest.adjust_platform_high \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -170,7 +170,9 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/FilePolicyTest.parse_json_file \
               test/gtest_links/FilePolicyTest.negative_bad_files \
               test/gtest_links/FilePolicyTest.negative_parse_json_file \
+              test/gtest_links/FFNetAgentTest.test_adjust_platform_all \
               test/gtest_links/FFNetAgentTest.test_adjust_platform_nans \
+              test/gtest_links/FFNetAgentTest.test_adjust_platform_no_gpu \
               test/gtest_links/FFNetAgentTest.test_validate_badsize_policy \
               test/gtest_links/FFNetAgentTest.test_validate_badphi_policy\
               test/gtest_links/FFNetAgentTest.test_validate_good_policy\

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -100,6 +100,8 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/DebugIOGroupTest.read_signal \
               test/gtest_links/DebugIOGroupTest.register_signal_error \
               test/gtest_links/DebugIOGroupTest.sample \
+              test/gtest_links/DenseLayerTest.test_bad_dimensions \
+              test/gtest_links/DenseLayerTest.test_inference \
               test/gtest_links/EditDistEpochRecordFilterTest.one_region_repeated \
               test/gtest_links/EditDistEpochRecordFilterTest.filter_in \
               test/gtest_links/EditDistEpochRecordFilterTest.filter_out \
@@ -435,6 +437,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/ControllerTest.cpp \
                           test/CSVTest.cpp \
                           test/DebugIOGroupTest.cpp \
+                          test/DenseLayerTest.cpp \
                           test/EditDistEpochRecordFilterTest.cpp \
                           test/EditDistPeriodicityDetectorTest.cpp \
                           test/EndpointTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -301,6 +301,9 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/TensorMathTest.test_sigmoid \
               test/gtest_links/TensorMathTest.test_bad_dimensions \
               test/gtest_links/TensorMathTest.test_mat_prod \
+              test/gtest_links/TensorOneDTest.test_sum \
+              test/gtest_links/TensorOneDTest.test_copy \
+              test/gtest_links/TensorOneDTest.test_input \
               test/gtest_links/TensorOneDIntegrationTest.test_bad_dimensions \
               test/gtest_links/TensorOneDIntegrationTest.test_copy \
               test/gtest_links/TensorOneDIntegrationTest.test_diff \
@@ -310,17 +313,15 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/TensorOneDIntegrationTest.test_self_diff \
               test/gtest_links/TensorOneDIntegrationTest.test_self_sum \
               test/gtest_links/TensorOneDIntegrationTest.test_sum \
-              test/gtest_links/TensorOneDTest.test_sum \
-              test/gtest_links/TensorOneDTest.test_copy \
-              test/gtest_links/TensorOneDTest.test_input \
+              test/gtest_links/TensorTwoDTest.test_vector_product \
+              test/gtest_links/TensorTwoDTest.test_bad_dimensions \
+              test/gtest_links/TensorTwoDTest.test_empty_weights \
+              test/gtest_links/TensorTwoDTest.test_copy_constructor \
+              test/gtest_links/TensorTwoDTest.test_array_overload \
+              test/gtest_links/TensorTwoDTest.test_input \
+              test/gtest_links/TensorTwoDTest.test_degenerate_size \
               test/gtest_links/TensorTwoDIntegrationTest.test_mat_prod \
-              test/gtest_links/TensorTwoDIntegrationTest.test_copy \
-              test/gtest_links/TensorTwoDIntegrationTest.test_copy_constructor \
-              test/gtest_links/TensorTwoDIntegrationTest.test_array_overload \
-              test/gtest_links/TensorTwoDIntegrationTest.test_input \
-              test/gtest_links/TensorTwoDIntegrationTest.test_degenerate_size \
               test/gtest_links/TensorTwoDIntegrationTest.test_bad_dimensions \
-              test/gtest_links/TensorTwoDIntegrationTest.test_empty_weights \
               test/gtest_links/TracerTest.columns \
               test/gtest_links/TracerTest.region_entry_exit \
               test/gtest_links/TracerTest.update_samples \
@@ -497,8 +498,9 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/SSTClosGovernorTest.cpp \
                           test/SSTFrequencyLimitDetectorTest.cpp \
                           test/TensorMathTest.cpp \
-                          test/TensorOneDIntegrationTest.cpp \
                           test/TensorOneDTest.cpp \
+                          test/TensorOneDIntegrationTest.cpp \
+                          test/TensorTwoDTest.cpp \
                           test/TensorTwoDIntegrationTest.cpp \
                           test/TracerTest.cpp \
                           test/TreeCommLevelTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -293,6 +293,34 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/SSTFrequencyLimitDetectorTest.detects_nearest_license_level_limit_bucket_0 \
               test/gtest_links/SSTFrequencyLimitDetectorTest.detects_nearest_license_level_limit_bucket_1 \
               test/gtest_links/SSTFrequencyLimitDetectorTest.limits_license_level_search_if_frequency_capped \
+              test/gtest_links/TensorMathTest.test_sum \
+              test/gtest_links/TensorMathTest.test_self_sum \
+              test/gtest_links/TensorMathTest.test_diff \
+              test/gtest_links/TensorMathTest.test_self_diff \
+              test/gtest_links/TensorMathTest.test_dot \
+              test/gtest_links/TensorMathTest.test_sigmoid \
+              test/gtest_links/TensorMathTest.test_bad_dimensions \
+              test/gtest_links/TensorMathTest.test_mat_prod \
+              test/gtest_links/TensorOneDIntegrationTest.test_bad_dimensions \
+              test/gtest_links/TensorOneDIntegrationTest.test_copy \
+              test/gtest_links/TensorOneDIntegrationTest.test_diff \
+              test/gtest_links/TensorOneDIntegrationTest.test_dot \
+              test/gtest_links/TensorOneDIntegrationTest.test_input \
+              test/gtest_links/TensorOneDIntegrationTest.test_sigmoid \
+              test/gtest_links/TensorOneDIntegrationTest.test_self_diff \
+              test/gtest_links/TensorOneDIntegrationTest.test_self_sum \
+              test/gtest_links/TensorOneDIntegrationTest.test_sum \
+              test/gtest_links/TensorOneDTest.test_sum \
+              test/gtest_links/TensorOneDTest.test_copy \
+              test/gtest_links/TensorOneDTest.test_input \
+              test/gtest_links/TensorTwoDIntegrationTest.test_mat_prod \
+              test/gtest_links/TensorTwoDIntegrationTest.test_copy \
+              test/gtest_links/TensorTwoDIntegrationTest.test_copy_constructor \
+              test/gtest_links/TensorTwoDIntegrationTest.test_array_overload \
+              test/gtest_links/TensorTwoDIntegrationTest.test_input \
+              test/gtest_links/TensorTwoDIntegrationTest.test_degenerate_size \
+              test/gtest_links/TensorTwoDIntegrationTest.test_bad_dimensions \
+              test/gtest_links/TensorTwoDIntegrationTest.test_empty_weights \
               test/gtest_links/TracerTest.columns \
               test/gtest_links/TracerTest.region_entry_exit \
               test/gtest_links/TracerTest.update_samples \
@@ -443,6 +471,8 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/MockSampleAggregator.hpp \
                           test/MockSharedMemory.hpp \
                           test/MockSSTClosGovernor.hpp \
+                          test/MockTensorMath.hpp \
+                          test/MockTracer.hpp \
                           test/MockTracer.hpp \
                           test/MockTreeComm.hpp \
                           test/MockTreeCommLevel.hpp \
@@ -466,6 +496,10 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/SchedTest.cpp \
                           test/SSTClosGovernorTest.cpp \
                           test/SSTFrequencyLimitDetectorTest.cpp \
+                          test/TensorMathTest.cpp \
+                          test/TensorOneDIntegrationTest.cpp \
+                          test/TensorOneDTest.cpp \
+                          test/TensorTwoDIntegrationTest.cpp \
                           test/TracerTest.cpp \
                           test/TreeCommLevelTest.cpp \
                           test/TreeCommTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -168,6 +168,10 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/FilePolicyTest.parse_json_file \
               test/gtest_links/FilePolicyTest.negative_bad_files \
               test/gtest_links/FilePolicyTest.negative_parse_json_file \
+              test/gtest_links/FFNetAgentTest.test_validate_badsize_policy \
+              test/gtest_links/FFNetAgentTest.test_validate_badphi_policy\
+              test/gtest_links/FFNetAgentTest.test_validate_good_policy\
+              test/gtest_links/FFNetAgentTest.test_validate_empty_policy \
               test/gtest_links/FrequencyGovernorTest.frequency_control_domain_default \
               test/gtest_links/FrequencyGovernorTest.adjust_platform \
               test/gtest_links/FrequencyGovernorTest.adjust_platform_clamping \
@@ -440,6 +444,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/EpochIOGroupTest.cpp \
                           test/EpochIOGroupIntegrationTest.cpp \
                           test/FilePolicyTest.cpp \
+                          test/FFNetAgentTest.cpp \
                           test/FrequencyGovernorTest.cpp \
                           test/FrequencyMapAgentTest.cpp \
                           test/InitControlTest.cpp \
@@ -451,6 +456,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/MockApplicationStatus.hpp \
                           test/MockComm.hpp \
                           test/MockControlMessage.hpp \
+                          test/MockDomainNetMap.hpp \
                           test/MockEndpoint.hpp \
                           test/MockEndpointPolicyTracer.hpp \
                           test/MockEndpointUser.hpp \
@@ -468,6 +474,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/MockProfileTable.hpp \
                           test/MockProfileTracer.hpp \
                           test/MockRecordFilter.hpp \
+                          test/MockRegionHintRecommender.hpp \
                           test/MockReporter.hpp \
                           test/MockSampleAggregator.hpp \
                           test/MockSharedMemory.hpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -170,6 +170,7 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/FilePolicyTest.parse_json_file \
               test/gtest_links/FilePolicyTest.negative_bad_files \
               test/gtest_links/FilePolicyTest.negative_parse_json_file \
+              test/gtest_links/FFNetAgentTest.test_adjust_platform_nans \
               test/gtest_links/FFNetAgentTest.test_validate_badsize_policy \
               test/gtest_links/FFNetAgentTest.test_validate_badphi_policy\
               test/gtest_links/FFNetAgentTest.test_validate_good_policy\

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -102,6 +102,8 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/DebugIOGroupTest.sample \
               test/gtest_links/DenseLayerTest.test_bad_dimensions \
               test/gtest_links/DenseLayerTest.test_inference \
+              test/gtest_links/DomainNetMapTest.test_json_parsing \
+              test/gtest_links/DomainNetMapTest.test_plumbing \
               test/gtest_links/EditDistEpochRecordFilterTest.one_region_repeated \
               test/gtest_links/EditDistEpochRecordFilterTest.filter_in \
               test/gtest_links/EditDistEpochRecordFilterTest.filter_out \
@@ -286,6 +288,8 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/RecordFilterTest.invalid_filter_name \
               test/gtest_links/RecordFilterTest.make_proxy_epoch \
               test/gtest_links/RecordFilterTest.make_edit_distance \
+              test/gtest_links/RegionHintRecommenderTest.test_json_parsing \
+              test/gtest_links/RegionHintRecommenderTest.test_plumbing \
               test/gtest_links/ReporterTest.generate \
               test/gtest_links/ReporterTest.generate_conditional \
               test/gtest_links/SampleAggregatorTest.epoch_application_total \
@@ -447,6 +451,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/CSVTest.cpp \
                           test/DebugIOGroupTest.cpp \
                           test/DenseLayerTest.cpp \
+                          test/DomainNetMapTest.cpp \
                           test/EditDistEpochRecordFilterTest.cpp \
                           test/EditDistPeriodicityDetectorTest.cpp \
                           test/EndpointTest.cpp \
@@ -514,6 +519,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/ProxyEpochRecordFilterTest.cpp \
                           test/ProcessRegionAggregatorTest.cpp \
                           test/RecordFilterTest.cpp \
+                          test/RegionHintRecommenderTest.cpp \
                           test/ReporterTest.cpp \
                           test/SampleAggregatorTest.cpp \
                           test/SchedTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -172,19 +172,6 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/FilePolicyTest.parse_json_file \
               test/gtest_links/FilePolicyTest.negative_bad_files \
               test/gtest_links/FilePolicyTest.negative_parse_json_file \
-              test/gtest_links/FFNetAgentTest.adjust_platform_all \
-              test/gtest_links/FFNetAgentTest.adjust_platform_nans \
-              test/gtest_links/FFNetAgentTest.adjust_platform_no_gpu \
-              test/gtest_links/FFNetAgentTest.sample_platform \
-              test/gtest_links/FFNetAgentTest.sample_platform_no_gpu \
-              test/gtest_links/FFNetAgentTest.trace_names \
-              test/gtest_links/FFNetAgentTest.trace_names_no_gpu \
-              test/gtest_links/FFNetAgentTest.trace_values \
-              test/gtest_links/FFNetAgentTest.trace_values_no_gpu \
-              test/gtest_links/FFNetAgentTest.validate_badsize_policy \
-              test/gtest_links/FFNetAgentTest.validate_badphi_policy\
-              test/gtest_links/FFNetAgentTest.validate_good_policy\
-              test/gtest_links/FFNetAgentTest.validate_empty_policy \
               test/gtest_links/FrequencyGovernorTest.frequency_control_domain_default \
               test/gtest_links/FrequencyGovernorTest.adjust_platform \
               test/gtest_links/FrequencyGovernorTest.adjust_platform_clamping \
@@ -389,6 +376,19 @@ if ENABLE_BETA
                    test/gtest_links/CPUActivityAgentTest.invalid_fe_uncore_high \
                    test/gtest_links/DaemonTest.get_default_policy \
                    test/gtest_links/DaemonTest.get_profile_policy \
+                   test/gtest_links/FFNetAgentTest.adjust_platform_all \
+                   test/gtest_links/FFNetAgentTest.adjust_platform_nans \
+                   test/gtest_links/FFNetAgentTest.adjust_platform_no_gpu \
+                   test/gtest_links/FFNetAgentTest.sample_platform \
+                   test/gtest_links/FFNetAgentTest.sample_platform_no_gpu \
+                   test/gtest_links/FFNetAgentTest.trace_names \
+                   test/gtest_links/FFNetAgentTest.trace_names_no_gpu \
+                   test/gtest_links/FFNetAgentTest.trace_values \
+                   test/gtest_links/FFNetAgentTest.trace_values_no_gpu \
+                   test/gtest_links/FFNetAgentTest.validate_badsize_policy \
+                   test/gtest_links/FFNetAgentTest.validate_badphi_policy\
+                   test/gtest_links/FFNetAgentTest.validate_good_policy\
+                   test/gtest_links/FFNetAgentTest.validate_empty_policy \
                    test/gtest_links/GPUActivityAgentTest.name \
                    test/gtest_links/GPUActivityAgentTest.validate_policy \
                    test/gtest_links/GPUActivityAgentTest.adjust_platform_high \
@@ -463,7 +463,6 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/EpochIOGroupTest.cpp \
                           test/EpochIOGroupIntegrationTest.cpp \
                           test/FilePolicyTest.cpp \
-                          test/FFNetAgentTest.cpp \
                           test/FrequencyGovernorTest.cpp \
                           test/FrequencyMapAgentTest.cpp \
                           test/InitControlTest.cpp \
@@ -549,6 +548,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
 
 beta_test_sources = test/CPUActivityAgentTest.cpp \
                     test/DaemonTest.cpp \
+                    test/FFNetAgentTest.cpp \
                     test/GPUActivityAgentTest.cpp \
                     test/MockPolicyStore.hpp \
                     test/PolicyStoreImpTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -328,6 +328,8 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/TensorTwoDTest.test_array_overload \
               test/gtest_links/TensorTwoDTest.test_input \
               test/gtest_links/TensorTwoDTest.test_degenerate_size \
+              test/gtest_links/TensorTwoDTest.test_set_data \
+              test/gtest_links/TensorTwoDTest.test_equality \
               test/gtest_links/TensorTwoDIntegrationTest.test_mat_prod \
               test/gtest_links/TensorTwoDIntegrationTest.test_bad_dimensions \
               test/gtest_links/TracerTest.columns \
@@ -379,6 +381,8 @@ if ENABLE_BETA
                    test/gtest_links/FFNetAgentTest.adjust_platform_all \
                    test/gtest_links/FFNetAgentTest.adjust_platform_nans \
                    test/gtest_links/FFNetAgentTest.adjust_platform_no_gpu \
+                   test/gtest_links/FFNetAgentTest.agent_name \
+                   test/gtest_links/FFNetAgentTest.policy_names \
                    test/gtest_links/FFNetAgentTest.sample_platform \
                    test/gtest_links/FFNetAgentTest.sample_platform_no_gpu \
                    test/gtest_links/FFNetAgentTest.trace_names \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -214,6 +214,8 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/InitControlTest.parse_empty_file_name \
               test/gtest_links/InitControlTest.throw_bad_input \
               test/gtest_links/InitControlTest.throw_invalid_write \
+              test/gtest_links/LocalNeuralNetTest.test_bad_dimensions \
+              test/gtest_links/LocalNeuralNetTest.test_inference \
               test/gtest_links/ModelApplicationTest.parse_config_errors \
               test/gtest_links/MonitorAgentTest.policy_names \
               test/gtest_links/MonitorAgentTest.sample_names \
@@ -465,6 +467,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/FrequencyGovernorTest.cpp \
                           test/FrequencyMapAgentTest.cpp \
                           test/InitControlTest.cpp \
+                          test/LocalNeuralNetTest.cpp \
                           test/MockAgent.hpp \
                           test/MockApplicationIO.hpp \
                           test/MockApplicationRecordLog.hpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -507,8 +507,12 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/TensorMathTest.cpp \
                           test/TensorOneDTest.cpp \
                           test/TensorOneDIntegrationTest.cpp \
+                          test/TensorOneDMatcher.cpp \
+                          test/TensorOneDMatcher.hpp \
                           test/TensorTwoDTest.cpp \
                           test/TensorTwoDIntegrationTest.cpp \
+                          test/TensorTwoDMatcher.cpp \
+                          test/TensorTwoDMatcher.hpp \
                           test/TracerTest.cpp \
                           test/TreeCommLevelTest.cpp \
                           test/TreeCommTest.cpp \

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -170,13 +170,19 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/FilePolicyTest.parse_json_file \
               test/gtest_links/FilePolicyTest.negative_bad_files \
               test/gtest_links/FilePolicyTest.negative_parse_json_file \
-              test/gtest_links/FFNetAgentTest.test_adjust_platform_all \
-              test/gtest_links/FFNetAgentTest.test_adjust_platform_nans \
-              test/gtest_links/FFNetAgentTest.test_adjust_platform_no_gpu \
-              test/gtest_links/FFNetAgentTest.test_validate_badsize_policy \
-              test/gtest_links/FFNetAgentTest.test_validate_badphi_policy\
-              test/gtest_links/FFNetAgentTest.test_validate_good_policy\
-              test/gtest_links/FFNetAgentTest.test_validate_empty_policy \
+              test/gtest_links/FFNetAgentTest.adjust_platform_all \
+              test/gtest_links/FFNetAgentTest.adjust_platform_nans \
+              test/gtest_links/FFNetAgentTest.adjust_platform_no_gpu \
+              test/gtest_links/FFNetAgentTest.sample_platform \
+              test/gtest_links/FFNetAgentTest.sample_platform_no_gpu \
+              test/gtest_links/FFNetAgentTest.trace_names \
+              test/gtest_links/FFNetAgentTest.trace_names_no_gpu \
+              test/gtest_links/FFNetAgentTest.trace_values \
+              test/gtest_links/FFNetAgentTest.trace_values_no_gpu \
+              test/gtest_links/FFNetAgentTest.validate_badsize_policy \
+              test/gtest_links/FFNetAgentTest.validate_badphi_policy\
+              test/gtest_links/FFNetAgentTest.validate_good_policy\
+              test/gtest_links/FFNetAgentTest.validate_empty_policy \
               test/gtest_links/FrequencyGovernorTest.frequency_control_domain_default \
               test/gtest_links/FrequencyGovernorTest.adjust_platform \
               test/gtest_links/FrequencyGovernorTest.adjust_platform_clamping \
@@ -462,14 +468,17 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/MockApplicationStatus.hpp \
                           test/MockComm.hpp \
                           test/MockControlMessage.hpp \
+                          test/MockDenseLayer.hpp \
                           test/MockDomainNetMap.hpp \
                           test/MockEndpoint.hpp \
                           test/MockEndpointPolicyTracer.hpp \
                           test/MockEndpointUser.hpp \
                           test/MockFrequencyLimitDetector.hpp \
                           test/MockFrequencyGovernor.hpp \
+                          test/MockLocalNeuralNet.hpp \
                           test/MockIOGroup.hpp \
                           test/MockInitControl.hpp \
+                          test/MockNNFactory.hpp \
                           test/MockPlatformTopo.cpp \
                           test/MockPlatformTopo.hpp \
                           test/MockPlatformIO.hpp \

--- a/test/MockDenseLayer.hpp
+++ b/test/MockDenseLayer.hpp
@@ -10,15 +10,13 @@
 #include "DenseLayer.hpp"
 #include "TensorOneD.hpp"
 
-namespace geopm {
-
-class MockDenseLayer : public DenseLayer {
- public:
-  MOCK_METHOD(TensorOneD, forward, (const TensorOneD &input), (const override));
-  MOCK_METHOD(size_t, get_input_dim, (), (const override));
-  MOCK_METHOD(size_t, get_output_dim, (), (const override));
+class MockDenseLayer : public geopm::DenseLayer
+{
+    public:
+        MOCK_METHOD(geopm::TensorOneD, forward, (const geopm::TensorOneD &input),
+                    (const override));
+        MOCK_METHOD(size_t, get_input_dim, (), (const override));
+        MOCK_METHOD(size_t, get_output_dim, (), (const override));
 };
-
-}  // namespace geopm
 
 #endif //MOCKDenseLayer_HPP_INCLUDE

--- a/test/MockDenseLayer.hpp
+++ b/test/MockDenseLayer.hpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOCKDENSELAYER_HPP_INCLUDE
+#define MOCKDENSELAYER_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+#include "DenseLayer.hpp"
+#include "TensorOneD.hpp"
+
+namespace geopm {
+
+class MockDenseLayer : public DenseLayer {
+ public:
+  MOCK_METHOD(TensorOneD, forward, (const TensorOneD &input), (const override));
+  MOCK_METHOD(size_t, get_input_dim, (), (const override));
+  MOCK_METHOD(size_t, get_output_dim, (), (const override));
+};
+
+}  // namespace geopm
+
+#endif //MOCKDenseLayer_HPP_INCLUDE

--- a/test/MockDomainNetMap.hpp
+++ b/test/MockDomainNetMap.hpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOCKDOMAINNETMAP_HPP_INCLUDE
+#define MOCKDOMAINNETMAP_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+#include "DomainNetMap.hpp"
+
+namespace geopm {
+
+class MockDomainNetMap : public DomainNetMap {
+ public:
+  MOCK_METHOD(void, sample, (), (override));
+  MOCK_METHOD(std::vector<std::string>, trace_names, (), (const, override));
+  MOCK_METHOD(std::vector<double>, trace_values, (), (const, override));
+  MOCK_METHOD((std::map<std::string, float>), last_output, (), (const, override));
+};
+
+}  // namespace geopm
+
+#endif //MOCKDOMAINNETMAP_HPP_INCLUDE

--- a/test/MockDomainNetMap.hpp
+++ b/test/MockDomainNetMap.hpp
@@ -9,16 +9,13 @@
 #include "gmock/gmock.h"
 #include "DomainNetMap.hpp"
 
-namespace geopm {
-
-class MockDomainNetMap : public DomainNetMap {
- public:
-  MOCK_METHOD(void, sample, (), (override));
-  MOCK_METHOD(std::vector<std::string>, trace_names, (), (const, override));
-  MOCK_METHOD(std::vector<double>, trace_values, (), (const, override));
-  MOCK_METHOD((std::map<std::string, double>), last_output, (), (const, override));
+class MockDomainNetMap : public geopm::DomainNetMap
+{
+    public:
+        MOCK_METHOD(void, sample, (), (override));
+        MOCK_METHOD(std::vector<std::string>, trace_names, (), (const, override));
+        MOCK_METHOD(std::vector<double>, trace_values, (), (const, override));
+        MOCK_METHOD((std::map<std::string, double>), last_output, (), (const, override));
 };
-
-}  // namespace geopm
 
 #endif //MOCKDOMAINNETMAP_HPP_INCLUDE

--- a/test/MockDomainNetMap.hpp
+++ b/test/MockDomainNetMap.hpp
@@ -16,7 +16,7 @@ class MockDomainNetMap : public DomainNetMap {
   MOCK_METHOD(void, sample, (), (override));
   MOCK_METHOD(std::vector<std::string>, trace_names, (), (const, override));
   MOCK_METHOD(std::vector<double>, trace_values, (), (const, override));
-  MOCK_METHOD((std::map<std::string, float>), last_output, (), (const, override));
+  MOCK_METHOD((std::map<std::string, double>), last_output, (), (const, override));
 };
 
 }  // namespace geopm

--- a/test/MockLocalNeuralNet.hpp
+++ b/test/MockLocalNeuralNet.hpp
@@ -14,6 +14,8 @@ namespace geopm {
 class MockLocalNeuralNet : public LocalNeuralNet {
  public:
   MOCK_METHOD(TensorOneD, forward, (const TensorOneD &input), (const override));
+  MOCK_METHOD(size_t, get_input_dim, (), (const override));
+  MOCK_METHOD(size_t, get_output_dim, (), (const override));
 };
 
 }  // namespace geopm

--- a/test/MockLocalNeuralNet.hpp
+++ b/test/MockLocalNeuralNet.hpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOCKLOCALNEURALNET_HPP_INCLUDE
+#define MOCKLOCALNEURALNET_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+#include "LocalNeuralNet.hpp"
+
+namespace geopm {
+
+class MockLocalNeuralNet : public LocalNeuralNet {
+ public:
+  MOCK_METHOD(TensorOneD, forward, (const TensorOneD &input), (const override));
+};
+
+}  // namespace geopm
+
+#endif //MOCKLOCALNEURALNET_HPP_INCLUDE

--- a/test/MockLocalNeuralNet.hpp
+++ b/test/MockLocalNeuralNet.hpp
@@ -9,15 +9,13 @@
 #include "gmock/gmock.h"
 #include "LocalNeuralNet.hpp"
 
-namespace geopm {
-
-class MockLocalNeuralNet : public LocalNeuralNet {
- public:
-  MOCK_METHOD(TensorOneD, forward, (const TensorOneD &input), (const override));
-  MOCK_METHOD(size_t, get_input_dim, (), (const override));
-  MOCK_METHOD(size_t, get_output_dim, (), (const override));
+class MockLocalNeuralNet : public geopm::LocalNeuralNet
+{
+    public:
+        MOCK_METHOD(geopm::TensorOneD, forward, (const geopm::TensorOneD &input),
+                    (const override));
+        MOCK_METHOD(size_t, get_input_dim, (), (const override));
+        MOCK_METHOD(size_t, get_output_dim, (), (const override));
 };
-
-}  // namespace geopm
 
 #endif //MOCKLOCALNEURALNET_HPP_INCLUDE

--- a/test/MockNNFactory.hpp
+++ b/test/MockNNFactory.hpp
@@ -9,16 +9,20 @@
 #include "gmock/gmock.h"
 #include "NNFactory.hpp"
 
-namespace geopm {
-
-class MockNNFactory : public NNFactory {
- public:
-  MOCK_METHOD(std::shared_ptr<LocalNeuralNet>, createLocalNeuralNet, (const std::vector<std::shared_ptr<DenseLayer>> &layers), (const, override));
-  MOCK_METHOD(std::shared_ptr<DenseLayer>, createDenseLayer, (const TensorTwoD &weights, const TensorOneD &biases), (const, override));
-  MOCK_METHOD(TensorTwoD, createTensorTwoD, (const std::vector<std::vector<double>> &vals), (const, override));
-  MOCK_METHOD(TensorOneD, createTensorOneD, (const std::vector<double> &vals), (const, override));
+class MockNNFactory : public geopm::NNFactory
+{
+    public:
+        MOCK_METHOD(std::shared_ptr<geopm::LocalNeuralNet>, createLocalNeuralNet,
+                    (const std::vector<std::shared_ptr<geopm::DenseLayer>> &layers),
+                    (const, override));
+        MOCK_METHOD(std::shared_ptr<geopm::DenseLayer>, createDenseLayer,
+                    (const geopm::TensorTwoD &weights, const geopm::TensorOneD &biases),
+                    (const, override));
+        MOCK_METHOD(geopm::TensorTwoD, createTensorTwoD,
+                    (const std::vector<std::vector<double>> &vals),
+                    (const, override));
+        MOCK_METHOD(geopm::TensorOneD, createTensorOneD, (const std::vector<double> &vals),
+                    (const, override));
 };
-
-}  // namespace geopm
 
 #endif // MOCKNNFACTORY_HPP_INCLUDE

--- a/test/MockNNFactory.hpp
+++ b/test/MockNNFactory.hpp
@@ -13,7 +13,7 @@ namespace geopm {
 
 class MockNNFactory : public NNFactory {
  public:
-  MOCK_METHOD(std::unique_ptr<LocalNeuralNet>, createLocalNeuralNet, (const std::vector<std::shared_ptr<DenseLayer>> &layers), (const, override));
+  MOCK_METHOD(std::shared_ptr<LocalNeuralNet>, createLocalNeuralNet, (const std::vector<std::shared_ptr<DenseLayer>> &layers), (const, override));
   MOCK_METHOD(std::shared_ptr<DenseLayer>, createDenseLayer, (const TensorTwoD &weights, const TensorOneD &biases), (const, override));
   MOCK_METHOD(TensorTwoD, createTensorTwoD, (const std::vector<std::vector<float>> &vals), (const, override));
   MOCK_METHOD(TensorOneD, createTensorOneD, (const std::vector<float> &vals), (const, override));

--- a/test/MockNNFactory.hpp
+++ b/test/MockNNFactory.hpp
@@ -15,8 +15,8 @@ class MockNNFactory : public NNFactory {
  public:
   MOCK_METHOD(std::shared_ptr<LocalNeuralNet>, createLocalNeuralNet, (const std::vector<std::shared_ptr<DenseLayer>> &layers), (const, override));
   MOCK_METHOD(std::shared_ptr<DenseLayer>, createDenseLayer, (const TensorTwoD &weights, const TensorOneD &biases), (const, override));
-  MOCK_METHOD(TensorTwoD, createTensorTwoD, (const std::vector<std::vector<float>> &vals), (const, override));
-  MOCK_METHOD(TensorOneD, createTensorOneD, (const std::vector<float> &vals), (const, override));
+  MOCK_METHOD(TensorTwoD, createTensorTwoD, (const std::vector<std::vector<double>> &vals), (const, override));
+  MOCK_METHOD(TensorOneD, createTensorOneD, (const std::vector<double> &vals), (const, override));
 };
 
 }  // namespace geopm

--- a/test/MockNNFactory.hpp
+++ b/test/MockNNFactory.hpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOCKNNFACTORY_HPP_INCLUDE
+#define MOCKNNFACTORY_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+#include "NNFactory.hpp"
+
+namespace geopm {
+
+class MockNNFactory : public NNFactory {
+ public:
+  MOCK_METHOD(std::unique_ptr<LocalNeuralNet>, createLocalNeuralNet, (const std::vector<std::shared_ptr<DenseLayer>> &layers), (const, override));
+  MOCK_METHOD(std::shared_ptr<DenseLayer>, createDenseLayer, (const TensorTwoD &weights, const TensorOneD &biases), (const, override));
+  MOCK_METHOD(TensorTwoD, createTensorTwoD, (const std::vector<std::vector<float>> &vals), (const, override));
+  MOCK_METHOD(TensorOneD, createTensorOneD, (const std::vector<float> &vals), (const, override));
+};
+
+}  // namespace geopm
+
+#endif // MOCKNNFACTORY_HPP_INCLUDE

--- a/test/MockRegionHintRecommender.hpp
+++ b/test/MockRegionHintRecommender.hpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOCKREGIONHINTRECOMMENDER_HPP_INCLUDE
+#define MOCKREGIONHINTRECOMMENDER_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+#include "RegionHintRecommender.hpp"
+
+namespace geopm {
+
+class MockRegionHintRecommender : public RegionHintRecommender {
+ public:
+  MOCK_METHOD(double, recommend_frequency, ((std::map<std::string, float> region_class), double phi), (const, override));
+};
+
+}  // namespace geopm
+#endif //MOCKREGIONHINTRECOMMENDER_HPP_INCLUDE

--- a/test/MockRegionHintRecommender.hpp
+++ b/test/MockRegionHintRecommender.hpp
@@ -13,7 +13,9 @@ namespace geopm {
 
 class MockRegionHintRecommender : public RegionHintRecommender {
  public:
-  MOCK_METHOD(double, recommend_frequency, ((std::map<std::string, double> region_class), double phi), (const, override));
+  MOCK_METHOD(double, recommend_frequency,
+              ((const std::map<std::string, double> &region_class), double phi),
+              (const, override));
 };
 
 }  // namespace geopm

--- a/test/MockRegionHintRecommender.hpp
+++ b/test/MockRegionHintRecommender.hpp
@@ -13,7 +13,7 @@ namespace geopm {
 
 class MockRegionHintRecommender : public RegionHintRecommender {
  public:
-  MOCK_METHOD(double, recommend_frequency, ((std::map<std::string, float> region_class), double phi), (const, override));
+  MOCK_METHOD(double, recommend_frequency, ((std::map<std::string, double> region_class), double phi), (const, override));
 };
 
 }  // namespace geopm

--- a/test/MockRegionHintRecommender.hpp
+++ b/test/MockRegionHintRecommender.hpp
@@ -9,14 +9,12 @@
 #include "gmock/gmock.h"
 #include "RegionHintRecommender.hpp"
 
-namespace geopm {
-
-class MockRegionHintRecommender : public RegionHintRecommender {
- public:
-  MOCK_METHOD(double, recommend_frequency,
-              ((const std::map<std::string, double> &region_class), double phi),
-              (const, override));
+class MockRegionHintRecommender : public geopm::RegionHintRecommender
+{
+    public:
+        MOCK_METHOD(double, recommend_frequency,
+                    ((const std::map<std::string, double> &region_class), double phi),
+                    (const, override));
 };
 
-}  // namespace geopm
 #endif //MOCKREGIONHINTRECOMMENDER_HPP_INCLUDE

--- a/test/MockTensorMath.hpp
+++ b/test/MockTensorMath.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOCKTENSORMATH_HPP_INCLUDE
+#define MOCKTENSORMATH_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "TensorMath.hpp"
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+// TODO figure out how to move this inside the class below
+using geopm::TensorMath;
+using geopm::TensorOneD;
+using geopm::TensorTwoD;
+
+class MockTensorMath : public geopm::TensorMath {
+    public:
+        MOCK_METHOD(TensorOneD, add, (const TensorOneD& tensor_a, const TensorOneD& tensor_b), (const, override));
+        MOCK_METHOD(TensorOneD, subtract, (const TensorOneD& tensor_a, const TensorOneD& tensor_b), (const, override));
+        MOCK_METHOD(float, inner_product, (const TensorOneD& tensor_a, const TensorOneD& tensor_b), (const, override));
+        MOCK_METHOD(TensorOneD, sigmoid, (const TensorOneD& tensor), (const, override));
+        MOCK_METHOD(TensorOneD, multiply, (const TensorTwoD& tensor_a, const TensorOneD& tensor_b), (const, override));
+};
+
+#endif

--- a/test/MockTensorMath.hpp
+++ b/test/MockTensorMath.hpp
@@ -21,7 +21,7 @@ class MockTensorMath : public geopm::TensorMath {
     public:
         MOCK_METHOD(TensorOneD, add, (const TensorOneD& tensor_a, const TensorOneD& tensor_b), (const, override));
         MOCK_METHOD(TensorOneD, subtract, (const TensorOneD& tensor_a, const TensorOneD& tensor_b), (const, override));
-        MOCK_METHOD(float, inner_product, (const TensorOneD& tensor_a, const TensorOneD& tensor_b), (const, override));
+        MOCK_METHOD(double, inner_product, (const TensorOneD& tensor_a, const TensorOneD& tensor_b), (const, override));
         MOCK_METHOD(TensorOneD, sigmoid, (const TensorOneD& tensor), (const, override));
         MOCK_METHOD(TensorOneD, multiply, (const TensorTwoD& tensor_a, const TensorOneD& tensor_b), (const, override));
 };

--- a/test/MockTensorMath.hpp
+++ b/test/MockTensorMath.hpp
@@ -12,18 +12,19 @@
 #include "TensorOneD.hpp"
 #include "TensorTwoD.hpp"
 
-// TODO figure out how to move this inside the class below
-using geopm::TensorMath;
-using geopm::TensorOneD;
-using geopm::TensorTwoD;
-
-class MockTensorMath : public geopm::TensorMath {
+class MockTensorMath : public geopm::TensorMath
+{
     public:
-        MOCK_METHOD(TensorOneD, add, (const TensorOneD& tensor_a, const TensorOneD& tensor_b), (const, override));
-        MOCK_METHOD(TensorOneD, subtract, (const TensorOneD& tensor_a, const TensorOneD& tensor_b), (const, override));
-        MOCK_METHOD(double, inner_product, (const TensorOneD& tensor_a, const TensorOneD& tensor_b), (const, override));
-        MOCK_METHOD(TensorOneD, sigmoid, (const TensorOneD& tensor), (const, override));
-        MOCK_METHOD(TensorOneD, multiply, (const TensorTwoD& tensor_a, const TensorOneD& tensor_b), (const, override));
+        MOCK_METHOD(geopm::TensorOneD, add, (const geopm::TensorOneD& tensor_a,
+                    const geopm::TensorOneD& tensor_b), (const, override));
+        MOCK_METHOD(geopm::TensorOneD, subtract, (const geopm::TensorOneD& tensor_a,
+                    const geopm::TensorOneD& tensor_b), (const, override));
+        MOCK_METHOD(double, inner_product, (const geopm::TensorOneD& tensor_a,
+                    const geopm::TensorOneD& tensor_b), (const, override));
+        MOCK_METHOD(geopm::TensorOneD, sigmoid, (const geopm::TensorOneD& tensor),
+                    (const, override));
+        MOCK_METHOD(geopm::TensorOneD, multiply, (const geopm::TensorTwoD& tensor_a,
+                    const geopm::TensorOneD& tensor_b), (const, override));
 };
 
 #endif

--- a/test/RegionHintRecommenderTest.cpp
+++ b/test/RegionHintRecommenderTest.cpp
@@ -65,38 +65,23 @@ TEST_F(RegionHintRecommenderTest, test_plumbing)
 
     RegionHintRecommenderImp hint_map(m_filename, 0, 1);
 
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"A", 1}}), 0),
-            0);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"A", 1}}), 0.25),
-            0);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"A", 1}}), 0.5),
-            8e7);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"A", 1}}), 0.75),
-            8e7);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"A", 1}}), 1),
-            0);
+    EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0), 0);
+    EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0.25), 0);
+    EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0.5), 8e7);
+    EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0.75), 8e7);
+    EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 1), 0);
 
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"B", 1}}), 0),
-            0);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"B", 1}}), 0.25),
-            1e8);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"B", 1}}), 0.5),
-            0);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"B", 1}}), 0.75),
-            1e8);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"B", 1}}), 1),
-            0);
+    EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 0), 0);
+    EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 0.25), 1e8);
+    EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 0.5), 0);
+    EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 0.75), 1e8);
+    EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 1), 0);
 
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"C", 1}}), 0),
-            3e7);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"C", 1}}), 0.25),
-            3e7);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"C", 1}}), 0.5),
-            3e7);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"C", 1}}), 0.75),
-            3e7);
-    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"C", 1}}), 1),
-            3e7);
+    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0), 3e7);
+    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0.25), 3e7);
+    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0.5), 3e7);
+    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0.75), 3e7);
+    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 1), 3e7);
 
-    EXPECT_NEAR(hint_map.recommend_frequency(std::map<std::string, float>({{"A", log(2)}, {"B", 0}, {"C", log(0.5)}}), 0.5), 5e7, 1e4);
+    EXPECT_NEAR(hint_map.recommend_frequency({{"A", log(2)}, {"B", 0}, {"C", log(0.5)}}, 0.5), 5e7, 1);
 }

--- a/test/RegionHintRecommenderTest.cpp
+++ b/test/RegionHintRecommenderTest.cpp
@@ -15,16 +15,8 @@
 #include "RegionHintRecommender.hpp"
 #include "RegionHintRecommenderImp.hpp"
 
-// TODO delete what isn't used
 using geopm::RegionHintRecommender;
 using geopm::RegionHintRecommenderImp;
-//using geopm::MockDenseLayer;
-//using geopm::MockLocalNeuralNet;
-//using geopm::MockNNFactory;
-//using ::testing::ByMove;
-//using ::testing::ElementsAre;
-//using ::testing::Mock;
-//using ::testing::Return;
 using ::testing::_;
 
 class RegionHintRecommenderTest : public ::testing::Test

--- a/test/RegionHintRecommenderTest.cpp
+++ b/test/RegionHintRecommenderTest.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <cmath>
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm/Exception.hpp"
+#include "geopm_test.hpp"
+
+#include "RegionHintRecommender.hpp"
+#include "RegionHintRecommenderImp.hpp"
+
+// TODO delete what isn't used
+using geopm::RegionHintRecommender;
+using geopm::RegionHintRecommenderImp;
+//using geopm::MockDenseLayer;
+//using geopm::MockLocalNeuralNet;
+//using geopm::MockNNFactory;
+//using ::testing::ByMove;
+//using ::testing::ElementsAre;
+//using ::testing::Mock;
+//using ::testing::Return;
+using ::testing::_;
+
+class RegionHintRecommenderTest : public ::testing::Test
+{
+    protected:
+        std::string m_filename = "freq_map_test.json";
+        void TearDown() override
+        {
+            std::remove(m_filename.c_str());
+        }
+};
+
+TEST_F(RegionHintRecommenderTest, test_json_parsing)
+{
+    {
+        std::ofstream bad_json(m_filename);
+        bad_json << "{[\"test\"]" << std::endl;
+        bad_json.close();
+
+        GEOPM_EXPECT_THROW_MESSAGE(
+                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        GEOPM_ERROR_INVALID,
+                        "Frequency map file format is incorrect");
+    }
+
+    {
+        std::ofstream bad_json(m_filename);
+        bad_json << "{\"A\": \"not this!\"}" << std::endl;
+        bad_json.close();
+
+        GEOPM_EXPECT_THROW_MESSAGE(
+                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        GEOPM_ERROR_INVALID,
+                        "Frequency map file format is incorrect");
+    }
+
+}
+
+TEST_F(RegionHintRecommenderTest, test_plumbing)
+{
+    std::ofstream good_json(m_filename);
+    good_json << "{\"A\": [0, 0.8, 0],"
+                 "\"B\": [0, 1, 0, 1, 0],"
+                 "\"C\": [0.3]}" << std::endl;
+    good_json.close();
+
+    RegionHintRecommenderImp hint_map(m_filename, 0, 1);
+
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"A", 1}}), 0),
+            0);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"A", 1}}), 0.25),
+            0);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"A", 1}}), 0.5),
+            8e7);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"A", 1}}), 0.75),
+            8e7);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"A", 1}}), 1),
+            0);
+
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"B", 1}}), 0),
+            0);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"B", 1}}), 0.25),
+            1e8);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"B", 1}}), 0.5),
+            0);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"B", 1}}), 0.75),
+            1e8);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"B", 1}}), 1),
+            0);
+
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"C", 1}}), 0),
+            3e7);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"C", 1}}), 0.25),
+            3e7);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"C", 1}}), 0.5),
+            3e7);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"C", 1}}), 0.75),
+            3e7);
+    EXPECT_EQ(hint_map.recommend_frequency(std::map<std::string, float>({{"C", 1}}), 1),
+            3e7);
+
+    EXPECT_NEAR(hint_map.recommend_frequency(std::map<std::string, float>({{"A", log(2)}, {"B", 0}, {"C", log(0.5)}}), 0.5), 5e7, 1e4);
+}

--- a/test/RegionHintRecommenderTest.cpp
+++ b/test/RegionHintRecommenderTest.cpp
@@ -56,13 +56,45 @@ TEST_F(RegionHintRecommenderTest, test_json_parsing)
                         "Frequency map file format is incorrect");
     }
 
+    {
+        std::ofstream bad_json(m_filename);
+        bad_json << "{\"A\": 5.0}" << std::endl;
+        bad_json.close();
+
+        GEOPM_EXPECT_THROW_MESSAGE(
+                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        GEOPM_ERROR_INVALID,
+                        "Frequency map file format is incorrect");
+    }
+
+    {
+        std::ofstream bad_json(m_filename);
+        bad_json << "{\"A\": []}" << std::endl;
+        bad_json.close();
+
+        GEOPM_EXPECT_THROW_MESSAGE(
+                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        GEOPM_ERROR_INVALID,
+                        "Frequency map file format is incorrect");
+    }
+
+    {
+        std::ofstream bad_json(m_filename);
+        bad_json << "[1, 2, 4]" << std::endl;
+        bad_json.close();
+
+        GEOPM_EXPECT_THROW_MESSAGE(
+                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        GEOPM_ERROR_INVALID,
+                        "Frequency map file format is incorrect");
+    }
 }
 
 TEST_F(RegionHintRecommenderTest, test_plumbing)
 {
     std::ofstream good_json(m_filename);
     good_json << "{\"A\": [0, 0.8, 0],"
-                 "\"B\": [0, 1, 0, 1, 0],"
+                 "\"B\": [0, 1, 0, 1, -3],"
                  "\"C\": [0.3]}" << std::endl;
     good_json.close();
 

--- a/test/RegionHintRecommenderTest.cpp
+++ b/test/RegionHintRecommenderTest.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
+
 #include <cmath>
 #include <fstream>
 #include <string>
@@ -134,21 +136,24 @@ TEST_F(RegionHintRecommenderTest, test_plumbing)
 
     EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0), 0);
     EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0.25), 0);
-    EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0.5), 8e7);
-    EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0.75), 8e7);
+    EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0.5), 0.8);
+    EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0.75), 0.8);
     EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 1), 0);
 
     EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 0), 0);
-    EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 0.25), 1e8);
+    EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 0.25), 1);
     EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 0.5), 0);
-    EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 0.75), 1e8);
+    EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 0.75), 1);
     EXPECT_EQ(hint_map.recommend_frequency({{"B", 1}}, 1), 0);
 
-    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0), 3e7);
-    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0.25), 3e7);
-    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0.5), 3e7);
-    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0.75), 3e7);
-    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 1), 3e7);
+    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0), 0.3);
+    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0.25), 0.3);
+    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0.5), 0.3);
+    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 0.75), 0.3);
+    EXPECT_EQ(hint_map.recommend_frequency({{"C", 1}}, 1), 0.3);
 
-    EXPECT_NEAR(hint_map.recommend_frequency({{"A", log(2)}, {"B", 0}, {"C", log(0.5)}}, 0.5), 5e7, 1);
+    EXPECT_NEAR(hint_map.recommend_frequency({{"A", log(2)}, {"B", 0}, {"C", log(0.5)}}, 0.5), 0.5, 1);
+
+    //If probabilities are hugely negative, recommend max frequency
+    EXPECT_EQ(hint_map.recommend_frequency({{"A", -HUGE_VAL}, {"B", -HUGE_VAL}}, 0.5), 1);
 }

--- a/test/RegionHintRecommenderTest.cpp
+++ b/test/RegionHintRecommenderTest.cpp
@@ -46,6 +46,28 @@ TEST_F(RegionHintRecommenderTest, test_json_parsing)
 
     {
         std::ofstream bad_json(m_filename);
+        bad_json << "" << std::endl;
+        bad_json.close();
+
+        GEOPM_EXPECT_THROW_MESSAGE(
+                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        GEOPM_ERROR_INVALID,
+                        "Frequency map file format is incorrect");
+    }
+
+    {
+        std::ofstream bad_json(m_filename);
+        bad_json << "{ }" << std::endl;
+        bad_json.close();
+
+        GEOPM_EXPECT_THROW_MESSAGE(
+                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        GEOPM_ERROR_INVALID,
+                        "must contain a frequency map");
+    }
+
+    {
+        std::ofstream bad_json(m_filename);
         bad_json << "{\"A\": \"not this!\"}" << std::endl;
         bad_json.close();
 
@@ -86,6 +108,17 @@ TEST_F(RegionHintRecommenderTest, test_json_parsing)
                         RegionHintRecommenderImp(m_filename, 0, 1),
                         GEOPM_ERROR_INVALID,
                         "Frequency map file format is incorrect");
+    }
+
+    {
+        std::ofstream bad_json(m_filename);
+        bad_json << "{\"A\": [\"a\", \"b\", \"c\"]}" << std::endl;
+        bad_json.close();
+
+        GEOPM_EXPECT_THROW_MESSAGE(
+                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        GEOPM_ERROR_INVALID,
+                        "Non-numeric value found");
     }
 }
 

--- a/test/RegionHintRecommenderTest.cpp
+++ b/test/RegionHintRecommenderTest.cpp
@@ -19,6 +19,7 @@ using geopm::RegionHintRecommender;
 using geopm::RegionHintRecommenderImp;
 using ::testing::_;
 
+//TODO: Change from logits to probabilities
 class RegionHintRecommenderTest : public ::testing::Test
 {
     protected:

--- a/test/RegionHintRecommenderTest.cpp
+++ b/test/RegionHintRecommenderTest.cpp
@@ -24,11 +24,13 @@ class RegionHintRecommenderTest : public ::testing::Test
 {
     protected:
         std::string m_filename = "freq_map_test.json";
-        void TearDown() override
-        {
-            std::remove(m_filename.c_str());
-        }
+        void TearDown() override;
 };
+
+void RegionHintRecommenderTest::TearDown()
+{
+    std::remove(m_filename.c_str());
+}
 
 TEST_F(RegionHintRecommenderTest, test_json_parsing)
 {

--- a/test/RegionHintRecommenderTest.cpp
+++ b/test/RegionHintRecommenderTest.cpp
@@ -19,7 +19,6 @@ using geopm::RegionHintRecommender;
 using geopm::RegionHintRecommenderImp;
 using ::testing::_;
 
-//TODO: Change from logits to probabilities
 class RegionHintRecommenderTest : public ::testing::Test
 {
     protected:

--- a/test/RegionHintRecommenderTest.cpp
+++ b/test/RegionHintRecommenderTest.cpp
@@ -22,101 +22,101 @@ using ::testing::_;
 class RegionHintRecommenderTest : public ::testing::Test
 {
     protected:
-        std::string m_filename = "freq_map_test.json";
+        const std::string M_FILENAME = "freq_map_test.json";
         void TearDown() override;
 };
 
 void RegionHintRecommenderTest::TearDown()
 {
-    std::remove(m_filename.c_str());
+    std::remove(M_FILENAME.c_str());
 }
 
 TEST_F(RegionHintRecommenderTest, test_json_parsing)
 {
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "{[\"test\"]" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        RegionHintRecommenderImp(M_FILENAME, 0, 1),
                         GEOPM_ERROR_INVALID,
                         "Frequency map file format is incorrect");
     }
 
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        RegionHintRecommenderImp(M_FILENAME, 0, 1),
                         GEOPM_ERROR_INVALID,
                         "Frequency map file format is incorrect");
     }
 
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "{ }" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        RegionHintRecommenderImp(M_FILENAME, 0, 1),
                         GEOPM_ERROR_INVALID,
                         "must contain a frequency map");
     }
 
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "{\"A\": \"not this!\"}" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        RegionHintRecommenderImp(M_FILENAME, 0, 1),
                         GEOPM_ERROR_INVALID,
                         "Frequency map file format is incorrect");
     }
 
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "{\"A\": 5.0}" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        RegionHintRecommenderImp(M_FILENAME, 0, 1),
                         GEOPM_ERROR_INVALID,
                         "Frequency map file format is incorrect");
     }
 
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "{\"A\": []}" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        RegionHintRecommenderImp(M_FILENAME, 0, 1),
                         GEOPM_ERROR_INVALID,
                         "Frequency map file format is incorrect");
     }
 
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "[1, 2, 4]" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        RegionHintRecommenderImp(M_FILENAME, 0, 1),
                         GEOPM_ERROR_INVALID,
                         "Frequency map file format is incorrect");
     }
 
     {
-        std::ofstream bad_json(m_filename);
+        std::ofstream bad_json(M_FILENAME);
         bad_json << "{\"A\": [\"a\", \"b\", \"c\"]}" << std::endl;
         bad_json.close();
 
         GEOPM_EXPECT_THROW_MESSAGE(
-                        RegionHintRecommenderImp(m_filename, 0, 1),
+                        RegionHintRecommenderImp(M_FILENAME, 0, 1),
                         GEOPM_ERROR_INVALID,
                         "Non-numeric value found");
     }
@@ -124,13 +124,13 @@ TEST_F(RegionHintRecommenderTest, test_json_parsing)
 
 TEST_F(RegionHintRecommenderTest, test_plumbing)
 {
-    std::ofstream good_json(m_filename);
+    std::ofstream good_json(M_FILENAME);
     good_json << "{\"A\": [0, 0.8, 0],"
                  "\"B\": [0, 1, 0, 1, -3],"
                  "\"C\": [0.3]}" << std::endl;
     good_json.close();
 
-    RegionHintRecommenderImp hint_map(m_filename, 0, 1);
+    RegionHintRecommenderImp hint_map(M_FILENAME, 0, 1);
 
     EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0), 0);
     EXPECT_EQ(hint_map.recommend_frequency({{"A", 1}}, 0.25), 0);

--- a/test/TensorMathTest.cpp
+++ b/test/TensorMathTest.cpp
@@ -21,71 +21,71 @@ class TensorMathTest : public ::testing::Test
     protected:
         void SetUp();
 
-        TensorOneD one, two, three;
-        TensorMathImp math;
-        TensorTwoD mat, row;
+        TensorOneD m_one, m_two, three;
+        TensorTwoD m_mat, m_row;
+        TensorMathImp m_math;
 };
 
 void TensorMathTest::SetUp()
 {
-    one.set_dim(2);
-    two.set_dim(2);
+    m_one.set_dim(2);
+    m_two.set_dim(2);
     three.set_dim(3);
 
-    one[0] = 1;
-    one[1] = 2;
-    two[0] = 3;
-    two[1] = 4;
+    m_one[0] = 1;
+    m_one[1] = 2;
+    m_two[0] = 3;
+    m_two[1] = 4;
     three[0] = 0;
     three[1] = 1;
     three[2] = 1;
 
-    mat.set_dim(2, 3);
+    m_mat.set_dim(2, 3);
 
-    mat[0][0] = 1;
-    mat[0][1] = 2;
-    mat[0][2] = 3;
-    mat[1][0] = 4;
-    mat[1][1] = 5;
-    mat[1][2] = 6;
+    m_mat[0][0] = 1;
+    m_mat[0][1] = 2;
+    m_mat[0][2] = 3;
+    m_mat[1][0] = 4;
+    m_mat[1][1] = 5;
+    m_mat[1][2] = 6;
 
-    row.set_dim(1, 3);
-    row[0][0] = 1;
-    row[0][1] = 2;
-    row[0][2] = 3;
+    m_row.set_dim(1, 3);
+    m_row[0][0] = 1;
+    m_row[0][1] = 2;
+    m_row[0][2] = 3;
 }
 
 TEST_F(TensorMathTest, test_sum)
 {
-    TensorOneD four = math.add(one, two);
+    TensorOneD four = m_math.add(m_one, m_two);
     EXPECT_EQ(4, four[0]);
     EXPECT_EQ(6, four[1]);
 }
 
 TEST_F(TensorMathTest, test_self_sum)
 {
-    TensorOneD four = math.add(two, two);
+    TensorOneD four = m_math.add(m_two, m_two);
     EXPECT_EQ(6, four[0]);
     EXPECT_EQ(8, four[1]);
 }
 
 TEST_F(TensorMathTest, test_diff)
 {
-    TensorOneD four = math.subtract(one, two);
+    TensorOneD four = m_math.subtract(m_one, m_two);
     EXPECT_EQ(-2, four[0]);
     EXPECT_EQ(-2, four[1]);
 }
 
 TEST_F(TensorMathTest, test_self_diff)
 {
-    TensorOneD four = math.subtract(one, one);
+    TensorOneD four = m_math.subtract(m_one, m_one);
     EXPECT_EQ(0, four[0]);
     EXPECT_EQ(0, four[1]);
 }
 
 TEST_F(TensorMathTest, test_dot)
 {
-    EXPECT_EQ(11, math.inner_product(one, two));
+    EXPECT_EQ(11, m_math.inner_product(m_one, m_two));
 }
 
 TEST_F(TensorMathTest, test_sigmoid)
@@ -98,7 +98,7 @@ TEST_F(TensorMathTest, test_sigmoid)
     activations[3] = -log(1/0.75 - 1);
     activations[4] = -log(1/0.9 - 1);
 
-    TensorOneD output = math.sigmoid(activations);
+    TensorOneD output = m_math.sigmoid(activations);
 
     EXPECT_FLOAT_EQ(0.1, output[0]);
     EXPECT_FLOAT_EQ(0.25, output[1]);
@@ -109,7 +109,7 @@ TEST_F(TensorMathTest, test_sigmoid)
 
 TEST_F(TensorMathTest, test_mat_prod)
 {
-    TensorOneD prod = math.multiply(mat, row[0]);
+    TensorOneD prod = m_math.multiply(m_mat, m_row[0]);
     EXPECT_EQ(2u, prod.get_dim());
     EXPECT_EQ(14, prod[0]);
     EXPECT_EQ(32, prod[1]);
@@ -117,9 +117,9 @@ TEST_F(TensorMathTest, test_mat_prod)
 
 TEST_F(TensorMathTest, test_bad_dimensions)
 {
-    GEOPM_EXPECT_THROW_MESSAGE(math.add(one, three), GEOPM_ERROR_INVALID, "mismatched dimensions");
-    GEOPM_EXPECT_THROW_MESSAGE(math.subtract(one, three), GEOPM_ERROR_INVALID, "mismatched dimensions");
-    GEOPM_EXPECT_THROW_MESSAGE(math.inner_product(one, three), GEOPM_ERROR_INVALID, "mismatched dimensions");
-    row.set_dim(1, 2);
-    GEOPM_EXPECT_THROW_MESSAGE(math.multiply(mat, row[0]), GEOPM_ERROR_INVALID, "incompatible dimensions");
+    GEOPM_EXPECT_THROW_MESSAGE(m_math.add(m_one, three), GEOPM_ERROR_INVALID, "mismatched dimensions");
+    GEOPM_EXPECT_THROW_MESSAGE(m_math.subtract(m_one, three), GEOPM_ERROR_INVALID, "mismatched dimensions");
+    GEOPM_EXPECT_THROW_MESSAGE(m_math.inner_product(m_one, three), GEOPM_ERROR_INVALID, "mismatched dimensions");
+    m_row.set_dim(1, 2);
+    GEOPM_EXPECT_THROW_MESSAGE(m_math.multiply(m_mat, m_row[0]), GEOPM_ERROR_INVALID, "incompatible dimensions");
 }

--- a/test/TensorMathTest.cpp
+++ b/test/TensorMathTest.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm/Exception.hpp"
+#include "geopm_test.hpp"
+
+#include "TensorMath.hpp"
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+using geopm::TensorMathImp;
+using geopm::TensorOneD;
+using geopm::TensorTwoD;
+
+class TensorMathTest : public ::testing::Test
+{
+    protected:
+        void SetUp();
+
+        TensorOneD one, two, three;
+        TensorMathImp math;
+        TensorTwoD mat, row;
+};
+
+void TensorMathTest::SetUp()
+{
+    one.set_dim(2);
+    two.set_dim(2);
+    three.set_dim(3);
+
+    one[0] = 1;
+    one[1] = 2;
+    two[0] = 3;
+    two[1] = 4;
+    three[0] = 0;
+    three[1] = 1;
+    three[2] = 1;
+
+    mat.set_dim(2, 3);
+
+    mat[0][0] = 1;
+    mat[0][1] = 2;
+    mat[0][2] = 3;
+    mat[1][0] = 4;
+    mat[1][1] = 5;
+    mat[1][2] = 6;
+
+    row.set_dim(1, 3);
+    row[0][0] = 1;
+    row[0][1] = 2;
+    row[0][2] = 3;
+}
+
+TEST_F(TensorMathTest, test_sum)
+{
+    TensorOneD four = math.add(one, two);
+    EXPECT_EQ(4, four[0]);
+    EXPECT_EQ(6, four[1]);
+}
+
+TEST_F(TensorMathTest, test_self_sum)
+{
+    TensorOneD four = math.add(two, two);
+    EXPECT_EQ(6, four[0]);
+    EXPECT_EQ(8, four[1]);
+}
+
+TEST_F(TensorMathTest, test_diff)
+{
+    TensorOneD four = math.subtract(one, two);
+    EXPECT_EQ(-2, four[0]);
+    EXPECT_EQ(-2, four[1]);
+}
+
+TEST_F(TensorMathTest, test_self_diff)
+{
+    TensorOneD four = math.subtract(one, one);
+    EXPECT_EQ(0, four[0]);
+    EXPECT_EQ(0, four[1]);
+}
+
+TEST_F(TensorMathTest, test_dot)
+{
+    EXPECT_EQ(11, math.inner_product(one, two));
+}
+
+TEST_F(TensorMathTest, test_sigmoid)
+{
+    TensorOneD activations(5);
+
+    activations[0] = -log(1/0.1 - 1);
+    activations[1] = -log(1/0.25 - 1);
+    activations[2] = -log(1/0.5 - 1);
+    activations[3] = -log(1/0.75 - 1);
+    activations[4] = -log(1/0.9 - 1);
+
+    TensorOneD output = math.sigmoid(activations);
+
+    EXPECT_FLOAT_EQ(0.1, output[0]);
+    EXPECT_FLOAT_EQ(0.25, output[1]);
+    EXPECT_FLOAT_EQ(0.5, output[2]);
+    EXPECT_FLOAT_EQ(0.75, output[3]);
+    EXPECT_FLOAT_EQ(0.9, output[4]);
+}
+
+TEST_F(TensorMathTest, test_mat_prod)
+{
+    TensorOneD prod = math.multiply(mat, row[0]);
+    EXPECT_EQ(2u, prod.get_dim());
+    EXPECT_EQ(14, prod[0]);
+    EXPECT_EQ(32, prod[1]);
+}
+
+TEST_F(TensorMathTest, test_bad_dimensions)
+{
+    GEOPM_EXPECT_THROW_MESSAGE(math.add(one, three), GEOPM_ERROR_INVALID, "mismatched dimensions");
+    GEOPM_EXPECT_THROW_MESSAGE(math.subtract(one, three), GEOPM_ERROR_INVALID, "mismatched dimensions");
+    GEOPM_EXPECT_THROW_MESSAGE(math.inner_product(one, three), GEOPM_ERROR_INVALID, "mismatched dimensions");
+    row.set_dim(1, 2);
+    GEOPM_EXPECT_THROW_MESSAGE(math.multiply(mat, row[0]), GEOPM_ERROR_INVALID, "incompatible dimensions");
+}

--- a/test/TensorMathTest.cpp
+++ b/test/TensorMathTest.cpp
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
+
+#include <cmath>
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "geopm/Exception.hpp"
@@ -90,7 +94,7 @@ TEST_F(TensorMathTest, test_dot)
 
 TEST_F(TensorMathTest, test_sigmoid)
 {
-    TensorOneD activations(5);
+    TensorOneD activations(5), boundary_act(2);
 
     activations[0] = -log(1/0.1 - 1);
     activations[1] = -log(1/0.25 - 1);
@@ -98,13 +102,22 @@ TEST_F(TensorMathTest, test_sigmoid)
     activations[3] = -log(1/0.75 - 1);
     activations[4] = -log(1/0.9 - 1);
 
+
     TensorOneD output = m_math.sigmoid(activations);
 
-    EXPECT_FLOAT_EQ(0.1, output[0]);
-    EXPECT_FLOAT_EQ(0.25, output[1]);
-    EXPECT_FLOAT_EQ(0.5, output[2]);
-    EXPECT_FLOAT_EQ(0.75, output[3]);
-    EXPECT_FLOAT_EQ(0.9, output[4]);
+    EXPECT_DOUBLE_EQ(0.1, output[0]);
+    EXPECT_DOUBLE_EQ(0.25, output[1]);
+    EXPECT_DOUBLE_EQ(0.5, output[2]);
+    EXPECT_DOUBLE_EQ(0.75, output[3]);
+    EXPECT_DOUBLE_EQ(0.9, output[4]);
+
+    boundary_act[0] = -HUGE_VAL;
+    boundary_act[1] = HUGE_VAL;
+
+    TensorOneD boundary_out = m_math.sigmoid(boundary_act);
+
+    EXPECT_DOUBLE_EQ(0.0, boundary_out[0]);
+    EXPECT_DOUBLE_EQ(1.0, boundary_out[1]);
 }
 
 TEST_F(TensorMathTest, test_mat_prod)

--- a/test/TensorOneDIntegrationTest.cpp
+++ b/test/TensorOneDIntegrationTest.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "geopm/Exception.hpp"

--- a/test/TensorOneDIntegrationTest.cpp
+++ b/test/TensorOneDIntegrationTest.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm/Exception.hpp"
+#include "geopm_test.hpp"
+
+#include "TensorOneD.hpp"
+
+using geopm::TensorOneD;
+
+class TensorOneDIntegrationTest : public ::testing::Test
+{
+    protected:
+        void SetUp();
+
+        TensorOneD one, two, three;
+};
+
+void TensorOneDIntegrationTest::SetUp()
+{
+    one.set_dim(2);
+    two.set_dim(2);
+    three.set_dim(3);
+
+    one[0] = 1;
+    one[1] = 2;
+    two[0] = 3;
+    two[1] = 4;
+    three[0] = 0;
+    three[1] = 1;
+    three[2] = 1;
+}
+
+TEST_F(TensorOneDIntegrationTest, test_sum)
+{
+    TensorOneD four = one + two;
+    EXPECT_EQ(4, four[0]);
+    EXPECT_EQ(6, four[1]);
+}
+
+TEST_F(TensorOneDIntegrationTest, test_self_sum)
+{
+    TensorOneD four = two + two;
+    EXPECT_EQ(6, four[0]);
+    EXPECT_EQ(8, four[1]);
+}
+
+TEST_F(TensorOneDIntegrationTest, test_diff)
+{
+    TensorOneD four(one - two);
+    EXPECT_EQ(-2, four[0]);
+    EXPECT_EQ(-2, four[1]);
+}
+
+TEST_F(TensorOneDIntegrationTest, test_self_diff)
+{
+    TensorOneD four = one - one;
+    EXPECT_EQ(0, four[0]);
+    EXPECT_EQ(0, four[1]);
+}
+
+TEST_F(TensorOneDIntegrationTest, test_dot)
+{
+    EXPECT_EQ(11, one * two);
+}
+
+TEST_F(TensorOneDIntegrationTest, test_sigmoid)
+{
+    TensorOneD activations(5);
+
+    activations[0] = -log(1/0.1 - 1);
+    activations[1] = -log(1/0.25 - 1);
+    activations[2] = -log(1/0.5 - 1);
+    activations[3] = -log(1/0.75 - 1);
+    activations[4] = -log(1/0.9 - 1);
+
+    TensorOneD output = activations.sigmoid();
+
+    EXPECT_FLOAT_EQ(0.1, output[0]);
+    EXPECT_FLOAT_EQ(0.25, output[1]);
+    EXPECT_FLOAT_EQ(0.5, output[2]);
+    EXPECT_FLOAT_EQ(0.75, output[3]);
+    EXPECT_FLOAT_EQ(0.9, output[4]);
+}
+
+TEST_F(TensorOneDIntegrationTest, test_copy)
+{
+    two = one;
+
+    // copy is successful
+    EXPECT_EQ(1, two[0]);
+    EXPECT_EQ(2, two[1]);
+
+    // copy is deep
+    two[0] = 9;
+    EXPECT_EQ(1, one[0]);
+    EXPECT_EQ(9, two[0]);
+}
+
+TEST_F(TensorOneDIntegrationTest, test_input)
+{
+    TensorOneD x(3);
+    x.set_dim(4);
+    std::vector<float> vals = {8, 16};
+    x = TensorOneD(vals);
+    EXPECT_EQ(2u, x.get_dim());
+    EXPECT_EQ(8, x[0]);
+    EXPECT_EQ(16, x[1]);
+}
+
+TEST_F(TensorOneDIntegrationTest, test_bad_dimensions)
+{
+    GEOPM_EXPECT_THROW_MESSAGE(one + three, GEOPM_ERROR_INVALID, "mismatched dimensions");
+    GEOPM_EXPECT_THROW_MESSAGE(one - three, GEOPM_ERROR_INVALID, "mismatched dimensions");
+    GEOPM_EXPECT_THROW_MESSAGE(one * three, GEOPM_ERROR_INVALID, "mismatched dimensions");
+}

--- a/test/TensorOneDIntegrationTest.cpp
+++ b/test/TensorOneDIntegrationTest.cpp
@@ -17,55 +17,55 @@ class TensorOneDIntegrationTest : public ::testing::Test
     protected:
         void SetUp();
 
-        TensorOneD one, two, three;
+        TensorOneD m_one, m_two, m_three;
 };
 
 void TensorOneDIntegrationTest::SetUp()
 {
-    one.set_dim(2);
-    two.set_dim(2);
-    three.set_dim(3);
+    m_one.set_dim(2);
+    m_two.set_dim(2);
+    m_three.set_dim(3);
 
-    one[0] = 1;
-    one[1] = 2;
-    two[0] = 3;
-    two[1] = 4;
-    three[0] = 0;
-    three[1] = 1;
-    three[2] = 1;
+    m_one[0] = 1;
+    m_one[1] = 2;
+    m_two[0] = 3;
+    m_two[1] = 4;
+    m_three[0] = 0;
+    m_three[1] = 1;
+    m_three[2] = 1;
 }
 
 TEST_F(TensorOneDIntegrationTest, test_sum)
 {
-    TensorOneD four = one + two;
+    TensorOneD four = m_one + m_two;
     EXPECT_EQ(4, four[0]);
     EXPECT_EQ(6, four[1]);
 }
 
 TEST_F(TensorOneDIntegrationTest, test_self_sum)
 {
-    TensorOneD four = two + two;
+    TensorOneD four = m_two + m_two;
     EXPECT_EQ(6, four[0]);
     EXPECT_EQ(8, four[1]);
 }
 
 TEST_F(TensorOneDIntegrationTest, test_diff)
 {
-    TensorOneD four(one - two);
+    TensorOneD four(m_one - m_two);
     EXPECT_EQ(-2, four[0]);
     EXPECT_EQ(-2, four[1]);
 }
 
 TEST_F(TensorOneDIntegrationTest, test_self_diff)
 {
-    TensorOneD four = one - one;
+    TensorOneD four = m_one - m_one;
     EXPECT_EQ(0, four[0]);
     EXPECT_EQ(0, four[1]);
 }
 
 TEST_F(TensorOneDIntegrationTest, test_dot)
 {
-    EXPECT_EQ(11, one * two);
+    EXPECT_EQ(11, m_one * m_two);
 }
 
 TEST_F(TensorOneDIntegrationTest, test_sigmoid)
@@ -89,16 +89,16 @@ TEST_F(TensorOneDIntegrationTest, test_sigmoid)
 
 TEST_F(TensorOneDIntegrationTest, test_copy)
 {
-    two = one;
+    m_two = m_one;
 
     // copy is successful
-    EXPECT_EQ(1, two[0]);
-    EXPECT_EQ(2, two[1]);
+    EXPECT_EQ(1, m_two[0]);
+    EXPECT_EQ(2, m_two[1]);
 
     // copy is deep
-    two[0] = 9;
-    EXPECT_EQ(1, one[0]);
-    EXPECT_EQ(9, two[0]);
+    m_two[0] = 9;
+    EXPECT_EQ(1, m_one[0]);
+    EXPECT_EQ(9, m_two[0]);
 }
 
 TEST_F(TensorOneDIntegrationTest, test_input)
@@ -114,7 +114,7 @@ TEST_F(TensorOneDIntegrationTest, test_input)
 
 TEST_F(TensorOneDIntegrationTest, test_bad_dimensions)
 {
-    GEOPM_EXPECT_THROW_MESSAGE(one + three, GEOPM_ERROR_INVALID, "mismatched dimensions");
-    GEOPM_EXPECT_THROW_MESSAGE(one - three, GEOPM_ERROR_INVALID, "mismatched dimensions");
-    GEOPM_EXPECT_THROW_MESSAGE(one * three, GEOPM_ERROR_INVALID, "mismatched dimensions");
+    GEOPM_EXPECT_THROW_MESSAGE(m_one + m_three, GEOPM_ERROR_INVALID, "mismatched dimensions");
+    GEOPM_EXPECT_THROW_MESSAGE(m_one - m_three, GEOPM_ERROR_INVALID, "mismatched dimensions");
+    GEOPM_EXPECT_THROW_MESSAGE(m_one * m_three, GEOPM_ERROR_INVALID, "mismatched dimensions");
 }

--- a/test/TensorOneDIntegrationTest.cpp
+++ b/test/TensorOneDIntegrationTest.cpp
@@ -105,7 +105,7 @@ TEST_F(TensorOneDIntegrationTest, test_input)
 {
     TensorOneD x(3);
     x.set_dim(4);
-    std::vector<float> vals = {8, 16};
+    std::vector<double> vals = {8, 16};
     x = TensorOneD(vals);
     EXPECT_EQ(2u, x.get_dim());
     EXPECT_EQ(8, x[0]);

--- a/test/TensorOneDMatcher.cpp
+++ b/test/TensorOneDMatcher.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
+
 #include "gtest/gtest.h"
 #include "TensorOneD.hpp"
 #include "TensorOneDMatcher.hpp"

--- a/test/TensorOneDMatcher.cpp
+++ b/test/TensorOneDMatcher.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gtest/gtest.h"
+#include "TensorOneD.hpp"
+#include "TensorOneDMatcher.hpp"
+
+using geopm::TensorOneD;
+
+::testing::Matcher<const TensorOneD&> TensorOneDEqualTo(const TensorOneD& expected) {
+  return TensorOneDMatcher(expected);
+}

--- a/test/TensorOneDMatcher.cpp
+++ b/test/TensorOneDMatcher.cpp
@@ -10,5 +10,5 @@
 using geopm::TensorOneD;
 
 ::testing::Matcher<const TensorOneD&> TensorOneDEqualTo(const TensorOneD& expected) {
-  return TensorOneDMatcher(expected);
+    return TensorOneDMatcher(expected);
 }

--- a/test/TensorOneDMatcher.hpp
+++ b/test/TensorOneDMatcher.hpp
@@ -10,39 +10,44 @@
 
 using geopm::TensorOneD;
 
-class TensorOneDMatcher {
-  public:
-    using is_gtest_matcher = void;
+class TensorOneDMatcher
+{
+    public:
+        using is_gtest_matcher = void;
 
-    /* We store the data, not the instance. This helps
-     * us avoid leaking the mock objects.
-     */
-    explicit TensorOneDMatcher(const TensorOneD& expected)
-        : m_expected_values(expected.get_data()) {}
-
-    bool MatchAndExplain(const TensorOneD& actual,
-        std::ostream* /* listener */) const {
-        return actual.get_data() == m_expected_values;
-    }
-
-    void DescribeTo(std::ostream* os) const {
-        *os << "TensorOneD contents equal [";
-        for (auto val : m_expected_values) {
-            *os << val << " ";
+        /* We store the data, not the instance. This helps
+         * us avoid leaking the mock objects.
+         */
+        explicit TensorOneDMatcher(const TensorOneD& expected)
+            : m_expected_values(expected.get_data())
+        {
         }
-        *os << "]";
-    }
 
-    void DescribeNegationTo(std::ostream* os) const {
-        *os << "TensorOneD contents do not equal [";
-        for (auto val : m_expected_values) {
-            *os << val << " ";
+        bool MatchAndExplain(const TensorOneD& actual, std::ostream* /* listener */) const
+        {
+            return actual.get_data() == m_expected_values;
         }
-        *os << "]";
-    }
 
-  private:
-    const std::vector<double> m_expected_values;
+        void DescribeTo(std::ostream* os) const
+        {
+            *os << "TensorOneD contents equal [";
+            for (auto val : m_expected_values) {
+                *os << val << " ";
+            }
+            *os << "]";
+        }
+
+        void DescribeNegationTo(std::ostream* os) const
+        {
+            *os << "TensorOneD contents do not equal [";
+            for (auto val : m_expected_values) {
+                *os << val << " ";
+            }
+            *os << "]";
+        }
+
+    private:
+        const std::vector<double> m_expected_values;
 };
 
 ::testing::Matcher<const TensorOneD&> TensorOneDEqualTo(const TensorOneD& expected);

--- a/test/TensorOneDMatcher.hpp
+++ b/test/TensorOneDMatcher.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TENSORONEDMATCHER_HPP_INCLUDE
+#define TENSORONEDMATCHER_HPP_INCLUDE
+
+#include "TensorOneD.hpp"
+
+using geopm::TensorOneD;
+
+class TensorOneDMatcher {
+  public:
+    using is_gtest_matcher = void;
+
+    /* We store the data, not the instance. This helps
+     * us avoid leaking the mock objects.
+     */
+    explicit TensorOneDMatcher(const TensorOneD& expected)
+      : m_expected_values(expected.get_data()) {}
+
+    bool MatchAndExplain(const TensorOneD& actual,
+        std::ostream* /* listener */) const {
+      return actual.get_data() == m_expected_values;
+    }
+
+    void DescribeTo(std::ostream* os) const {
+      *os << "TensorOneD contents equal [";
+      for (auto val : m_expected_values) {
+	*os << val << " ";
+      }
+      *os << "]";
+    }
+
+    void DescribeNegationTo(std::ostream* os) const {
+      *os << "TensorOneD contents do not equal [";
+      for (auto val : m_expected_values) {
+	*os << val << " ";
+      }
+      *os << "]";
+    }
+
+  private:
+    const std::vector<float> m_expected_values;
+};
+
+::testing::Matcher<const TensorOneD&> TensorOneDEqualTo(const TensorOneD& expected);
+
+#endif  // TENSORONEDMATCHER_HPP_INCLUDE

--- a/test/TensorOneDMatcher.hpp
+++ b/test/TensorOneDMatcher.hpp
@@ -18,27 +18,27 @@ class TensorOneDMatcher {
      * us avoid leaking the mock objects.
      */
     explicit TensorOneDMatcher(const TensorOneD& expected)
-      : m_expected_values(expected.get_data()) {}
+        : m_expected_values(expected.get_data()) {}
 
     bool MatchAndExplain(const TensorOneD& actual,
         std::ostream* /* listener */) const {
-      return actual.get_data() == m_expected_values;
+        return actual.get_data() == m_expected_values;
     }
 
     void DescribeTo(std::ostream* os) const {
-      *os << "TensorOneD contents equal [";
-      for (auto val : m_expected_values) {
-	*os << val << " ";
-      }
-      *os << "]";
+        *os << "TensorOneD contents equal [";
+        for (auto val : m_expected_values) {
+            *os << val << " ";
+        }
+        *os << "]";
     }
 
     void DescribeNegationTo(std::ostream* os) const {
-      *os << "TensorOneD contents do not equal [";
-      for (auto val : m_expected_values) {
-	*os << val << " ";
-      }
-      *os << "]";
+        *os << "TensorOneD contents do not equal [";
+        for (auto val : m_expected_values) {
+            *os << val << " ";
+        }
+        *os << "]";
     }
 
   private:

--- a/test/TensorOneDMatcher.hpp
+++ b/test/TensorOneDMatcher.hpp
@@ -42,7 +42,7 @@ class TensorOneDMatcher {
     }
 
   private:
-    const std::vector<float> m_expected_values;
+    const std::vector<double> m_expected_values;
 };
 
 ::testing::Matcher<const TensorOneD&> TensorOneDEqualTo(const TensorOneD& expected);

--- a/test/TensorOneDTest.cpp
+++ b/test/TensorOneDTest.cpp
@@ -25,8 +25,8 @@ TEST_F(TensorOneDTest, test_sum)
 {
     auto fake_math = std::make_shared<MockTensorMath>();
 
-    std::vector<float> vec_a = {1, 2, 3};
-    std::vector<float> vec_b = {6, 7};
+    std::vector<double> vec_a = {1, 2, 3};
+    std::vector<double> vec_b = {6, 7};
 
     TensorOneD tensor_a(vec_a, fake_math);
     TensorOneD tensor_b(vec_b);
@@ -40,7 +40,7 @@ TEST_F(TensorOneDTest, test_sum)
 
 TEST_F(TensorOneDTest, test_copy)
 {
-    TensorOneD one(std::vector<float>({1, 2})), two;
+    TensorOneD one(std::vector<double>({1, 2})), two;
 
     two = one;
 
@@ -58,7 +58,7 @@ TEST_F(TensorOneDTest, test_input)
 {
     TensorOneD x(3);
     x.set_dim(4);
-    std::vector<float> vals = {8, 16};
+    std::vector<double> vals = {8, 16};
     x = TensorOneD(vals);
     EXPECT_EQ(2u, x.get_dim());
     EXPECT_EQ(8, x[0]);

--- a/test/TensorOneDTest.cpp
+++ b/test/TensorOneDTest.cpp
@@ -12,6 +12,7 @@
 #include "MockTensorMath.hpp"
 
 using geopm::TensorOneD;
+using ::testing::Mock;
 using ::testing::Return;
 using ::testing::_;
 
@@ -27,8 +28,9 @@ TEST_F(TensorOneDTest, test_sum)
     std::vector<float> vec_b = {6, 7};
 
     TensorOneD tensor_a(vec_a, fake_math);
-    TensorOneD tensor_b(vec_b, fake_math);
+    TensorOneD tensor_b(vec_b);
 
+    Mock::AllowLeak(&*fake_math);
     EXPECT_CALL(*fake_math, add(tensor_a, tensor_a)).WillOnce(Return(tensor_b));
     TensorOneD tensor_c = tensor_a + tensor_a;
 

--- a/test/TensorOneDTest.cpp
+++ b/test/TensorOneDTest.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm/Exception.hpp"
+
+#include "TensorOneD.hpp"
+
+#include "MockTensorMath.hpp"
+
+using geopm::TensorOneD;
+using ::testing::Return;
+using ::testing::_;
+
+class TensorOneDTest : public ::testing::Test
+{
+};
+
+TEST_F(TensorOneDTest, test_sum)
+{
+    auto fake_math = std::make_shared<MockTensorMath>();
+
+    std::vector<float> vec_a = {1, 2, 3};
+    std::vector<float> vec_b = {6, 7};
+
+    TensorOneD tensor_a(vec_a, fake_math);
+    TensorOneD tensor_b(vec_b, fake_math);
+
+    EXPECT_CALL(*fake_math, add(tensor_a, tensor_a)).WillOnce(Return(tensor_b));
+    TensorOneD tensor_c = tensor_a + tensor_a;
+
+    EXPECT_EQ(tensor_b.get_data(), tensor_c.get_data());
+}
+
+TEST_F(TensorOneDTest, test_copy)
+{
+    TensorOneD one(std::vector<float>({1, 2})), two;
+
+    two = one;
+
+    // copy is successful
+    EXPECT_EQ(1, two[0]);
+    EXPECT_EQ(2, two[1]);
+
+    // copy is deep
+    two[0] = 9;
+    EXPECT_EQ(1, one[0]);
+    EXPECT_EQ(9, two[0]);
+}
+
+TEST_F(TensorOneDTest, test_input)
+{
+    TensorOneD x(3);
+    x.set_dim(4);
+    std::vector<float> vals = {8, 16};
+    x = TensorOneD(vals);
+    EXPECT_EQ(2u, x.get_dim());
+    EXPECT_EQ(8, x[0]);
+    EXPECT_EQ(16, x[1]);
+}

--- a/test/TensorOneDTest.cpp
+++ b/test/TensorOneDTest.cpp
@@ -30,7 +30,6 @@ TEST_F(TensorOneDTest, test_sum)
     TensorOneD tensor_a(vec_a, fake_math);
     TensorOneD tensor_b(vec_b);
 
-    //Mock::AllowLeak(&*fake_math);
     ON_CALL(*fake_math, add(_, _)).WillByDefault(Return(tensor_b));
     EXPECT_CALL(*fake_math, add(tensor_a, tensor_a)).Times(1);
     TensorOneD tensor_c = tensor_a + tensor_a;

--- a/test/TensorOneDTest.cpp
+++ b/test/TensorOneDTest.cpp
@@ -17,11 +17,8 @@ using ::testing::Mock;
 using ::testing::Return;
 using ::testing::_;
 
-class TensorOneDTest : public ::testing::Test
-{
-};
 
-TEST_F(TensorOneDTest, test_sum)
+TEST(TensorOneDTest, test_sum)
 {
     auto fake_math = std::make_shared<MockTensorMath>();
 
@@ -38,7 +35,7 @@ TEST_F(TensorOneDTest, test_sum)
     EXPECT_EQ(tensor_b.get_data(), tensor_c.get_data());
 }
 
-TEST_F(TensorOneDTest, test_copy)
+TEST(TensorOneDTest, test_copy)
 {
     TensorOneD one(std::vector<double>({1, 2})), two;
 
@@ -54,7 +51,7 @@ TEST_F(TensorOneDTest, test_copy)
     EXPECT_EQ(9, two[0]);
 }
 
-TEST_F(TensorOneDTest, test_input)
+TEST(TensorOneDTest, test_input)
 {
     TensorOneD x(3);
     x.set_dim(4);

--- a/test/TensorOneDTest.cpp
+++ b/test/TensorOneDTest.cpp
@@ -17,6 +17,80 @@ using ::testing::Mock;
 using ::testing::Return;
 using ::testing::_;
 
+TEST(TensorOneDTest, test_copy)
+{
+    TensorOneD one(std::vector<double>({1, 2})), two;
+
+    two = one;
+
+    // copy is successful
+    EXPECT_EQ(1, two[0]);
+    EXPECT_EQ(2, two[1]);
+
+    // copy is deep
+    two[0] = 9;
+    EXPECT_EQ(1, one[0]);
+    EXPECT_EQ(9, two[0]);
+}
+
+TEST(TensorOneDTest, test_diff)
+{
+    auto fake_math = std::make_shared<MockTensorMath>();
+
+    std::vector<double> vec_a = {1, 2, 3};
+    std::vector<double> vec_b = {6, 7};
+
+    TensorOneD tensor_a(vec_a, fake_math);
+    TensorOneD tensor_b(vec_b);
+
+    ON_CALL(*fake_math, subtract(_, _)).WillByDefault(Return(tensor_b));
+    EXPECT_CALL(*fake_math, subtract(TensorOneDEqualTo(tensor_a), TensorOneDEqualTo(tensor_a))).Times(1);
+    TensorOneD tensor_c = tensor_a - tensor_a;
+
+    EXPECT_EQ(tensor_b.get_data(), tensor_c.get_data());
+}
+
+TEST(TensorOneDTest, test_input)
+{
+    TensorOneD x(3);
+    x.set_dim(4);
+    std::vector<double> vals = {8, 16};
+    x = TensorOneD(vals);
+    EXPECT_EQ(2u, x.get_dim());
+    EXPECT_EQ(8, x[0]);
+    EXPECT_EQ(16, x[1]);
+}
+
+TEST(TensorOneDTest, test_equivalent)
+{
+    std::vector<double> vec_a = {1, 2, 3};
+    std::vector<double> vec_b = {6, 7};
+
+    TensorOneD tensor_a(vec_a);
+    TensorOneD tensor_b(vec_b);
+
+    EXPECT_TRUE(tensor_a == tensor_a);
+    EXPECT_FALSE(tensor_a == tensor_b);
+}
+
+TEST(TensorOneDTest, test_prod)
+{
+    auto fake_math = std::make_shared<MockTensorMath>();
+
+    std::vector<double> vec_a = {1, 2, 3};
+    std::vector<double> vec_b = {6, 7};
+    double retval = 5.0;
+
+    TensorOneD tensor_a(vec_a, fake_math);
+    TensorOneD tensor_b(vec_b);
+
+    ON_CALL(*fake_math, inner_product(_, _)).WillByDefault(Return(retval));
+    EXPECT_CALL(*fake_math, inner_product(TensorOneDEqualTo(tensor_a), TensorOneDEqualTo(tensor_b)))
+        .Times(1);
+    double prod = tensor_a * tensor_b;
+
+    EXPECT_EQ(retval, prod);
+}
 
 TEST(TensorOneDTest, test_sum)
 {
@@ -35,29 +109,19 @@ TEST(TensorOneDTest, test_sum)
     EXPECT_EQ(tensor_b.get_data(), tensor_c.get_data());
 }
 
-TEST(TensorOneDTest, test_copy)
+TEST(TensorOneDTest, test_sigmoid)
 {
-    TensorOneD one(std::vector<double>({1, 2})), two;
+    auto fake_math = std::make_shared<MockTensorMath>();
 
-    two = one;
+    std::vector<double> vec_a = {1, 2, 3};
+    std::vector<double> vec_b = {6, 7};
 
-    // copy is successful
-    EXPECT_EQ(1, two[0]);
-    EXPECT_EQ(2, two[1]);
+    TensorOneD tensor_a(vec_a, fake_math);
+    TensorOneD tensor_b(vec_b);
 
-    // copy is deep
-    two[0] = 9;
-    EXPECT_EQ(1, one[0]);
-    EXPECT_EQ(9, two[0]);
-}
+    ON_CALL(*fake_math, sigmoid(_)).WillByDefault(Return(tensor_b));
+    EXPECT_CALL(*fake_math, sigmoid(TensorOneDEqualTo(tensor_a))).Times(1);
+    TensorOneD tensor_c = tensor_a.sigmoid();
 
-TEST(TensorOneDTest, test_input)
-{
-    TensorOneD x(3);
-    x.set_dim(4);
-    std::vector<double> vals = {8, 16};
-    x = TensorOneD(vals);
-    EXPECT_EQ(2u, x.get_dim());
-    EXPECT_EQ(8, x[0]);
-    EXPECT_EQ(16, x[1]);
+    EXPECT_EQ(tensor_b.get_data(), tensor_c.get_data());
 }

--- a/test/TensorOneDTest.cpp
+++ b/test/TensorOneDTest.cpp
@@ -30,8 +30,9 @@ TEST_F(TensorOneDTest, test_sum)
     TensorOneD tensor_a(vec_a, fake_math);
     TensorOneD tensor_b(vec_b);
 
-    Mock::AllowLeak(&*fake_math);
-    EXPECT_CALL(*fake_math, add(tensor_a, tensor_a)).WillOnce(Return(tensor_b));
+    //Mock::AllowLeak(&*fake_math);
+    ON_CALL(*fake_math, add(_, _)).WillByDefault(Return(tensor_b));
+    EXPECT_CALL(*fake_math, add(tensor_a, tensor_a)).Times(1);
     TensorOneD tensor_c = tensor_a + tensor_a;
 
     EXPECT_EQ(tensor_b.get_data(), tensor_c.get_data());

--- a/test/TensorOneDTest.cpp
+++ b/test/TensorOneDTest.cpp
@@ -10,6 +10,7 @@
 #include "TensorOneD.hpp"
 
 #include "MockTensorMath.hpp"
+#include "TensorOneDMatcher.hpp"
 
 using geopm::TensorOneD;
 using ::testing::Mock;
@@ -31,7 +32,7 @@ TEST_F(TensorOneDTest, test_sum)
     TensorOneD tensor_b(vec_b);
 
     ON_CALL(*fake_math, add(_, _)).WillByDefault(Return(tensor_b));
-    EXPECT_CALL(*fake_math, add(tensor_a, tensor_a)).Times(1);
+    EXPECT_CALL(*fake_math, add(TensorOneDEqualTo(tensor_a), TensorOneDEqualTo(tensor_a))).Times(1);
     TensorOneD tensor_c = tensor_a + tensor_a;
 
     EXPECT_EQ(tensor_b.get_data(), tensor_c.get_data());

--- a/test/TensorTwoDIntegrationTest.cpp
+++ b/test/TensorTwoDIntegrationTest.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "config.h"
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "geopm/Exception.hpp"

--- a/test/TensorTwoDIntegrationTest.cpp
+++ b/test/TensorTwoDIntegrationTest.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm/Exception.hpp"
+
+#include "TensorTwoD.hpp"
+
+#include <iostream>
+
+using geopm::TensorOneD;
+using geopm::TensorTwoD;
+
+class TensorTwoDIntegrationTest : public ::testing::Test
+{
+    protected:
+        void SetUp();
+
+        TensorTwoD mat;
+        TensorTwoD row;
+};
+
+void TensorTwoDIntegrationTest::SetUp()
+{
+    mat.set_dim(2, 3);
+
+    mat[0][0] = 1;
+    mat[0][1] = 2;
+    mat[0][2] = 3;
+    mat[1][0] = 4;
+    mat[1][1] = 5;
+    mat[1][2] = 6;
+
+    row.set_dim(1, 3);
+    row[0][0] = 1;
+    row[0][1] = 2;
+    row[0][2] = 3;
+}
+
+TEST_F(TensorTwoDIntegrationTest, test_mat_prod) {
+    TensorOneD prod = mat * row[0];
+    EXPECT_EQ(2u, prod.get_dim());
+    EXPECT_EQ(14, prod[0]);
+    EXPECT_EQ(32, prod[1]);
+}
+
+TEST_F(TensorTwoDIntegrationTest, test_copy) {
+    TensorTwoD copy(3, 4);
+    copy.set_dim(1, 1);
+    copy = mat;
+    EXPECT_EQ(1, copy[0][0]);
+    EXPECT_EQ(2, copy[0][1]);
+    EXPECT_EQ(3, copy[0][2]);
+    EXPECT_EQ(4, copy[1][0]);
+    EXPECT_EQ(5, copy[1][1]);
+    EXPECT_EQ(6, copy[1][2]);
+
+    // check that the copy is deep
+    copy[1][0] = -1;
+    EXPECT_EQ(4, mat[1][0]);
+    EXPECT_EQ(-1, copy[1][0]);
+}
+
+TEST_F(TensorTwoDIntegrationTest, test_copy_constructor) {
+    TensorTwoD copy(mat);
+    EXPECT_EQ(1, copy[0][0]);
+    EXPECT_EQ(2, copy[0][1]);
+    EXPECT_EQ(3, copy[0][2]);
+    EXPECT_EQ(4, copy[1][0]);
+    EXPECT_EQ(5, copy[1][1]);
+    EXPECT_EQ(6, copy[1][2]);
+
+    // check that the copy is deep
+    copy[1][0] = -1;
+    EXPECT_EQ(4, mat[1][0]);
+    EXPECT_EQ(-1, copy[1][0]);
+}
+
+TEST_F(TensorTwoDIntegrationTest, test_array_overload) {
+    const TensorTwoD mat_copy(mat);
+    mat[0] = mat_copy[1];
+    EXPECT_EQ(4, mat[0][0]);
+    EXPECT_EQ(5, mat[0][1]);
+    EXPECT_EQ(6, mat[0][2]);
+
+    // check that the copy is deep
+    mat[0][0] = 7;
+    EXPECT_EQ(7, mat[0][0]);
+    EXPECT_EQ(4, mat_copy[1][0]);
+}
+
+TEST_F(TensorTwoDIntegrationTest, test_input) {
+    std::vector<std::vector<float> > vals = {{1}, {2}};
+    TensorTwoD x;
+    x = TensorTwoD(vals);
+    EXPECT_EQ(2u, x.get_rows());
+    EXPECT_EQ(1u, x.get_cols());
+    EXPECT_EQ(1, x[0][0]);
+    EXPECT_EQ(2, x[1][0]);
+}
+
+TEST_F(TensorTwoDIntegrationTest, test_degenerate_size) {
+    TensorTwoD x;
+    EXPECT_EQ(0u, x.get_cols());
+}
+
+TEST_F(TensorTwoDIntegrationTest, test_bad_dimensions) {
+    row.set_dim(1, 2);
+    EXPECT_THROW(mat * row[0], geopm::Exception);
+    EXPECT_THROW(row.set_dim(0, 1), geopm::Exception);
+    std::vector<std::vector<float> > vals = {{1}, {2, 3}};
+    EXPECT_THROW(new TensorTwoD(vals), geopm::Exception);  // TODO - new?
+}
+
+TEST_F(TensorTwoDIntegrationTest, test_empty_weights)
+{
+    std::vector<std::vector<float> > vals = {};
+    EXPECT_THROW(new TensorTwoD(vals), geopm::Exception);  // TODO - new?
+}

--- a/test/TensorTwoDIntegrationTest.cpp
+++ b/test/TensorTwoDIntegrationTest.cpp
@@ -8,11 +8,13 @@
 #include "geopm/Exception.hpp"
 
 #include "TensorTwoD.hpp"
+#include "geopm_test.hpp"
 
 #include <iostream>
 
 using geopm::TensorOneD;
 using geopm::TensorTwoD;
+using testing::Throw;
 
 class TensorTwoDIntegrationTest : public ::testing::Test
 {
@@ -49,6 +51,8 @@ TEST_F(TensorTwoDIntegrationTest, test_mat_prod) {
 
 TEST_F(TensorTwoDIntegrationTest, test_bad_dimensions) {
     row.set_dim(1, 2);
-    EXPECT_THROW(mat * row[0], geopm::Exception);
-    EXPECT_THROW(row.set_dim(0, 1), geopm::Exception);
+    GEOPM_EXPECT_THROW_MESSAGE(mat * row[0], GEOPM_ERROR_INVALID,
+                               "Attempted to multiply matrix and vector with incompatible dimensions.");
+    GEOPM_EXPECT_THROW_MESSAGE(row.set_dim(0, 1), GEOPM_ERROR_INVALID,
+                               "Tried to allocate degenerate matrix.");
 }

--- a/test/TensorTwoDIntegrationTest.cpp
+++ b/test/TensorTwoDIntegrationTest.cpp
@@ -47,76 +47,8 @@ TEST_F(TensorTwoDIntegrationTest, test_mat_prod) {
     EXPECT_EQ(32, prod[1]);
 }
 
-TEST_F(TensorTwoDIntegrationTest, test_copy) {
-    TensorTwoD copy(3, 4);
-    copy.set_dim(1, 1);
-    copy = mat;
-    EXPECT_EQ(1, copy[0][0]);
-    EXPECT_EQ(2, copy[0][1]);
-    EXPECT_EQ(3, copy[0][2]);
-    EXPECT_EQ(4, copy[1][0]);
-    EXPECT_EQ(5, copy[1][1]);
-    EXPECT_EQ(6, copy[1][2]);
-
-    // check that the copy is deep
-    copy[1][0] = -1;
-    EXPECT_EQ(4, mat[1][0]);
-    EXPECT_EQ(-1, copy[1][0]);
-}
-
-TEST_F(TensorTwoDIntegrationTest, test_copy_constructor) {
-    TensorTwoD copy(mat);
-    EXPECT_EQ(1, copy[0][0]);
-    EXPECT_EQ(2, copy[0][1]);
-    EXPECT_EQ(3, copy[0][2]);
-    EXPECT_EQ(4, copy[1][0]);
-    EXPECT_EQ(5, copy[1][1]);
-    EXPECT_EQ(6, copy[1][2]);
-
-    // check that the copy is deep
-    copy[1][0] = -1;
-    EXPECT_EQ(4, mat[1][0]);
-    EXPECT_EQ(-1, copy[1][0]);
-}
-
-TEST_F(TensorTwoDIntegrationTest, test_array_overload) {
-    const TensorTwoD mat_copy(mat);
-    mat[0] = mat_copy[1];
-    EXPECT_EQ(4, mat[0][0]);
-    EXPECT_EQ(5, mat[0][1]);
-    EXPECT_EQ(6, mat[0][2]);
-
-    // check that the copy is deep
-    mat[0][0] = 7;
-    EXPECT_EQ(7, mat[0][0]);
-    EXPECT_EQ(4, mat_copy[1][0]);
-}
-
-TEST_F(TensorTwoDIntegrationTest, test_input) {
-    std::vector<std::vector<float> > vals = {{1}, {2}};
-    TensorTwoD x;
-    x = TensorTwoD(vals);
-    EXPECT_EQ(2u, x.get_rows());
-    EXPECT_EQ(1u, x.get_cols());
-    EXPECT_EQ(1, x[0][0]);
-    EXPECT_EQ(2, x[1][0]);
-}
-
-TEST_F(TensorTwoDIntegrationTest, test_degenerate_size) {
-    TensorTwoD x;
-    EXPECT_EQ(0u, x.get_cols());
-}
-
 TEST_F(TensorTwoDIntegrationTest, test_bad_dimensions) {
     row.set_dim(1, 2);
     EXPECT_THROW(mat * row[0], geopm::Exception);
     EXPECT_THROW(row.set_dim(0, 1), geopm::Exception);
-    std::vector<std::vector<float> > vals = {{1}, {2, 3}};
-    EXPECT_THROW(new TensorTwoD(vals), geopm::Exception);  // TODO - new?
-}
-
-TEST_F(TensorTwoDIntegrationTest, test_empty_weights)
-{
-    std::vector<std::vector<float> > vals = {};
-    EXPECT_THROW(new TensorTwoD(vals), geopm::Exception);  // TODO - new?
 }

--- a/test/TensorTwoDMatcher.cpp
+++ b/test/TensorTwoDMatcher.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gtest/gtest.h"
+#include "TensorTwoD.hpp"
+#include "TensorTwoDMatcher.hpp"
+
+using geopm::TensorTwoD;
+
+::testing::Matcher<const TensorTwoD&> TensorTwoDEqualTo(const TensorTwoD& expected) {
+  return TensorTwoDMatcher(expected);
+}

--- a/test/TensorTwoDMatcher.hpp
+++ b/test/TensorTwoDMatcher.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TENSORTWODMATCHER_HPP_INCLUDE
+#define TENSORTWODMATCHER_HPP_INCLUDE
+
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+using geopm::TensorTwoD;
+
+class TensorTwoDMatcher {
+  public:
+    using is_gtest_matcher = void;
+
+    /* We store the data, not the instance. This helps
+     * us avoid leaking the mock objects.
+     */
+    explicit TensorTwoDMatcher(const TensorTwoD& expected)
+      : m_expected_values(expected.get_rows())
+    {
+      for (size_t i = 0; i < expected.get_rows(); ++i) {
+	m_expected_values[i] = std::vector<float>(expected[i].get_data());
+      }
+    }
+
+    bool MatchAndExplain(const TensorTwoD& actual,
+        std::ostream* /* listener */) const {
+      bool rval = true;
+      for (size_t i = 0; i < m_expected_values.size(); ++i) {
+	if (actual[i].get_data() != m_expected_values[i]) {
+	  rval = false;
+	}
+      }
+      return rval;
+    }
+
+    void DescribeTo(std::ostream* os) const {
+      *os << "TensorTwoD contents equal [";
+      for (std::vector<float> row : m_expected_values) {
+	for (float val : row) {
+	  *os << val << " ";
+	}
+	*os << "; ";
+      }
+      *os << "]";
+    }
+
+    void DescribeNegationTo(std::ostream* os) const {
+      *os << "TensorTwoD contents do not equal [";
+      for (std::vector<float> row : m_expected_values) {
+	for (float val : row) {
+	  *os << val << " ";
+	}
+	*os << "; ";
+      }
+      *os << "]";
+    }
+
+  private:
+    std::vector<std::vector<float>> m_expected_values;
+};
+
+::testing::Matcher<const TensorTwoD&> TensorTwoDEqualTo(const TensorTwoD& expected);
+
+#endif  // TENSORTWODMATCHER_HPP_INCLUDE

--- a/test/TensorTwoDMatcher.hpp
+++ b/test/TensorTwoDMatcher.hpp
@@ -11,56 +11,59 @@
 
 using geopm::TensorTwoD;
 
-class TensorTwoDMatcher {
-  public:
-    using is_gtest_matcher = void;
+class TensorTwoDMatcher
+{
+    public:
+        using is_gtest_matcher = void;
 
-    /* We store the data, not the instance. This helps
-     * us avoid leaking the mock objects.
-     */
-    explicit TensorTwoDMatcher(const TensorTwoD& expected)
-      : m_expected_values(expected.get_rows())
-    {
-      for (size_t i = 0; i < expected.get_rows(); ++i) {
-	m_expected_values[i] = std::vector<double>(expected[i].get_data());
-      }
-    }
+        /* We store the data, not the instance. This helps
+         * us avoid leaking the mock objects.
+         */
+        explicit TensorTwoDMatcher(const TensorTwoD& expected)
+            : m_expected_values(expected.get_rows())
+        {
+            for (size_t i = 0; i < expected.get_rows(); ++i) {
+                m_expected_values[i] = std::vector<double>(expected[i].get_data());
+            }
+        }
 
-    bool MatchAndExplain(const TensorTwoD& actual,
-        std::ostream* /* listener */) const {
-      bool rval = true;
-      for (size_t i = 0; i < m_expected_values.size(); ++i) {
-	if (actual[i].get_data() != m_expected_values[i]) {
-	  rval = false;
-	}
-      }
-      return rval;
-    }
+        bool MatchAndExplain(const TensorTwoD& actual, std::ostream* /* listener */) const
+        {
+            bool rval = true;
+            for (size_t i = 0; i < m_expected_values.size(); ++i) {
+                if (actual[i].get_data() != m_expected_values[i]) {
+                    rval = false;
+                }
+            }
+            return rval;
+        }
 
-    void DescribeTo(std::ostream* os) const {
-      *os << "TensorTwoD contents equal [";
-      for (std::vector<double> row : m_expected_values) {
-	for (double val : row) {
-	  *os << val << " ";
-	}
-	*os << "; ";
-      }
-      *os << "]";
-    }
+        void DescribeTo(std::ostream* os) const
+        {
+            *os << "TensorTwoD contents equal [";
+            for (std::vector<double> row : m_expected_values) {
+                for (double val : row) {
+                    *os << val << " ";
+                }
+                *os << "; ";
+            }
+            *os << "]";
+        }
 
-    void DescribeNegationTo(std::ostream* os) const {
-      *os << "TensorTwoD contents do not equal [";
-      for (std::vector<double> row : m_expected_values) {
-	for (double val : row) {
-	  *os << val << " ";
-	}
-	*os << "; ";
-      }
-      *os << "]";
-    }
+        void DescribeNegationTo(std::ostream* os) const
+        {
+            *os << "TensorTwoD contents do not equal [";
+            for (std::vector<double> row : m_expected_values) {
+                for (double val : row) {
+                    *os << val << " ";
+                }
+                *os << "; ";
+            }
+            *os << "]";
+        }
 
-  private:
-    std::vector<std::vector<double>> m_expected_values;
+    private:
+        std::vector<std::vector<double> > m_expected_values;
 };
 
 ::testing::Matcher<const TensorTwoD&> TensorTwoDEqualTo(const TensorTwoD& expected);

--- a/test/TensorTwoDMatcher.hpp
+++ b/test/TensorTwoDMatcher.hpp
@@ -22,7 +22,7 @@ class TensorTwoDMatcher {
       : m_expected_values(expected.get_rows())
     {
       for (size_t i = 0; i < expected.get_rows(); ++i) {
-	m_expected_values[i] = std::vector<float>(expected[i].get_data());
+	m_expected_values[i] = std::vector<double>(expected[i].get_data());
       }
     }
 
@@ -39,8 +39,8 @@ class TensorTwoDMatcher {
 
     void DescribeTo(std::ostream* os) const {
       *os << "TensorTwoD contents equal [";
-      for (std::vector<float> row : m_expected_values) {
-	for (float val : row) {
+      for (std::vector<double> row : m_expected_values) {
+	for (double val : row) {
 	  *os << val << " ";
 	}
 	*os << "; ";
@@ -50,8 +50,8 @@ class TensorTwoDMatcher {
 
     void DescribeNegationTo(std::ostream* os) const {
       *os << "TensorTwoD contents do not equal [";
-      for (std::vector<float> row : m_expected_values) {
-	for (float val : row) {
+      for (std::vector<double> row : m_expected_values) {
+	for (double val : row) {
 	  *os << val << " ";
 	}
 	*os << "; ";
@@ -60,7 +60,7 @@ class TensorTwoDMatcher {
     }
 
   private:
-    std::vector<std::vector<float>> m_expected_values;
+    std::vector<std::vector<double>> m_expected_values;
 };
 
 ::testing::Matcher<const TensorTwoD&> TensorTwoDEqualTo(const TensorTwoD& expected);

--- a/test/TensorTwoDTest.cpp
+++ b/test/TensorTwoDTest.cpp
@@ -11,6 +11,8 @@
 #include "TensorTwoD.hpp"
 
 #include "MockTensorMath.hpp"
+#include "TensorOneDMatcher.hpp"
+#include "TensorTwoDMatcher.hpp"
 
 using geopm::TensorOneD;
 using geopm::TensorTwoD;
@@ -50,7 +52,7 @@ TEST_F(TensorTwoDTest, test_vector_product)
     TensorOneD tensor_b(vec_b, fake_math);
     TensorOneD tensor_c(vec_c, fake_math);
 
-    EXPECT_CALL(*fake_math, multiply(tensor_a, tensor_b)).WillOnce(Return(tensor_c));
+    EXPECT_CALL(*fake_math, multiply(TensorTwoDEqualTo(tensor_a), TensorOneDEqualTo(tensor_b))).WillOnce(Return(tensor_c));
     TensorOneD tensor_d = tensor_a * tensor_b;
 
     EXPECT_EQ(tensor_c.get_data(), tensor_d.get_data());

--- a/test/TensorTwoDTest.cpp
+++ b/test/TensorTwoDTest.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "geopm/Exception.hpp"
+
+#include "TensorOneD.hpp"
+#include "TensorTwoD.hpp"
+
+#include "MockTensorMath.hpp"
+
+using geopm::TensorOneD;
+using geopm::TensorTwoD;
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::_;
+
+class TensorTwoDTest : public ::testing::Test
+{
+    protected:
+        void SetUp();
+
+        TensorTwoD mat;
+};
+
+void TensorTwoDTest::SetUp()
+{
+    mat.set_dim(2, 3);
+
+    mat[0][0] = 1;
+    mat[0][1] = 2;
+    mat[0][2] = 3;
+    mat[1][0] = 4;
+    mat[1][1] = 5;
+    mat[1][2] = 6;
+}
+
+TEST_F(TensorTwoDTest, test_vector_product)
+{
+    auto fake_math = std::make_shared<MockTensorMath>();
+
+    std::vector<std::vector<float> > mat_a = {{1, 2}, {3, 4}, {5, 6}};
+    std::vector<float> vec_b = {7, 8};
+    std::vector<float> vec_c = {9, 10, 11};
+
+    TensorTwoD tensor_a(mat_a, fake_math);
+    TensorOneD tensor_b(vec_b, fake_math);
+    TensorOneD tensor_c(vec_c, fake_math);
+
+    Mock::AllowLeak(&*fake_math);
+    EXPECT_CALL(*fake_math, multiply(tensor_a, tensor_b)).WillOnce(Return(tensor_c));
+    TensorOneD tensor_d = tensor_a * tensor_b;
+
+    EXPECT_EQ(tensor_c.get_data(), tensor_d.get_data());
+}
+
+TEST_F(TensorTwoDTest, test_copy_constructor) {
+    TensorTwoD copy(mat);
+    EXPECT_EQ(1, copy[0][0]);
+    EXPECT_EQ(2, copy[0][1]);
+    EXPECT_EQ(3, copy[0][2]);
+    EXPECT_EQ(4, copy[1][0]);
+    EXPECT_EQ(5, copy[1][1]);
+    EXPECT_EQ(6, copy[1][2]);
+
+    // check that the copy is deep
+    copy[1][0] = -1;
+    EXPECT_EQ(4, mat[1][0]);
+    EXPECT_EQ(-1, copy[1][0]);
+}
+
+TEST_F(TensorTwoDTest, test_array_overload) {
+    const TensorTwoD mat_copy(mat);
+    mat[0] = mat_copy[1];
+    EXPECT_EQ(4, mat[0][0]);
+    EXPECT_EQ(5, mat[0][1]);
+    EXPECT_EQ(6, mat[0][2]);
+
+    // check that the copy is deep
+    mat[0][0] = 7;
+    EXPECT_EQ(7, mat[0][0]);
+    EXPECT_EQ(4, mat_copy[1][0]);
+}
+
+TEST_F(TensorTwoDTest, test_input) {
+    std::vector<std::vector<float> > vals = {{1}, {2}};
+    TensorTwoD x;
+    x = TensorTwoD(vals);
+    EXPECT_EQ(2u, x.get_rows());
+    EXPECT_EQ(1u, x.get_cols());
+    EXPECT_EQ(1, x[0][0]);
+    EXPECT_EQ(2, x[1][0]);
+}
+
+TEST_F(TensorTwoDTest, test_degenerate_size) {
+    TensorTwoD x;
+    EXPECT_EQ(0u, x.get_cols());
+}
+
+TEST_F(TensorTwoDTest, test_copy) {
+    TensorTwoD copy(3, 4);
+    copy.set_dim(1, 1);
+    copy = mat;
+
+    // copy is successful
+    EXPECT_EQ(1, copy[0][0]);
+    EXPECT_EQ(2, copy[0][1]);
+    EXPECT_EQ(3, copy[0][2]);
+    EXPECT_EQ(4, copy[1][0]);
+    EXPECT_EQ(5, copy[1][1]);
+    EXPECT_EQ(6, copy[1][2]);
+
+    // check that the copy is deep
+    copy[1][0] = -1;
+    EXPECT_EQ(4, mat[1][0]);
+    EXPECT_EQ(-1, copy[1][0]);
+}
+
+TEST_F(TensorTwoDTest, test_bad_dimensions)
+{
+    std::vector<std::vector<float> > vals = {{1}, {2, 3}};
+    EXPECT_THROW(new TensorTwoD(vals), geopm::Exception);  // TODO - new?
+}
+
+TEST_F(TensorTwoDTest, test_empty_weights)
+{
+    std::vector<std::vector<float> > vals = {};
+    EXPECT_THROW(new TensorTwoD(vals), geopm::Exception);  // TODO - new?
+}

--- a/test/TensorTwoDTest.cpp
+++ b/test/TensorTwoDTest.cpp
@@ -14,30 +14,31 @@
 #include "TensorOneDMatcher.hpp"
 #include "TensorTwoDMatcher.hpp"
 
-using geopm::TensorOneD;
-using geopm::TensorTwoD;
 using ::testing::Mock;
 using ::testing::Return;
 using ::testing::_;
+
+using geopm::TensorOneD;
+using geopm::TensorTwoD;
 
 class TensorTwoDTest : public ::testing::Test
 {
     protected:
         void SetUp();
 
-        TensorTwoD mat;
+        TensorTwoD m_mat;
 };
 
 void TensorTwoDTest::SetUp()
 {
-    mat.set_dim(2, 3);
+    m_mat.set_dim(2, 3);
 
-    mat[0][0] = 1;
-    mat[0][1] = 2;
-    mat[0][2] = 3;
-    mat[1][0] = 4;
-    mat[1][1] = 5;
-    mat[1][2] = 6;
+    m_mat[0][0] = 1;
+    m_mat[0][1] = 2;
+    m_mat[0][2] = 3;
+    m_mat[1][0] = 4;
+    m_mat[1][1] = 5;
+    m_mat[1][2] = 6;
 }
 
 TEST_F(TensorTwoDTest, test_vector_product)
@@ -52,14 +53,15 @@ TEST_F(TensorTwoDTest, test_vector_product)
     TensorOneD tensor_b(vec_b, fake_math);
     TensorOneD tensor_c(vec_c, fake_math);
 
-    EXPECT_CALL(*fake_math, multiply(TensorTwoDEqualTo(tensor_a), TensorOneDEqualTo(tensor_b))).WillOnce(Return(tensor_c));
+    EXPECT_CALL(*fake_math, multiply(TensorTwoDEqualTo(tensor_a),
+                TensorOneDEqualTo(tensor_b))).WillOnce(Return(tensor_c));
     TensorOneD tensor_d = tensor_a * tensor_b;
 
     EXPECT_EQ(tensor_c.get_data(), tensor_d.get_data());
 }
 
 TEST_F(TensorTwoDTest, test_copy_constructor) {
-    TensorTwoD copy(mat);
+    TensorTwoD copy(m_mat);
     EXPECT_EQ(1, copy[0][0]);
     EXPECT_EQ(2, copy[0][1]);
     EXPECT_EQ(3, copy[0][2]);
@@ -69,20 +71,20 @@ TEST_F(TensorTwoDTest, test_copy_constructor) {
 
     // check that the copy is deep
     copy[1][0] = -1;
-    EXPECT_EQ(4, mat[1][0]);
+    EXPECT_EQ(4, m_mat[1][0]);
     EXPECT_EQ(-1, copy[1][0]);
 }
 
 TEST_F(TensorTwoDTest, test_array_overload) {
-    const TensorTwoD mat_copy(mat);
-    mat[0] = mat_copy[1];
-    EXPECT_EQ(4, mat[0][0]);
-    EXPECT_EQ(5, mat[0][1]);
-    EXPECT_EQ(6, mat[0][2]);
+    const TensorTwoD mat_copy(m_mat);
+    m_mat[0] = mat_copy[1];
+    EXPECT_EQ(4, m_mat[0][0]);
+    EXPECT_EQ(5, m_mat[0][1]);
+    EXPECT_EQ(6, m_mat[0][2]);
 
     // check that the copy is deep
-    mat[0][0] = 7;
-    EXPECT_EQ(7, mat[0][0]);
+    m_mat[0][0] = 7;
+    EXPECT_EQ(7, m_mat[0][0]);
     EXPECT_EQ(4, mat_copy[1][0]);
 }
 
@@ -99,12 +101,13 @@ TEST_F(TensorTwoDTest, test_input) {
 TEST_F(TensorTwoDTest, test_degenerate_size) {
     TensorTwoD x;
     EXPECT_EQ(0u, x.get_cols());
+    EXPECT_EQ(0u, x.get_rows());
 }
 
 TEST_F(TensorTwoDTest, test_copy) {
     TensorTwoD copy(3, 4);
     copy.set_dim(1, 1);
-    copy = mat;
+    copy = m_mat;
 
     // copy is successful
     EXPECT_EQ(1, copy[0][0]);
@@ -116,7 +119,7 @@ TEST_F(TensorTwoDTest, test_copy) {
 
     // check that the copy is deep
     copy[1][0] = -1;
-    EXPECT_EQ(4, mat[1][0]);
+    EXPECT_EQ(4, m_mat[1][0]);
     EXPECT_EQ(-1, copy[1][0]);
 }
 

--- a/test/TensorTwoDTest.cpp
+++ b/test/TensorTwoDTest.cpp
@@ -50,7 +50,6 @@ TEST_F(TensorTwoDTest, test_vector_product)
     TensorOneD tensor_b(vec_b, fake_math);
     TensorOneD tensor_c(vec_c, fake_math);
 
-    Mock::AllowLeak(&*fake_math);
     EXPECT_CALL(*fake_math, multiply(tensor_a, tensor_b)).WillOnce(Return(tensor_c));
     TensorOneD tensor_d = tensor_a * tensor_b;
 

--- a/test/TensorTwoDTest.cpp
+++ b/test/TensorTwoDTest.cpp
@@ -5,6 +5,8 @@
 
 #include "config.h"
 
+#include <initializer_list>
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "geopm/Exception.hpp"
@@ -144,7 +146,8 @@ TEST_F(TensorTwoDTest, test_empty_weights)
 TEST_F(TensorTwoDTest, test_set_data)
 {
     TensorTwoD xx(2, 3);
-    std::vector<TensorOneD> vals_bad = {TensorOneD({1}), TensorOneD({2, 3})};
+    std::vector<TensorOneD> vals_bad = {TensorOneD(std::initializer_list<double>{1}),
+                                        TensorOneD({2, 3})};
     std::vector<TensorOneD> vals_good = {TensorOneD({1, 4}), TensorOneD({2, 3})};
     GEOPM_EXPECT_THROW_MESSAGE(xx.set_data(vals_bad), GEOPM_ERROR_INVALID,
                                "Attempt to load non-rectangular matrix.");

--- a/test/TensorTwoDTest.cpp
+++ b/test/TensorTwoDTest.cpp
@@ -44,9 +44,9 @@ TEST_F(TensorTwoDTest, test_vector_product)
 {
     auto fake_math = std::make_shared<MockTensorMath>();
 
-    std::vector<std::vector<float> > mat_a = {{1, 2}, {3, 4}, {5, 6}};
-    std::vector<float> vec_b = {7, 8};
-    std::vector<float> vec_c = {9, 10, 11};
+    std::vector<std::vector<double> > mat_a = {{1, 2}, {3, 4}, {5, 6}};
+    std::vector<double> vec_b = {7, 8};
+    std::vector<double> vec_c = {9, 10, 11};
 
     TensorTwoD tensor_a(mat_a, fake_math);
     TensorOneD tensor_b(vec_b, fake_math);
@@ -87,7 +87,7 @@ TEST_F(TensorTwoDTest, test_array_overload) {
 }
 
 TEST_F(TensorTwoDTest, test_input) {
-    std::vector<std::vector<float> > vals = {{1}, {2}};
+    std::vector<std::vector<double> > vals = {{1}, {2}};
     TensorTwoD x;
     x = TensorTwoD(vals);
     EXPECT_EQ(2u, x.get_rows());
@@ -122,12 +122,12 @@ TEST_F(TensorTwoDTest, test_copy) {
 
 TEST_F(TensorTwoDTest, test_bad_dimensions)
 {
-    std::vector<std::vector<float> > vals = {{1}, {2, 3}};
+    std::vector<std::vector<double> > vals = {{1}, {2, 3}};
     EXPECT_THROW(new TensorTwoD(vals), geopm::Exception);  // TODO - new?
 }
 
 TEST_F(TensorTwoDTest, test_empty_weights)
 {
-    std::vector<std::vector<float> > vals = {};
+    std::vector<std::vector<double> > vals = {};
     EXPECT_THROW(new TensorTwoD(vals), geopm::Exception);  // TODO - new?
 }


### PR DESCRIPTION
- Relates to #2617 
- Addresses #2693 
- Replaces #2618 
- Replaces #2628
- Replaces #2506 
- Replaces #2759 
- Replaces #2629  

-  Adds classes: TensorOneD, TensorTwoD, TensorMath, LocalNeuralNet, DomainNetMap, RegionHintRecommender
- Adds agent FFNetAgent for steering CPU / GPU frequency decisions