### PR TITLE
Avoid accidental profiling on import of geopmdpy.gffi

### DIFF
--- a/service/geopmdpy/gffi.py
+++ b/service/geopmdpy/gffi.py
@@ -15,6 +15,7 @@ the geopm::ApplicationSampler).
 '''
 
 import cffi
+import os
 
 '''gffi is the global FFI object used by all geopm python modules
 
@@ -49,8 +50,14 @@ def get_dl_geopm():
 
 # Enforce load order of libgeopm.so and libgeopmd.so
 try:
+    old_env = os.environ.get('GEOPM_PROGRAM_FILTER')
+    os.environ['GEOPM_PROGRAM_FILTER'] = ''
     _dl_geopm = gffi.dlopen('libgeopm.so.1',
                             gffi.RTLD_GLOBAL|gffi.RTLD_LAZY)
+    if old_env is not None:
+        os.environ['GEOPM_PROGRAM_FILTER'] = old_env
+    else:
+        os.environ.pop('GEOPM_PROGRAM_FILTER')
 except OSError as err:
     _dl_geopm = err
 

--- a/src/ApplicationIO.cpp
+++ b/src/ApplicationIO.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <unistd.h>
 #include <ctime>
+#include <iostream>
 
 #include "geopm_time.h"
 #include "geopm/Exception.hpp"
@@ -83,6 +84,13 @@ namespace geopm
             clock_nanosleep(CLOCK_REALTIME, 0, &delay, NULL);
             geopm_time(&time_curr);
         } while (!m_is_connected && geopm_time_diff(&time_zero, &time_curr) < timeout);
+#ifdef GEOPM_DEBUG
+        std::cout << "Info: <geopm> Controller will profile PIDs: ";
+        for (auto pid : m_profile_pids) {
+            std::cout << pid << " ";
+        }
+        std::cout << std::endl;
+#endif
         result.assign(m_profile_pids.begin(), m_profile_pids.end());
         return result;
     }

--- a/tutorial/tutorial_0.sh
+++ b/tutorial/tutorial_0.sh
@@ -26,6 +26,7 @@ HOSTNAME=$(hostname)
 if [ "$MPIEXEC" ]; then
     # Use MPIEXEC and set GEOPM environment variables to launch the job
     LD_PRELOAD=$GEOPM_LIB/libgeopm.so \
+    GEOPM_PROGRAM_FILTER=tutorial_0 \
     LD_DYNAMIC_WEAK=true \
     GEOPM_CTL=process \
     GEOPM_REPORT=tutorial_0_report_${HOSTNAME} \

--- a/tutorial/tutorial_1.sh
+++ b/tutorial/tutorial_1.sh
@@ -26,6 +26,7 @@ HOSTNAME=$(hostname)
 if [ "$MPIEXEC" ]; then
     # Use MPIEXEC and set GEOPM environment variables to launch the job
     LD_PRELOAD=$GEOPM_LIB/libgeopm.so \
+    GEOPM_PROGRAM_FILTER=tutorial_1 \
     LD_DYNAMIC_WEAK=true \
     GEOPM_CTL=process \
     GEOPM_REPORT=tutorial_1_report_${HOSTNAME} \


### PR DESCRIPTION
- Since profiling is now opt-out, ensure that undesired processes (e.g. python) are not accidently included for profiling.
- Add loop to print the PIDs that will be profiled on debug builds.