### PR TITLE
Fix RPM install on CentOS 9 stream

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,9 +1,9 @@
-cffi>=1.15.0
+cffi>=1.14.5
 cycler>=0.11.0
 natsort>=8.1.0
 numpy>=1.19.5
 pandas>=1.1.5
-psutil>=5.9.0
+psutil>=5.8.0
 pyyaml>=6.0.0
-setuptools>=59.6.0
+setuptools>=53.0.0
 tables>=3.7.0

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,12 +1,12 @@
-cffi>=1.15.0
+cffi>=1.14.5
 dasbus>=1.6
-psutil>=5.9.0
+psutil>=5.8.0
 docstring_parser>=0.13
 sphinx>=4.5.0
 sphinx_rtd_theme>=1.0.0
 sphinxemoji>=0.2.0
 jsonschema>=3.2.0
 pyyaml>=6.0.0
-setuptools>=59.6.0
+setuptools>=53.0.0
 pygments>=2.13.0
 sphinx-tabs>=3.3.1


### PR DESCRIPTION
Reduce python3 dependency version requirements to those supported by CententOS 9 stream
