### PR TITLE
Fix issue with pthread launch mode

### DIFF
--- a/src/ApplicationIO.cpp
+++ b/src/ApplicationIO.cpp
@@ -25,7 +25,8 @@ namespace geopm
                            environment().profile(),
                            environment().report(),
                            environment().timeout(),
-                           environment().num_proc())
+                           environment().num_proc(),
+                           environment().pmpi_ctl())
     {
 
     }
@@ -34,13 +35,15 @@ namespace geopm
                                        const std::string &profile_name,
                                        const std::string &report_name,
                                        int timeout,
-                                       int num_proc)
+                                       int num_proc,
+                                       int ctl_mode)
         : m_is_connected(false)
         , m_service_proxy(service_proxy)
         , m_profile_name(profile_name)
         , m_report_name(report_name)
         , m_timeout(timeout)
         , m_num_proc(num_proc)
+        , m_ctl_mode(ctl_mode)
     {
 
     }
@@ -67,9 +70,11 @@ namespace geopm
         timespec delay = {0, 1000000};
         do {
             m_profile_pids = get_profile_pids();
-            auto ctl_it = m_profile_pids.find(getpid());
-            if (ctl_it != m_profile_pids.end()) {
-                m_profile_pids.erase(ctl_it);
+            if (m_ctl_mode != Environment::M_CTL_PTHREAD) {
+                auto ctl_it = m_profile_pids.find(getpid());
+                if (ctl_it != m_profile_pids.end()) {
+                    m_profile_pids.erase(ctl_it);
+                }
             }
             if (m_profile_pids.size() >= (size_t)m_num_proc) {
                 m_is_connected = true;

--- a/src/ApplicationIO.hpp
+++ b/src/ApplicationIO.hpp
@@ -52,7 +52,8 @@ namespace geopm
                              const std::string &profile_name,
                              const std::string &report_name,
                              int timeout,
-                             int num_proc);
+                             int num_proc,
+                             int ctl_mode);
             virtual ~ApplicationIOImp();
             std::vector<int> connect(void) override;
             bool do_shutdown(void) override;
@@ -70,6 +71,7 @@ namespace geopm
             const int m_timeout;
             std::set<int> m_profile_pids;
             int m_num_proc;
+            int m_ctl_mode;
     };
 }
 

--- a/test/ApplicationIOTest.cpp
+++ b/test/ApplicationIOTest.cpp
@@ -12,6 +12,7 @@
 #include "gmock/gmock.h"
 
 #include "ApplicationIO.hpp"
+#include "Environment.hpp"
 #include "geopm/Helper.hpp"
 #include "MockPlatformIO.hpp"
 #include "MockPlatformTopo.hpp"
@@ -46,7 +47,8 @@ void ApplicationIOTest::SetUp()
                                                     m_profile_name,
                                                     m_report_name,
                                                     5,
-                                                    1);
+                                                    1,
+                                                    geopm::Environment::M_CTL_NONE);
     m_app_io->connect();
 }
 


### PR DESCRIPTION
- In the case of pthread launch mode, allow the controller process to track itself.
- Fixes #2989
