### PR TITLE
Do not enable fixed counters by default

### DIFF
--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -102,10 +102,6 @@ namespace geopm
          "    description: The current operating frequency of the CPU.\n"
          "    iogroup: MSR\n"
          "    alias_for: MSR::PERF_STATUS:FREQ"},
-        {"CPU_INSTRUCTIONS_RETIRED",
-         "    description: The count of the number of instructions executed.\n"
-         "    iogroup: MSR\n"
-         "    alias_for: MSR::FIXED_CTR0:INST_RETIRED_ANY"},
         {"CPU_POWER_LIMIT_CONTROL",
          "    description: The average power usage limit over the time window specified in "
          "PL1_TIME_WINDOW.\n"

--- a/service/src/geopm/MSRIOGroup.hpp
+++ b/service/src/geopm/MSRIOGroup.hpp
@@ -145,8 +145,6 @@ namespace geopm
             /// @brief Add support for frequency control aliases if underlying
             ///        controls are available.
             void register_frequency_controls(void);
-            /// @brief Write to enable bits for all fixed counters.
-            void enable_fixed_counters(void);
             /// @brief Check system configuration and warn if it ma
             ///        interfere with the given control.
             void check_control(const std::string &control_name);
@@ -199,7 +197,6 @@ namespace geopm
             int m_num_cpu;
             bool m_is_active;
             bool m_is_read;
-            bool m_is_fixed_enabled;
             std::vector<bool> m_is_adjusted;
 
             // time for derivative signals


### PR DESCRIPTION
- Use APERF and MPERF for clock counts.
- Instructions retired will be zero unless the user programs the fixed counters manually.
- Removed alias for CPU_INSTRUCTIONS_RETIRED.
- TODO: Man page documentation still needs to be updated (including examples that use the signal).