### PR TITLE
Change logic for Environment::do_profile()

### DIFF
--- a/integration/test/README.md
+++ b/integration/test/README.md
@@ -35,7 +35,7 @@ python3 -m unittest discover \
 
 # Execute tests in test_monitor.py and log to file
 PYTHONPATH=${GEOPM_SOURCE}:${PYTHONPATH} \
-python3 ${GEOPM_SOURCE}/test/integration/test_monitor.py \
+python3 ${GEOPM_SOURCE}/integration/test/test_monitor.py \
     --verbose >& test-monitor.log
 
 # Use discover to execute tests in test_monitor.py log to file

--- a/integration/test/test_multi_app.sh
+++ b/integration/test/test_multi_app.sh
@@ -3,6 +3,11 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 
+TEST_NAME=test_multi_app
+export GEOPM_PROFILE=${TEST_NAME}
+export GEOPM_PROGRAM_FILTER=geopmbench,stress-ng
+export LD_PRELOAD=libgeopm.so.1.0.0
+
 cat > temp_config.json << "EOF"
 {
     "loop-count": 2,
@@ -13,20 +18,17 @@ EOF
 
 source ${GEOPM_SOURCE}/integration/config/run_env.sh
 
-TEST_NAME=test_multi_app
-export GEOPM_REPORT=${TEST_NAME}_report.yaml
-export GEOPM_TRACE=${TEST_NAME}_trace.csv
-export GEOPM_TRACE_PROFILE=${TEST_NAME}_trace_profile.csv
-export GEOPM_PROFILE=${TEST_NAME}
-export GEOPM_REPORT_SIGNALS=TIME@package
-export GEOPM_NUM_PROC=2
-
+GEOPM_REPORT=${TEST_NAME}_report.yaml \
+GEOPM_TRACE=${TEST_NAME}_trace.csv \
+GEOPM_TRACE_PROFILE=${TEST_NAME}_trace_profile.csv \
+GEOPM_REPORT_SIGNALS=TIME@package \
+GEOPM_NUM_PROC=2 \
 geopmctl &
 
 # geopmbench
-numactl --cpunodebind=0 -- sh -c "LD_PRELOAD=libgeopm.so.1.0.0 geopmbench temp_config.json" &
+numactl --cpunodebind=0 -- geopmbench temp_config.json &
 
 # stress-ng
-numactl --cpunodebind=1 -- sh -c "LD_PRELOAD=libgeopm.so.1.0.0 stress-ng --cpu 1 --timeout 10" &
+numactl --cpunodebind=1 -- stress-ng --cpu 1 --timeout 10 &
 
 wait $(jobs -p)

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -148,6 +148,7 @@ class Config(object):
         parser.add_argument('--geopm-launch-script', dest='launch_script', type=str)
         parser.add_argument('--geopm-init-control', dest='init_control', type=str)
         parser.add_argument('--geopm-period', dest='period', type=str)
+        parser.add_argument('--geopm-program-filter', dest='program_filter', type=str)
         opts, self.argv_unparsed = parser.parse_known_args(argv)
         # Error check inputs
         if opts.ctl not in ('process', 'pthread', 'application'):
@@ -177,6 +178,7 @@ class Config(object):
         self.launch_script = opts.launch_script
         self.init_control = opts.init_control
         self.period = opts.period
+        self.program_filter = opts.program_filter
 
     def __repr__(self):
         """
@@ -243,6 +245,8 @@ class Config(object):
             result['GEOPM_INIT_CONTROL'] = self.init_control
         if self.period:
             result['GEOPM_PERIOD'] = self.period
+        if self.program_filter:
+            result['GEOPM_PROGRAM_FILTER'] = self.program_filter
 
         # Add geopm installed OpenMP library to LD_LIBRARY_PATH if it
         # is present.
@@ -1791,8 +1795,12 @@ GEOPM_OPTIONS:
                                emit launch script to output_file
       --geopm-init-control=path
                                set initial control values with data read from "path"
-      --geopm-period=sec       Control loop period override for Agent value
-      --geopm-preload          Use LD_PRELOAD to load libgeopm with the target application
+      --geopm-period=sec       control loop period override for Agent value
+      --geopm-preload          use LD_PRELOAD to load libgeopm with the target application
+      --geopm-program-filter=names
+                               only enable profiling for processes with program invocation
+                               names that match one of the comma separated list of "names",
+                               especially useful when launching a bash script
 
 {}
 

--- a/scripts/geopmpy/launcher.py
+++ b/scripts/geopmpy/launcher.py
@@ -828,11 +828,7 @@ Warning: <geopm> geopmpy.launcher: Incompatible CPU frequency governor
         return []
 
     def preload_option(self):
-        if self.config and self.config.get_preload():
-            self.environ_ext['LD_PRELOAD'] = ':'.join((ll for ll in
-                                                       (self.lib_name, os.getenv('LD_PRELOAD'))
-                                                       if ll is not None))
-        return []
+        raise NotImplementedError('<geopm> geopmpy.launcher: preload_option() not implemented in base class.')
 
     def timeout_option(self):
         """
@@ -1497,6 +1493,15 @@ class IMPIExecLauncher(Launcher):
 
         return result
 
+    def preload_option(self):
+        result = []
+        if self.config and self.config.get_preload():
+            value = ':'.join((ll for ll in
+                              (self.lib_name, os.getenv('LD_PRELOAD'))
+                              if ll is not None))
+            result = ["--env=LD_PRELOAD={}".format(value)]
+        return result
+
     def bootstrap_option(self):
         """
         Returns a list containing the command line options specifying the
@@ -1566,6 +1571,15 @@ class PALSLauncher(IMPIExecLauncher):
                 result.append('list:' + ':'.join(set_list))
             else:
                 result.append('verbose,list:' + ':'.join(set_list))
+        return result
+
+    def preload_option(self):
+        result = []
+        if self.config and self.config.get_preload():
+            value = ':'.join((ll for ll in
+                              (self.lib_name, os.getenv('LD_PRELOAD'))
+                              if ll is not None))
+            result = ["--env=LD_PRELOAD={}".format(value)]
         return result
 
 

--- a/service/docs/source/geopmlaunch.1.rst
+++ b/service/docs/source/geopmlaunch.1.rst
@@ -569,16 +569,16 @@ GEOPM Options
                 using GEOPM will be reduced, but more interpolation will be
                 required when aligning the sparsely sampled hardware signals
                 with the application feedback.  Additionally, agent reaction
-                time is reduced with longer control loop period.
+                time is reduced with longer control loop periods.
 --geopm-program-filter  .. _geopm-program-filter option:
 
-                        Only enable profiling for processes with
-                        program invocation name or short program
-                        invocation name that matches one of the names
+                        Only enable profiling for processes where their
+                        ``program_invocation_name`` or 
+                        ``program_invocation_name_short_name`` matches one of the names
                         in the comma separated list provided by
-                        option.  This option is especially useful when
+                        option.  This is especially useful when
                         launching a bash script to avoid profiling
-                        bash or other ancilary commands that are not
+                        bash or other ancillary commands that are not
                         part of the main application process set.  See
                         `program_invocation_name(3)` for more details.
 

--- a/service/docs/source/geopmlaunch.1.rst
+++ b/service/docs/source/geopmlaunch.1.rst
@@ -562,14 +562,26 @@ GEOPM Options
                       for more information about OpenMP region detection.
 --geopm-period  .. _geopm-period option:
 
-               Override the control loop period specified by the Agent.  All
-	       agents have a default control loop period, and this command
-	       line option allows users to set a different value in units of
-	       seconds.  With longer control loop periods, the overhead for
-	       using GEOPM will be reduced, but more interpolation will be
-	       required when aligning the sparsely sampled hardware signals
-	       with the application feedback.  Additionally, agent reaction
-	       time is reduced with longer control loop period.
+                Override the control loop period specified by the Agent.  All
+                agents have a default control loop period, and this command
+                line option allows users to set a different value in units of
+                seconds.  With longer control loop periods, the overhead for
+                using GEOPM will be reduced, but more interpolation will be
+                required when aligning the sparsely sampled hardware signals
+                with the application feedback.  Additionally, agent reaction
+                time is reduced with longer control loop period.
+--geopm-program-filter  .. _geopm-program-filter option:
+
+                        Only enable profiling for processes with
+                        program invocation name or short program
+                        invocation name that matches one of the names
+                        in the comma separated list provided by
+                        option.  This option is especially useful when
+                        launching a bash script to avoid profiling
+                        bash or other ancilary commands that are not
+                        part of the main application process set.  See
+                        `program_invocation_name(3)` for more details.
+
 
 Examples
 --------

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -99,7 +99,6 @@ namespace geopm
                                 environment().do_record_filter(),
                                 environment().record_filter(),
                                 {},
-                                environment().timeout() != -1,
                                 environment().profile(),
                                 {},
                                 Scheduler::make_unique())
@@ -113,7 +112,6 @@ namespace geopm
                                                  bool is_filtered,
                                                  const std::string &filter_name,
                                                  const std::vector<bool> &is_cpu_active,
-                                                 bool do_profile,
                                                  const std::string &profile_name,
                                                  const std::map<int, std::set<int> > &client_cpu_map,
                                                  std::shared_ptr<Scheduler> scheduler)
@@ -128,7 +126,6 @@ namespace geopm
         , m_update_time({{0, 0}})
         , m_is_first_update(true)
         , m_hint_last(m_num_cpu, uint64_t(GEOPM_REGION_HINT_UNSET))
-        , m_do_profile(do_profile)
         , m_profile_name(profile_name)
         , m_client_cpu_map(client_cpu_map)
         , m_scheduler(std::move(scheduler))
@@ -146,7 +143,7 @@ namespace geopm
 
     void ApplicationSamplerImp::update(const geopm_time_s &curr_time)
     {
-        if (!m_do_profile || !m_status) {
+        if (!m_status) {
             return;
         }
         GEOPM_DEBUG_ASSERT((int) m_hint_time.size() == m_num_cpu &&
@@ -407,7 +404,7 @@ namespace geopm
 
     void ApplicationSamplerImp::connect(const std::vector<int> &client_pids)
     {
-        if (!m_status && m_do_profile) {
+        if (!m_status) {
             m_num_client = (int)client_pids.size();
             GEOPM_DEBUG_ASSERT(m_process_map.empty(),
                                "m_process_map is not empty, but we are connecting");

--- a/src/ApplicationSamplerImp.hpp
+++ b/src/ApplicationSamplerImp.hpp
@@ -37,7 +37,6 @@ namespace geopm
                                   bool is_filtered,
                                   const std::string &filter_name,
                                   const std::vector<bool> &is_cpu_active,
-                                  bool do_profile,
                                   const std::string &profile_name,
                                   const std::map<int, std::set<int> > &client_cpu_map,
                                   std::shared_ptr<Scheduler> scheduler);
@@ -75,7 +74,6 @@ namespace geopm
             geopm_time_s m_update_time;
             bool m_is_first_update;
             std::vector<uint64_t> m_hint_last;
-            bool m_do_profile;
             std::string m_profile_name;
             std::map<int, std::set<int> > m_client_cpu_map;
             std::shared_ptr<Scheduler> m_scheduler;

--- a/src/Environment.hpp
+++ b/src/Environment.hpp
@@ -122,7 +122,6 @@ namespace geopm
             bool is_set(const std::string &env_var) const;
             std::string lookup(const std::string &env_var) const;
             const std::set<std::string> m_all_names;
-            const std::set<std::string> m_runtime_names;
             std::set<std::string> m_user_defined_names;
             std::map<std::string, std::string> m_name_value_map;
             const std::string m_default_config_path;

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -375,6 +375,10 @@ namespace geopm
 
     std::vector<std::string> ProfileImp::region_names(void)
     {
+        if (!m_is_enabled) {
+            return {};
+        }
+
 #ifdef GEOPM_OVERHEAD
         struct geopm_time_s overhead_entry;
         geopm_time(&overhead_entry);
@@ -392,6 +396,9 @@ namespace geopm
 
     void ProfileImp::set_hint(uint64_t hint)
     {
+        if (!m_is_enabled) {
+            return;
+        }
         for (auto cpu : m_cpu_set) {
             m_app_status->set_hint(cpu, hint);
         }
@@ -399,6 +406,9 @@ namespace geopm
 
     void ProfileImp::overhead(double overhead_sec)
     {
+        if (!m_is_enabled) {
+            return;
+        }
         geopm_time_s now;
         geopm_time(&now);
         m_app_record_log->overhead(now, overhead_sec);

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -122,7 +122,7 @@ namespace geopm
                      {},  // cpu_set
                      nullptr,  // app_status
                      nullptr,  // app_record_log
-                     environment().timeout() != -1,
+                     environment().do_profile(),
                      ServiceProxy::make_unique(),
                      Scheduler::make_unique(),
                      M_PID_INIT)

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -53,8 +53,7 @@ namespace geopm
                       nullptr,
                       environment().report_signals(),
                       environment().policy(),
-                      environment().do_endpoint(),
-                      environment().timeout() != -1)
+                      environment().do_endpoint())
     {
 
     }
@@ -68,8 +67,7 @@ namespace geopm
                              std::shared_ptr<ProcessRegionAggregator> proc_agg,
                              const std::vector<std::pair<std::string, int> > &env_signals,
                              const std::string &policy_path,
-                             bool do_endpoint,
-                             bool do_profile)
+                             bool do_endpoint)
         : m_start_time(start_time)
         , m_report_name(report_name)
         , m_platform_io(platform_io)
@@ -82,7 +80,6 @@ namespace geopm
         , m_rank(rank)
         , m_sticker_freq(m_platform_io.read_signal("CPUINFO::FREQ_STICKER", GEOPM_DOMAIN_BOARD, 0))
         , m_epoch_count_idx(-1)
-        , m_do_profile(do_profile)
         , m_do_init(true)
         , m_total_time(0.0)
         , m_overhead_time(0.0)
@@ -113,7 +110,7 @@ namespace geopm
 
     void ReporterImp::init(void)
     {
-        if (m_do_profile && m_do_init) {
+        if (m_do_init) {
             // ProcessRegionAggregator should not be constructed until
             // application connection is established.
             init_sync_fields();
@@ -130,7 +127,7 @@ namespace geopm
     void ReporterImp::update()
     {
         m_sample_agg->update();
-        if (m_proc_region_agg != nullptr && m_do_profile) {
+        if (m_proc_region_agg != nullptr) {
             m_proc_region_agg->update();
         }
     }

--- a/src/Reporter.hpp
+++ b/src/Reporter.hpp
@@ -100,8 +100,7 @@ namespace geopm
                         std::shared_ptr<ProcessRegionAggregator> proc_agg,
                         const std::vector<std::pair<std::string, int> > &env_signal,
                         const std::string &policy_path,
-                        bool do_endpoint,
-                        bool do_profile);
+                        bool do_endpoint);
             virtual ~ReporterImp() = default;
             void init(void) override;
             void update(void) override;
@@ -193,7 +192,6 @@ namespace geopm
 
             // Signals added through environment
             std::vector<std::pair<std::string, int> > m_env_signal_name_idx;
-            bool m_do_profile;
             bool m_do_init;
             double m_total_time;
             double m_overhead_time;

--- a/src/geopm_lib_init.cpp
+++ b/src/geopm_lib_init.cpp
@@ -17,7 +17,6 @@ static void __attribute__((constructor)) geopm_lib_init(void)
         try {
             geopm_time_s zero = geopm::time_zero();
             auto &prof = geopm::Profile::default_profile();
-            prof.connect();
             prof.overhead(geopm_time_since(&zero));
         }
         catch (...) {

--- a/src/geopm_lib_init.cpp
+++ b/src/geopm_lib_init.cpp
@@ -17,6 +17,10 @@ static void __attribute__((constructor)) geopm_lib_init(void)
         try {
             geopm_time_s zero = geopm::time_zero();
             auto &prof = geopm::Profile::default_profile();
+            // If this is a forked process, it will need to call
+            // connect() since DefaultProfile constructor was called
+            // by parent process.
+            prof.connect();
             prof.overhead(geopm_time_since(&zero));
         }
         catch (...) {

--- a/test/ApplicationSamplerTest.cpp
+++ b/test/ApplicationSamplerTest.cpp
@@ -83,7 +83,6 @@ void ApplicationSamplerTest::SetUp()
                                                             false,
                                                             "",
                                                             is_active,
-                                                            true,
                                                             "profile_name",
                                                             m_client_cpu_map,
                                                             m_scheduler);

--- a/test/EnvironmentTest.cpp
+++ b/test/EnvironmentTest.cpp
@@ -82,18 +82,18 @@ void EnvironmentTest::expect_vars(std::map<std::string, std::string> exp_vars) c
 {
     EXPECT_EQ(exp_vars.find("GEOPM_TRACE") != exp_vars.end(), m_env->do_trace());
     EXPECT_EQ(exp_vars.find("GEOPM_TRACE_PROFILE") != exp_vars.end(), m_env->do_trace_profile());
-    EXPECT_EQ(exp_vars.find("GEOPM_PROFILE") != exp_vars.end() ||
-              exp_vars.find("GEOPM_REPORT") != exp_vars.end() ||
-              exp_vars.find("GEOPM_TRACE") != exp_vars.end() ||
-              exp_vars.find("GEOPM_TRACE_PROFILE") != exp_vars.end() ||
-              exp_vars.find("GEOPM_CTL") != exp_vars.end(), m_env->do_profile());
     EXPECT_EQ(exp_vars["GEOPM_REPORT"], m_env->report());
     EXPECT_EQ(exp_vars["GEOPM_COMM"], m_env->comm());
     EXPECT_EQ(exp_vars["GEOPM_POLICY"], m_env->policy());
     EXPECT_EQ(exp_vars["GEOPM_AGENT"], m_env->agent());
     EXPECT_EQ(exp_vars["GEOPM_TRACE"], m_env->trace());
     EXPECT_EQ(exp_vars["GEOPM_TRACE_PROFILE"], m_env->trace_profile());
-    EXPECT_EQ("\"" + exp_vars["GEOPM_PROFILE"] + "\"", m_env->profile());
+    if (exp_vars.find("GEOPM_PROFILE") != exp_vars.end()) {
+        EXPECT_EQ("\"" + exp_vars["GEOPM_PROFILE"] + "\"", m_env->profile());
+    }
+    else {
+        EXPECT_EQ("\"default\"", m_env->profile());
+    }
     EXPECT_EQ(exp_vars["GEOPM_FREQUENCY_MAP"], m_env->frequency_map());
     auto it = m_pmpi_ctl_map.find(exp_vars["GEOPM_CTL"]);
     if (it != m_pmpi_ctl_map.end()) {

--- a/test/ReporterTest.cpp
+++ b/test/ReporterTest.cpp
@@ -346,7 +346,6 @@ TEST_F(ReporterTest, generate)
                                                  m_region_agg,
                                                  env_signals,
                                                  "",
-                                                 true,
                                                  true);
     m_reporter->init();
 
@@ -531,7 +530,6 @@ TEST_F(ReporterTest, generate_conditional)
                                                  m_region_agg,
                                                  env_signals,
                                                  "",
-                                                 true,
                                                  true);
     m_reporter->init();
     m_reporter->total_time(56.0);


### PR DESCRIPTION
- This gates the request to geopmd to initiate profiling.
- Previously it was triggered whenever a user set one of the one of a set of GEOPM variables.
- Now, requests for profiling are made unless the variable GEOPM_PROGRAM_FILTER is set.
- This variable filters based on errno.h program_invocation_name and program_invocation_short_name
