### PR TITLE
Fix invalid pointer bug in cpu_affinity_ideal_mask

### DIFF
--- a/service/src/NVMLDevicePool.cpp
+++ b/service/src/NVMLDevicePool.cpp
@@ -92,11 +92,12 @@ namespace geopm
         }
     }
 
-    cpu_set_t *NVMLDevicePoolImp::cpu_affinity_ideal_mask(int gpu_idx) const
+    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >
+        NVMLDevicePoolImp::cpu_affinity_ideal_mask(int gpu_idx) const
     {
         check_gpu_range(gpu_idx);
         unsigned int cpu_set_size = CPU_ALLOC_SIZE(M_NUM_CPU) / sizeof(unsigned long);
-	auto gpu_cpuset = make_cpu_set(M_NUM_CPU, {});
+        auto gpu_cpuset = make_cpu_set(M_NUM_CPU, {});
         CPU_ZERO_S(CPU_ALLOC_SIZE(M_NUM_CPU), gpu_cpuset.get());
 
         if (!gpu_cpuset) {
@@ -109,7 +110,7 @@ namespace geopm
         check_nvml_result(nvml_result, GEOPM_ERROR_RUNTIME, "NVMLDevicePool::" + std::string(__func__) +
                           ": NVML failed to get CPU Affinity bitmask for GPU " +
                           std::to_string(gpu_idx) + ".", __LINE__);
-        return gpu_cpuset.get();
+        return gpu_cpuset;
     }
 
     uint64_t NVMLDevicePoolImp::frequency_status_sm(int gpu_idx) const

--- a/service/src/NVMLDevicePool.hpp
+++ b/service/src/NVMLDevicePool.hpp
@@ -27,7 +27,8 @@ namespace geopm
             /// @param [in] gpu_idx The index indicating a particular
             ///        GPU.
             /// @return CPU to GPU idea affinitization bitmask.
-            virtual cpu_set_t *cpu_affinity_ideal_mask(int gpu_idx) const = 0;
+            virtual std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >
+                cpu_affinity_ideal_mask(int gpu_idx) const = 0;
             /// @brief Get the NVML device streaming multiprocessor frequency
             ///        in MHz.
             /// @param [in] gpu_idx The index indicating a particular

--- a/service/src/NVMLDevicePoolImp.hpp
+++ b/service/src/NVMLDevicePoolImp.hpp
@@ -17,7 +17,8 @@ namespace geopm
             NVMLDevicePoolImp(const int num_cpu);
             virtual ~NVMLDevicePoolImp();
             virtual int num_gpu(void) const override;
-            virtual cpu_set_t *cpu_affinity_ideal_mask(int gpu_idx) const override;
+            virtual std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >
+                cpu_affinity_ideal_mask(int gpu_idx) const override;
             virtual uint64_t frequency_status_sm(int gpu_idx) const override;
             virtual std::vector<unsigned int> frequency_supported_sm(int gpu_idx) const override;
             virtual uint64_t utilization(int gpu_idx) const override;

--- a/service/test/MockNVMLDevicePool.hpp
+++ b/service/test/MockNVMLDevicePool.hpp
@@ -14,7 +14,8 @@ class MockNVMLDevicePool : public geopm::NVMLDevicePool
 {
     public:
         MOCK_METHOD(int, num_gpu, (), (const, override));
-        MOCK_METHOD(cpu_set_t *, cpu_affinity_ideal_mask, (int), (const, override));
+        MOCK_METHOD((std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >),
+                    cpu_affinity_ideal_mask, (int), (const, override));
         MOCK_METHOD(uint64_t, frequency_status_sm, (int), (const, override));
         MOCK_METHOD(std::vector<unsigned int>, frequency_supported_sm, (int), (const, override));
         MOCK_METHOD(uint64_t, utilization, (int), (const, override));


### PR DESCRIPTION
Make NVMLDevicePoolImp::cpu_affinity_ideal_mask return a std::unique_ptr.

- Fixes #3041 