### PR TITLE
Remove system_files.py from gitignore

### DIFF
--- a/service/.gitignore
+++ b/service/.gitignore
@@ -25,7 +25,6 @@ compile_commands.json
 /fuzz_test/geopmhash_corpus
 /geopmdpy.egg-info
 /geopmdpy/schemas.py
-/geopmdpy/system_files.py
 /geopmdpy/version.py
 /geopmdpy_test/pytest_links/
 /geopmread


### PR DESCRIPTION
- After change 1e9bc15e system_files.py is not a generated file so it should no longer be ignored