### PR TITLE
Remove automatic python dependency tracking to avoid dependencies not available in yum

### DIFF
--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -70,6 +70,8 @@ BuildRequires: python-rpm-macros
 Requires: python%{python3_pkgversion}-geopmdpy = %{version}
 Requires: libgeopmd1 = %{version}
 
+%{?python_disable_dependency_generator}
+
 %description
 
 The GEOPM Service provides a user-level interface to read telemetry

--- a/specs/geopm-runtime.spec.in
+++ b/specs/geopm-runtime.spec.in
@@ -67,6 +67,8 @@ Prefix: %{_prefix}
 %define compdir "%{_sysconfdir}/bash_completion.d"
 %endif
 
+%{?python_disable_dependency_generator}
+
 %description
 @BLURB@
 


### PR DESCRIPTION
- CentOS 9 uses upstream requements tracked by pypi which leads to requirements that cannot be satisified by yum.
