### PR TITLE
Add a frequency rebalancer agent

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -92,6 +92,7 @@ install_man:
 	rm -f $(DESTDIR)$(mandir)/man3/geopm_fortran.3
 	rm -f $(DESTDIR)$(mandir)/man3/geopm_policystore.3
 	rm -f $(DESTDIR)$(mandir)/man7/geopm_agent_cpu_activity.7
+	rm -f $(DESTDIR)$(mandir)/man7/geopm_agent_frequency_balancer.7
 	rm -f $(DESTDIR)$(mandir)/man7/geopm_agent_gpu_activity.7
 
 install_completion:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,6 +173,7 @@ rst_files = [
     "geopm_agent.3",
     "geopm_agent_cpu_activity.7",
     "geopm_agent_ffnet.7",
+    "geopm_agent_frequency_balancer.7",
     "geopm_agent_frequency_map.7",
     "geopm_agent_gpu_activity.7",
     "geopm_agent_monitor.7",

--- a/docs/source/geopm.7.rst
+++ b/docs/source/geopm.7.rst
@@ -108,6 +108,7 @@ GEOPM comes packaged with several built-in power management algorithms (*agents*
 * :doc:`geopm_agent_power_balancer(7) <geopm_agent_power_balancer.7>`: An agent that optimizes performance under a power cap across multiple CPU packages.
 * :doc:`geopm_agent_power_governor(7) <geopm_agent_power_governor.7>`: An agent that enforces a power cap.
 * :doc:`geopm_agent_gpu_activity(7) <geopm_agent_gpu_activity.7>` : An agent that sets GPU frequency based on GPU compute activity
+* :doc:`geopm_agent_frequency_balancer(7) <geopm_agent_frequency_balancer.7>`: An agent that reduces imbalance through CPU core frequency controls.
 
 Use the :doc:`geopmagent(1) <geopmagent.1>` application or the
 :doc:`geopm_agent(3) <geopm_agent.3>` C interface to query agent
@@ -408,6 +409,7 @@ See Also
 :doc:`geopm_agent_gpu_activity(7) <geopm_agent_gpu_activity.7>`,
 :doc:`geopm_agent_power_balancer(7) <geopm_agent_power_balancer.7>`,
 :doc:`geopm_agent_power_governor(7) <geopm_agent_power_governor.7>`,
+:doc:`geopm_agent_frequency_balancer(7) <geopm_agent_frequency_balancer.7>`,
 :doc:`geopm_pio(7) <geopm_pio.7>`,
 :doc:`geopm_pio_const_config(7) <geopm_pio_const_config.7>`,
 :doc:`geopm_pio_cnl(7) <geopm_pio_cnl.7>`,

--- a/docs/source/geopm_agent_frequency_balancer.7.rst
+++ b/docs/source/geopm_agent_frequency_balancer.7.rst
@@ -1,0 +1,136 @@
+geopm_agent_frequency_balancer(7) -- Agent reduces imbalance across CPU cores
+=============================================================================
+.. meta::
+
+    :description: The GEOPM frequency_balancer agent reduces imbalance across
+                  CPU cores through frequency controls and performance-guided
+                  turbo limits.
+    :keywords: frequency balancer agent imbalance SST-TF P-States
+
+Description
+-----------
+The ``frequency_balancer`` agent reduces imbalance across CPU cores.
+The executing application's main compute loop must be annotated with
+``geopm_prof_epoch()`` from :doc:`geopm_prof(3) <geopm_prof.3>`. The agent
+assumes that core application time can be measured as time spent outside of
+networking regions of code. CPU cores that spend less networking time per
+epoch are allocated higher CPU frequency limits, while cores that spend more
+networking time per epoch are allocated lower CPU frequency limits.
+
+Allocating CPU Core Frequency Limits
+------------------------------------
+The agent estimates a running application's critical path in each epoch,
+estimates the best-case critical path time the agent can make the application
+achieve (sometimes with energy savings, sometimes with performance improvement),
+and applies frequency control settings that the agent estimates will let each
+core achieve the target best-case time.
+
+The following subsections outline the agent's responsibilities at a high level.
+See `Guiding Hardware-Driven Turbo with Application Performance Awareness <https://ieeexplore.ieee.org/abstract/document/9969356>`_
+for more details.
+
+Critical Path Time Estimates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The agent measures the non-networking time as time that each core spends with
+the ``GEOPM_REGION_HINT_NETWORK`` hint *inactive* in each epoch. By default,
+GEOPM annotates all MPI function calls with that hint. The agent aims to set
+frequency controls that reduce the variation of non-networking time across
+cores.
+
+Frequency Control Decisions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Frequency control decisions applied to one core may impact the achievable
+frequency on other cores. In general, if the platform throttles frequency
+lower than a user's requested frequency due to resource constraints, then
+throttling other cores may lessen the need for platform-induced throttling.
+Furthermore some platforms support heterogeneous turbo frequency limits, where
+the number of cores configured with high turbo limits impacts the maximum
+achievable frequency. The agent performs estimates of the application
+performance tradeoffs in these cases.
+
+Heterogeneous Turbo Frequency Limits
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Turbo frequency boosting allows a CPU to temporarily achieve higher than its
+base frequency while still respecting hardware design constraints. Typically,
+higher turbo frequency is achievable when only one CPU core is active (i.e.,
+*single-core turbo*) than when all CPU cores are active (i.e., *all-core
+turbo*). Some platforms support heterogeneous user-configurable turbo frequency
+limits through the *Intel(R) Speed Select Technology - Turbo Frequency*
+(SST-TF) feature.
+
+This agent queries the platform to learn the frequency trade-offs of different
+possible SST-TF configurations. The agent estimates the potential critical
+path time for each possible configuration, and applies the configuration that
+results in the least estimated time.
+
+Agent Configuration
+-------------------
+Execute an application with this agent by specifying
+``--geopm-agent=frequency_balancer`` in the :doc:`geopmlaunch(1) <geopmlaunch.1>`
+command line arguments.
+
+The agent is capable of influencing CPU core performance through P-State
+settings and through heterogeneous turbo frequency limits via SST-TF. Each
+type of control can be used in isolation, or they can be used together.
+If SST-TF is requested on a platform that does not support that feature, then
+the request to use SST-TF is ignored.
+
+Specify the desired types of performance influencers through a policy json file
+and indicate the location of the file with ``--geopm-policy=<path-to-file>``.
+The :doc:`geopmagent(1) <geopmagent.1>` tool can help construct a policy file.
+
+Agent Policy Definitions
+------------------------
+This agent's behavior is influenced by the following GEOPM policy fields. At
+least one balancing option must be set to ``1``.
+
+``USE_FREQUENCY_LIMITS``
+    Set to ``1`` if you want the agent to use per-core P-States to help balance
+    the application. Default: ``1``
+``USE_SST_TF``
+    Set to ``1`` if you want the agent to use SST-TF to help balance the
+    application. Default: ``1``
+
+If both P-States and SST-TF are used, then the agent uses both per-core
+P-States and SST-TF controls to help balance the application.
+
+Trace Column Extensions
+-----------------------
+This agent adds the following columns to GEOPM trace files:
+
+``NON_NET_TIME_PER_EPOCH-core-<core>``
+    This collection of columns indicates the amount of non-networking time the
+    agent measured for each core in the epoch prior to the in-progress epoch.
+    This is the time metric that the agent attempts to balance across cores
+    within each CPU package.
+``DESIRED_NON_NETWORK_TIME-package-<package>``
+    This collection of columns indicates the agent's estimate for the most time
+    any core will spend in non-networking code for the current epoch in each
+    package.
+
+Report Extensions
+-----------------
+This agent adds the following fields to the root level of GEOPM reports:
+
+``Agent uses frequency control``
+    Indicates whether the agent used P-State frequency limits to manipulate
+    application performance across CPU cores.
+``Agent uses SST-TF``
+    Indicates whether the agent used SST-TF heterogeneous turbo limits to
+    manipulate application performance across CPU cores. This may indicate
+    ``0`` even if ``USE_SST_TF`` was set to ``1`` in the policy if the platform
+    does not support SST-TF, or if the agent is otherwise not able to use that
+    feature on the platform.
+
+Control Loop Gate
+-----------------
+The agent limits each step of the the GEOPM Controller's main loop to execute
+no faster than once every *5 ms*.
+
+See Also
+--------
+:doc:`geopm(7) <geopm.7>`,
+:doc:`geopmagent(1) <geopmagent.1>`,
+:doc:`geopm_agent(3) <geopm_agent.3>`,
+:doc:`geopmlaunch(1) <geopmlaunch.1>`,
+:doc:`geopm_prof(3) <geopm_prof.3>`

--- a/docs/source/geopmagent.1.rst
+++ b/docs/source/geopmagent.1.rst
@@ -109,4 +109,5 @@ See Also
 :doc:`geopm_agent_power_balancer(7) <geopm_agent_power_balancer.7>`,
 :doc:`geopm_agent_power_governor(7) <geopm_agent_power_governor.7>`,
 :doc:`geopm_agent_ffnet(7) <geopm_agent_ffnet.7>`,
+:doc:`geopm_agent_frequency_balancer(7) <geopm_agent_frequency_balancer.7>`,
 :doc:`geopm_agent(3) <geopm_agent.3>`

--- a/docs/source/geopmlaunch.1.rst
+++ b/docs/source/geopmlaunch.1.rst
@@ -308,6 +308,7 @@ GEOPM Options
                       are: ``"monitor"`` (default, enables profiling features
                       only), ``"power_balancer"`` (optimizes runtime under a power
                       cap), ``"power_governor"`` (enforces a uniform power cap),
+                      ``"frequency_balancer"`` (reduces imbalance across CPU cores),
                       and ``"frequency_map"`` (runs each region at a specified
                       frequency).  See :doc:`geopm_agent_monitor(7)
                       <geopm_agent_monitor.7>`,
@@ -315,6 +316,8 @@ GEOPM Options
                       <geopm_agent_power_balancer.7>`,
                       :doc:`geopm_agent_power_governor(7)
                       <geopm_agent_power_governor.7>`,
+                      :doc:`geopm_agent_frequency_balancer(7)
+                      <geopm_agent_frequency_balancer.7>`, and
                       :doc:`geopm_agent_frequency_map(7)
                       <geopm_agent_frequency_map.7>` and
                       :doc:`geopm_agent_ffnet(7)
@@ -673,6 +676,7 @@ See Also
 :doc:`geopm_agent_monitor(7) <geopm_agent_monitor.7>`,
 :doc:`geopm_agent_power_balancer(7) <geopm_agent_power_balancer.7>`,
 :doc:`geopm_agent_power_governor(7) <geopm_agent_power_governor.7>`,
+:doc:`geopm_agent_frequency_balancer(7) <geopm_agent_frequency_balancer.7>`,
 :doc:`geopm_report(7) <geopm_report.7>`,
 :doc:`geopm_error(3) <geopm_error.3>`,
 :doc:`geopmctl(1) <geopmctl.1>`

--- a/integration/.gitignore
+++ b/integration/.gitignore
@@ -1,3 +1,4 @@
+/apps/arithmetic_intensity/ARITHMETIC_INTENSITY*.tgz
 /apps/hpcg/hpcg/
 /apps/hpl_netlib/hpl-2.3/
 /apps/nasft/nasft/nas_ft

--- a/integration/.gitignore
+++ b/integration/.gitignore
@@ -12,6 +12,7 @@
 /test/*.h5
 /test/*.log
 /test/*.report
+/test/test_cores_rebalance_output/
 /test/test_ee_short_region_slop
 /test/test_ee_timed_scaling_mix
 /test/test_enforce_policy

--- a/integration/apps/apps.py
+++ b/integration/apps/apps.py
@@ -218,6 +218,15 @@ class AppConf(object):
         '''
         return self._exec_path
 
+    def get_program_filter(self):
+        ''' Name of the executable used by application, used as a filter for GEOPM reporting.
+
+            Returns:
+                str: program name to profile
+
+        '''
+        return self._exec_path
+
     def get_bash_exec_args(self):
         ''' Command line arguments to the application as a string or
             list of strings to be joined using " ".

--- a/integration/apps/arithmetic_intensity/arithmetic_intensity.py
+++ b/integration/apps/arithmetic_intensity/arithmetic_intensity.py
@@ -119,3 +119,11 @@ class ArithmeticIntensityAppConf(apps.AppConf):
                 '--ntasks-per-core=1'
             ])
         return args
+
+    def parse_fom(self, log_path):
+        with open(log_path) as fid:
+            for line in fid.readlines():
+                if line.strip().startswith('Performance'):
+                    total_ops_sec = float(line.split()[1])
+                    return total_ops_sec
+        return float('nan')

--- a/integration/apps/arithmetic_intensity/arithmetic_intensity.py
+++ b/integration/apps/arithmetic_intensity/arithmetic_intensity.py
@@ -14,6 +14,7 @@ import sys
 
 from integration.apps import apps
 
+
 def exec_path(run_type):
     '''
     Args
@@ -27,6 +28,7 @@ def exec_path(run_type):
     benchmark_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(benchmark_dir, "ARITHMETIC_INTENSITY", "bench_" + run_type)
 
+
 def setup_run_args(parser):
     """ Add common arguments for all run scripts.
     """
@@ -37,18 +39,20 @@ def setup_run_args(parser):
     parser.add_argument('--ranks-per-node', dest='ranks_per_node',
                         action='store', type=int,
                         help='Number of physical cores to reserve for the app. '
-                             'If not defined, all nodes but one will be reserved (leaving one '
-                             'node for GEOPM).')
+                             'If not defined, all nodes but one will be '
+                             'reserved (leaving one node for GEOPM).')
     parser.add_argument('--slowdown', type=float, default=1,
-        help='When imbalance is present, this specifies the amount of work for slow ranks'
-             ' to perform, as a factor of the amount of work the fast ranks perform.')
+                        help='When imbalance is present, this specifies the '
+                        'amount of work for slow ranks to perform, as a factor '
+                        'of the amount of work the fast ranks perform.')
     parser.add_argument('--base-internal-iterations', type=int,
-        help='How many iterations to perform in the inner loop, for the fast set of ranks '
-             '(all ranks if there is no imbalance).')
+                        help='How many iterations to perform in the inner loop, '
+                        'for the fast set of ranks (all ranks if there is no imbalance).')
     parser.add_argument('--slow-ranks', type=int,
-        help='The number of ranks to run with extra work for an imbalanced load.')
+                        help='The number of ranks to run with extra work for an imbalanced load.')
     parser.add_argument('--slow-ranks-per-imbalanced-group', type=int,
-        help='The number of ranks to run with extra work within each imbalance group for an imbalanced load.')
+                        help='The number of ranks to run with extra work within '
+                        'each imbalance group for an imbalanced load.')
     parser.add_argument('--ranks-per-imbalanced-group', type=int, default=0,
                         help='Total number of ranks in each imbalanced group of ranks. When '
                              '--slowdown is used, the first --slow-ranks count of '
@@ -56,20 +60,25 @@ def setup_run_args(parser):
                              'will receive extra work. Default: All ranks are in a '
                              'single group.')
     parser.add_argument('--floats', type=int, default=67108864,
-        help='The number of floating-point numbers per rank in the problem array.')
+                        help='The number of floating-point numbers per rank in '
+                        'the problem array.')
     parser.add_argument('-v', '--verbose', help='Run in verbose mode.')
     parser.add_argument('-s', '--single-precision', help='Run in single-precision mode.')
     parser.add_argument('-l', '--list', action='store_true',
-        help='List the available arithmetic intensity levels for use with the --benchmarks option.')
+                        help='List the available arithmetic intensity levels '
+                        'for use with the --benchmarks option.')
     parser.add_argument('-i', '--iterations', type=int, default=5,
-        help='The number of times to run each phase of the benchmark.')
+                        help='The number of times to run each phase of the '
+                        'benchmark.')
     parser.add_argument('-b', '--benchmarks', nargs='+',
-        type=float, choices=[0, 0.25, 0.5, 1, 2, 4, 8, 16, 32],
-        help='List of benchmark intensity variants to run (all are run if this option is not'
-             ' specified).')
+                        type=float, choices=[0, 0.25, 0.5, 1, 2, 4, 8, 16, 32],
+                        help='List of benchmark intensity variants to run '
+                        '(all are run if this option is not specified).')
     parser.add_argument('--start-time', type=int,
-        help='Time at which the benchmark will start, in seconds since the system clock\'s epoch.'
-             ' Start immediately by default, or if the provided time is in the past.')
+                        help='Time at which the benchmark will start, in seconds '
+                        'since the system clock\'s epoch. Start immediately by '
+                        'default, or if the provided time is in the past.')
+
 
 def create_appconf(mach, args):
     ''' Create a ArithmeticIntensityAppConf object from an ArgParse and experiment.machine object.
@@ -94,6 +103,7 @@ def create_appconf(mach, args):
 
     return ArithmeticIntensityAppConf(app_args, mach, args.run_type, args.ranks_per_node)
 
+
 class ArithmeticIntensityAppConf(apps.AppConf):
     def name(self):
         return f"arithmetic_intensity_{self.__run_type}"
@@ -115,6 +125,9 @@ class ArithmeticIntensityAppConf(apps.AppConf):
 
     def get_cpu_per_rank(self):
         return 1
+
+    def get_custom_geopm_args(self):
+        return ['--geopm-affinity-enable']
 
     def parse_fom(self, log_path):
         with open(log_path) as fid:

--- a/integration/apps/arithmetic_intensity/build.sh
+++ b/integration/apps/arithmetic_intensity/build.sh
@@ -10,8 +10,8 @@ set -e
 source ../build_func.sh
 
 if [[ $# -eq 0 ]]; then
-    echo 'Building from a1761f9'
-    TOPHASH=a1761f9
+    echo 'Building from 12d0c5a'
+    TOPHASH=12d0c5a
 elif [[ $# -eq 1 ]]; then
     echo 'Building from head of main'
     TOPHASH=$1

--- a/integration/experiment/Makefile.mk
+++ b/integration/experiment/Makefile.mk
@@ -25,5 +25,6 @@ include experiment/frequency_sweep/Makefile.mk
 include experiment/gpu_frequency_sweep/Makefile.mk
 include experiment/monitor/Makefile.mk
 include experiment/power_sweep/Makefile.mk
+include experiment/sst_evaluation/Makefile.mk
 include experiment/trace_analysis/Makefile.mk
 include experiment/uncore_frequency_sweep/Makefile.mk

--- a/integration/experiment/launch_util.py
+++ b/integration/experiment/launch_util.py
@@ -50,7 +50,7 @@ def launch_run(agent_conf, app_conf, run_id, output_dir, extra_cli_args,
     # some are generic enough they could be, though
     extra_cli_args += ['--geopm-report', report_path,
                        '--geopm-profile', profile_name,
-                       '--geopm-program-filter', app_conf.get_bash_exec_path(),
+                       '--geopm-program-filter', app_conf.get_program_filter(),
     ]
     if enable_traces:
         extra_cli_args += ['--geopm-trace', trace_path]

--- a/integration/experiment/sst_evaluation/Makefile.mk
+++ b/integration/experiment/sst_evaluation/Makefile.mk
@@ -1,0 +1,11 @@
+#  Copyright (c) 2015 - 2025, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+EXTRA_DIST += \
+              integration/experiment/sst_evaluation/__init__.py \
+              integration/experiment/sst_evaluation/gen_plot_time.py \
+              integration/experiment/sst_evaluation/run_sst_evaluation_arithmetic_intensity.py \
+              integration/experiment/sst_evaluation/run_sst_evaluation_nas_bt.py \
+              integration/experiment/sst_evaluation/sst_evaluation.py \
+              # end

--- a/integration/experiment/sst_evaluation/__init__.py
+++ b/integration/experiment/sst_evaluation/__init__.py
@@ -1,0 +1,3 @@
+#  Copyright (c) 2015 - 2025, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#

--- a/integration/experiment/sst_evaluation/gen_plot_time.py
+++ b/integration/experiment/sst_evaluation/gen_plot_time.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2025, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
+import seaborn as sns
+import pandas as pd
+import os
+import argparse
+import yaml
+import pathlib
+
+from experiment import common_args
+from experiment import plotting
+
+
+def reports_and_traces_to_dataframes(report_paths):
+    runs = list()
+    core_frequencies = dict()
+    epoch_dfs = list()
+    core_frequencies_by_time = list()
+    for report_path in report_paths:
+        with open(report_path, 'r') as report_fd:
+            report = yaml.load(report_fd, Loader=yaml.SafeLoader)
+
+            if 'Agent' not in report:
+                print('Warning: skipping incomplete report:', report_path)
+                continue
+
+            if report['Agent'] == 'frequency_balancer':
+                using_pstates = report['Policy']['USE_FREQUENCY_LIMITS']
+                using_sst_tf = report['Policy']['USE_SST_TF']
+                variant = ('Combined' if (using_pstates and using_sst_tf)
+                           else 'P-States' if using_pstates
+                           else 'SST-TF')
+                agent = f'frequency_balancer ({variant})'
+            else:
+                agent = report['Agent']
+                variant = agent.replace('_', ' ').title()
+
+            time_to_solution = max(data['Application Totals']['runtime (s)']
+                                   for host, data in report['Hosts'].items())
+            package_energy_to_solution = sum(data['Application Totals']['package-energy (J)']
+                                             for host, data in report['Hosts'].items())
+            dram_energy_to_solution = sum(data['Application Totals']['dram-energy (J)']
+                                          for host, data in report['Hosts'].items())
+
+            app_time_by_core = [time
+                                for host, data in report['Hosts'].items()
+                                for c, time in data['Application Totals'].items()
+                                if c.startswith('TIME@core-')]
+            app_network_time_by_core = [time
+                                        for host, data in report['Hosts'].items()
+                                        for c, time in data['Application Totals'].items()
+                                        if c.startswith('TIME_HINT_NETWORK@core-')]
+            app_non_network_time_by_core = [time - net_time
+                                            for time, net_time
+                                            in zip(app_time_by_core, app_network_time_by_core)
+                                            if time > 0]
+
+            non_net_time_core_total = sum(app_non_network_time_by_core)
+            non_net_time_core_count = len(app_non_network_time_by_core)
+            non_net_time_core_max = max(app_non_network_time_by_core)
+
+            # Report imbalance as a percentage where 0% represents perfect
+            # balance across all processing units and 100% represents the case
+            # where all except one processing unit are waiting on a single
+            # processing unit (as in a serial execution region). For more
+            # information about this metric, see "Detecting Application Load
+            # Imbalance on High End Massively Parallel Systems" by DeRose,
+            # Homer, and Johnson (2007).
+            imbalance = (
+                (non_net_time_core_max - non_net_time_core_total / non_net_time_core_count)
+                * non_net_time_core_count
+                / (non_net_time_core_max * (non_net_time_core_count - 1))
+            )
+
+            app_name = report['Profile'][:report['Profile'].index('_' + report['Agent'])]
+            trial = int(report['Profile'].rsplit('_', 1)[-1])
+
+            runs.append({
+                'Profile': report['Profile'],
+                'Application': app_name,
+                'Agent': agent,
+                'Variant': variant,
+                'trial': trial,
+                'Time to Solution': time_to_solution,
+                'CPU Package Energy': package_energy_to_solution,
+                'DRAM Energy': dram_energy_to_solution,
+                'Energy to Solution': package_energy_to_solution + dram_energy_to_solution,
+                'Imbalance': imbalance,
+            })
+
+            for host, data in report['Hosts'].items():
+                trace_path = report_path.parent.joinpath(report_path.stem + f'.trace-{host}')
+                for field, value in data['Application Totals'].items():
+                    if field.startswith('CPU_FREQUENCY_STATUS@core-') and value != 0:
+                        core = int(field.split('@core-', 1)[-1])
+                        core_frequencies[(report['Profile'], core)] = {
+                            'Profile': report['Profile'],
+                            'Application': app_name,
+                            'Agent': agent,
+                            'Variant': variant,
+                            'trial': trial,
+                            'Frequency': value,
+                        }
+
+                # Determine the processor's sticker frequency from the measured
+                # absolute frequency and the measured frequency as a percentage
+                # of sticker. Round down to 100 MHz steps.
+                sticker_frequency = (
+                    data['Application Totals']['frequency (Hz)']
+                    / data['Application Totals']['frequency (%)']
+                    * 100) // 1e8 * 1e8
+
+                trace_df = pd.read_csv(trace_path, sep='|', comment='#', na_values='NAN')
+                trace_df['timediff'] = trace_df['TIME'].diff()
+                core_count = len([c for c in trace_df.columns if c.startswith('MSR::APERF:ACNT-core')])
+                for core in range(core_count):
+                    # 0x00000004 indicates that GEOPM's network hint is active
+                    is_networking = (trace_df[f'REGION_HINT-core-{core}'] == '0x00000004')
+                    trace_df[f'network-time-core-{core}'] = is_networking * trace_df['timediff']
+                    diff_acnt = trace_df[f'MSR::APERF:ACNT-core-{core}'].diff()
+                    diff_mcnt = trace_df[f'MSR::MPERF:MCNT-core-{core}'].diff()
+                    if (report['Profile'], core) in core_frequencies:
+                        if (~is_networking).sum() > 0:
+                            core_frequencies[(report['Profile'], core)]['Non-Networking Frequency'] = (
+                                diff_acnt.loc[~is_networking].sum()
+                                / diff_mcnt.loc[~is_networking].sum()
+                                * sticker_frequency)
+                        if is_networking.sum() > 0:
+                            core_frequencies[(report['Profile'], core)]['Networking Frequency'] = (
+                                diff_acnt.loc[is_networking].sum()
+                                / diff_mcnt.loc[is_networking].sum()
+                                * sticker_frequency)
+
+                acnt_mcnt_by_epoch = trace_df.pivot_table(
+                    [c for c in trace_df.columns
+                     if c.startswith('MSR::APERF:ACNT-core') or c.startswith('MSR::MPERF:MCNT-core')],
+                    'EPOCH_COUNT',
+                    aggfunc='last').diff().dropna()
+                time_by_epoch = trace_df.pivot_table(
+                    'TIME',
+                    'EPOCH_COUNT',
+                    aggfunc='last').diff().dropna()
+                network_time_by_epoch = trace_df.pivot_table(
+                    [c for c in trace_df.columns
+                     if c.startswith('network-time-core') or c.startswith('network-time-core')],
+                    'EPOCH_COUNT',
+                    aggfunc='sum').loc[1:]  # ignore epoch 0 (before the main loop)
+
+                desired_time_by_epoch = None
+                if 'DESIRED_NON_NETWORK_TIME-package-0' in trace_df:
+                    desired_time_by_epoch = pd.wide_to_long(
+                        trace_df.pivot_table(
+                            [c for c in trace_df.columns if c.startswith('DESIRED_NON_NETWORK_TIME-package')],
+                            'EPOCH_COUNT',
+                            aggfunc='last').loc[1:].reset_index(),
+                        'DESIRED_NON_NETWORK_TIME', 'EPOCH_COUNT', 'package', sep='-package-')
+
+                desired_cutoff_by_epoch = None
+                if 'DESIRED_CUTOFF_FREQUENCY-package-0' in trace_df:
+                    desired_cutoff_by_epoch = pd.wide_to_long(
+                        trace_df.pivot_table(
+                            [c for c in trace_df.columns if c.startswith('DESIRED_CUTOFF_FREQUENCY-package')],
+                            'EPOCH_COUNT',
+                            aggfunc='last').loc[1:].reset_index(),
+                        'DESIRED_CUTOFF_FREQUENCY', 'EPOCH_COUNT', 'package', sep='-package-')
+
+                stubs = {c[:c.index('-core-')] for c in trace_df.columns if '-core-' in c}
+                percore_trace_df = pd.wide_to_long(trace_df.drop(stubs, axis=1, errors='ignore'), stubnames=stubs, i='TIME', j='core', sep='-core-')
+
+                epoch_df = pd.DataFrame(index=acnt_mcnt_by_epoch.index)
+                epoch_df.columns.name = 'Core'
+                for core in range(core_count):
+                    if trace_df[f'REGION_HASH-core-{core}'].notna().sum() > 0:
+                        epoch_df[f'Frequency-core-{core}'] = (
+                            acnt_mcnt_by_epoch[f'MSR::APERF:ACNT-core-{core}']
+                            / acnt_mcnt_by_epoch[f'MSR::MPERF:MCNT-core-{core}']
+                            * sticker_frequency)
+                        epoch_df[f'Network Time-core-{core}'] = network_time_by_epoch[f'network-time-core-{core}']
+                epoch_df = pd.wide_to_long(epoch_df.reset_index(),
+                                           stubnames=['Network Time', 'Frequency'],
+                                           i='EPOCH_COUNT', j='Core', sep='-core-').reset_index().rename(
+                    {'EPOCH_COUNT': 'Epoch', 'Network Tim': 'Network Time'}, axis=1)  # Pandas is truncating the name for some reason
+                # epoch_df.stack().rename('Frequency').reset_index().rename({'EPOCH_COUNT': 'Epoch'}, axis=1)
+                epoch_df['Time'] = epoch_df['Epoch'].map(time_by_epoch['TIME'])
+                epoch_df['Non-Network Time'] = epoch_df['Time'] - epoch_df['Network Time']
+                epoch_df['Package'] = epoch_df['Core'] // (core_count // 2)
+                epoch_df['Package Core'] = epoch_df['Core'] % (core_count // 2)
+                if desired_time_by_epoch is not None:
+                    epoch_df['Desired Time'] = epoch_df[['Epoch', 'Package']].apply(tuple, axis=1).map(
+                        desired_time_by_epoch['DESIRED_NON_NETWORK_TIME'])
+                else:
+                    epoch_df['Desired Cutoff'] = float('inf')
+                if desired_cutoff_by_epoch is not None:
+                    epoch_df['Desired Cutoff'] = epoch_df[['Epoch', 'Package']].apply(tuple, axis=1).map(
+                        desired_cutoff_by_epoch['DESIRED_CUTOFF_FREQUENCY'])
+                else:
+                    epoch_df['Desired Time'] = float('inf')
+                epoch_df['Host'] = host
+                epoch_df['Application'] = app_name
+                epoch_df['Variant'] = variant
+                epoch_df['trial'] = trial
+                epoch_critical_path_core = epoch_df.pivot('Epoch', 'Core', 'Non-Network Time').idxmax(axis=1)
+                epoch_df['Critical Path Frequency'] = epoch_df.loc[epoch_df['Core'] == epoch_df['Epoch'].map(
+                    epoch_critical_path_core), 'Frequency']
+
+                epoch_dfs.append(epoch_df)
+
+                frequency_by_time = pd.DataFrame(index=trace_df['TIME'])
+                frequency_by_time.columns.name = 'Core'
+                for core in range(core_count):
+                    if trace_df[f'REGION_HASH-core-{core}'].notna().sum() > 0:
+                        # If we're in here, then at least one sample for this core had a region hash.
+                        # Otherwise, assume it is a non-application core.
+                        frequency_by_time[core] = (
+                            trace_df.set_index('TIME')[f'MSR::APERF:ACNT-core-{core}'].diff()
+                            / trace_df.set_index('TIME')[f'MSR::MPERF:MCNT-core-{core}'].diff()
+                            * sticker_frequency)
+                frequency_by_time = frequency_by_time.stack().rename('Frequency').reset_index().rename({'TIME': 'Time'}, axis=1)
+                frequency_by_time['Package'] = frequency_by_time['Core'] // (core_count // 2)
+                frequency_by_time['Package Core'] = frequency_by_time['Core'] % (core_count // 2)
+                frequency_by_time['Host'] = host
+                frequency_by_time['Application'] = app_name
+                frequency_by_time['Variant'] = variant
+                frequency_by_time['trial'] = trial
+                core_frequencies_by_time.append(frequency_by_time)
+
+    df = pd.DataFrame(runs)
+    reference_time = df.loc[df['Agent'] == 'monitor'].groupby('Application')['Time to Solution'].mean()
+    df['Time Savings'] = 1 - df['Time to Solution'] / df['Application'].map(reference_time)
+
+    reference_energy = df.loc[df['Agent'] == 'monitor'].groupby('Application')['Energy to Solution'].mean()
+    df['Energy Savings'] = 1 - df['Energy to Solution'] / df['Application'].map(reference_energy)
+
+    frequency_df = pd.DataFrame(core_frequencies.values())
+    epoch_df = pd.concat(epoch_dfs)
+
+    core_frequencies_by_time_df = pd.concat(core_frequencies_by_time)
+
+    return df, frequency_df, epoch_df, core_frequencies_by_time_df
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    common_args.add_output_dir(parser)
+    common_args.add_analysis_dir(parser)
+
+    parser.add_argument('report_paths', type=pathlib.Path, nargs='+', help='Paths to report files')
+    parser.add_argument('--all-core-turbo-hz', type=float, help='All-core turbo limit, in hertz')
+    parser.add_argument('--plot-suffix', default='png', help='File suffix to use for plots')
+    args, _ = parser.parse_known_args()
+
+    os.makedirs(args.analysis_dir, exist_ok=True)
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    try:
+        # Try to load the preprocessed data from a cached file
+        df = pd.read_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), 'df')
+        frequency_df = pd.read_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), 'frequency_df')
+        epoch_df = pd.read_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), 'epoch_df')
+        core_frequencies_by_time_df = pd.read_hdf(os.path.join(args.analysis_dir, 'cache.hdf'),
+                                                  'core_frequencies_by_time_df')
+    except OSError:
+        # Write the preprocessed data to a cached file
+        df, frequency_df, epoch_df, core_frequencies_by_time_df = reports_and_traces_to_dataframes(args.report_paths)
+        df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), 'df', 'w')
+        frequency_df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), 'frequency_df', 'a')
+        epoch_df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), 'epoch_df', 'a')
+        core_frequencies_by_time_df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'),
+                                           'core_frequencies_by_time_df', 'a')
+
+    df['Application'] = df['Application'].str.rsplit('_', 1).str[-1]
+    epoch_df['Application'] = epoch_df['Application'].str.rsplit('_', 1).str[-1]
+    frequency_df['Application'] = frequency_df['Application'].str.rsplit('_', 1).str[-1]
+
+    epoch_df = epoch_df.loc[epoch_df['Epoch'] > 30]
+    epoch_df = epoch_df.loc[epoch_df['Epoch'] < 50]
+
+    sns.set_theme(context='paper', style='whitegrid', palette='colorblind')
+
+    variant_order = ['Monitor', 'P-States', 'SST-TF', 'Combined', 'Power Governor']
+    variant_order = [v for v in variant_order if v in df['Variant'].unique()]
+    variant_palette = dict(zip(variant_order, sns.color_palette(n_colors=len(variant_order))))
+
+    fig, ax = plt.subplots(figsize=(4, 2))
+    sns.barplot(
+        ax=ax,
+        data=df.loc[df['Agent'] != 'monitor'],
+        hue='Variant',
+        hue_order=[v for v in variant_order if v != 'Monitor'],
+        palette=variant_palette,
+        x='Application',
+        y='Time Savings',
+    )
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(1, 0))
+    ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    fig.suptitle('Time Savings by Application')
+    fig.savefig(os.path.join(args.output_dir, f'time-to-solution.{args.plot_suffix}'),
+                pad_inches=0, bbox_inches='tight')
+
+    fig, ax = plt.subplots(figsize=(4, 2))
+    sns.barplot(
+        ax=ax,
+        data=df.loc[df['Agent'] != 'monitor'],
+        hue='Variant',
+        hue_order=[v for v in variant_order if v != 'Monitor'],
+        palette=variant_palette,
+        x='Application',
+        y='Energy Savings',
+    )
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(1, 0))
+    ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    fig.suptitle('Energy Savings by Application')
+    fig.savefig(os.path.join(args.output_dir, f'energy-to-solution.{args.plot_suffix}'),
+                pad_inches=0, bbox_inches='tight')
+
+    fig, ax = plt.subplots(figsize=(4, 2))
+    sns.barplot(
+        ax=ax,
+        data=df,
+        hue='Variant',
+        hue_order=variant_order,
+        palette=variant_palette,
+        x='Application',
+        y='Imbalance',
+    )
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(1, 0))
+    ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    fig.suptitle('Imbalance by Application')
+    fig.savefig(os.path.join(args.output_dir, f'imbalance.{args.plot_suffix}'), pad_inches=0, bbox_inches='tight')
+
+    fig, ax = plt.subplots(figsize=(4, 2))
+    sns.violinplot(
+        data=epoch_df,
+        ax=ax,
+        inner=None,
+        dodge=True,
+        linewidth=0.5,
+        cut=0,
+        scale='count',
+        hue='Variant',
+        hue_order=variant_order,
+        palette=variant_palette,
+        x='Application',
+        y='Frequency',
+    )
+    if args.all_core_turbo_hz is not None:
+        ax.axhline(y=args.all_core_turbo_hz, ls=":", c='k', linewidth=0.5, label='All-Core Turbo')
+    ax.yaxis.set_major_formatter(mtick.EngFormatter('Hz', 0))
+    ax.set_ylim(bottom=0)
+    ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+
+    fig.suptitle('CPU Core Frequencies by Application')
+    fig.savefig(os.path.join(args.output_dir, f'frequencies.{args.plot_suffix}'), pad_inches=0, bbox_inches='tight')
+
+    fig, ax = plt.subplots(figsize=(4, 2))
+    sns.violinplot(
+        data=epoch_df,
+        ax=ax,
+        inner=None,
+        dodge=True,
+        linewidth=0.5,
+        cut=0,
+        scale='count',
+        hue='Variant',
+        hue_order=variant_order,
+        palette=variant_palette,
+        x='Application',
+        y='Critical Path Frequency',
+    )
+    if args.all_core_turbo_hz is not None:
+        ax.axhline(y=args.all_core_turbo_hz, ls=":", c='k', linewidth=0.5, label='All-Core Turbo')
+    ax.yaxis.set_major_formatter(mtick.EngFormatter('Hz', 0))
+    ax.set_ylim(bottom=0)
+    ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    ax.set_ylabel('Frequency')
+
+    fig.suptitle('Critical Path Frequencies by Application')
+    fig.savefig(os.path.join(args.output_dir, f'critical-path-frequencies.{args.plot_suffix}'),
+                pad_inches=0, bbox_inches='tight')
+
+    for application, data in epoch_df.groupby('Application'):
+        plot_data = data.loc[(data['trial'] == 1) & (data['Host'] == 'mcfly5')]
+        g = sns.FacetGrid(
+            height=2.5,
+            aspect=3,
+            data=plot_data,
+            row='Variant',
+            col='Package',
+        )
+        if 'Desired Cutoff' in plot_data.columns:
+            g.map_dataframe(sns.lineplot, 'Epoch', 'Desired Cutoff', linewidth=0.8, color='b', zorder=3)
+        g.map_dataframe(
+            sns.lineplot,
+            ci=None,
+            hue='Package Core',
+            estimator=None,
+            x='Epoch',
+            y='Frequency',
+        )
+        for ax in g.axes.flatten():
+            ax.yaxis.set_major_formatter(mtick.EngFormatter('Hz', 2))
+            ax.set_xlim(plot_data['Epoch'].min(), plot_data['Epoch'].max())
+        g.fig.suptitle(f'CPU Core Frequencies in {application}')
+        g.savefig(os.path.join(args.output_dir, f'core-frequencies-{application.replace("_", "-")}.{args.plot_suffix}'))
+
+        g = sns.FacetGrid(
+            height=2.5,
+            aspect=3,
+            data=plot_data,
+            row='Variant',
+            col='Package',
+        )
+        if 'Desired Time' in plot_data.columns:
+            g.map_dataframe(sns.lineplot, 'Epoch', 'Desired Time', linewidth=0.8, color='b', zorder=3)
+        g.map_dataframe(
+            sns.lineplot,
+            ci=None,
+            hue='Package Core',
+            estimator=None,
+            x='Epoch',
+            y='Non-Network Time',
+        )
+        for ax in g.axes.flatten():
+            ax.set_xlim(plot_data['Epoch'].min(), plot_data['Epoch'].max())
+        g.fig.suptitle(f'CPU Core Non-Network Time in {application}')
+        g.savefig(os.path.join(args.output_dir,
+                               f'core-non-network-time-{application.replace("_", "-")}.{args.plot_suffix}'))
+
+        g = sns.relplot(
+            height=2.5,
+            aspect=3,
+            data=plot_data,
+            kind='line',
+            ci=None,
+            hue='Package Core',
+            estimator=None,
+            row='Variant',
+            col='Package',
+            x='Epoch',
+            y='Network Time',
+        )
+        for ax in g.axes.flatten():
+            ax.set_xlim(plot_data['Epoch'].min(), plot_data['Epoch'].max())
+        g.fig.suptitle(f'CPU Core Network Time in {application}')
+        g.savefig(os.path.join(args.output_dir,
+                               f'core-network-time-{application.replace("_", "-")}.{args.plot_suffix}'))
+
+        g = sns.relplot(
+            height=2.5,
+            aspect=3,
+            data=plot_data,
+            kind='line',
+            ci=None,
+            hue='Package Core',
+            estimator=None,
+            row='Variant',
+            col='Package',
+            x='Epoch',
+            y='Time',
+        )
+        for ax in g.axes.flatten():
+            ax.set_xlim(plot_data['Epoch'].min(), plot_data['Epoch'].max())
+        g.fig.suptitle(f'CPU Core Time in {application}')
+        g.savefig(os.path.join(args.output_dir, f'core-time-{application.replace("_", "-")}.{args.plot_suffix}'))

--- a/integration/experiment/sst_evaluation/run_sst_evaluation_arithmetic_intensity.py
+++ b/integration/experiment/sst_evaluation/run_sst_evaluation_arithmetic_intensity.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2025, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+'''
+Run an SST evaluation with the arithmetic intensity benchmark.
+'''
+
+import argparse
+
+from experiment.sst_evaluation import sst_evaluation
+from experiment import machine
+from apps.arithmetic_intensity import arithmetic_intensity
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    sst_evaluation.setup_run_args(parser)
+    arithmetic_intensity.setup_run_args(parser)
+    args, extra_args = parser.parse_known_args()
+    mach = machine.init_output_dir(args.output_dir)
+    app_conf = arithmetic_intensity.create_appconf(mach, args)
+    sst_evaluation.launch(app_conf=app_conf, args=args,
+                          experiment_cli_args=extra_args)

--- a/integration/experiment/sst_evaluation/run_sst_evaluation_nas_bt.py
+++ b/integration/experiment/sst_evaluation/run_sst_evaluation_nas_bt.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2025, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+'''
+Run a power sweep with NPB BT.
+'''
+
+import argparse
+
+from experiment.sst_evaluation import sst_evaluation
+from experiment import machine
+from apps.nasbt import nasbt
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    sst_evaluation.setup_run_args(parser)
+    nasbt.setup_run_args(parser)
+    args, extra_args = parser.parse_known_args()
+    mach = machine.init_output_dir(args.output_dir)
+    app_conf = nasbt.create_appconf(mach, args)
+    sst_evaluation.launch(app_conf=app_conf, args=args,
+                          experiment_cli_args=extra_args)

--- a/integration/experiment/sst_evaluation/sst_evaluation.py
+++ b/integration/experiment/sst_evaluation/sst_evaluation.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2025, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+'''
+Helper functions for running power sweep experiments.
+'''
+
+import sys
+import math
+import argparse
+import os
+
+import geopmpy.agent
+
+from experiment import launch_util
+from experiment import common_args
+from experiment import machine
+
+
+def setup_run_args(parser):
+    common_args.setup_run_args(parser)
+    common_args.add_min_power(parser)
+    common_args.add_max_power(parser)
+    common_args.add_step_power(parser)
+    parser.add_argument('--power-cap',
+                        type=float,
+                        help='Apply a node power cap to balancers, and add a power_governor comparison')
+    parser.add_argument('--agent-list',
+                        type=str,
+                        nargs='+',
+                        choices=['monitor', 'balancer_sst_only',
+                                 'balancer_dvfs_only', 'balancer_combined'],
+                        default=['monitor', 'balancer_sst_only',
+                                 'balancer_dvfs_only', 'balancer_combined'],
+                        help='Agent configurations to be compared')
+
+
+def report_signals():
+    return ["CPU_CYCLES_THREAD@package", "CPU_CYCLES_REFERENCE@package",
+            "TIME@package", "CPU_ENERGY@package", "TIME@core", "TIME_HINT_NETWORK@core", "CPU_FREQUENCY_STATUS@core",
+            "CPU_UNCORE_FREQUENCY_STATUS@package",
+            "CPU_FREQUENCY_MAX_CONTROL@core",
+            "MSR::PM_ENABLE:HWP_ENABLE@package",
+            "MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0@package",
+            "MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_1@package",
+            "MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_2@package",
+            "MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_3@package"]
+
+
+def trace_signals():
+    return ['REGION_PROGRESS@core', 'REGION_HASH@core',
+            'REGION_HINT@core',
+            'MSR::APERF:ACNT@core', 'MSR::MPERF:MCNT@core',
+            'CPU_INSTRUCTIONS_RETIRED@core', 'CPU_FREQUENCY_MAX_CONTROL@core',
+            ]
+
+
+def launch_configs(output_dir, app_conf, agent_types=None, power_cap=None):
+    targets = []
+    if agent_types is None:
+        agent_types = ['monitor', 'balancer_sst_only',
+                       'balancer_dvfs_only', 'balancer_combined']
+    if power_cap is not None and 'monitor' in agent_types and 'power_governor' not in agent_types:
+        agent_types.append('power_governor')
+
+    for agent in agent_types:
+        name = agent
+        if agent == 'monitor':
+            options = {}
+        elif agent in ['power_governor', 'power_balancer']:
+            options = dict()
+            if power_cap is not None:
+                options['POWER_PACKAGE_LIMIT_TOTAL'] = power_cap
+        else:
+            options = {
+                'USE_FREQUENCY_LIMITS': 0 if agent == 'balancer_sst_only' else 1,
+                'USE_SST_TF': 0 if agent == 'balancer_dvfs_only' else 1
+            }
+            if power_cap is not None:
+                options['POWER_PACKAGE_LIMIT_TOTAL'] = power_cap
+        config_file = os.path.join(output_dir, name + '_agent.config')
+        agent_conf = geopmpy.agent.AgentConf(path=config_file,
+                                             agent='frequency_balancer' if agent.startswith('balancer_') else agent,
+                                             options=options)
+        targets.append(launch_util.LaunchConfig(app_conf=app_conf,
+                                                agent_conf=agent_conf,
+                                                name=name))
+    return targets
+
+
+def launch(app_conf, args, experiment_cli_args):
+    output_dir = os.path.abspath(args.output_dir)
+    agent_types = args.agent_list
+    mach = machine.init_output_dir(output_dir)
+    targets = launch_configs(output_dir, app_conf, agent_types, args.power_cap)
+    extra_cli_args = list(experiment_cli_args)
+    extra_cli_args += launch_util.geopm_signal_args(report_signals=report_signals(),
+                                                    trace_signals=trace_signals())
+    launch_util.launch_all_runs(targets=targets,
+                                num_nodes=args.node_count,
+                                iterations=args.trial_count,
+                                extra_cli_args=extra_cli_args,
+                                output_dir=output_dir,
+                                cool_off_time=args.cool_off_time,
+                                enable_traces=args.enable_traces,
+                                enable_profile_traces=args.enable_profile_traces)
+
+
+def main(app_conf, **defaults):
+    parser = argparse.ArgumentParser()
+    setup_run_args(parser)
+    parser.set_defaults(**defaults)
+    args, extra_cli_args = parser.parse_known_args()
+    launch(app_conf=app_conf, args=args,
+           experiment_cli_args=extra_cli_args)

--- a/integration/test/Makefile.mk
+++ b/integration/test/Makefile.mk
@@ -1,4 +1,4 @@
-#  Copyright (c) 2015 - 2024 Intel Corporation
+#  Copyright (c) 2015 - 2025 Intel Corporation
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,6 +9,7 @@ EXTRA_DIST += test/check_trace.py \
               test/README.md \
               test/short_region/plot_margin_sweep.py \
               test/test_plugin_static_policy.py \
+              test/test_frequency_balancer.py \
               test/test_template.cpp.in \
               test/test_template.mk.in \
               test/test_template.py.in \

--- a/integration/test/test_frequency_balancer.py
+++ b/integration/test/test_frequency_balancer.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2025, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+"""This integration test verifies that the frequency_balancer agent can improve
+efficiency of an imbalanced application. If only P-State controls are available,
+it aims to achieve efficiency gains through energy reduction. If SST-TF is also
+available, the test aims to improve both energy and performance on an imbalanced
+workload.
+
+"""
+
+import sys
+import unittest
+from pathlib import Path
+import shutil
+from experiment import machine
+from types import SimpleNamespace
+
+import geopmpy.agent
+from geopmpy.io import RawReport
+from collections import defaultdict
+
+from integration.test import util
+from integration.test import geopm_test_launcher
+from experiment.sst_evaluation import sst_evaluation
+from apps.arithmetic_intensity import arithmetic_intensity
+
+
+@util.skip_unless_do_launch()
+@util.skip_unless_workload_exists("apps/arithmetic_intensity/ARITHMETIC_INTENSITY/bench_avx2")
+class TestIntegration_frequency_balancer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._do_use_sst = geopm_test_launcher.geopmread("SST::TURBOFREQ_SUPPORT:SUPPORTED board 0")
+        except:
+            cls._do_use_sst = False
+
+    def tearDown(self):
+        if sys.exc_info() != (None, None, None):
+            TestIntegration_frequency_balancer._keep_files = True
+
+    def test_cores_rebalance(self):
+        """
+        An imbalanced application gets rebalanced by the frequency_balancer agent.
+        """
+        output_dir = Path('test_cores_rebalance_output')
+        if output_dir.exists() and output_dir.is_dir():
+            shutil.rmtree(output_dir)
+
+        mach = machine.init_output_dir(output_dir)
+
+        node_count = 1
+        ranks_per_node = mach.num_core() - mach.num_package()
+        ranks_per_package = ranks_per_node // mach.num_package()
+
+        try:
+            slow_ranks_per_package = int(geopm_test_launcher.geopmread("SST::HIGHPRIORITY_NCORES:0 package 0"))
+        except Exception:
+            slow_ranks_per_package = ranks_per_package // 4
+
+        # Configure the test application
+        app_conf = arithmetic_intensity.ArithmeticIntensityAppConf(
+            ['--slowdown=2.5',
+             f'--slow-ranks-per-imbalanced-group={slow_ranks_per_package}',
+             f'--ranks-per-imbalanced-group={ranks_per_package}',
+             '--base-internal-iterations=4',
+             '--iterations=100',
+             f'--floats={1<<22}',
+             '--benchmarks=32'],
+            mach,
+            run_type='avx2',
+            ranks_per_node=ranks_per_node)
+        experiment_args = SimpleNamespace(
+            output_dir=output_dir,
+            agent_list=None,
+            node_count=node_count,
+            trial_count=3,
+            cool_off_time=10,
+            enable_traces=False,
+            enable_profile_traces=False,
+            power_cap=None,
+        )
+
+        sst_evaluation.launch(app_conf, args=experiment_args, experiment_cli_args=[])
+
+        results = defaultdict(lambda: defaultdict(list))
+        for report_path in output_dir.glob('*.report'):
+            report = RawReport(report_path).raw_report()
+            agent_variant = report['Agent']
+            if agent_variant != 'monitor':
+                if report['Policy'].get('USE_FREQUENCY_LIMITS', 0):
+                    agent_variant += '_pstate'
+                    agent_variant += '(used)' if report.get('Agent uses frequency control', 0) else '(unused)'
+                if report['Policy'].get('USE_SST_TF', 0):
+                    agent_variant += '_ssttf'
+                    agent_variant += '(used)' if report.get('Agent uses SST-TF', 0) else '(unused)'
+
+            results[agent_variant]['FoM'].append(report['Figure of Merit'])
+            results[agent_variant]['package-energy (J)'].append(sum(
+                host_data['Epoch Totals']['package-energy (J)']
+                for host_data in report['Hosts'].values()))
+            results[agent_variant]['time-hint-network (s)'].append(max(
+                network_time
+                for host_data in report['Hosts'].values()
+                for network_time_field, network_time in host_data['Epoch Totals'].items()
+                if network_time_field.startswith('TIME_HINT_NETWORK@core')))
+        # Record the meai across trials
+        summary_results = {agent: {k: (sum(v) / len(v)) for k, v in agent_results.items()}
+                           for agent, agent_results in results.items()}
+
+        # Save both energy and time when SST-TF is present
+        for agent_variant in summary_results:
+            if 'pstate(used)' in agent_variant or 'ssttf(used)' in agent_variant:
+                self.assertLess(summary_results[agent_variant]['package-energy (J)'],
+                                summary_results['monitor']['package-energy (J)'],
+                                msg=f'{agent_variant} reduce energy')
+                self.assertLess(summary_results[agent_variant]['time-hint-network (s)'],
+                                summary_results['monitor']['time-hint-network (s)'],
+                                msg=f'{agent_variant} should reduce time spent waiting in network routines')
+                self.assertGreater(summary_results[agent_variant]['FoM'],
+                                   summary_results['monitor']['FoM'] * 0.95,
+                                   msg=f'{agent_variant} should not decrease figure of merit by a lot')
+            if 'ssttf(used)' in agent_variant:
+                self.assertGreater(summary_results[agent_variant]['FoM'],
+                                   summary_results['monitor']['FoM'],
+                                   msg=f'{agent_variant} should increase figure of merit')
+
+
+if __name__ == '__main__':
+    # Call do_launch to clear non-pyunit command line option
+    util.do_launch()
+    unittest.main()

--- a/libgeopm/Makefile.am
+++ b/libgeopm/Makefile.am
@@ -198,6 +198,8 @@ libgeopm_la_SOURCES = src/Accumulator.cpp \
                       src/EpochIOGroup.hpp \
                       src/FilePolicy.cpp \
                       src/FilePolicy.hpp \
+                      src/FrequencyBalancerAgent.cpp \
+                      src/FrequencyBalancerAgent.hpp \
                       src/FrequencyGovernor.cpp \
                       src/FrequencyGovernorImp.hpp \
                       src/FrequencyLimitDetector.cpp \

--- a/libgeopm/src/Agent.cpp
+++ b/libgeopm/src/Agent.cpp
@@ -20,6 +20,7 @@
 #include "PowerBalancerAgent.hpp"
 #include "PowerGovernorAgent.hpp"
 #include "FrequencyMapAgent.hpp"
+#include "FrequencyBalancerAgent.hpp"
 #include "geopm/Environment.hpp"
 #include "geopm/Helper.hpp"
 #include "geopm/Exception.hpp"
@@ -70,6 +71,10 @@ namespace geopm
                         Agent::make_dictionary(FFNetAgent::policy_names(),
                                                FFNetAgent::sample_names()));
 #endif
+        register_plugin(FrequencyBalancerAgent::plugin_name(),
+                        FrequencyBalancerAgent::make_plugin,
+                        Agent::make_dictionary(FrequencyBalancerAgent::policy_names(),
+                                               FrequencyBalancerAgent::sample_names()));
     }
 
 

--- a/libgeopm/src/FrequencyBalancerAgent.cpp
+++ b/libgeopm/src/FrequencyBalancerAgent.cpp
@@ -1,0 +1,645 @@
+/*
+ * Copyright (c) 2015 - 2025, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include "FrequencyBalancerAgent.hpp"
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <exception>
+#include <iterator>
+#include <numeric>
+#include <thread>
+#include <utility>
+
+#include "geopm/Environment.hpp"
+#include "geopm/Exception.hpp"
+#include "geopm/FrequencyGovernor.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm/PlatformIO.hpp"
+#include "geopm/PlatformTopo.hpp"
+#include "geopm/PowerGovernor.hpp"
+#include "geopm/Waiter.hpp"
+#include "geopm_hash.h"
+#include "geopm_hint.h"
+#include "geopm_time.h"
+#include "geopm_topo.h"
+
+#include "FrequencyLimitDetector.hpp"
+#include "FrequencyTimeBalancer.hpp"
+#include "SSTClosGovernor.hpp"
+#include "geopm_debug.hpp"
+
+// Minimum number of sampling wait periods before applying new epoch controls.
+static constexpr const int MINIMUM_WAIT_PERIODS_FOR_NEW_EPOCH_CONTROL = 5;
+
+// Minimum number of epochs to wait before applying new epoch controls.
+static constexpr const int MINIMUM_EPOCHS_FOR_NEW_EPOCH_CONTROL = 3;
+
+// Number of back-to-back network hints to treat as "in a network region."
+// Lower numbers respond more quickly, but risk throttling regions that
+// happen to land next to a short-running network region.
+// -- Arbitrarily set to 3 because that produces acceptable behavior so far.
+static constexpr const int NETWORK_HINT_MINIMUM_SAMPLE_LENGTH = 3;
+
+// Number of back-to-back non-network hints to treat as not "in a network region."
+static constexpr const int NON_NETWORK_HINT_MINIMUM_SAMPLE_LENGTH = 1;
+
+namespace geopm
+{
+    FrequencyBalancerAgent::FrequencyBalancerAgent()
+        : FrequencyBalancerAgent(platform_io(), platform_topo(),
+                                 Waiter::make_unique(environment().period(M_WAIT_SEC)),
+                                 PowerGovernor::make_shared(),
+                                 FrequencyGovernor::make_shared(),
+                                 (SSTClosGovernor::is_supported(platform_io())
+                                      ? SSTClosGovernor::make_shared()
+                                      : nullptr),
+                                 {}, {})
+    {
+    }
+
+    FrequencyBalancerAgent::FrequencyBalancerAgent(PlatformIO &plat_io,
+                                                   const PlatformTopo &topo,
+                                                   std::shared_ptr<Waiter> waiter,
+                                                   std::shared_ptr<PowerGovernor> power_gov,
+                                                   std::shared_ptr<FrequencyGovernor> frequency_gov,
+                                                   std::shared_ptr<SSTClosGovernor> sst_gov,
+                                                   std::vector<std::shared_ptr<FrequencyTimeBalancer> > package_balancers,
+                                                   std::shared_ptr<FrequencyLimitDetector> frequency_limit_detector)
+        : m_platform_io(plat_io)
+        , m_platform_topo(topo)
+        , m_waiter(std::move(waiter))
+        , m_update_time(time_zero())
+        , m_num_children(0)
+        , m_is_policy_updated(false)
+        , m_do_write_batch(false)
+        , m_is_adjust_initialized(false)
+        , m_is_real_policy(false)
+        , m_package_count(m_platform_topo.num_domain(GEOPM_DOMAIN_PACKAGE))
+        , m_core_count(m_platform_topo.num_domain(GEOPM_DOMAIN_CORE))
+        , m_package_core_indices()
+        , m_policy_power_package_limit_total(NAN)
+        , m_policy_use_frequency_limits(true)
+        , m_use_sst_tf(false)
+        , m_min_power_setting(m_platform_io.read_signal("CPU_POWER_MIN_AVAIL",
+                                                        GEOPM_DOMAIN_BOARD, 0))
+        , m_max_power_setting(m_platform_io.read_signal("CPU_POWER_MAX_AVAIL",
+                                                        GEOPM_DOMAIN_BOARD, 0))
+        , m_tdp_power_setting(m_platform_io.read_signal("CPU_POWER_LIMIT_DEFAULT",
+                                                        GEOPM_DOMAIN_BOARD, 0))
+        , m_frequency_min(
+              m_platform_io.read_signal("CPU_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD, 0))
+        , m_frequency_sticker(m_platform_io.read_signal("CPU_FREQUENCY_STICKER",
+                                                        GEOPM_DOMAIN_BOARD, 0))
+        , m_frequency_max(
+              m_platform_io.read_signal("CPU_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD, 0))
+        , m_frequency_step(
+              m_platform_io.read_signal("CPU_FREQUENCY_STEP", GEOPM_DOMAIN_BOARD, 0))
+        , m_power_gov(power_gov)
+        , m_freq_governor(frequency_gov)
+        , m_sst_clos_governor(sst_gov)
+        , m_frequency_ctl_domain_type(m_freq_governor->frequency_domain_type())
+        , m_frequency_control_domain_count(m_platform_topo.num_domain(m_frequency_ctl_domain_type))
+        , m_network_hint_sample_length(m_frequency_control_domain_count, 0)
+        , m_non_network_hint_sample_length(m_frequency_control_domain_count, 0)
+        , m_last_hp_count(2, 0)
+        , m_handle_new_epoch(false)
+        , m_epoch_wait_count(MINIMUM_EPOCHS_FOR_NEW_EPOCH_CONTROL)
+        , m_package_balancers(package_balancers)
+        , m_frequency_limit_detector(frequency_limit_detector)
+    {
+        if (m_package_balancers.empty()) {
+            for (int i = 0; i < m_package_count; ++i) {
+                // We balance each CPU package independently so we can take
+                // advantage of power headroom within each package. Create
+                // one balancer per package.
+                m_package_balancers.push_back(FrequencyTimeBalancer::make_unique(
+                    m_frequency_min, m_frequency_max, m_frequency_step));
+            }
+        }
+        for (int i = 0; i < m_package_count; ++i) {
+            // Determine which control indices (e.g., CPUs or cores) map to
+            // each balancer. We need this since some operations (e.g., platform IO)
+            // are made with respect to all controls in a domain, and others (e.g.,
+            // intra-package rebalancing) operate on subsets.
+            auto control_indices_in_package = m_platform_topo.domain_nested(
+                m_frequency_ctl_domain_type, GEOPM_DOMAIN_PACKAGE, i);
+            m_package_core_indices.emplace_back(
+                control_indices_in_package.begin(), control_indices_in_package.end());
+        }
+        if (!m_frequency_limit_detector) {
+            m_frequency_limit_detector = FrequencyLimitDetector::make_unique(
+                m_platform_io, m_platform_topo);
+        }
+
+        if (m_sst_clos_governor) {
+            m_frequency_ctl_domain_type = m_sst_clos_governor->clos_domain_type();
+            m_frequency_control_domain_count = m_platform_topo.num_domain(m_frequency_ctl_domain_type);
+            m_network_hint_sample_length.resize(m_frequency_control_domain_count, 0);
+            m_non_network_hint_sample_length.resize(m_frequency_control_domain_count, 0);
+        }
+    }
+
+    std::string FrequencyBalancerAgent::plugin_name(void)
+    {
+        return "frequency_balancer";
+    }
+
+    std::unique_ptr<Agent> FrequencyBalancerAgent::make_plugin(void)
+    {
+        return geopm::make_unique<FrequencyBalancerAgent>();
+    }
+
+    void FrequencyBalancerAgent::init(int level, const std::vector<int> &fan_in,
+                                      bool is_level_root)
+    {
+        static_cast<void>(is_level_root);
+        if (level == 0) {
+            m_num_children = 0;
+            init_platform_io();
+        }
+        else {
+            m_num_children = fan_in[level - 1];
+        }
+
+        m_platform_io.write_control("CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_BOARD, 0, m_frequency_max);
+    }
+
+    void FrequencyBalancerAgent::validate_policy(std::vector<double> &policy) const
+    {
+        GEOPM_DEBUG_ASSERT(policy.size() == M_NUM_POLICY,
+                           "FrequencyBalancerAgent::validate_policy(): "
+                           "policy vector not correctly sized.");
+
+        if (std::isnan(policy[M_POLICY_POWER_PACKAGE_LIMIT_TOTAL])) {
+            policy[M_POLICY_POWER_PACKAGE_LIMIT_TOTAL] = m_tdp_power_setting;
+        }
+        if (policy[M_POLICY_POWER_PACKAGE_LIMIT_TOTAL] < m_min_power_setting) {
+            policy[M_POLICY_POWER_PACKAGE_LIMIT_TOTAL] = m_min_power_setting;
+        }
+        else if (policy[M_POLICY_POWER_PACKAGE_LIMIT_TOTAL] > m_max_power_setting) {
+            policy[M_POLICY_POWER_PACKAGE_LIMIT_TOTAL] = m_max_power_setting;
+        }
+
+        if (std::isnan(policy[M_POLICY_USE_FREQUENCY_LIMITS])) {
+            policy[M_POLICY_USE_FREQUENCY_LIMITS] = 1;
+        }
+
+        if (std::isnan(policy[M_POLICY_USE_SST_TF])) {
+            policy[M_POLICY_USE_SST_TF] = 1;
+        }
+
+        if (policy[M_POLICY_USE_FREQUENCY_LIMITS] == 0 && policy[M_POLICY_USE_SST_TF] == 0) {
+            throw Exception("FrequencyBalancerAgent::validate_policy(): must allow at "
+                            "least one of frequency limits or SST-TF.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+
+    void FrequencyBalancerAgent::update_policy(const std::vector<double> &policy)
+    {
+        if (is_all_nan(policy) && !m_is_real_policy) {
+            // All-NAN policy is ignored until first real policy is received
+            m_is_policy_updated = false;
+            return;
+        }
+        m_is_real_policy = true;
+    }
+
+    void FrequencyBalancerAgent::split_policy(const std::vector<double> &in_policy,
+                                              std::vector<std::vector<double> > &out_policy)
+    {
+#ifdef GEOPM_DEBUG
+        if (out_policy.size() != (size_t)m_num_children) {
+            throw Exception("FrequencyBalancerAgent::" + std::string(__func__) +
+                                "(): out_policy vector not correctly sized.",
+                            GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+        }
+        for (auto &child_policy : out_policy) {
+            if (child_policy.size() != M_NUM_POLICY) {
+                throw Exception("FrequencyBalancerAgent::" + std::string(__func__) +
+                                    "(): child_policy vector not correctly sized.",
+                                GEOPM_ERROR_LOGIC, __FILE__, __LINE__);
+            }
+        }
+#endif
+        update_policy(in_policy);
+
+        if (m_is_policy_updated) {
+            std::fill(out_policy.begin(), out_policy.end(), in_policy);
+        }
+    }
+
+    bool FrequencyBalancerAgent::do_send_policy(void) const
+    {
+        return m_is_policy_updated;
+    }
+
+    void FrequencyBalancerAgent::aggregate_sample(const std::vector<std::vector<double> > &in_sample,
+                                                 std::vector<double> &out_sample)
+    {
+        static_cast<void>(in_sample);
+        static_cast<void>(out_sample);
+    }
+
+    bool FrequencyBalancerAgent::do_send_sample(void) const
+    {
+        return false;
+    }
+
+    void FrequencyBalancerAgent::initialize_policies(const std::vector<double> &in_policy)
+    {
+        double power_budget_in = in_policy[M_POLICY_POWER_PACKAGE_LIMIT_TOTAL];
+        m_policy_power_package_limit_total = power_budget_in;
+        double adjusted_power;
+        m_power_gov->adjust_platform(power_budget_in, adjusted_power);
+        m_do_write_batch = true;
+
+        m_policy_use_frequency_limits = in_policy[M_POLICY_USE_FREQUENCY_LIMITS] != 0;
+        bool sst_tf_is_supported = m_sst_clos_governor && SSTClosGovernor::is_supported(m_platform_io);
+        m_use_sst_tf = in_policy[M_POLICY_USE_SST_TF] != 0 && sst_tf_is_supported;
+
+        m_freq_governor->set_frequency_bounds(m_frequency_min, m_frequency_max);
+
+        // Initialize to max frequency limit and max CLOS
+        m_freq_governor->adjust_platform(m_last_ctl_frequency);
+        if (sst_tf_is_supported) {
+            m_sst_clos_governor->adjust_platform(m_last_ctl_clos);
+            if (m_use_sst_tf) {
+                m_sst_clos_governor->enable_sst_turbo_prioritization();
+            } else {
+                m_sst_clos_governor->disable_sst_turbo_prioritization();
+            }
+        }
+    }
+
+    void FrequencyBalancerAgent::adjust_platform(const std::vector<double> &in_policy)
+    {
+        update_policy(in_policy);
+
+        m_do_write_batch = false;
+        if (!m_is_adjust_initialized) {
+            initialize_policies(in_policy);
+            m_is_adjust_initialized = true;
+            return;
+        }
+
+        std::vector<double> frequency_by_core = m_last_ctl_frequency;
+        std::vector<double> clos_by_core = m_last_ctl_clos;
+
+        if (m_handle_new_epoch) {
+            m_handle_new_epoch = false;
+            m_frequency_limit_detector->update_max_frequency_estimates(
+                m_last_epoch_max_frequency);
+            for (int package_idx = 0; package_idx < m_package_count; ++package_idx) {
+                std::vector<double> pkg_ctl_frequency;
+                pkg_ctl_frequency.reserve(m_package_core_indices[package_idx].size());
+
+                double max_achievable_frequency = 0;
+                std::vector<std::pair<unsigned int, double> > core_frequency_limits;
+                double low_priority_frequency = m_frequency_min;
+
+                for (auto ctl_idx : m_package_core_indices[package_idx]) {
+                    pkg_ctl_frequency.push_back(m_last_ctl_frequency[ctl_idx]);
+                    auto limits = m_frequency_limit_detector->get_core_frequency_limits(ctl_idx);
+                    // Assume that the max-achievable frequency is the greatest
+                    // of all expected achievable frequencies on app cores in this package
+                    for (const auto &limit : limits) {
+                        if (limit.second > max_achievable_frequency) {
+                            core_frequency_limits = limits;
+                            max_achievable_frequency = limit.second;
+                            low_priority_frequency = m_frequency_limit_detector->get_core_low_priority_frequency(ctl_idx);
+                        }
+                    }
+                }
+                frequency_by_core = m_package_balancers[package_idx]->balance_frequencies_by_time(
+                    m_last_epoch_non_network_time_diff[package_idx],
+                    pkg_ctl_frequency,
+                    m_last_epoch_frequency[package_idx],
+                    core_frequency_limits,
+                    low_priority_frequency);
+
+                for (size_t pkg_nested_ctl_idx = 0; pkg_nested_ctl_idx < m_package_core_indices[package_idx].size(); ++pkg_nested_ctl_idx) {
+                    // Note: ctl_idx is the index used for PlatformIO interactions.
+                    //       pkg_nested_ctl_idx is the local index within per-package vectors.
+                    auto ctl_idx = m_package_core_indices[package_idx][pkg_nested_ctl_idx];
+                    if (m_last_ctl_frequency[ctl_idx] > frequency_by_core[pkg_nested_ctl_idx]) {
+                        // Going down. Round up toward previous.
+                        frequency_by_core[pkg_nested_ctl_idx] = std::ceil(frequency_by_core[pkg_nested_ctl_idx] / m_frequency_step) * m_frequency_step;
+                    }
+                    else {
+                        // Going up. Round down toward previous.
+                        frequency_by_core[pkg_nested_ctl_idx] = std::floor(frequency_by_core[pkg_nested_ctl_idx] / m_frequency_step) * m_frequency_step;
+                    }
+                    m_last_ctl_frequency[ctl_idx] = frequency_by_core[pkg_nested_ctl_idx];
+                }
+            }
+            geopm_time(&m_update_time);
+        }
+
+        // Apply immediate controls for workloads that change rapidly within
+        // epochs.
+        auto immediate_ctl_frequency = m_last_ctl_frequency;
+        for (size_t package_idx = 0;
+             package_idx < static_cast<size_t>(m_package_count); ++package_idx) {
+            int hp_not_waiting_count = 0;
+            for (size_t pkg_nested_ctl_idx = 0; pkg_nested_ctl_idx < m_package_core_indices[package_idx].size(); ++pkg_nested_ctl_idx) {
+                // Note: ctl_idx is the index used for PlatformIO interactions.
+                //       pkg_nested_ctl_idx is the local index within per-package vectors.
+                const auto ctl_idx = m_package_core_indices[package_idx][pkg_nested_ctl_idx];
+
+                if (std::isnan(m_last_hash[ctl_idx]) || m_last_hash[ctl_idx] == GEOPM_REGION_HASH_INVALID) {
+                    // Non-application regions get the expected low-priority
+                    // frequency so we can focus our turbo budget on
+                    // application regions.
+                    immediate_ctl_frequency[ctl_idx] = m_frequency_limit_detector->get_core_low_priority_frequency(ctl_idx);
+                }
+                else if(m_network_hint_sample_length[ctl_idx] >= NETWORK_HINT_MINIMUM_SAMPLE_LENGTH) {
+                    // Don't assume that (last hint)==NETWORK alone implies
+                    // that we are in a network region because it may be a
+                    // short-lasting region that we just happened to sample.
+                    immediate_ctl_frequency[ctl_idx] = m_frequency_limit_detector->get_core_low_priority_frequency(ctl_idx);
+                } else if (immediate_ctl_frequency[ctl_idx] >= m_frequency_max) {
+                    // This is a HP core that is not in a networking region
+                    hp_not_waiting_count += 1;
+                }
+            }
+
+            if (hp_not_waiting_count == 0) {
+                // All HP cores are waiting... Move the all non-waiting cores to HP
+                for (size_t pkg_nested_ctl_idx = 0; pkg_nested_ctl_idx < m_package_core_indices[package_idx].size(); ++pkg_nested_ctl_idx) {
+                    // Note: ctl_idx is the index used for PlatformIO interactions.
+                    //       pkg_nested_ctl_idx is the local index within per-package vectors.
+                    const auto ctl_idx = m_package_core_indices[package_idx][pkg_nested_ctl_idx];
+                    if (m_non_network_hint_sample_length[ctl_idx] >= NON_NETWORK_HINT_MINIMUM_SAMPLE_LENGTH) {
+                        immediate_ctl_frequency[ctl_idx] = m_frequency_max;
+                    }
+                }
+            }
+        }
+
+        if (m_use_sst_tf) {
+            // Assign to low priority CLOS if we expect that the core's
+            // workload properties allow it to achieve our requested frequency
+            // while in the low priority CLOS configuration. Otherwise, set it
+            // to high priority CLOS.
+            // The reason for selecting priority this way is that we are taking
+            // a conservative approach to risks of over-throttling a core vs
+            // missed opportunities from underthrottling cores.
+            for (size_t ctl_idx = 0; ctl_idx < frequency_by_core.size(); ++ctl_idx) {
+                clos_by_core[ctl_idx] =
+                    (immediate_ctl_frequency[ctl_idx] > m_frequency_limit_detector->get_core_low_priority_frequency(ctl_idx))
+                        ? SSTClosGovernor::HIGH_PRIORITY
+                        : SSTClosGovernor::LOW_PRIORITY;
+            }
+            m_sst_clos_governor->adjust_platform(clos_by_core);
+        }
+        if (m_policy_use_frequency_limits) {
+            m_freq_governor->adjust_platform(immediate_ctl_frequency);
+        }
+    }
+
+
+    bool FrequencyBalancerAgent::do_write_batch(void) const
+    {
+        bool do_write = m_do_write_batch || m_freq_governor->do_write_batch();
+        if (m_use_sst_tf) {
+            do_write |= m_sst_clos_governor->do_write_batch();
+        }
+        return do_write;
+    }
+
+    void FrequencyBalancerAgent::sample_platform(std::vector<double> &out_sample)
+    {
+        static_cast<void>(out_sample);
+
+        for (size_t ctl_idx = 0;
+             ctl_idx < (size_t)m_frequency_control_domain_count; ++ctl_idx) {
+            m_last_hash[ctl_idx] = m_platform_io.sample(m_hash_signal_idx[ctl_idx]);
+            auto last_hint = m_platform_io.sample(m_hint_signal_idx[ctl_idx]);
+            if (last_hint == GEOPM_REGION_HINT_NETWORK) {
+                m_network_hint_sample_length[ctl_idx] += 1;
+                m_non_network_hint_sample_length[ctl_idx] = 0;
+            }
+            else {
+                m_network_hint_sample_length[ctl_idx] = 0;
+                m_non_network_hint_sample_length[ctl_idx] += 1;
+            }
+
+            const auto prev_sample_acnt = m_last_sample_acnt[ctl_idx];
+            const auto prev_sample_mcnt = m_last_sample_mcnt[ctl_idx];
+            m_last_sample_acnt[ctl_idx] = m_platform_io.sample(m_acnt_signal_idx[ctl_idx]);
+            m_last_sample_mcnt[ctl_idx] = m_platform_io.sample(m_mcnt_signal_idx[ctl_idx]);
+            const auto last_sample_frequency =
+                (m_last_sample_acnt[ctl_idx] - prev_sample_acnt) /
+                (m_last_sample_mcnt[ctl_idx] - prev_sample_mcnt) * m_frequency_sticker;
+            if (!std::isnan(m_last_hash[ctl_idx]) && m_last_hash[ctl_idx] != GEOPM_REGION_HASH_INVALID) {
+                m_current_epoch_max_frequency[ctl_idx] = std::max(m_current_epoch_max_frequency[ctl_idx], last_sample_frequency);
+            }
+        }
+
+        double epoch_count = m_platform_io.sample(m_epoch_signal_idx);
+        const auto counted_epochs = epoch_count - m_last_epoch_count;
+        if (!std::isnan(epoch_count) && !std::isnan(m_last_epoch_count) &&
+            counted_epochs >= m_epoch_wait_count) {
+            double new_epoch_time = m_platform_io.read_signal(
+                "TIME", GEOPM_DOMAIN_BOARD, 0);
+            auto last_epoch_time_diff = new_epoch_time - m_last_epoch_time;
+            if (last_epoch_time_diff < MINIMUM_WAIT_PERIODS_FOR_NEW_EPOCH_CONTROL * m_waiter->period()) {
+                // Wait for some number of epochs to pass before calculating
+                // time per epoch. The wait period should end at the boundary of
+                // an epoch, but the minimum wait length depends on our sample
+                // rate. We are trying to reduce the impact of aliasing on the
+                // TIME_HINT_NETWORK signal.
+                m_epoch_wait_count += 1;
+            }
+            else {
+                // We encountered a new epoch and we are ready to evaluate the
+                // signal differences over the previous group of epochs.
+                for (int package_idx = 0; package_idx < m_package_count; ++package_idx) {
+                    for (size_t pkg_nested_ctl_idx = 0; pkg_nested_ctl_idx < m_package_core_indices[package_idx].size(); ++pkg_nested_ctl_idx) {
+                        // Note: ctl_idx is the index used for PlatformIO interactions.
+                        //       pkg_nested_ctl_idx is the local index within per-package vectors.
+                        const auto ctl_idx = m_package_core_indices[package_idx][pkg_nested_ctl_idx];
+                        const auto prev_epoch_acnt = m_last_epoch_acnt[ctl_idx];
+                        const auto prev_epoch_mcnt = m_last_epoch_mcnt[ctl_idx];
+                        m_last_epoch_acnt[ctl_idx] =
+                            m_platform_io.sample(m_acnt_signal_idx[ctl_idx]);
+                        m_last_epoch_mcnt[ctl_idx] =
+                            m_platform_io.sample(m_mcnt_signal_idx[ctl_idx]);
+                        m_last_epoch_frequency[package_idx][pkg_nested_ctl_idx] =
+                            (m_last_epoch_acnt[ctl_idx] - prev_epoch_acnt) /
+                            (m_last_epoch_mcnt[ctl_idx] - prev_epoch_mcnt) * m_frequency_sticker;
+
+                        double new_epoch_network_time =
+                            m_platform_io.sample(m_time_hint_network_idx[ctl_idx]);
+                        auto last_epoch_network_time_diff =
+                            new_epoch_network_time - m_last_epoch_network_time[package_idx][pkg_nested_ctl_idx];
+                        m_last_epoch_non_network_time_diff[package_idx][pkg_nested_ctl_idx] =
+                            std::max(0.0, last_epoch_time_diff - last_epoch_network_time_diff) /
+                            counted_epochs;
+                        m_last_epoch_network_time[package_idx][pkg_nested_ctl_idx] = new_epoch_network_time;
+                    }
+                }
+                m_last_epoch_max_frequency.swap(m_current_epoch_max_frequency);
+                std::fill(m_current_epoch_max_frequency.begin(),
+                          m_current_epoch_max_frequency.end(),
+                          m_frequency_min);
+
+                m_last_epoch_time = new_epoch_time;
+                m_last_epoch_count = epoch_count;
+                m_epoch_wait_count = MINIMUM_EPOCHS_FOR_NEW_EPOCH_CONTROL;
+                m_handle_new_epoch = true;
+            }
+        }
+        else if (std::isnan(m_last_epoch_count)) {
+            // We don't want to update the previous epoch count if the wait
+            // period has not been exceeded. BUT we must update it if the
+            // previous count was NaN (e.g., we are observing the first epoch
+            // now)
+            m_last_epoch_count = epoch_count;
+        }
+    }
+
+    void FrequencyBalancerAgent::wait(void)
+    {
+        m_waiter->wait();
+    }
+
+    std::vector<std::string> FrequencyBalancerAgent::policy_names(void)
+    {
+        return { "POWER_PACKAGE_LIMIT_TOTAL",
+                 "USE_FREQUENCY_LIMITS", "USE_SST_TF" };
+    }
+
+    std::vector<std::string> FrequencyBalancerAgent::sample_names(void)
+    {
+        return {};
+    }
+
+    std::vector<std::pair<std::string, std::string> >
+        FrequencyBalancerAgent::report_header(void) const
+    {
+        return {
+            {"Agent uses frequency control", std::to_string(m_policy_use_frequency_limits)},
+            {"Agent uses SST-TF", std::to_string(m_use_sst_tf)},
+        };
+    }
+
+    std::vector<std::pair<std::string, std::string> >
+        FrequencyBalancerAgent::report_host(void) const
+    {
+        return {};
+    }
+
+    std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >
+        FrequencyBalancerAgent::report_region(void) const
+    {
+        return {};
+    }
+
+    std::vector<std::string> FrequencyBalancerAgent::trace_names(void) const
+    {
+        std::vector<std::string> names;
+        for (int package_idx = 0; package_idx < m_package_count; ++package_idx) {
+            for (auto core_idx : m_package_core_indices[package_idx]) {
+                names.push_back(std::string("NON_NET_TIME_PER_EPOCH-core-") + std::to_string(core_idx));
+            }
+        }
+        for (int package_idx = 0; package_idx < m_package_count; ++package_idx) {
+            names.push_back(std::string("DESIRED_NON_NETWORK_TIME-package-") + std::to_string(package_idx));
+        }
+        return names;
+    }
+
+    std::vector<std::function<std::string(double)> >
+        FrequencyBalancerAgent::trace_formats(void) const
+    {
+        std::vector<std::function<std::string(double)> > formats;
+        for (int package_idx = 0; package_idx < m_package_count; ++package_idx) {
+            for (size_t i = 0; i < m_package_core_indices[package_idx].size(); ++i) {
+                formats.push_back(string_format_double);
+            }
+        }
+        for (int package_idx = 0; package_idx < m_package_count; ++package_idx) {
+            formats.push_back(string_format_double);
+        }
+        return formats;
+    }
+
+    void FrequencyBalancerAgent::trace_values(std::vector<double> &values)
+    {
+        if (static_cast<int>(values.size()) != (m_core_count + m_package_count)) {
+            throw Exception("FrequencyBalancerAgent::trace_values(): values vector is incorrectly sized.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        auto values_it = values.begin();
+        for (int package_idx = 0; package_idx < m_package_count; ++package_idx) {
+            values_it = std::copy(m_last_epoch_non_network_time_diff[package_idx].begin(),
+                                  m_last_epoch_non_network_time_diff[package_idx].end(),
+                                  values_it);
+        }
+        for (const auto &balancer : m_package_balancers) {
+            *values_it = balancer->get_target_time();
+            ++values_it;
+        }
+    }
+
+    void FrequencyBalancerAgent::enforce_policy(const std::vector<double> &policy) const
+    {
+        if (policy.size() != M_NUM_POLICY) {
+            throw Exception("FrequencyBalancerAgent::enforce_policy(): policy vector incorrectly sized.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+    }
+
+    void FrequencyBalancerAgent::init_platform_io(void)
+    {
+        m_power_gov->init_platform_io();
+        m_freq_governor->set_domain_type(m_frequency_ctl_domain_type);
+        m_freq_governor->init_platform_io();
+        if (SSTClosGovernor::is_supported(m_platform_io)) {
+            m_sst_clos_governor->init_platform_io();
+        }
+        m_last_ctl_frequency = std::vector<double>(
+            m_frequency_control_domain_count, m_frequency_max);
+        m_last_ctl_clos = std::vector<double>(
+            m_frequency_control_domain_count, SSTClosGovernor::HIGH_PRIORITY);
+        m_last_epoch_acnt = std::vector<double>(m_frequency_control_domain_count, NAN);
+        m_last_epoch_mcnt = std::vector<double>(m_frequency_control_domain_count, NAN);
+        m_last_sample_acnt = std::vector<double>(m_frequency_control_domain_count, NAN);
+        m_last_sample_mcnt = std::vector<double>(m_frequency_control_domain_count, NAN);
+        m_last_hash = std::vector<double>(m_frequency_control_domain_count, NAN);
+        m_current_epoch_max_frequency = std::vector<double>(m_frequency_control_domain_count, m_frequency_min);
+        m_last_epoch_max_frequency = std::vector<double>(m_frequency_control_domain_count, NAN);
+        for (int package_idx = 0; package_idx < m_package_count; ++package_idx) {
+            m_last_epoch_frequency.push_back(std::vector<double>(m_package_core_indices[package_idx].size(), NAN));
+            m_last_epoch_network_time.push_back(std::vector<double>(m_package_core_indices[package_idx].size(), NAN));
+            m_last_epoch_non_network_time_diff.push_back(std::vector<double>(m_package_core_indices[package_idx].size(), NAN));
+        }
+        m_last_epoch_count = NAN;
+        m_last_epoch_time = NAN;
+        for (size_t ctl_idx = 0;
+             ctl_idx < (size_t)m_frequency_control_domain_count; ++ctl_idx) {
+            m_acnt_signal_idx.push_back(m_platform_io.push_signal(
+                "MSR::APERF:ACNT", m_frequency_ctl_domain_type, ctl_idx));
+            m_mcnt_signal_idx.push_back(m_platform_io.push_signal(
+                "MSR::MPERF:MCNT", m_frequency_ctl_domain_type, ctl_idx));
+            m_hash_signal_idx.push_back(m_platform_io.push_signal(
+                "REGION_HASH", m_frequency_ctl_domain_type, ctl_idx));
+            m_hint_signal_idx.push_back(m_platform_io.push_signal(
+                "REGION_HINT", m_frequency_ctl_domain_type, ctl_idx));
+            m_time_hint_network_idx.push_back(m_platform_io.push_signal(
+                "TIME_HINT_NETWORK", m_frequency_ctl_domain_type, ctl_idx));
+        }
+        m_epoch_signal_idx = m_platform_io.push_signal("EPOCH_COUNT",
+                                                       GEOPM_DOMAIN_BOARD, 0);
+    }
+}

--- a/libgeopm/src/FrequencyBalancerAgent.hpp
+++ b/libgeopm/src/FrequencyBalancerAgent.hpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2015 - 2025, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FREQUENCYBALANCERAGENT_HPP_INCLUDE
+#define FREQUENCYBALANCERAGENT_HPP_INCLUDE
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "geopm/Agent.hpp"
+#include "geopm/CircularBuffer.hpp"
+#include "geopm_time.h"
+
+#include "FrequencyLimitDetector.hpp"
+#include "FrequencyTimeBalancer.hpp"
+
+#include <unordered_map>
+
+namespace geopm
+{
+    class PlatformIO;
+    class PlatformTopo;
+    class PowerGovernor;
+    class FrequencyGovernor;
+    class SSTClosGovernor;
+    class Waiter;
+
+    class FrequencyBalancerAgent : public Agent
+    {
+        public:
+            FrequencyBalancerAgent();
+            FrequencyBalancerAgent(PlatformIO &plat_io,
+                                   const PlatformTopo &topo,
+                                   std::shared_ptr<Waiter> waiter,
+                                   std::shared_ptr<PowerGovernor> power_gov,
+                                   std::shared_ptr<FrequencyGovernor> frequency_gov,
+                                   std::shared_ptr<SSTClosGovernor> sst_gov,
+                                   std::vector<std::shared_ptr<FrequencyTimeBalancer> > package_balancers,
+                                   std::shared_ptr<FrequencyLimitDetector> frequency_limit_detector);
+            virtual ~FrequencyBalancerAgent() = default;
+            void init(int level, const std::vector<int> &fan_in,
+                      bool is_level_root) override;
+            void validate_policy(std::vector<double> &policy) const override;
+            void split_policy(const std::vector<double> &in_policy,
+                              std::vector<std::vector<double> > &out_policy) override;
+            bool do_send_policy(void) const override;
+            void aggregate_sample(const std::vector<std::vector<double> > &in_sample,
+                                  std::vector<double> &out_sample) override;
+            bool do_send_sample(void) const override;
+            void adjust_platform(const std::vector<double> &in_policy) override;
+            bool do_write_batch(void) const override;
+            void sample_platform(std::vector<double> &out_sample) override;
+            void wait(void) override;
+            std::vector<std::pair<std::string, std::string> > report_header(void) const override;
+            std::vector<std::pair<std::string, std::string> > report_host(void) const override;
+            std::map<uint64_t, std::vector<std::pair<std::string, std::string> > >
+                report_region(void) const override;
+            std::vector<std::string> trace_names(void) const override;
+            std::vector<std::function<std::string(double)> > trace_formats(void) const override;
+            void trace_values(std::vector<double> &values) override;
+            void enforce_policy(const std::vector<double> &policy) const override;
+
+            static std::string plugin_name(void);
+            static std::unique_ptr<Agent> make_plugin(void);
+            static std::vector<std::string> policy_names(void);
+            static std::vector<std::string> sample_names(void);
+
+        private:
+            void update_policy(const std::vector<double> &policy);
+            void init_platform_io(void);
+
+            // Initialize policy-dependent members of this agent
+            void initialize_policies(const std::vector<double> &in_policy);
+
+            enum m_policy_e {
+                M_POLICY_POWER_PACKAGE_LIMIT_TOTAL,
+                M_POLICY_USE_FREQUENCY_LIMITS,
+                M_POLICY_USE_SST_TF,
+                M_NUM_POLICY,
+            };
+
+            static constexpr double M_WAIT_SEC = 0.005;
+            PlatformIO &m_platform_io;
+            const PlatformTopo &m_platform_topo;
+            std::shared_ptr<Waiter> m_waiter;
+            geopm_time_s m_update_time;
+            int m_epoch_signal_idx;
+            std::vector<int> m_acnt_signal_idx;
+            std::vector<int> m_mcnt_signal_idx;
+            std::vector<int> m_hash_signal_idx;
+            std::vector<int> m_hint_signal_idx;
+            std::vector<int> m_time_hint_network_idx;
+            std::vector<double> m_last_ctl_frequency;
+            std::vector<double> m_last_ctl_clos;
+            std::vector<double> m_last_epoch_acnt;
+            std::vector<double> m_last_epoch_mcnt;
+            std::vector<double> m_last_sample_acnt;
+            std::vector<double> m_last_sample_mcnt;
+            std::vector<double> m_last_hash;
+            std::vector<std::vector<double> > m_last_epoch_frequency;
+            std::vector<double> m_current_epoch_max_frequency;
+            std::vector<double> m_last_epoch_max_frequency;
+            std::vector<std::vector<double> > m_last_epoch_network_time;
+            std::vector<std::vector<double> > m_last_epoch_non_network_time_diff;
+            std::unordered_map<double, double> m_region_max_observed_frequency;
+            double m_last_epoch_time;
+            double m_last_epoch_count;
+            int m_num_children;
+            bool m_is_policy_updated;
+            bool m_do_write_batch;
+            bool m_is_adjust_initialized;
+            bool m_is_real_policy;
+            int m_package_count;
+            int m_core_count;
+            std::vector<std::vector<size_t> > m_package_core_indices;
+            double m_policy_power_package_limit_total;
+            bool m_policy_use_frequency_limits;
+            bool m_use_sst_tf;
+            double m_min_power_setting;
+            double m_max_power_setting;
+            double m_tdp_power_setting;
+            double m_frequency_min;
+            double m_frequency_sticker;
+            double m_frequency_max;
+            double m_frequency_step;
+            std::shared_ptr<PowerGovernor> m_power_gov;
+            std::shared_ptr<FrequencyGovernor> m_freq_governor;
+            std::shared_ptr<SSTClosGovernor> m_sst_clos_governor;
+            int m_frequency_ctl_domain_type;
+            int m_frequency_control_domain_count;
+            std::vector<long long> m_network_hint_sample_length;
+            std::vector<long long> m_non_network_hint_sample_length;
+            std::vector<size_t> m_last_hp_count;
+            bool m_handle_new_epoch;
+            int m_epoch_wait_count;
+            /* One balancer per package */
+            std::vector<std::shared_ptr<FrequencyTimeBalancer> > m_package_balancers;
+            std::shared_ptr<FrequencyLimitDetector> m_frequency_limit_detector;
+    };
+}
+
+#endif

--- a/libgeopm/src/FrequencyTimeBalancer.cpp
+++ b/libgeopm/src/FrequencyTimeBalancer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2024 Intel Corporation
+ * Copyright (c) 2015 - 2025 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -21,7 +21,8 @@ namespace geopm
             FrequencyTimeBalancerImp() = delete;
             FrequencyTimeBalancerImp(
                 double minimum_frequency,
-                double maximum_frequency);
+                double maximum_frequency,
+                double frequency_step_size);
             virtual ~FrequencyTimeBalancerImp() = default;
 
             std::vector<double> balance_frequencies_by_time(
@@ -35,10 +36,12 @@ namespace geopm
 
             static std::unique_ptr<FrequencyTimeBalancer> make_unique(
                 double minimum_frequency,
-                double maximum_frequency);
+                double maximum_frequency,
+                double frequency_step_size);
             static std::shared_ptr<FrequencyTimeBalancer> make_shared(
                 double minimum_frequency,
-                double maximum_frequency);
+                double maximum_frequency,
+                double frequency_step_size);
 
         private:
             void update_balance_targets(
@@ -56,9 +59,10 @@ namespace geopm
             std::vector<std::vector<int> > m_domain_index_groups;
             double m_minimum_frequency;
             double m_maximum_frequency;
+            double m_frequency_step_size;
             // Target balancing time
             double m_target_time;
-            // High/Low priority cutoff frequenciy
+            // High/Low priority cutoff frequency
             double m_cutoff_frequency;
             // Index order for argsorting each monitored domain by application
             // lagginess of processes running in that domain.
@@ -67,9 +71,11 @@ namespace geopm
 
     FrequencyTimeBalancerImp::FrequencyTimeBalancerImp(
         double minimum_frequency,
-        double maximum_frequency)
+        double maximum_frequency,
+        double frequency_step_size)
         : m_minimum_frequency(minimum_frequency)
         , m_maximum_frequency(maximum_frequency)
+        , m_frequency_step_size(frequency_step_size)
         , m_target_time(NAN)
         , m_cutoff_frequency(NAN)
     {
@@ -238,19 +244,16 @@ namespace geopm
             auto frequency_scale = m_maximum_frequency / max_group_frequency;
             // Scale up only the cores that we want to be high priority.
             // Scale them far enough that the highest-frequency one is at
-            // the maximum allowed frequency
+            // the maximum allowed frequency.
+            // If none of the cores exceed the high/low priority threshold,
+            // ensure at least the cores with the highest requested frequency
+            // are not limited.
             for (size_t ctl_idx = 0; ctl_idx < m_lagginess_idx.size(); ++ctl_idx) {
                 const auto ordered_ctl_idx = m_lagginess_idx[ctl_idx];
                 if (!std::isnan(previous_times[ordered_ctl_idx]) && !std::isnan(desired_frequencies[ordered_ctl_idx])) {
-                    if (desired_frequencies[ordered_ctl_idx] > m_cutoff_frequency) {
+                    if (desired_frequencies[ordered_ctl_idx] > m_cutoff_frequency || (max_group_frequency - desired_frequencies[ordered_ctl_idx] < m_frequency_step_size)) {
                         desired_frequencies[ordered_ctl_idx] =
                             std::min(m_maximum_frequency,
-                                     std::max(m_minimum_frequency,
-                                              desired_frequencies[ordered_ctl_idx] * frequency_scale));
-                    }
-                    else {
-                        desired_frequencies[ordered_ctl_idx] =
-                            std::min(m_cutoff_frequency,
                                      std::max(m_minimum_frequency,
                                               desired_frequencies[ordered_ctl_idx] * frequency_scale));
                     }
@@ -268,19 +271,23 @@ namespace geopm
 
     std::unique_ptr<FrequencyTimeBalancer> FrequencyTimeBalancer::make_unique(
         double minimum_frequency,
-        double maximum_frequency)
+        double maximum_frequency,
+        double frequency_step_size)
     {
         return geopm::make_unique<FrequencyTimeBalancerImp>(
             minimum_frequency,
-            maximum_frequency);
+            maximum_frequency,
+            frequency_step_size);
     }
 
     std::shared_ptr<FrequencyTimeBalancer> FrequencyTimeBalancer::make_shared(
         double minimum_frequency,
-        double maximum_frequency)
+        double maximum_frequency,
+        double frequency_step_size)
     {
         return std::make_shared<FrequencyTimeBalancerImp>(
             minimum_frequency,
-            maximum_frequency);
+            maximum_frequency,
+            frequency_step_size);
     }
 }

--- a/libgeopm/src/FrequencyTimeBalancer.hpp
+++ b/libgeopm/src/FrequencyTimeBalancer.hpp
@@ -50,14 +50,17 @@ namespace geopm
             ///        in rebalancing frequency control decisions.
             /// @param maximum_frequency  The highest frequency control to allow
             ///        in rebalancing frequency control decisions.
+            /// @param frequency_step_size  The step size used in frequency controls.
             static std::unique_ptr<FrequencyTimeBalancer> make_unique(
                 double minimum_frequency,
-                double maximum_frequency);
+                double maximum_frequency,
+                double frequency_step_size);
 
             /// \copydoc FrequencyTimeBalancer::make_unique
             static std::shared_ptr<FrequencyTimeBalancer> make_shared(
                 double minimum_frequency,
-                double maximum_frequency);
+                double maximum_frequency,
+                double frequency_step_size);
     };
 }
 

--- a/libgeopm/test/FrequencyBalancerAgentTest.cpp
+++ b/libgeopm/test/FrequencyBalancerAgentTest.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2015 - 2025, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include "FrequencyBalancerAgent.hpp"
+
+#include "MockFrequencyGovernor.hpp"
+#include "MockFrequencyLimitDetector.hpp"
+#include "MockFrequencyTimeBalancer.hpp"
+#include "MockPlatformIO.hpp"
+#include "MockPlatformTopo.hpp"
+#include "MockPowerGovernor.hpp"
+#include "MockSSTClosGovernor.hpp"
+#include "MockWaiter.hpp"
+#include "SSTClosGovernor.hpp"
+#include "geopm/Helper.hpp"
+#include "geopm_hash.h"
+#include "geopm_hint.h"
+#include "geopm_test.hpp"
+
+#include "gmock/gmock-matchers.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <numeric>
+
+using geopm::FrequencyBalancerAgent;
+using geopm::FrequencyTimeBalancer;
+using geopm::FrequencyLimitDetector;
+using geopm::PlatformTopo;
+using ::testing::_;
+using ::testing::Return;
+using ::testing::Invoke;
+using ::testing::AtLeast;
+using ::testing::Expectation;
+using ::testing::Pointwise;
+using ::testing::DoubleEq;
+using ::testing::ElementsAre;
+using ::testing::Ge;
+using ::testing::Lt;
+using ::testing::AllOf;
+
+const int EPOCH_SIGNAL_IDX = 1000;
+const int ACNT_SIGNAL_IDX = 2000;
+const int MCNT_SIGNAL_IDX = 3000;
+const int REGION_SIGNAL_IDX = 4000;
+const int HINT_SIGNAL_IDX = 5000;
+const int NETWORK_SIGNAL_IDX = 6000;
+
+const double MAX_FREQ = 3e9;
+const double STICKER_FREQ = 2e9;
+
+const double MIN_POWER = 50;
+const double TDP_POWER = 100;
+const double MAX_POWER = 200;
+
+const int CORE_COUNT = 4;
+const int PACKAGE_COUNT = 1;
+
+const auto REGION_SIGNALS = AllOf(Ge(REGION_SIGNAL_IDX), Lt(REGION_SIGNAL_IDX + CORE_COUNT));
+const auto HINT_SIGNALS = AllOf(Ge(HINT_SIGNAL_IDX), Lt(HINT_SIGNAL_IDX + CORE_COUNT));
+
+class FrequencyBalancerAgentTest : public ::testing::Test
+{
+    protected:
+        void SetUp();
+
+        MockPlatformIO m_platform_io;
+        MockPlatformTopo m_platform_topo;
+        std::shared_ptr<MockPowerGovernor> m_power_governor;
+        std::shared_ptr<MockFrequencyGovernor> m_frequency_governor;
+        std::shared_ptr<MockSSTClosGovernor> m_sst_clos_governor;
+        std::unique_ptr<FrequencyBalancerAgent> m_agent;
+        std::shared_ptr<MockWaiter> m_waiter;
+        std::shared_ptr<MockFrequencyTimeBalancer> m_frequency_time_balancer;
+        std::shared_ptr<MockFrequencyLimitDetector> m_frequency_limit_detector;
+
+        void expect_initial_batch_control_adjustments();
+};
+
+void FrequencyBalancerAgentTest::SetUp()
+{
+    m_waiter = std::make_shared<MockWaiter>();
+    m_power_governor = std::make_shared<MockPowerGovernor>();
+    m_frequency_governor = std::make_shared<MockFrequencyGovernor>();
+    ON_CALL(*m_frequency_governor, frequency_domain_type()).WillByDefault(Return(GEOPM_DOMAIN_CORE));
+    m_sst_clos_governor = std::make_shared<MockSSTClosGovernor>();
+    ON_CALL(m_platform_io, read_signal("SST::COREPRIORITY_SUPPORT:CAPABILITIES", _, _))
+        .WillByDefault(Return(1));
+    ON_CALL(m_platform_io, read_signal("SST::TURBOFREQ_SUPPORT:SUPPORTED", _, _))
+        .WillByDefault(Return(1));
+    ON_CALL(m_platform_io, read_signal("CPU_POWER_MIN_AVAIL", _, _))
+        .WillByDefault(Return(MIN_POWER));
+    ON_CALL(m_platform_io, read_signal("CPU_POWER_LIMIT_DEFAULT", _, _))
+        .WillByDefault(Return(TDP_POWER));
+    ON_CALL(m_platform_io, read_signal("CPU_POWER_MAX_AVAIL", _, _))
+        .WillByDefault(Return(MAX_POWER));
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_MAX_AVAIL", _, _))
+        .WillByDefault(Return(MAX_FREQ));
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_STEP", _, _))
+        .WillByDefault(Return(1e8));
+    ON_CALL(m_platform_io, read_signal("CPU_FREQUENCY_STICKER", _, _))
+        .WillByDefault(Return(STICKER_FREQ));
+    ON_CALL(m_platform_io, push_signal("EPOCH_COUNT", _, _)).WillByDefault(Return(EPOCH_SIGNAL_IDX));
+    ON_CALL(m_platform_io, push_signal("MSR::APERF:ACNT", _, _)).WillByDefault(Return(ACNT_SIGNAL_IDX));
+    ON_CALL(m_platform_io, push_signal("MSR::MPERF:MCNT", _, _)).WillByDefault(Return(MCNT_SIGNAL_IDX));
+    ON_CALL(m_platform_io, push_signal("REGION_HASH", GEOPM_DOMAIN_CORE, _))
+        .WillByDefault(Invoke([] (const std::string&, int, int core) {
+            return REGION_SIGNAL_IDX + core;
+        }));
+    ON_CALL(m_platform_io, push_signal("REGION_HINT", GEOPM_DOMAIN_CORE, _))
+        .WillByDefault(Invoke([] (const std::string&, int, int core) {
+            return HINT_SIGNAL_IDX + core;
+        }));
+    ON_CALL(m_platform_io, push_signal("TIME_HINT_NETWORK", _, _)).WillByDefault(Return(NETWORK_SIGNAL_IDX));
+
+    ON_CALL(m_platform_io, sample(EPOCH_SIGNAL_IDX)).WillByDefault(Return(0));
+    ON_CALL(m_platform_io, sample(REGION_SIGNALS)).WillByDefault(Return(GEOPM_REGION_HASH_UNMARKED));
+    ON_CALL(m_platform_io, sample(HINT_SIGNALS)).WillByDefault(Return(GEOPM_REGION_HINT_UNKNOWN));
+    ON_CALL(m_platform_topo, num_domain(GEOPM_DOMAIN_PACKAGE))
+        .WillByDefault(Return(PACKAGE_COUNT));
+    ON_CALL(m_platform_topo, num_domain(GEOPM_DOMAIN_CORE))
+        .WillByDefault(Return(CORE_COUNT));
+    ON_CALL(m_platform_topo, domain_nested(GEOPM_DOMAIN_CORE, GEOPM_DOMAIN_PACKAGE, _))
+        .WillByDefault(Invoke([] (int, int, int package_idx) -> std::set<int> {
+            // Mock the set of cores per package by evenly dividing cores into each
+            // package, in order (e.g., 4 cores in 2 packages are {0, 1}, {2, 3})
+            std::vector<int> cores_in_package(CORE_COUNT / PACKAGE_COUNT);
+            std::iota(cores_in_package.begin(), cores_in_package.end(), CORE_COUNT / PACKAGE_COUNT * package_idx);
+            return std::set<int>(cores_in_package.begin(), cores_in_package.end());
+        }));
+    ON_CALL(*m_sst_clos_governor, clos_domain_type())
+        .WillByDefault(Return(GEOPM_DOMAIN_CORE));
+
+    m_frequency_time_balancer = std::make_shared<MockFrequencyTimeBalancer>();
+    m_frequency_limit_detector = std::make_shared<MockFrequencyLimitDetector>();
+
+    m_agent = std::make_unique<FrequencyBalancerAgent>(
+        m_platform_io, m_platform_topo, m_waiter, m_power_governor,
+        m_frequency_governor, m_sst_clos_governor,
+        std::vector<std::shared_ptr<FrequencyTimeBalancer> >{m_frequency_time_balancer},
+        m_frequency_limit_detector);
+}
+
+TEST_F(FrequencyBalancerAgentTest, adjust_new_epoch)
+{
+    std::vector<double> out_sample;
+    const std::vector<double> POLICY{ NAN, NAN, NAN };
+    const auto HP = geopm::SSTClosGovernor::HIGH_PRIORITY;
+    const auto LP = geopm::SSTClosGovernor::LOW_PRIORITY;
+
+    m_agent->init(0, {}, false);
+
+    // Only the first agent adjustment expects initial batch adjustments
+    EXPECT_CALL(*m_frequency_governor, set_frequency_bounds(_, _));
+    Expectation initial_freq_adjust = EXPECT_CALL(*m_frequency_governor,
+            adjust_platform(Pointwise(DoubleEq(), { 3e9, 3e9, 3e9, 3e9 }))).Times(1);
+    Expectation initial_clos_adjust = EXPECT_CALL(*m_sst_clos_governor,
+            adjust_platform(ElementsAre(HP, HP, HP, HP))).Times(1);
+    EXPECT_CALL(*m_sst_clos_governor, enable_sst_turbo_prioritization());
+    m_agent->sample_platform(out_sample);
+
+    EXPECT_FALSE(m_agent->do_write_batch());
+    m_agent->adjust_platform(POLICY);
+    // Now there should be batch IO, from initializing our controls
+    EXPECT_TRUE(m_agent->do_write_batch());
+
+    // Sample a new epoch and adjust again
+    EXPECT_CALL(m_platform_io, sample(EPOCH_SIGNAL_IDX)).WillOnce(Return(10));
+    EXPECT_CALL(m_platform_io, sample(ACNT_SIGNAL_IDX)).WillRepeatedly(Return(100));
+    EXPECT_CALL(m_platform_io, sample(MCNT_SIGNAL_IDX)).WillRepeatedly(Return(100));
+    EXPECT_CALL(m_platform_io, sample(REGION_SIGNALS)).WillRepeatedly(Return(GEOPM_REGION_HASH_UNMARKED));
+    EXPECT_CALL(m_platform_io, sample(HINT_SIGNALS)).Times(AtLeast(1));
+    EXPECT_CALL(m_platform_io, sample(NETWORK_SIGNAL_IDX)).Times(AtLeast(1))
+        .WillRepeatedly(Return(0.1));
+
+    m_agent->sample_platform(out_sample);
+
+    // Make the balancer give a value that needs to be rounded up to a p-state
+    // step, plus others that don't need rounding.
+    EXPECT_CALL(*m_frequency_time_balancer, balance_frequencies_by_time(_, _, _, _, _))
+        .WillOnce(Return(std::vector<double>{2.87e9, 3e9, 2e9, 2.5e9}));
+    EXPECT_CALL(*m_frequency_governor,
+                adjust_platform(Pointwise(DoubleEq(), {2.9e9, 3e9, 2e9, 2.5e9})))
+        .Times(1).After(initial_freq_adjust);
+
+    // Set the test's cutoff frequency. Anything less than or equal to cutoff
+    // should get low priority.
+    EXPECT_CALL(*m_frequency_limit_detector, get_core_low_priority_frequency(_))
+        .WillRepeatedly(Return(2.5e9));
+    EXPECT_CALL(*m_sst_clos_governor,
+                adjust_platform(ElementsAre( HP, HP, LP, LP )))
+        .Times(1).After(initial_clos_adjust);
+    m_agent->adjust_platform(POLICY);
+}
+
+TEST_F(FrequencyBalancerAgentTest, adjust_frequency_overrides)
+{
+    std::vector<double> out_sample;
+    const std::vector<double> POLICY{ NAN, NAN, NAN };
+    const auto HP = geopm::SSTClosGovernor::HIGH_PRIORITY;
+    const auto LP = geopm::SSTClosGovernor::LOW_PRIORITY;
+
+    m_agent->init(0, {}, false);
+
+    // Only the first agent adjustment expects initial batch adjustments
+    EXPECT_CALL(*m_frequency_governor, set_frequency_bounds(_, _));
+    Expectation initial_freq_adjust = EXPECT_CALL(*m_frequency_governor,
+            adjust_platform(Pointwise(DoubleEq(), { 3e9, 3e9, 3e9, 3e9 }))).Times(1);
+    Expectation initial_clos_adjust = EXPECT_CALL(*m_sst_clos_governor,
+            adjust_platform(ElementsAre(HP, HP, HP, HP))).Times(1);
+    EXPECT_CALL(*m_sst_clos_governor, enable_sst_turbo_prioritization());
+    m_agent->sample_platform(out_sample);
+    m_agent->adjust_platform(POLICY);
+
+    // Act like we're still in epoch 0
+    EXPECT_CALL(m_platform_io, sample(EPOCH_SIGNAL_IDX))
+        .WillRepeatedly(Return(0));
+    EXPECT_CALL(m_platform_io, sample(ACNT_SIGNAL_IDX)).WillRepeatedly(Return(100));
+    EXPECT_CALL(m_platform_io, sample(MCNT_SIGNAL_IDX)).WillRepeatedly(Return(100));
+    EXPECT_CALL(m_platform_io, sample(REGION_SIGNALS))
+        .WillRepeatedly(Return(GEOPM_REGION_HASH_UNMARKED));
+    // Act like core 0 not in the app. Should throttle.
+    EXPECT_CALL(m_platform_io, sample(REGION_SIGNAL_IDX + 0))
+        .WillRepeatedly(Return(NAN));
+    EXPECT_CALL(m_platform_io, sample(HINT_SIGNALS)).Times(AtLeast(1));
+    // Act like core 3 is constantly in a network region. Throttle.
+    EXPECT_CALL(m_platform_io, sample(HINT_SIGNAL_IDX + 3))
+        .WillRepeatedly(Return(GEOPM_REGION_HINT_NETWORK));
+
+    // Act like we're multiple samples in.
+    for (size_t i = 0; i < 5; ++i) {
+        m_agent->sample_platform(out_sample);
+    }
+
+    // "Previous control" is still "initial control", which is all freq-max.
+    // But our non-app core and our always-networking core should be throttled
+    // to our cutoff frequency.
+    EXPECT_CALL(*m_frequency_limit_detector, get_core_low_priority_frequency(_))
+        .WillRepeatedly(Return(2.1e9));
+    EXPECT_CALL(*m_frequency_governor,
+                adjust_platform(Pointwise(DoubleEq(), {2.1e9, 3e9, 3e9, 2.1e9})))
+        .Times(1).After(initial_freq_adjust);
+    EXPECT_CALL(*m_sst_clos_governor,
+                adjust_platform(ElementsAre( LP, HP, HP, LP )))
+        .Times(1).After(initial_clos_adjust);
+    m_agent->adjust_platform(POLICY);
+}
+
+TEST_F(FrequencyBalancerAgentTest, validate_policy_fills_defaults)
+{
+    std::vector<double> policy{ NAN, NAN, NAN };
+    const double P_STATES_ENABLED = 1;
+    const double SST_TF_ENABLED = 1;
+    m_agent->validate_policy(policy);
+    EXPECT_THAT(policy, ElementsAre(TDP_POWER, P_STATES_ENABLED, SST_TF_ENABLED));
+}

--- a/libgeopm/test/FrequencyTimeBalancerTest.cpp
+++ b/libgeopm/test/FrequencyTimeBalancerTest.cpp
@@ -26,7 +26,7 @@ static const std::vector<std::pair<unsigned int, double> > EMPTY_TRADEOFF_TABLE 
 
 TEST(FrequencyTimeBalancerTest, balance_when_current_frequencies_are_all_unlimited)
 {
-    auto balancer = FrequencyTimeBalancer::make_unique(1e9, 3e9);
+    auto balancer = FrequencyTimeBalancer::make_unique(1e9, 3e9, 1e8);
     const std::vector<double> previous_control_frequencies = {3e9, 3e9, 3e9, 3e9};
     // For all subtests, the outputs must contain at least one value at the max
     // frequency.
@@ -50,7 +50,7 @@ TEST(FrequencyTimeBalancerTest, balance_when_current_frequencies_are_all_unlimit
 
 TEST(FrequencyTimeBalancerTest, balance_when_all_frequencies_should_go_unlimited)
 {
-    auto balancer = FrequencyTimeBalancer::make_unique(1e9, 3e9);
+    auto balancer = FrequencyTimeBalancer::make_unique(1e9, 3e9, 1e8);
     const std::vector<double> desired_frequencies = {3e9, 3e9, 3e9, 3e9};
     EXPECT_THAT(balancer->balance_frequencies_by_time({1.33, 1.6, 2.0, 4.0},
                                                       {3.0e9, 2.5e9, 2e9, 1e9},
@@ -62,7 +62,7 @@ TEST(FrequencyTimeBalancerTest, balance_when_all_frequencies_should_go_unlimited
 
 TEST(FrequencyTimeBalancerTest, does_not_change_when_already_balanced)
 {
-    auto balancer = FrequencyTimeBalancer::make_unique(1e9, 3e9);
+    auto balancer = FrequencyTimeBalancer::make_unique(1e9, 3e9, 1e8);
 
     const std::vector<double> balanced_frequencies = {1e9, 3e9, 2e9, 1e9};
     EXPECT_THAT(balancer->balance_frequencies_by_time({2.0, 2.0, 2.0, 2.0},
@@ -78,7 +78,7 @@ TEST(FrequencyTimeBalancerTest, does_not_use_capped_cores_as_balance_reference)
     // E.g., What if the previous control decision was a misjudgement?
     // If the lagger core is also a freqeuncy-limited core, we shouldn't use it
     // as a balancing reference. Otherwise, we could get stuck in a descent.
-    auto balancer = FrequencyTimeBalancer::make_unique(1e9, 3e9);
+    auto balancer = FrequencyTimeBalancer::make_unique(1e9, 3e9, 1e8);
 
     // Just one core had a bad setting:
     EXPECT_THAT(balancer->balance_frequencies_by_time({4.0, 3.0, 2.0, 1.0},
@@ -111,7 +111,7 @@ TEST(FrequencyTimeBalancerTest, resets_to_baseline_if_invariants_are_violated)
     // performance objective assumes that there is at least always one
     // unlimited frequency. If for any reason that is not true, the helper
     // should fix that issue in the current decision.
-    auto balancer = FrequencyTimeBalancer::make_unique(1e9, 5e9);
+    auto balancer = FrequencyTimeBalancer::make_unique(1e9, 5e9, 1e8);
 
     // No cores currently have a max frequency control (5e9) setting
     EXPECT_THAT(balancer->balance_frequencies_by_time({4.0, 3.0, 2.0, 1.0},
@@ -126,7 +126,7 @@ TEST(FrequencyTimeBalancerTest, resets_to_baseline_if_invariants_are_violated)
 
 TEST(FrequencyTimeBalancerTest, no_time_spent_in_balancing_regions)
 {
-    auto balancer = FrequencyTimeBalancer::make_unique(0.9e9, 3e9);
+    auto balancer = FrequencyTimeBalancer::make_unique(0.9e9, 3e9, 1e8);
 
     EXPECT_THAT(balancer->balance_frequencies_by_time({0, 0, 0, 0},
                                                       {3e9, 2e9, 2e9, 2e9},
@@ -150,7 +150,7 @@ TEST(FrequencyTimeBalancerTest, no_time_spent_in_balancing_regions)
 // since it seems likely our callers may encounter this.
 TEST(FrequencyTimeBalancerTest, negative_time_spent_in_balancing_regions)
 {
-    auto balancer = FrequencyTimeBalancer::make_unique(0.9e9, 4e9);
+    auto balancer = FrequencyTimeBalancer::make_unique(0.9e9, 4e9, 1e8);
 
     // All negative times
     EXPECT_THAT(balancer->balance_frequencies_by_time({-1, -2, -3, -4},
@@ -183,7 +183,7 @@ TEST(FrequencyTimeBalancerTest, negative_time_spent_in_balancing_regions)
 //       control   control
 TEST(FrequencyTimeBalancerTest, selects_high_priority_critical_path)
 {
-    auto balancer = FrequencyTimeBalancer::make_unique(0.5e9, 5e9);
+    auto balancer = FrequencyTimeBalancer::make_unique(0.5e9, 5e9, 1e8);
 
     std::vector<double> control_frequencies{5e9, 5e9, 5e9, 5e9};
     std::vector<double> observed_frequencies{2e9, 2e9, 2e9, 2e9};
@@ -227,7 +227,7 @@ TEST(FrequencyTimeBalancerTest, selects_high_priority_critical_path)
 //       control   control
 TEST(FrequencyTimeBalancerTest, selects_low_priority_critical_path)
 {
-    auto balancer = FrequencyTimeBalancer::make_unique(0.5e9, 5e9);
+    auto balancer = FrequencyTimeBalancer::make_unique(0.5e9, 5e9, 1e8);
 
     std::vector<double> control_frequencies{5e9, 5e9, 5e9, 5e9};
     std::vector<double> observed_frequencies{2e9, 2e9, 2e9, 2e9};

--- a/libgeopm/test/Makefile.mk
+++ b/libgeopm/test/Makefile.mk
@@ -59,6 +59,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/EpochIOGroupTest.cpp \
                           test/EpochIOGroupIntegrationTest.cpp \
                           test/FilePolicyTest.cpp \
+                          test/FrequencyBalancerAgentTest.cpp \
                           test/FrequencyGovernorTest.cpp \
                           test/FrequencyMapAgentTest.cpp \
                           test/FrequencyTimeBalancerTest.cpp \

--- a/libgeopm/test/MockFrequencyTimeBalancer.hpp
+++ b/libgeopm/test/MockFrequencyTimeBalancer.hpp
@@ -14,13 +14,13 @@ class MockFrequencyTimeBalancer : public geopm::FrequencyTimeBalancer
 {
     public:
         MOCK_METHOD(std::vector<double>, balance_frequencies_by_time,
-                    (const std::vector<double>& previous_times,
-                     const std::vector<double>& previous_control_frequencies,
-                     const std::vector<double>& previous_achieved_frequencies,
-                     const std::vector<double>& previous_max_frequencies),
+                    (const std::vector<double> &previous_times,
+                     const std::vector<double> &previous_control_frequencies,
+                     const std::vector<double> &previous_achieved_frequencies,
+                     (const std::vector<std::pair<unsigned int, double> >) &frequency_limits_by_high_priority_count,
+                     double low_priority_frequency),
                     (override));
-        MOCK_METHOD(std::vector<double>, get_target_times, (), (const, override));
-        MOCK_METHOD(double, get_cutoff_frequency, (unsigned int core), (const, override));
+        MOCK_METHOD(double, get_target_time, (), (const, override));
 };
 
 #endif /* MOCKFREQUENCYTIMEBALANCER_HPP_INCLUDE */


### PR DESCRIPTION
This set of changes introduces the frequency_balancer agent, which  adjusts for imbalance by assigning more CPU
  frequency resources cores that spend less MPI time per epoch. The changes include integration tests that check for energy savings, and also for performance improvement if SST is available on the test system.