### PR TITLE
Enable clang sanitizers for C++ code and unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: codespell-project/actions-codespell@v1.0
   build_and_test:
-    name: "build_and_test: ${{ matrix.config.name }} ${{ matrix.debug-flag }}"
+    name: "build: ${{ matrix.config.name }} ${{ matrix.debug-flag }} service:${{ matrix.service-asan-flag }} base:${{ matrix.base-asan-flag  }}"
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -45,6 +45,18 @@ jobs:
           cc: "gcc-9", cxx: "g++-9"
         }
         debug-flag: ["enable-debug", "disable-debug"]
+        service-asan-flag: ["disable-asan"]
+        base-asan-flag: ["disable-asan"]
+        include:
+        - config: {name: clang-12, cc: "clang-12", cxx: "clang++-12"}
+          debug-flag: "enable-debug"
+          service-asan-flag: "enable-asan"
+          base-asan-flag: "disable-asan"
+        - config: {name: clang-12, cc: "clang-12", cxx: "clang++-12"}
+          debug-flag: "enable-debug"
+          service-asan-flag: "disable-asan"
+          base-asan-flag: "enable-asan"
+
     env:
       CC: ${{ matrix.config.cc }}
       CXX: ${{ matrix.config.cxx }}
@@ -65,18 +77,21 @@ jobs:
       run: .github/include_guards.sh
     - name: configure service dir
       working-directory: service
-      run: ./autogen.sh && ./configure --${{ matrix.debug-flag }}
+      run: ./autogen.sh && ./configure --${{ matrix.debug-flag }} --${{ matrix.service-asan-flag }}
     - name: make service dir
       working-directory: service
       run: make -j2
     - name: configure base dir
-      run: ./autogen.sh && ./configure --enable-beta --disable-openmp --with-geopmd-lib=./service/.libs --with-geopmd-include=./service/src --${{ matrix.debug-flag }}
+      if: matrix.service-asan-flag != 'enable-asan'
+      run: ./autogen.sh && ./configure --enable-beta --disable-openmp --with-geopmd-lib=./service/.libs --with-geopmd-include=./service/src --${{ matrix.debug-flag }} --${{ matrix.base-asan-flag  }}
     - name: make base dir
+      if: matrix.service-asan-flag != 'enable-asan'
       run: make -j2
     - name: make checkprogs service
       working-directory: service
       run: make checkprogs -j2
     - name: make checkprogs base dir
+      if: matrix.service-asan-flag != 'enable-asan'
       run: make checkprogs -j2
     - name: make check service
       working-directory: service
@@ -84,11 +99,13 @@ jobs:
         LD_LIBRARY_PATH: .libs:${LD_LIBRARY_PATH}
       run: make check
     - name: make check basedir
+      if: matrix.service-asan-flag != 'enable-asan'
       run: make check
       env:
         LD_LIBRARY_PATH: .libs:./service/.libs:${LD_LIBRARY_PATH}
         PYTHONPATH: scripts:${PYTHONPATH}
     - name: test-dist
+      if: matrix.service-asan-flag != 'enable-asan' && matrix.base-asan-flag != 'enable-asan'
       run: ./copying_headers/test-dist
     - name: show failure logs
       if: ${{ failure() }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -682,7 +682,11 @@ rpm-dudley: dist
 geopm-tutorial.tar.gz: $(TUTORIAL_DIST)
 	tar --transform='s|^|geopm-|' -zcf $@ $^
 
+if !ENABLE_SANITIZERS
 checkprogs: gtest-checkprogs pytest-checkprogs $(check_PROGRAMS) $(check_LTLIBRARIES)
+else
+checkprogs: gtest-checkprogs $(check_PROGRAMS) $(check_LTLIBRARIES)
+endif
 
 # INCLUDES
 check_PROGRAMS =
@@ -699,9 +703,12 @@ PHONY_TARGETS = clean-local \
                 # end
 
 include test/Makefile.mk
+
+if !ENABLE_SANITIZERS
 include integration/Makefile.mk
 include examples/Makefile.mk
 include scripts/Makefile.mk
 include shell_completion/Makefile.mk
+endif
 
 .PHONY: $(PHONY_TARGETS)

--- a/configure.ac
+++ b/configure.ac
@@ -79,27 +79,6 @@ fi
 AC_SUBST([enable_beta])
 AM_CONDITIONAL([ENABLE_BETA], [test "x$enable_beta" = "x1"])
 
-if test "x$enable_debug" = "x1" ; then
-  AC_DEFINE([GEOPM_DEBUG], [ ], [Enables code for debugging])
-  CFLAGS="$CFLAGS -O0 -g"
-  CXXFLAGS="$CXXFLAGS -O0 -g"
-fi
-AC_SUBST([enable_debug])
-
-
-if test "x$enable_coverage" = "x1" ; then
-  AC_DEFINE([GEOPM_COVERAGE], [ ], [Enables test coverage reporting])
-  EXTRA_CFLAGS="$EXTRA_CFLAGS --coverage"
-  EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS --coverage"
-  EXTRA_LDFLAGS="$EXTRA_LDFLAGS --coverage -lgcov"
-fi
-AC_SUBST([enable_coverage])
-
-if test "x$enable_overhead" = "x1" ; then
-  AC_DEFINE([GEOPM_OVERHEAD], [ ], [Enables code for measuring overhead])
-fi
-AC_SUBST([enable_overhead])
-
 AC_ARG_WITH([sqlite3], [AS_HELP_STRING([--with-sqlite3=PATH],
             [specify directory for installed sqlite3 package.])])
 if test "x$with_sqlite3" != x; then
@@ -175,8 +154,6 @@ fi
 ],
 [enable_mpi="1"]
 )
-AC_SUBST([enable_mpi])
-AM_CONDITIONAL([ENABLE_MPI], [test "x$enable_mpi" = "x1"])
 
 AC_ARG_ENABLE([fortran],
   [AS_HELP_STRING([--disable-fortran], [Do not build fortran interface])],
@@ -188,6 +165,52 @@ fi
 ],
 [enable_fortran="1"]
 )
+
+# This block of code for enabling address sanitizers must come after debug,
+# mpi and fortran options, so its settings take precedence. At the moment,
+# sanitizers are targeted for C++ code and unit tests.
+AC_ARG_ENABLE([asan],
+  [AS_HELP_STRING([--enable-asan], [Build and test with address sanitizers enabled])],
+[if test "x$enable_asan" = "xno" ; then
+  enable_asan="0"
+else
+  enable_asan="1"
+  enable_debug="1"
+  enable_mpi="0"
+  enable_fortran="0"
+fi
+],
+[enable_asan="0"]
+)
+
+if test "x$enable_debug" = "x1" ; then
+  AC_DEFINE([GEOPM_DEBUG], [ ], [Enables code for debugging])
+  CFLAGS="$CFLAGS -O0 -g"
+  CXXFLAGS="$CXXFLAGS -O0 -g"
+fi
+AC_SUBST([enable_debug])
+
+if test "x$enable_coverage" = "x1" ; then
+  AC_DEFINE([GEOPM_COVERAGE], [ ], [Enables test coverage reporting])
+  EXTRA_CFLAGS="$EXTRA_CFLAGS --coverage"
+  EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS --coverage"
+  EXTRA_LDFLAGS="$EXTRA_LDFLAGS --coverage -lgcov"
+fi
+AC_SUBST([enable_coverage])
+
+if test "x$enable_asan" = "x1" ; then
+  EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -fsanitize=address -fno-omit-frame-pointer -mllvm -asan-use-private-alias=1"
+fi
+
+if test "x$enable_overhead" = "x1" ; then
+  AC_DEFINE([GEOPM_OVERHEAD], [ ], [Enables code for measuring overhead])
+fi
+AC_SUBST([enable_overhead])
+
+AC_SUBST([enable_asan])
+AM_CONDITIONAL([ENABLE_SANITIZERS], [test "x$enable_asan" = "x1"])
+AC_SUBST([enable_mpi])
+AM_CONDITIONAL([ENABLE_MPI], [test "x$enable_mpi" = "x1"])
 AC_SUBST([enable_fortran])
 AM_CONDITIONAL([ENABLE_FORTRAN], [test "x$enable_fortran" = "x1"])
 
@@ -243,7 +266,6 @@ if test "x$with_geopmd_lib" != x; then
   EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L$GEOPMD_LIBDIR"
   AC_SUBST([GEOPMD_LIBDIR])
 fi
-
 
 AC_ARG_WITH([libelf], [AS_HELP_STRING([--with-libelf=PATH],
             [specify directory for installed libelf package.])])
@@ -432,6 +454,7 @@ AC_SEARCH_LIBS([geopm_pio_read_signal], [geopmd])
 AC_CHECK_LIB([geopmd], [geopm_pio_read_signal], [], [
     echo "missing libgeopmd: Install the geopm-service and use --with-geopmd or --with-geopmd-lib to specify location"
     exit -1])
+
 AC_CHECK_HEADER([geopm_pio.h], [], [
     echo "missing geopm_pio.h: Install the geopm-service and use --with-geopmd or --with-geopmd-include to specify location"
     exit -1])

--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -328,7 +328,11 @@ rpm: dist
 	cp geopm-service.spec $(rpm_topdir)/SPECS/geopm-service.spec
 	rpmbuild $(rpmbuild_flags) -ba $(rpm_topdir)/SPECS/geopm-service.spec
 
+if !ENABLE_SANITIZERS
 checkprogs: gtest-checkprogs geopmdpy-checkprogs $(check_PROGRAMS) $(check_LTLIBRARIES)
+else
+checkprogs: gtest-checkprogs $(check_PROGRAMS) $(check_LTLIBRARIES)
+endif
 
 all-local: $(all_local)
 
@@ -351,6 +355,10 @@ DISTCLEANFILES =
 CLEANFILES = $(msr_cpp_files)
 
 include test/Makefile.mk
+
+if !ENABLE_SANITIZERS
 include geopmdpy_test/Makefile.mk
-include docs/Makefile.mk
 include integration/Makefile.mk
+endif
+
+include docs/Makefile.mk

--- a/service/configure.ac
+++ b/service/configure.ac
@@ -47,6 +47,20 @@ fi
 [enable_coverage="0"]
 )
 
+AC_ARG_ENABLE([asan],
+  [AS_HELP_STRING([--enable-asan], [Build and test with address sanitizers enabled])],
+[if test "x$enable_asan" = "xno" ; then
+  enable_asan="0"
+else
+  enable_asan="1"
+  enable_debug="1"
+fi
+],
+[enable_asan="0"]
+)
+AC_SUBST([enable_asan])
+AM_CONDITIONAL([ENABLE_SANITIZERS], [test "x$enable_asan" = "x1"])
+
 AC_ARG_ENABLE([docs],
   [AS_HELP_STRING([--disable-docs], [Disable the use of the Python sphinx tool to generate documentation])],
 [if test "x$enable_docs" = "xno" ; then
@@ -148,6 +162,10 @@ if test "x$enable_coverage" = "x1" ; then
 fi
 AC_SUBST([enable_coverage])
 
+if test "x$enable_asan" = "x1" ; then
+  EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -fsanitize=address -fno-omit-frame-pointer -mllvm -asan-use-private-alias=1"
+fi
+
 if test "x$enable_dcgm" = "x1" ; then
   ENABLE_DCGM=True
   AC_DEFINE([GEOPM_ENABLE_DCGM], [ ], [Enables use of the DCGM library to support NVIDA board GPUs])
@@ -219,11 +237,6 @@ AC_DEFINE_UNQUOTED([GEOPM_CONFIG_PATH],
 
 [EXTRA_CFLAGS="$EXTRA_CFLAGS -std=c99 -msse4.2"]
 [EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -std=c++17 -msse4.2"]
-
-[LDFLAGS="$EXTRA_LDFLAGS $LDFLAGS"]
-[CFLAGS="$EXTRA_CFLAGS $CFLAGS"]
-[CXXFLAGS="$EXTRA_CXXFLAGS $CXXFLAGS"]
-[CPPFLAGS="$EXTRA_CPPFLAGS $CPPFLAGS"]
 
 AC_SEARCH_LIBS([shm_open], [rt])
 AC_SEARCH_LIBS([shm_unlink], [rt])

--- a/service/src/Helper.cpp
+++ b/service/src/Helper.cpp
@@ -268,4 +268,31 @@ namespace geopm
         }
         return stat_struct.st_gid;
     };
+
+    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >
+        make_cpu_set(int num_cpu, const std::set<int> &cpu_enabled)
+    {
+        if (num_cpu < 128) {
+            num_cpu = 128;
+        }
+        std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> > result(
+            CPU_ALLOC(num_cpu),
+            [](cpu_set_t *ptr)
+            {
+                CPU_FREE(ptr);
+            });
+
+        auto enabled_it = cpu_enabled.cbegin();
+        for (int cpu_idx = 0; cpu_idx != num_cpu; ++cpu_idx) {
+            if (enabled_it != cpu_enabled.cend() &&
+                *enabled_it == cpu_idx) {
+                CPU_SET(cpu_idx, result.get());
+                ++enabled_it;
+            }
+            else {
+                CPU_CLR(cpu_idx, result.get());
+            }
+        }
+        return result;
+    }
 }

--- a/service/src/NVMLDevicePool.cpp
+++ b/service/src/NVMLDevicePool.cpp
@@ -96,8 +96,8 @@ namespace geopm
     {
         check_gpu_range(gpu_idx);
         unsigned int cpu_set_size = CPU_ALLOC_SIZE(M_NUM_CPU) / sizeof(unsigned long);
-        cpu_set_t *gpu_cpuset = CPU_ALLOC(M_NUM_CPU);
-        CPU_ZERO_S(CPU_ALLOC_SIZE(M_NUM_CPU), gpu_cpuset);
+	auto gpu_cpuset = make_cpu_set(M_NUM_CPU, {});
+        CPU_ZERO_S(CPU_ALLOC_SIZE(M_NUM_CPU), gpu_cpuset.get());
 
         if (!gpu_cpuset) {
             throw Exception("NVMLDevicePool: unable to allocate process CPU mask",
@@ -105,11 +105,11 @@ namespace geopm
         }
 
         nvmlReturn_t nvml_result = nvmlDeviceGetCpuAffinity(m_nvml_device.at(gpu_idx), cpu_set_size,
-                                                            (unsigned long *)gpu_cpuset);
+                                                            (unsigned long *)gpu_cpuset.get());
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get CPU Affinity bitmask for GPU " +
                           std::to_string(gpu_idx) + ".", __LINE__);
-        return gpu_cpuset;
+        return gpu_cpuset.get();
     }
 
     uint64_t NVMLDevicePoolImp::frequency_status_sm(int gpu_idx) const

--- a/service/src/NVMLGPUTopo.cpp
+++ b/service/src/NVMLGPUTopo.cpp
@@ -11,6 +11,7 @@
 
 #include "config.h"
 #include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
 #include "NVMLDevicePool.hpp"
 #include "NVMLGPUTopo.hpp"
 #include "geopm_topo.h"
@@ -32,9 +33,9 @@ namespace geopm
         else {
             int cpu_remaining = 0;
             std::vector<cpu_set_t *> ideal_affinitization_mask_vec;
-            cpu_set_t *affinitized_cpuset = CPU_ALLOC(num_cpu);
 
-            CPU_ZERO_S(CPU_ALLOC_SIZE(num_cpu), affinitized_cpuset);
+	    auto affinitized_cpuset = make_cpu_set(num_cpu, {});
+            CPU_ZERO_S(CPU_ALLOC_SIZE(num_cpu), affinitized_cpuset.get());
 
             m_cpu_affinity_ideal.resize(num_gpu);
 
@@ -48,10 +49,10 @@ namespace geopm
             for (unsigned int gpu_idx = 0; gpu_idx <  num_gpu; ++gpu_idx) {
                 for (int cpu_idx = 0; cpu_idx < num_cpu; cpu_idx++) {
                     if (CPU_ISSET(cpu_idx, ideal_affinitization_mask_vec.at(gpu_idx))) {
-                        if (CPU_ISSET(cpu_idx, affinitized_cpuset) == 0) {
+                        if (CPU_ISSET(cpu_idx, affinitized_cpuset.get()) == 0) {
                             //if this is in this GPU mask and has not
                             //been picked by another GPU
-                            CPU_SET(cpu_idx, affinitized_cpuset);
+                            CPU_SET(cpu_idx, affinitized_cpuset.get());
                             ++cpu_remaining;
                         }
                     }

--- a/service/src/NVMLIOGroup.cpp
+++ b/service/src/NVMLIOGroup.cpp
@@ -504,20 +504,20 @@ namespace geopm
         double result = -1;
         size_t num_cpu = m_platform_topo.num_domain(GEOPM_DOMAIN_CPU);
         size_t alloc_size = CPU_ALLOC_SIZE(num_cpu);
-        cpu_set_t *proc_cpuset = CPU_ALLOC(num_cpu);
+	auto proc_cpuset = make_cpu_set(num_cpu, {});
         if (proc_cpuset == NULL) {
             throw Exception("NVMLIOGroup::" + std::string(__func__) +
                             ": failed to allocate process CPU mask",
                             ENOMEM, __FILE__, __LINE__);
         }
         for (auto &proc : process_map) {
-            int err = sched_getaffinity(proc.first, alloc_size, proc_cpuset);
+            int err = sched_getaffinity(proc.first, alloc_size, proc_cpuset.get());
             if (err == EINVAL || err == EFAULT) {
                 throw Exception("NVMLIOGroup::" + std::string(__func__) +
                                 ": failed to get affinity mask for process: " +
                                 std::to_string(proc.first), err, __FILE__, __LINE__);
             }
-            if (!err && CPU_ISSET(cpu_idx, proc_cpuset)) {
+            if (!err && CPU_ISSET(cpu_idx, proc_cpuset.get())) {
                 result = proc.second;
                 // Return first match, w/o break will return last match
                 break;

--- a/service/src/SDBus.cpp
+++ b/service/src/SDBus.cpp
@@ -33,6 +33,12 @@ namespace geopm
         }
     }
 
+    static std::unique_ptr<sd_bus_error, void(*)(sd_bus_error*)>
+    create_bus_error_ptr(sd_bus_error *bus_error)
+    {
+        return std::unique_ptr<sd_bus_error, void(*)(sd_bus_error*)>(bus_error, sd_bus_error_free);
+    }
+
     std::unique_ptr<SDBus> SDBus::make_unique(void)
     {
         return geopm::make_unique<SDBusImp>();
@@ -53,7 +59,9 @@ namespace geopm
 
     SDBusImp::~SDBusImp()
     {
+        //sd_bus_flush(m_bus);
         sd_bus_close(m_bus);
+        sd_bus_unref(m_bus);
     }
 
     std::shared_ptr<SDBusMessage> SDBusImp::call_method(
@@ -61,6 +69,7 @@ namespace geopm
     {
         sd_bus_message *bus_reply;
         sd_bus_error bus_error = SD_BUS_ERROR_NULL;
+        auto bus_error_ptr = create_bus_error_ptr(&bus_error);
         int err = sd_bus_call(m_bus,
                               message->get_sd_ptr(),
                               m_dbus_timeout_usec,
@@ -74,6 +83,7 @@ namespace geopm
         const std::string &member)
     {
         sd_bus_error bus_error = SD_BUS_ERROR_NULL;
+        auto bus_error_ptr = create_bus_error_ptr(&bus_error);
         sd_bus_message *bus_reply = nullptr;
         int err = sd_bus_call_method(m_bus,
                                      m_dbus_destination,
@@ -94,6 +104,7 @@ namespace geopm
         int arg2)
     {
         sd_bus_error bus_error = SD_BUS_ERROR_NULL;
+        auto bus_error_ptr = create_bus_error_ptr(&bus_error);
         sd_bus_message *bus_reply = nullptr;
         int err = sd_bus_call_method(m_bus,
                                      m_dbus_destination,
@@ -116,6 +127,7 @@ namespace geopm
         double arg3)
     {
         sd_bus_error bus_error = SD_BUS_ERROR_NULL;
+        auto bus_error_ptr = create_bus_error_ptr(&bus_error);
         sd_bus_message *bus_reply = nullptr;
         int err = sd_bus_call_method(m_bus,
                                      m_dbus_destination,
@@ -135,6 +147,7 @@ namespace geopm
         int arg0)
     {
         sd_bus_error bus_error = SD_BUS_ERROR_NULL;
+        auto bus_error_ptr = create_bus_error_ptr(&bus_error);
         sd_bus_message *bus_reply = nullptr;
         int err = sd_bus_call_method(m_bus,
                                      m_dbus_destination,
@@ -154,6 +167,7 @@ namespace geopm
         const std::string &arg0)
     {
         sd_bus_error bus_error = SD_BUS_ERROR_NULL;
+        auto bus_error_ptr = create_bus_error_ptr(&bus_error);
         sd_bus_message *bus_reply = nullptr;
         int err = sd_bus_call_method(m_bus,
                                      m_dbus_destination,

--- a/service/src/geopm/Helper.hpp
+++ b/service/src/geopm/Helper.hpp
@@ -6,13 +6,15 @@
 #ifndef HELPER_HPP_INCLUDE
 #define HELPER_HPP_INCLUDE
 
+#include <stdint.h>
+#include <sched.h>
+
 #include <string>
 #include <memory>
 #include <utility>
 #include <vector>
-#include <stdint.h>
 #include <functional>
-
+#include <set>
 
 namespace geopm
 {
@@ -140,6 +142,14 @@ namespace geopm
     /// @param [in] pid The process id to query.
     /// @return The group id.
     unsigned int pid_to_gid(const int pid);
+
+    /// @brief Wrapper around CPU_ALLOC and CPU_FREE
+    /// @param [in] num_cpu The number of CPUs to allocate the CPU set
+    /// @param [in] cpu_enabled The CPUs to be included in the CPU set
+    /// @return A std::unique_ptr to a cpu_set_t configured to use CPU_FREE as
+    ///         the deleter.
+    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >
+        make_cpu_set(int num_cpu, const std::set<int> &cpu_enabled);
 }
 
 #endif

--- a/service/test/BatchServerTest.cpp
+++ b/service/test/BatchServerTest.cpp
@@ -946,7 +946,7 @@ int BatchServerTest::fork_other(std::function<void(int, int)> child_process_func
 {
     int main_pid = getpid();
     int pipe_fd[2];
-    pipe(pipe_fd);
+    (void)!pipe(pipe_fd);
     int &write_pipe_fd = pipe_fd[1];
     int &read_pipe_fd  = pipe_fd[0];
     int result = fork();
@@ -1052,7 +1052,7 @@ TEST_F(BatchServerTest, fork_and_terminate_child)
             .WillOnce([&write_pipe_fd](){
                 /* Extra code for synchronizing the server. */
                 char unique_char = '!';
-                write(write_pipe_fd, &unique_char, sizeof(unique_char));
+                (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
                 sleep(1024);
                 throw geopm::Exception("BatchStatusImp: System call failed: "
                                        "read(2)", EINTR, __FILE__, __LINE__);
@@ -1177,7 +1177,7 @@ TEST_F(BatchServerTest, fork_and_terminate_parent)
             .WillOnce([&write_pipe_fd](){
                 /* Extra code for synchronizing the server. */
                 char unique_char = '!';
-                write(write_pipe_fd, &unique_char, sizeof(unique_char));
+                (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
                 sleep(1024);
                 throw geopm::Exception("BatchStatusImp: System call failed: "
                                        "read(2)", EINTR, __FILE__, __LINE__);
@@ -1253,7 +1253,7 @@ TEST_F(BatchServerTest, action_sigchld)
 
         /* Extra code for synchronizing the server. */
         char unique_char = '!';
-        write(write_pipe_fd, &unique_char, sizeof(unique_char));
+        (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
 
         errno = 0;
         sleep(UINT_MAX);  // exits the sleep when it is interrupted by a signal
@@ -1307,7 +1307,7 @@ TEST_F(BatchServerTest, action_sigchld_error)
 
         /* Extra code for synchronizing the server. */
         char unique_char = '!';
-        write(write_pipe_fd, &unique_char, sizeof(unique_char));
+        (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
 
         errno = 0;
         sleep(UINT_MAX);  // exits the sleep when it is interrupted by a signal

--- a/service/test/BatchStatusTest.cpp
+++ b/service/test/BatchStatusTest.cpp
@@ -44,20 +44,20 @@ void BatchStatusTest::SetUp(void)
     // Explicitly force the fifo to be removed if it is already existing.
     m_status_path_in = m_server_prefix + m_server_key + "-in" ;
     m_status_path_out = m_server_prefix + m_server_key + "-out";
-    (void)unlink(m_status_path_in.c_str());
-    (void)unlink(m_status_path_out.c_str());
+    (void)!unlink(m_status_path_in.c_str());
+    (void)!unlink(m_status_path_out.c_str());
 }
 
 void BatchStatusTest::TearDown(void)
 {
-    (void)unlink(m_status_path_in.c_str());
-    (void)unlink(m_status_path_out.c_str());
+    (void)!unlink(m_status_path_in.c_str());
+    (void)!unlink(m_status_path_out.c_str());
 }
 
 int BatchStatusTest::fork_other(std::function<void(int)> child_process_func)
 {
     int pipe_fd[2];
-    pipe(pipe_fd);
+    (void)!pipe(pipe_fd);
     int &write_pipe_fd = pipe_fd[1];
     int &read_pipe_fd  = pipe_fd[0];
     int result = fork();
@@ -112,7 +112,7 @@ TEST_F(BatchStatusTest, client_send_to_server_fifo_expect)
         auto server_status = this->make_test_server(client_pid);
         /* Extra code for synchronizing the server process. */
         char unique_char = '!';
-        write(write_pipe_fd, &unique_char, sizeof(unique_char));
+        (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
 
         server_status->receive_message(BatchStatus::M_MESSAGE_READ);
     };
@@ -131,7 +131,7 @@ TEST_F(BatchStatusTest, server_send_to_client_fifo_expect)
         auto server_status = this->make_test_server(client_pid);
         /* Extra code for synchronizing the server process. */
         char unique_char = '!';
-        write(write_pipe_fd, &unique_char, sizeof(unique_char));
+        (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
 
         server_status->send_message(BatchStatus::M_MESSAGE_READ);
     };
@@ -150,7 +150,7 @@ TEST_F(BatchStatusTest, server_send_to_client_fifo)
         auto server_status = this->make_test_server(client_pid);
         /* Extra code for synchronizing the server process. */
         char unique_char = '!';
-        write(write_pipe_fd, &unique_char, sizeof(unique_char));
+        (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
 
         server_status->send_message(BatchStatus::M_MESSAGE_READ);
     };
@@ -171,7 +171,7 @@ TEST_F(BatchStatusTest, both_send_at_once_fifo_expect)
         auto server_status = this->make_test_server(client_pid);
         /* Extra code for synchronizing the server process. */
         char unique_char = '!';
-        write(write_pipe_fd, &unique_char, sizeof(unique_char));
+        (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
 
         server_status->send_message(BatchStatus::M_MESSAGE_WRITE);
         server_status->receive_message(BatchStatus::M_MESSAGE_READ);
@@ -192,7 +192,7 @@ TEST_F(BatchStatusTest, server_and_client_do_nothing)
         auto server_status = this->make_test_server(client_pid);
         /* Extra code for synchronizing the server process. */
         char unique_char = '!';
-        write(write_pipe_fd, &unique_char, sizeof(unique_char));
+        (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
     };
     int server_pid = fork_other(child_process_func);
 
@@ -208,7 +208,7 @@ TEST_F(BatchStatusTest, client_send_to_server_fifo_incorrect_expect)
         auto server_status = this->make_test_server(client_pid);
         /* Extra code for synchronizing the server process. */
         char unique_char = '!';
-        write(write_pipe_fd, &unique_char, sizeof(unique_char));
+        (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
 
         GEOPM_EXPECT_THROW_MESSAGE(
             server_status->receive_message(BatchStatus::M_MESSAGE_CONTINUE),
@@ -231,7 +231,7 @@ TEST_F(BatchStatusTest, bad_client_key)
         auto server_status = this->make_test_server(client_pid);
         /* Extra code for synchronizing the server process. */
         char unique_char = '!';
-        write(write_pipe_fd, &unique_char, sizeof(unique_char));
+        (void)!write(write_pipe_fd, &unique_char, sizeof(unique_char));
     };
     int server_pid = fork_other(child_process_func);
 

--- a/service/test/ConstConfigIOGroupTest.cpp
+++ b/service/test/ConstConfigIOGroupTest.cpp
@@ -23,8 +23,6 @@
 #include "geopm/Helper.hpp"
 #include "geopm/Agg.hpp"
 #include "geopm/Exception.hpp"
-#include "geopm/PlatformIO.hpp"
-#include "geopm/PlatformTopo.hpp"
 
 #include "MockPlatformTopo.hpp"
 
@@ -34,8 +32,6 @@ using ::testing::AtMost;
 
 using geopm::ConstConfigIOGroup;
 using geopm::Exception;
-using geopm::PlatformIO;
-using geopm::PlatformTopo;
 
 class ConstConfigIOGroupTest : public::testing::Test
 {

--- a/service/test/PlatformIOTest.cpp
+++ b/service/test/PlatformIOTest.cpp
@@ -14,6 +14,7 @@
 #include "gmock/gmock.h"
 
 #include "geopm_hash.h"
+#include "geopm_field.h"
 #include "PlatformIOImp.hpp"
 #include "geopm/IOGroup.hpp"
 #include "MockIOGroup.hpp"
@@ -824,7 +825,7 @@ TEST_F(PlatformIOTest, is_valid_value)
     EXPECT_EQ(false, m_platio->is_valid_value(std::numeric_limits<double>::quiet_NaN()));
     EXPECT_EQ(false, m_platio->is_valid_value(std::numeric_limits<double>::signaling_NaN()));
     {
-        long temp = 0x7ff00ff000000000;  // One of the possible NaN values
-        EXPECT_EQ(false, m_platio->is_valid_value(*(double*)&temp));
+        uint64_t temp = 0x7ff00ff000000000;  // One of the possible NaN values
+        EXPECT_EQ(false, m_platio->is_valid_value(geopm_field_to_signal(temp)));
     }
 }

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <iostream>
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <cerrno>
 #include <stdexcept>

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -25,6 +25,7 @@
 #include "ValidateRecord.hpp"
 #include "geopm/SharedMemory.hpp"
 #include "geopm/PlatformTopo.hpp"
+#include "geopm/Helper.hpp"
 #include "Scheduler.hpp"
 #include "record.hpp"
 #include "geopm_debug.hpp"
@@ -32,7 +33,6 @@
 #include "geopm_hint.h"
 #include "geopm_shmem.h"
 #include "geopm_field.h"
-#include "Scheduler.hpp"
 
 namespace geopm
 {

--- a/src/ProfileIOGroup.hpp
+++ b/src/ProfileIOGroup.hpp
@@ -9,6 +9,7 @@
 #include <set>
 #include <string>
 #include <functional>
+#include <array>
 
 #include "geopm/IOGroup.hpp"
 

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -7,37 +7,11 @@
 
 #include "Scheduler.hpp"
 #include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
 #include "geopm_sched.h"
 
 namespace geopm
 {
-    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >
-        make_cpu_set(int num_cpu, const std::set<int> &cpu_enabled)
-    {
-        if (num_cpu < 128) {
-            num_cpu = 128;
-        }
-        std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> > result(
-            CPU_ALLOC(num_cpu),
-            [](cpu_set_t *ptr)
-            {
-                CPU_FREE(ptr);
-            });
-
-        auto enabled_it = cpu_enabled.cbegin();
-        for (int cpu_idx = 0; cpu_idx != num_cpu; ++cpu_idx) {
-            if (enabled_it != cpu_enabled.cend() &&
-                *enabled_it == cpu_idx) {
-                CPU_SET(cpu_idx, result.get());
-                ++enabled_it;
-            }
-            else {
-                CPU_CLR(cpu_idx, result.get());
-            }
-        }
-        return result;
-    }
-
     std::unique_ptr<Scheduler> Scheduler::make_unique(void)
     {
         return std::make_unique<SchedulerImp>();

--- a/src/Scheduler.hpp
+++ b/src/Scheduler.hpp
@@ -7,15 +7,11 @@
 #define SCHEDULER_HPP_INCLUDE
 
 #include <memory>
-#include <set>
 #include <functional>
 #include <sched.h>
 
 namespace geopm
 {
-    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >
-        make_cpu_set(int num_cpu, const std::set<int> &cpu_enabled);
-
     class Scheduler
     {
         public:


### PR DESCRIPTION
- Relates to #2978 
- Fixes #2978 #2509 