### PR TITLE
Fix static analyis issues

### DIFF
--- a/service/src/IOUringImp.cpp
+++ b/service/src/IOUringImp.cpp
@@ -48,8 +48,8 @@ namespace geopm
         // to the location the user requested we write operation return values.
         // Ensure that point remains valid by keeping the shared_ptr in our
         // result destinations vector until we finish cleaning up the batch.
-        m_result_destinations.push_back(destination);
         io_uring_sqe_set_data(sqe, destination.get());
+        m_result_destinations.push_back(std::move(destination));
     }
 
     void IOUringImp::submit()

--- a/service/src/IOUringImp.cpp
+++ b/service/src/IOUringImp.cpp
@@ -87,7 +87,7 @@ namespace geopm
         auto sqe = get_sqe_or_throw();
         // Available since Linux 5.10
         io_uring_prep_read(sqe, fd, buf, nbytes, offset);
-        set_sqe_return_destination(sqe, ret);
+        set_sqe_return_destination(sqe, std::move(ret));
     }
 
     void IOUringImp::prep_write(std::shared_ptr<int> ret, int fd, const void *buf,
@@ -96,7 +96,7 @@ namespace geopm
         auto sqe = get_sqe_or_throw();
         // Available since Linux 5.10
         io_uring_prep_write(sqe, fd, buf, nbytes, offset);
-        set_sqe_return_destination(sqe, ret);
+        set_sqe_return_destination(sqe, std::move(ret));
     }
 
     bool IOUringImp::is_supported()

--- a/service/src/IOUringImp.hpp
+++ b/service/src/IOUringImp.hpp
@@ -25,6 +25,8 @@ namespace geopm
         public:
             IOUringImp(unsigned entries);
             virtual ~IOUringImp();
+            IOUringImp(const IOUringImp &other) = delete;
+            IOUringImp &operator=(const IOUringImp &other) = delete;
 
             void submit() override;
 

--- a/service/src/MSRIO.cpp
+++ b/service/src/MSRIO.cpp
@@ -52,8 +52,8 @@ namespace geopm
         , m_is_batch_enabled(true)
         , m_is_open(false)
         , m_path(std::move(path))
-        , m_batch_reader(batch_reader)
-        , m_batch_writer(batch_writer)
+        , m_batch_reader(std::move(batch_reader))
+        , m_batch_writer(std::move(batch_writer))
     {
         create_batch_context();
         open_all();


### PR DESCRIPTION
- Use std::move() where appropriate
- Delete unimplemented copy constructor and copy assignment operator for IOUringImp
