### PR TITLE
Do not use program name for profile

### DIFF
--- a/service/docs/source/geopmlaunch.1.rst
+++ b/service/docs/source/geopmlaunch.1.rst
@@ -255,9 +255,8 @@ GEOPM Options
                                 example, when running a sweep of experiments
                                 with multiple power caps, the profile could
                                 contain the power setting for one run.  The
-                                default profile name is the name of the compute
-                                application executable.  This option is used by
-                                the launcher to set the ``GEOPM_PROFILE``
+                                default profile name is "default".  This option
+                                is used by the launcher to set the ``GEOPM_PROFILE``
                                 environment variable.  The command line option
                                 will override any value currently set in the
                                 environment.  See the :ref:`ENVIRONMENT section

--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -8,7 +8,6 @@
 #include <iostream>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -276,7 +275,7 @@ namespace geopm
         std::string env_profile = lookup("GEOPM_PROFILE");
         std::string ret = env_profile;
         if (do_profile() && ret.empty()) {
-            ret = std::string(program_invocation_name);
+            ret = "default";
         }
         else if (!ret.empty()) {
             // Sanitize the input: No carriage returns nor double quotes

--- a/test/EnvironmentTest.cpp
+++ b/test/EnvironmentTest.cpp
@@ -237,7 +237,7 @@ TEST_F(EnvironmentTest, user_only)
 
     m_env = geopm::make_unique<EnvironmentImp>("", "", &m_platform_io);
     std::map<std::string, std::string> exp_vars = m_user;
-    exp_vars["GEOPM_PROFILE"] = std::string(program_invocation_name);
+    exp_vars["GEOPM_PROFILE"] = "default";
     exp_vars["GEOPM_TIMEOUT"] = internal_default_vars["GEOPM_TIMEOUT"];
 
     expect_vars(exp_vars);
@@ -259,7 +259,7 @@ TEST_F(EnvironmentTest, user_only_do_profile)
 
     m_env = geopm::make_unique<EnvironmentImp>("", "", &m_platform_io);
     std::map<std::string, std::string> exp_vars = m_user;
-    exp_vars["GEOPM_PROFILE"] = std::string(program_invocation_name);
+    exp_vars["GEOPM_PROFILE"] = "default";
     exp_vars["GEOPM_TIMEOUT"] = internal_default_vars["GEOPM_TIMEOUT"];
 
     expect_vars(exp_vars);
@@ -475,7 +475,7 @@ TEST_F(EnvironmentTest, user_default_and_override)
         {"GEOPM_AGENT", override_vars["GEOPM_AGENT"]},
         {"GEOPM_TRACE", m_user["GEOPM_TRACE"]},
         {"GEOPM_TRACE_PROFILE", m_user["GEOPM_TRACE_PROFILE"]},
-        {"GEOPM_PROFILE", std::string(program_invocation_name)},
+        {"GEOPM_PROFILE", "default"},
         {"GEOPM_FREQUENCY_MAP", m_user["GEOPM_FREQUENCY_MAP"]},
         {"GEOPM_CTL", override_vars["GEOPM_CTL"]},
         {"GEOPM_MAX_FAN_OUT", default_vars["GEOPM_MAX_FAN_OUT"]},


### PR DESCRIPTION
- If controller is launched in with geopmctl, then the geopmctl profile name will not match the applications
- Fixes #3024
