### PR TITLE
Change REGION_PROGRESS to Agg::sum

### DIFF
--- a/service/docs/source/geopm_pio_profile.7.rst
+++ b/service/docs/source/geopm_pio_profile.7.rst
@@ -53,11 +53,12 @@ Signals
     * **Unit**: geopm_region_hint_e
 
 ``PROFILE::REGION_PROGRESS``
-    Minimum per-rank reported progress through the current region.  When
-    utilizing OpenMP, the per-CPU returned value will be on the interval [0, 1
-    / *num_thread*] where *num_thread* is the number of requested OpenMP threads
-    per rank.  When running single-threaded (i.e. not leveraging OpenMP), the
-    per-CPU returned value will be on the interval [0, 1].
+    Sum of the fractional progress reported by all CPUs over the aggregated
+    domain.  When utilizing OpenMP, the per-CPU returned value will be on the
+    interval [0, 1 / *num_thread*] where *num_thread* is the number of
+    requested OpenMP threads per rank.  When running single-threaded (i.e. not
+    leveraging OpenMP), the per-CPU returned value will either be zero (no
+    active threads), or on the interval [0, 1].
 
     When aggregating this signal to the board domain, the aggregated value will
     always be on the interval [0, *num_rank*] where *num_rank* is equal to the
@@ -66,8 +67,8 @@ Signals
     aggregated signal) indicates the region is complete.
 
     This signal is not valid outside of a region.  Specifically, this signal
-    should be ignored any time the board aggregated ``REGION_HASH`` signal
-    resolves to ``GEOPM_REGION_HASH_UNMARKED``.
+    should be ignored any time the ``REGION_HASH`` signal aggregated to the
+    same domain resolves to ``GEOPM_REGION_HASH_UNMARKED``.
 
     * **Aggregation**: sum
     * **Domain**: cpu

--- a/service/docs/source/geopm_pio_profile.7.rst
+++ b/service/docs/source/geopm_pio_profile.7.rst
@@ -53,11 +53,23 @@ Signals
     * **Unit**: geopm_region_hint_e
 
 ``PROFILE::REGION_PROGRESS``
-    Minimum per-rank reported progress through the current region.  The
-    returned value will be on the interval [0, 1].  0 indicates no progress
-    while 1 indicates the region is complete.
+    Minimum per-rank reported progress through the current region.  When
+    utilizing OpenMP, the per-CPU returned value will be on the interval [0, 1
+    / *num_thread*] where *num_thread* is the number of requested OpenMP threads
+    per rank.  When running single-threaded (i.e. not leveraging OpenMP), the
+    per-CPU returned value will be on the interval [0, 1].
 
-    * **Aggregation**: min
+    When aggregating this signal to the board domain, the aggregated value will
+    always be on the interval [0, *num_rank*] where *num_rank* is equal to the
+    number of ranks (processes) in the run.  0 indicates no progress while 1 (if
+    examining the per-CPU signal) or *num_rank* (if examining the board
+    aggregated signal) indicates the region is complete.
+
+    This signal is not valid outside of a region.  Specifically, this signal
+    should be ignored any time the board aggregated ``REGION_HASH`` signal
+    resolves to ``GEOPM_REGION_HASH_UNMARKED``.
+
+    * **Aggregation**: sum
     * **Domain**: cpu
     * **Format**: float
     * **Unit**: progress percentage

--- a/src/ProfileIOGroup.cpp
+++ b/src/ProfileIOGroup.cpp
@@ -322,8 +322,8 @@ namespace geopm
     std::function<double(const std::vector<double> &)> ProfileIOGroup::agg_function(const std::string &signal_name) const
     {
         static const std::map<std::string, std::function<double(const std::vector<double> &)> > fn_map {
-            {"REGION_PROGRESS", Agg::min},
-            {"PROFILE::REGION_PROGRESS", Agg::min},
+            {"REGION_PROGRESS", Agg::sum},
+            {"PROFILE::REGION_PROGRESS", Agg::sum},
             {"REGION_HASH", Agg::region_hash},
             {"PROFILE::REGION_HASH", Agg::region_hash},
             {"REGION_HINT", Agg::region_hint},


### PR DESCRIPTION
- Aggregated REGION_PROGRESS will now have a max = the number of ranks in the run.
- Add integration test for no_omp use case.
- Resolves #2916.