### PR TITLE
Quiesce warnings about direct writes to the MSR module

### DIFF
--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -92,6 +92,7 @@ EXTRA_DIST = .gitignore \
              geopmdpy/gffi.py \
              geopmdpy/loop.py \
              geopmdpy/pio.py \
+             geopmdpy/restorable_file_writer.py \
              geopmdpy/service.py \
              geopmdpy/session.py \
              geopmdpy/shmem.py \

--- a/service/geopmdpy/restorable_file_writer.py
+++ b/service/geopmdpy/restorable_file_writer.py
@@ -1,0 +1,87 @@
+#  Copyright (c) 2015 - 2023, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+import os
+from typing import Union, Callable
+from geopmdpy import system_files
+
+
+class RestorableFileWriter:
+    def __init__(self,
+                 write_path: Union[str, os.PathLike],
+                 backup_path: Union[str, os.PathLike],
+                 warning_handler: Union[Callable[[str], None], None] = None):
+        """Create a context manager that restores the contents of backup_path
+        to write_path and deletes backup_path on context exit.
+        Note that only one RestorableFileWriter should use a given backup_path
+        at a time since the backup file is removed as soon as any instance
+        restores the backup.
+        """
+        self._write_path: Union[str, os.PathLike] = write_path
+        self._backup_path: Union[str, os.PathLike] = backup_path
+        # If no warning handler is requested, ignore warnings
+        self._warning_handler: Callable[[str], None] = (
+            warning_handler if warning_handler is not None else lambda warning: None)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # This function can potentially be called while handling another
+        # exception already. Log this function's exceptions so we don't clobber
+        # some other exception's logged stacktrace.
+        try:
+            self.restore_and_cleanup()
+        except Exception as e:
+            self._warning_handler(f'Encountered exception in restore to {self._write_path}: {repr(e)}')
+
+    def backup_and_try_update(self, new_file_contents: str):
+        """Copy the current contents (if any) of the write_path file to the
+        backup_path file, then replace the contents of the write_path file with
+        new_file_contents if the write_path file exists. If write_path does not
+        exist, do nothing.
+        """
+        try:
+            with open(self._write_path, 'r') as f:
+                old_setting = f.read()
+        except FileNotFoundError:
+            # If there is no write_path file, then there is nothing to back up
+            return
+
+        if os.path.isfile(self._backup_path):
+            # The backup file already exists. This could happen if the service
+            # terminated without being given a chance to restore the backup.
+            # Don't overwrite the existing backup with the current write_path
+            # contents, since that setting may be what the service wrote before.
+            self._warning_handler(f'Reusing existing backup at {self._backup_path}')
+        else:
+            system_files.secure_make_file(self._backup_path, old_setting)
+
+        with open(self._write_path, 'w') as f:
+            f.write(new_file_contents)
+
+    def restore_and_cleanup(self):
+        """Restore the contents of the backup file to the target file, deleting
+        the backup file after successful restore.
+        """
+        if os.path.exists(self._backup_path):
+            backup_contents = None
+            try:
+                backup_contents = system_files.secure_read_file(self._backup_path)
+            except Exception as e:
+                self._warning_handler(f'Encountered exception in secure read of {self._backup_path}: {e}')
+
+            if backup_contents is None:
+                # If there is (or was immediately recently) backup file but
+                # the secure read failed (exception or return None) then we want to know
+                self._warning_handler(f'Unable to securely read {self._backup_path}')
+                return
+        else:
+            # If there is no backup file (e.g., if there was no initial file),
+            # then there is nothing to restore
+            return
+
+        with open(self._write_path, 'w') as f:
+            f.write(backup_contents)
+        os.remove(self._backup_path)

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -12,6 +12,7 @@ EXTRA_DIST += geopmdpy_test/__init__.py \
               geopmdpy_test/TestPIO.py \
               geopmdpy_test/TestTopo.py \
               geopmdpy_test/TestRequestQueue.py \
+              geopmdpy_test/TestRestorableFileWriter.py \
               geopmdpy_test/TestSession.py \
               geopmdpy_test/TestActiveSessions.py \
               geopmdpy_test/TestSecureFiles.py \
@@ -90,6 +91,13 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestAccessLists.test__read_allowed_i
                  geopmdpy_test/pytest_links/TestRequestQueue.test_read_request_queue \
                  geopmdpy_test/pytest_links/TestRequestQueue.test_read_request_queue_invalid \
                  geopmdpy_test/pytest_links/TestRequestQueue.test_request_queue_invalid \
+		 geopmdpy_test/pytest_links/TestRestorableFileWriter.test_modify_existing_file \
+		 geopmdpy_test/pytest_links/TestRestorableFileWriter.test_modify_is_no_op_if_no_initial_file \
+		 geopmdpy_test/pytest_links/TestRestorableFileWriter.test_modify_does_not_overwrite_existing_backup \
+		 geopmdpy_test/pytest_links/TestRestorableFileWriter.test_restore_saved_file \
+		 geopmdpy_test/pytest_links/TestRestorableFileWriter.test_restore_is_no_op_if_no_backup_file \
+		 geopmdpy_test/pytest_links/TestRestorableFileWriter.test_context_manager_restores_backup \
+		 geopmdpy_test/pytest_links/TestRestorableFileWriter.test_context_manager_warns_on_cleanup_failure \
                  geopmdpy_test/pytest_links/TestSession.test_check_read_args \
                  geopmdpy_test/pytest_links/TestSession.test_format_signals \
                  geopmdpy_test/pytest_links/TestSession.test_format_signals_invalid \

--- a/service/geopmdpy_test/TestRestorableFileWriter.py
+++ b/service/geopmdpy_test/TestRestorableFileWriter.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2023, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+
+from geopmdpy.restorable_file_writer import RestorableFileWriter
+from geopmdpy import system_files
+import os
+import stat
+import tempfile
+import unittest
+
+
+class TestRestorableFileWriter(unittest.TestCase):
+    def setUp(self):
+        self._temp_dir = tempfile.TemporaryDirectory('TestRestorableFileWriter')
+        self._write_path = os.path.join(self._temp_dir.name, f'{self.id()}.write')
+        self._backup_path = os.path.join(self._temp_dir.name, f'{self.id()}.backup')
+
+    def tearDown(self):
+        self._temp_dir.cleanup()
+
+    def test_modify_existing_file(self):
+        warnings = list()
+        writer = RestorableFileWriter(
+            write_path=self._write_path,
+            backup_path=self._backup_path,
+            warning_handler=warnings.append)
+
+        # Test-case precondition: write_path file is populated
+        with open(self._write_path, 'w') as f:
+            f.write('old contents')
+
+        writer.backup_and_try_update('Updated text')
+
+        self.assertCountEqual([], warnings)
+        with open(self._backup_path) as f:
+            self.assertEqual('old contents', f.read())
+        with open(self._write_path) as f:
+            self.assertEqual('Updated text', f.read())
+
+    def test_modify_is_no_op_if_no_initial_file(self):
+        warnings = list()
+        writer = RestorableFileWriter(
+            write_path=self._write_path,
+            backup_path=self._backup_path,
+            warning_handler=warnings.append)
+
+        # Test-case precondition: write_path file does not exist
+        writer.backup_and_try_update('Updated text')
+
+        self.assertCountEqual([], warnings)
+        self.assertFalse(os.path.exists(self._write_path))
+        self.assertFalse(os.path.exists(self._backup_path))
+
+    def test_modify_does_not_overwrite_existing_backup(self):
+        warnings = list()
+        writer = RestorableFileWriter(
+            write_path=self._write_path,
+            backup_path=self._backup_path,
+            warning_handler=warnings.append)
+
+        # Test-case precondition: a backup already exists
+        with open(self._write_path, 'w') as f:
+            f.write('write_path contents')
+        system_files.secure_make_file(self._backup_path, 'backed-up contents')
+
+        writer.backup_and_try_update('Updated text')
+
+        self.assertEqual(1, len(warnings))
+        self.assertIn('Reusing existing backup', warnings[0])
+        with open(self._backup_path) as f:
+            self.assertEqual('backed-up contents', f.read())
+        with open(self._write_path) as f:
+            self.assertEqual('Updated text', f.read())
+
+    def test_restore_saved_file(self):
+        warnings = list()
+        writer = RestorableFileWriter(
+            write_path=self._write_path,
+            backup_path=self._backup_path,
+            warning_handler=warnings.append)
+
+        # Test-case precondition: write_path file is backed up and overwritten
+        with open(self._write_path, 'w') as f:
+            f.write('overwritten contents')
+        system_files.secure_make_file(self._backup_path, 'backed-up contents')
+
+        writer.restore_and_cleanup()
+
+        self.assertCountEqual([], warnings)
+        self.assertFalse(os.path.exists(self._backup_path))
+        with open(self._write_path) as f:
+            self.assertEqual('backed-up contents', f.read())
+
+    def test_restore_is_no_op_if_no_backup_file(self):
+        warnings = list()
+        writer = RestorableFileWriter(
+            write_path=self._write_path,
+            backup_path=self._backup_path,
+            warning_handler=warnings.append)
+
+        # Test-case precondition: backup_path file does not exist
+        with open(self._write_path, 'w') as f:
+            f.write('write_path contents')
+
+        writer.restore_and_cleanup()
+
+        self.assertCountEqual([], warnings)
+        with open(self._write_path) as f:
+            self.assertEqual('write_path contents', f.read())
+        self.assertFalse(os.path.exists(self._backup_path))
+
+    def test_context_manager_restores_backup(self):
+        warnings = list()
+        writer = RestorableFileWriter(
+            write_path=self._write_path,
+            backup_path=self._backup_path,
+            warning_handler=warnings.append)
+
+        # Test-case precondition: write_path file is populated
+        with open(self._write_path, 'w') as f:
+            f.write('old contents')
+
+        with writer:
+            writer.backup_and_try_update('Updated text')
+
+            # Overwritten while in context
+            with open(self._write_path) as f:
+                self.assertEqual('Updated text', f.read())
+
+        self.assertCountEqual([], warnings)
+
+        # Restored after exiting context
+        with open(self._write_path) as f:
+            self.assertEqual('old contents', f.read())
+
+    def test_context_manager_warns_on_cleanup_failure(self):
+        warnings = list()
+        writer = RestorableFileWriter(
+            write_path=self._write_path,
+            backup_path=self._backup_path,
+            warning_handler=warnings.append)
+
+        # Test-case precondition: write_path file is populated
+        with open(self._write_path, 'w') as f:
+            f.write('old contents')
+
+        with writer:
+            writer.backup_and_try_update('Updated text')
+            # Inject a failure on restore by making the to-be-updated file read-only
+            os.chmod(self._write_path, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
+
+        self.assertEqual(1, len(warnings))
+        self.assertIn('Encountered exception in restore', warnings[0])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- OSes with Linux version 5.9 or greater emit warnings about unexpected MSR writes unless an option is set to allow writes in the MSR driver
- This change writes the setting to allow writes in the MSR driver, restoring the initial setting when the geopm service exits.
- Resolves #2461

In addition to the unit tests in this change, the following manual validation was performed on an Ubuntu 22.04.3 LTS system (Kernel 5.15):
1. Install geopm, start the service
2. `sudo cat /var/run/geopm-service/msr-saved-allow-writes` prints `default`
3. `sudo cat /sys/module/msr/parameters/allow_writes` prints `on`
4. `geopmwrite CPU_FREQUENCY_MAX_CONTROL core 0 3700000000`
5. `sudo dmesg -H` shows no warnings about unexpected MSR writes at the time of the test
6. `sudo systemctl stop geopm`
7. `sudo cat /var/run/geopm-service/msr-saved-allow-writes` does not exist
8. `sudo cat /sys/module/msr/parameters/allow_writes` prints `default`
9. `sudo pkill -kill geopmd`
10. `sudo journalctl -u geopm` shows a warning that a pre-existing backup file is being reused. `msr-saved-allow-writes` is still `default` and `allow_writes` is `on`.