### PR TITLE
Add CosmicTagger to the GEOPM experiment infrastructure

### DIFF
--- a/integration/apps/cosmictagger/0001-Initial-changes-for-testing-with-GEOPM.patch
+++ b/integration/apps/cosmictagger/0001-Initial-changes-for-testing-with-GEOPM.patch
@@ -1,0 +1,71 @@
+From f367c792cdd5f1360623cd835bad347046baa84d Mon Sep 17 00:00:00 2001
+From: "lowren.h.lawson@intel.com" <lowren.h.lawson@intel.com>
+Date: Thu, 1 Jun 2023 14:45:11 -0700
+Subject: [PATCH] Initial changes for testing with GEOPM
+
+Signed-off-by: lowren.h.lawson@intel.com <lowren.h.lawson@intel.com>
+---
+ bin/exec.py                                  | 11 ++++++-----
+ src/utils/tensorflow2/distributed_trainer.py |  6 +++---
+ 2 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/bin/exec.py b/bin/exec.py
+index a79aeb2..2e6640a 100755
+--- a/bin/exec.py
++++ b/bin/exec.py
+@@ -145,7 +145,7 @@ class exec(object):
+ 
+     def make_trainer(self):
+ 
+-        # Set the random seed for numpy, which controls the order of the 
++        # Set the random seed for numpy, which controls the order of the
+         # data loading:
+         data_seed = self.args.data.seed
+         if data_seed == 0:
+@@ -205,7 +205,7 @@ class exec(object):
+                 import torch
+                 torch.manual_seed(self.args.framework.see)
+                 torch.use_deterministic_algorithms(True)
+-                
++
+                 # Seed python too:
+                 import random; random.seed(framework_seed)
+ 
+@@ -287,8 +287,9 @@ class exec(object):
+ 
+ 
+ 
+-
+-@hydra.main(version_base=None, config_path="../src/config", config_name="config")
++#version_base is not working on the test system currently
++#@hydra.main(version_base=None, config_path="../src/config", config_name="config")
++@hydra.main(config_path="../src/config", config_name="config")
+ def main(cfg : OmegaConf) -> None:
+ 
+     s = exec(cfg)
+@@ -300,4 +301,4 @@ if __name__ == '__main__':
+     if "--help" not in sys.argv and "--hydra-help" not in sys.argv:
+         sys.argv += ['hydra/job_logging=disabled']
+     main()
+-    
++
+diff --git a/src/utils/tensorflow2/distributed_trainer.py b/src/utils/tensorflow2/distributed_trainer.py
+index 38a7713..4a778f5 100644
+--- a/src/utils/tensorflow2/distributed_trainer.py
++++ b/src/utils/tensorflow2/distributed_trainer.py
+@@ -10,9 +10,9 @@ from .trainer import tf_trainer
+ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+ import tensorflow as tf
+ 
+-for i, p in enumerate(sys.path):
+-    if ".local" in p:
+-        sys.path.pop(i)
++#for i, p in enumerate(sys.path):
++#    if ".local" in p:
++#        sys.path.pop(i)
+ 
+ import horovod.tensorflow as hvd
+ hvd.init()
+-- 
+2.18.1
+

--- a/integration/apps/cosmictagger/build.sh
+++ b/integration/apps/cosmictagger/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2023, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+set -x
+set -e
+
+# Get helper functions
+source ../build_func.sh
+
+if [[ $# -eq 0 ]]; then
+    echo 'Building from 40c5c1a'
+    TOPHASH=40c5c1a
+elif [[ $# -eq 1 ]]; then
+    echo 'Building from head of main'
+    TOPHASH=$1
+else
+    1>&2 echo "usage: $0 [HASH_FOR_HEAD_OF_MAIN]"
+    exit 1
+fi
+
+DIRNAME=CosmicTagger
+GITREPO=https://github.com/coreyjadams/CosmicTagger
+clean_source ${DIRNAME}
+
+ARCHIVE=${DIRNAME}_${TOPHASH}.tgz
+get_archive ${ARCHIVE}
+if [ -f ${ARCHIVE} ]; then
+        unpack_archive ${ARCHIVE}
+else
+        clone_repo_git ${GITREPO} ${DIRNAME} ${TOPHASH}
+fi
+
+setup_source_git ${DIRNAME}
+
+# install dependencies
+cd ${DIRNAME}
+python3 -m pip install scikit-build numpy --user --force-reinstall
+python3 -m pip install -r requirements.txt --ignore-installed
+python3 -m pip install mpi4py --user --force-reinstall
+python3 -m pip install decorator --user --force-reinstall
+python3 -m pip install tensorflow --user --force-reinstall
+python3 -m pip install cloudpickle --user --force-reinstall
+python3 -m pip install horovod --user --force-reinstall
+
+# setup small dataset
+cp example_data/cosmic_tagging_light.h5 example_data/cosmic_tagging_val.h5
+cd ../

--- a/integration/apps/cosmictagger/cosmictagger.py
+++ b/integration/apps/cosmictagger/cosmictagger.py
@@ -1,0 +1,45 @@
+#  Copyright (c) 2015 - 2023, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+import os
+import sys
+import glob
+
+from apps import apps
+
+
+class CosmicTaggerAppConf(apps.AppConf):
+    @staticmethod
+    def name():
+        return 'CosmicTagger'
+
+    def __init__(self, mach, node_count):
+        self.ranks_per_node = mach.num_gpu()
+
+        benchmark_dir = os.path.dirname(os.path.abspath(__file__))
+        self.data_directory = os.path.join(benchmark_dir, 'CosmicTagger/example_data/') #TODO: Make argument
+
+        problem_sizes = {
+            1: 'mode=train run.distributed=true run.minibatch_size={} data.data_directory={}'.format(self.ranks_per_node, self.data_directory)
+        }
+
+        if node_count not in problem_sizes:
+            raise RuntimeError("No input size defined for CosmicTagger on {} nodes".format(node_count))
+        self.app_params = problem_sizes[node_count]
+
+        self.exe_path = os.path.join(benchmark_dir, 'CosmicTagger/bin/exec.py')
+
+    def get_rank_per_node(self):
+        return self.ranks_per_node
+
+    def get_bash_exec_path(self):
+        return "python3 " + self.exe_path
+
+    def get_bash_exec_args(self):
+        return self.app_params + ' run.id=' + self.get_run_id()
+
+    def parse_fom(self, log_path):
+        # log path is ignored; use unique_name from init
+        result = 0
+        return result

--- a/integration/apps/parres/parres.py
+++ b/integration/apps/parres/parres.py
@@ -11,7 +11,7 @@ import subprocess
 from apps import apps
 
 def setup_run_args(parser):
-    """ Add common arguments for all run scripts.                                                                                                                                                                                                                                                                                                                
+    """ Add common arguments for all run scripts.
     """
     parser.add_argument('--parres-init-setup-file', dest='parres_init_setup',
                         action='store', type=str,
@@ -44,15 +44,15 @@ def setup_run_args(parser):
                         action='store', type=str,
                         help='Arguments for parres binary')
 
-    
-    
+
+
 def create_dgemm_appconf_cuda(mach, args):
-    ''' Create a ParresAppConfig object from an ArgParse and experiment.machine object.                                                                                                                                                                                                                                                                         
+    ''' Create a ParresAppConfig object from an ArgParse and experiment.machine object.
     '''
     return ParresDgemmAppConfCuda(mach, args.node_count, args.parres_cores_per_node, args.node_count,
                                   args.parres_gpus_per_node, args.parres_cores_per_rank, args.parres_init_setup, args.parres_exp_setup, args.parres_teardown, args.parres_args)
 
-    
+
 class ParresDgemmAppConfCuda(apps.AppConf):
     @staticmethod
     def name():
@@ -73,16 +73,16 @@ class ParresDgemmAppConfCuda(apps.AppConf):
 
         if node_count != 1:
             raise RuntimeError('ParRes Dgemm is only setup for 1 node not {}'.format(node_count))
-        
+
         if gpus_per_node is None:
             gpus_per_node = mach.num_gpu()
         else:
             if (gpus_per_node != mach.num_gpu()):
                 raise RuntimeError('Number of requested GPUs must be the same as the available # of GPUs')
 
-        if not ( self._cores_per_node // self.get_cpu_per_rank() == gpus_per_node):           
+        if not ( self._cores_per_node // self.get_cpu_per_rank() == gpus_per_node):
             raise RunTimeError('Can currently only handle the same # of ranks and GPUs per node')
-                
+
         benchmark_dir = os.path.dirname(os.path.abspath(__file__))
         _parres_default_setup(benchmark_dir, parres_init_setup, parres_exp_setup, parres_teardown)
 
@@ -125,8 +125,8 @@ class ParresDgemmAppConfCuda(apps.AppConf):
             os.chmod(self._parres_exp_setup, 0o755)
             subprocess.call(self._parres_exp_setup, shell=True)
 
-        
-    
+
+
     def experiment_teardown(self, output_dir):
         if not self._parres_teardown is None:
             os.chmod(self._parres_teardown, 0o755)
@@ -138,7 +138,7 @@ class ParresDgemmAppConfCuda(apps.AppConf):
 
 
 def create_dgemm_appconf_oneapi(mach, args):
-    ''' Create a ParresAppConfig object from an ArgParse and experiment.machine object.                                                                                                                                                                                                                                                                         
+    ''' Create a ParresAppConfig object from an ArgParse and experiment.machine object.
     '''
     return ParresDgemmAppConfOneapi(mach, args.node_count, args.parres_cores_per_node, args.node_count,
                                     args.parres_gpus_per_node, args.parres_cores_per_rank, args.parres_init_setup, args.parres_exp_setup, args.parres_teardown, args.parres_args)
@@ -212,15 +212,15 @@ class ParresDgemmAppConfOneapi(apps.AppConf):
         key = 'Rate (MF/s): '
         return _parse_parres_fom(key, log_path)
 
-            
+
 def create_nstream_appconf_cuda(mach, args):
-    ''' Create a ParresAppConfig object from an ArgParse and experiment.machine object.                                                                                                                                                                                                                                                                         
+    ''' Create a ParresAppConfig object from an ArgParse and experiment.machine object.
     '''
     return ParresNstreamAppConfCuda(mach, args.node_count, args.parres_cores_per_node, args.node_count,
                                     args.parres_gpus_per_node, args.parres_cores_per_rank, args.parres_init_setup, args.parres_exp_setup, args.parres_teardown,
                                     args.parres_args)
 
-    
+
 class ParresNstreamAppConfCuda(apps.AppConf):
     @staticmethod
     def name():
@@ -240,7 +240,7 @@ class ParresNstreamAppConfCuda(apps.AppConf):
 
         if node_count != 1:
             raise RuntimeError('ParRes Dgemm is only setup for 1 node not {}'.format(node_count))
-        
+
         if gpus_per_node is None:
             gpus_per_node = 1
         else:
@@ -248,12 +248,12 @@ class ParresNstreamAppConfCuda(apps.AppConf):
                 raise RuntimeError('Number of requested GPUs is more than the number ' +
                                    'of available GPUs: {}'.format(gpus_per_node))
 
-        if not ( ( self._cores_per_node // self.get_cpu_per_rank() == 1 ) and gpus_per_node == 1):           
+        if not ( ( self._cores_per_node // self.get_cpu_per_rank() == 1 ) and gpus_per_node == 1):
             raise RunTimeError('Can currently only handle 1 ranks per node and 1 GPUs per node')
-                
+
         benchmark_dir = os.path.dirname(os.path.abspath(__file__))
         _parres_default_setup(benchmark_dir, parres_init_setup, parres_exp_setup, parres_teardown)
- 
+
         self._parres_exp_setup = parres_exp_setup
         self._parres_teardown = parres_teardown
 
@@ -293,8 +293,8 @@ class ParresNstreamAppConfCuda(apps.AppConf):
             os.chmod(self._parres_exp_setup, 0o755)
             subprocess.call(self._parres_exp_setup, shell=True)
 
-        
-    
+
+
     def experiment_teardown(self, output_dir):
         if not self._parres_teardown is None:
             os.chmod(self._parres_teardown, 0o755)
@@ -307,7 +307,7 @@ class ParresNstreamAppConfCuda(apps.AppConf):
 
 
 def create_nstream_appconf_oneapi(mach, args):
-    ''' Create a ParresAppConfig object from an ArgParse and experiment.machine object.                                                                                                                                                                                                                                                                         
+    ''' Create a ParresAppConfig object from an ArgParse and experiment.machine object.
     '''
     return ParresNstreamAppConfOneapi(mach, args.node_count, args.parres_cores_per_node, args.node_count,
                                       args.parres_gpus_per_node, args.parres_cores_per_rank, args.parres_init_setup, args.parres_exp_setup, args.parres_teardown,
@@ -345,7 +345,7 @@ class ParresNstreamAppConfOneapi(apps.AppConf):
 
         benchmark_dir = os.path.dirname(os.path.abspath(__file__))
         _parres_default_setup(benchmark_dir, parres_init_setup, parres_exp_setup, parres_teardown)
- 
+
         self._parres_exp_setup = parres_exp_setup
         self._parres_teardown = parres_teardown
 
@@ -410,7 +410,7 @@ def _parres_default_setup(benchmark_dir, parres_init_setup, parres_exp_setup, pa
                 parres_exp_setup = os.path.join(benchmark_dir, parres_exp_setup)
             else:
                 raise RuntimeError("Parres-exp-setup file not found:" + parres_exp_setup)
-        
+
     if not parres_teardown is None:
         if not os.path.isfile(parres_teardown):
             if (os.path.isfile(os.path.join(benchmark_dir, parres_teardown))):

--- a/integration/experiment/energy_efficiency/run_gpu_activity_cosmic_tagger.py
+++ b/integration/experiment/energy_efficiency/run_gpu_activity_cosmic_tagger.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2015 - 2023, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+'''
+Run CosmicTagger with the gpu_activity agent.
+'''
+import argparse
+
+from experiment import machine
+from experiment.energy_efficiency import gpu_activity
+from apps.cosmictagger import cosmictagger
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    gpu_activity.setup_run_args(parser)
+    args, extra_args = parser.parse_known_args()
+    mach = machine.init_output_dir(args.output_dir)
+    app_conf = cosmictagger.CosmicTaggerAppConf(mach, args.node_count)
+    gpu_activity.launch(app_conf=app_conf, args=args,
+                        experiment_cli_args=extra_args)

--- a/integration/experiment/monitor/run_monitor_cosmictagger.py
+++ b/integration/experiment/monitor/run_monitor_cosmictagger.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2023, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+'''
+Run CosmicTagger with the monitor agent.
+'''
+
+import argparse
+from experiment.monitor import monitor
+from experiment import machine
+from apps.cosmictagger import cosmictagger
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    monitor.setup_run_args(parser)
+    args, extra_args = parser.parse_known_args()
+    mach = machine.init_output_dir(args.output_dir)
+    app_conf = cosmictagger.CosmicTaggerAppConf(mach, args.node_count)
+    monitor.launch(app_conf=app_conf, args=args,
+                   experiment_cli_args=extra_args)


### PR DESCRIPTION
- Relates to #2966 story from github issues
- Fixes #2966 change request from github issues.

Addition of the CosmicTagger workload to GEOPM apps.  Only the example data set is supported at this time, a user is required to add other input files as discussed [in the readme](https://github.com/coreyjadams/CosmicTagger) for CosmicTagger.  

Required to move this out of draft
- [x] Addition of experiment scripts for monitor and GPU-CA
- [x] End to end testing of build & run
- [x] Fix-ups to known issues in the cosmictagger.py launcher script, support for various modes of operation, ...