### PR TITLE
Add unit test for secure_make_dirs() to handle nested dirs

### DIFF
--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -122,6 +122,7 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestAccessLists.test__read_allowed_i
                  geopmdpy_test/pytest_links/TestSecureFiles.test_creation_bad_perms \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_creation_bad_user_owner \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_creation_bad_group_owner \
+                 geopmdpy_test/pytest_links/TestSecureFiles.test_creation_nested_dirs \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_read_file_not_exists \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_read_file_is_directory \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_read_file_is_link \

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -123,6 +123,7 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestAccessLists.test__read_allowed_i
                  geopmdpy_test/pytest_links/TestSecureFiles.test_creation_bad_user_owner \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_creation_bad_group_owner \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_creation_nested_dirs \
+                 geopmdpy_test/pytest_links/TestSecureFiles.test_umask_restored_on_error \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_read_file_not_exists \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_read_file_is_directory \
                  geopmdpy_test/pytest_links/TestSecureFiles.test_read_file_is_link \


### PR DESCRIPTION
Ensure secure_make_dirs() can create a requested path when parent directories don't exist.

- Fixes #2906 