### PR TITLE
Adding text on running GEOPM runtime alongside non-MPI applications

### DIFF
--- a/service/docs/source/GEOPM_CXX_MAN_CNLIOGroup.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_CNLIOGroup.3.rst
@@ -17,7 +17,7 @@ Synopsis
 
 #include `<geopm/CNLIOGroup.hpp> <https://github.com/geopm/geopm/blob/dev/service/src/CNLIOGroup.hpp>`_
 
-Link with ``-lgeopm`` **(MPI)** or ``-lgeopm`` **(non-MPI)**
+Link with ``-lgeopmd``
 
 
 .. code-block:: c++

--- a/service/docs/source/GEOPM_CXX_MAN_CpuinfoIOGroup.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_CpuinfoIOGroup.3.rst
@@ -19,7 +19,7 @@ Synopsis
 
 #include `<geopm/CpuinfoIOGroup.hpp> <https://github.com/geopm/geopm/blob/dev/service/src/CpuinfoIOGroup.hpp>`_
 
-Link with ``-lgeopm`` **(MPI)** or ``-lgeopm`` **(non-MPI)**
+Link with ``-lgeopmd``
 
 
 .. code-block:: c++

--- a/service/docs/source/GEOPM_CXX_MAN_IOGroup.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_IOGroup.3.rst
@@ -18,7 +18,7 @@ Synopsis
 
 #include `<geopm/IOGroup.hpp> <https://github.com/geopm/geopm/blob/dev/service/src/geopm/IOGroup.hpp>`_\
 
-Link with ``-lgeopm`` **(MPI)** or ``-lgeopm`` **(non-MPI)**
+Link with ``-lgeopmd``
 
 
 .. code-block:: c++

--- a/service/docs/source/GEOPM_CXX_MAN_MSRIO.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_MSRIO.3.rst
@@ -18,7 +18,7 @@ Synopsis
 
 #include `<geopm/MSRIO.hpp> <https://github.com/geopm/geopm/blob/dev/service/src/MSRIO.hpp>`_
 
-Link with ``-lgeopm`` **(MPI)** or ``-lgeopm`` **(non-MPI)**
+Link with ``-lgeopmd``
 
 
 .. code-block:: c++

--- a/service/docs/source/GEOPM_CXX_MAN_MSRIOGroup.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_MSRIOGroup.3.rst
@@ -12,7 +12,7 @@ Synopsis
 
 #include `<geopm/MSRIOGroup.hpp> <https://github.com/geopm/geopm/blob/dev/service/src/geopm/MSRIOGroup.hpp>`_
 
-Link with ``-lgeopm`` **(MPI)** or ``-lgeopm`` **(non-MPI)**
+Link with ``-lgeopmd``
 
 
 .. code-block:: c++

--- a/service/docs/source/GEOPM_CXX_MAN_ProfileIOGroup.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_ProfileIOGroup.3.rst
@@ -19,7 +19,7 @@ Synopsis
 
 #include `<geopm/ProfileIOGroup.hpp> <https://github.com/geopm/geopm/blob/dev/src/ProfileIOGroup.hpp>`_
 
-Link with ``-lgeopm`` **(MPI)** or ``-lgeopm`` **(non-MPI)**
+Link with ``-lgeopmd``
 
 
 .. code-block:: c++

--- a/service/docs/source/geopm.7.rst
+++ b/service/docs/source/geopm.7.rst
@@ -353,6 +353,10 @@ GEOPM Environment Variables
   The control loop period in seconds, if not specified this is determined by
   the Agent. See the ``--geopm-period`` :ref:`option description <geopm-period option>`
   in :doc:`geopmlaunch(1) <geopmlaunch.1>` for details.
+``GEOPM_PROGRAM_FILTER``
+  Optional comma separated list of program invocation names of non-MPI processes which
+  need to be profiled. See the ``--geopm-program-filter`` :ref:`option description
+  <geopm-program-filter option>` in :doc:`geopmlaunch(1) <geopmlaunch.1>` for details.
 ``GEOPM_MSR_CONFIG_PATH``
   The colon-separated list of search paths for additional MSR definitions. See
   :doc:`geopm_pio_msr(7) <geopm_pio_msr.7>` for more details.

--- a/service/docs/source/geopm_pio.3.rst
+++ b/service/docs/source/geopm_pio.3.rst
@@ -8,7 +8,7 @@ Synopsis
 
 #include `<geopm_pio.h> <https://github.com/geopm/geopm/blob/dev/service/src/geopm_pio.h>`_\
 
-Link with ``-lgeopm`` **(MPI)** or ``-lgeopm`` **(non-MPI)**
+Link with ``-lgeopmd``
 
 
 .. code-block:: c

--- a/service/docs/source/index.rst
+++ b/service/docs/source/index.rst
@@ -10,7 +10,7 @@ package provides many built-in features. A simple use case is reading hardware
 counters and setting hardware controls with platform independent syntax using
 a command line tool on a particular compute node. An advanced use case is
 dynamically coordinating hardware settings across all compute nodes used by a
-distributed application is response to the application's behavior and requests
+distributed application in response to the application's behavior and requests
 from the resource manager.
 
 

--- a/service/docs/source/overview.rst
+++ b/service/docs/source/overview.rst
@@ -798,15 +798,16 @@ generate a report:
 3. The ``GEOPM_REPORT`` environment variable must be set in the
    environment of the ``geopmctl`` process.
 
-Beyond generating a report YAML file, we also show two of the optional
+Beyond generating a report YAML file, we also show three of the optional
 GEOPM Runtime features.  The first is creating a CSV trace file using
 the ``GEOPM_TRACE`` environment variable.  Additionally, by using the
 ``GEOPM_PERIOD`` environment variable we increase the sampling period
 of the controller to 200 milliseconds (default value is 5
-milliseconds). By using the optional ``GEOPM_PROGRAM_FILTER`` variable
+milliseconds). By using the third optional ``GEOPM_PROGRAM_FILTER`` variable,
 we can explicitly list the name of the non-MPI program invovation name
-of the non-MPI process to be profiled. These two options together will 
-create a CSV trace file with approximately 50 rows of samples (five 
+of the non-MPI process to be profiled. These three options together will inform
+the GEOPM runtime controller (``geopmctl``) to profile the ``sleep`` utility
+and generate a CSV trace file with approximately 50 rows of samples (five 
 per-second for ten seconds).  The ``awk`` command in the example selects
 the columns measuring time since application start from column 1, CPU 
 energy from column 6, and CPU power from column 8.

--- a/service/docs/source/overview.rst
+++ b/service/docs/source/overview.rst
@@ -803,11 +803,13 @@ GEOPM Runtime features.  The first is creating a CSV trace file using
 the ``GEOPM_TRACE`` environment variable.  Additionally, by using the
 ``GEOPM_PERIOD`` environment variable we increase the sampling period
 of the controller to 200 milliseconds (default value is 5
-milliseconds).  These two options together will create a CSV trace
-file with approximately 50 rows of samples (five per-second for ten
-seconds).  The ``awk`` command in the example selects the columns
-measuring time since application start from column 1, CPU energy from
-column 6, and CPU power from column 8.
+milliseconds). By using the optional ``GEOPM_PROGRAM_FILTER`` variable
+we can explicitly list the name of the non-MPI program invovation name
+of the non-MPI process to be profiled. These two options together will 
+create a CSV trace file with approximately 50 rows of samples (five 
+per-second for ten seconds).  The ``awk`` command in the example selects
+the columns measuring time since application start from column 1, CPU 
+energy from column 6, and CPU power from column 8.
 
 .. code-block:: bash
 
@@ -817,6 +819,7 @@ column 6, and CPU power from column 8.
       GEOPM_PERIOD=0.2 \
       geopmctl &
     $ GEOPM_PROFILE=sleep-ten \
+      GEOPM_PROGRAM_FILTER=sleep \
       LD_PRELOAD=libgeopm.so.2 \
       sleep 10
     $ cat sleep-ten.yaml

--- a/service/docs/source/publications.rst
+++ b/service/docs/source/publications.rst
@@ -29,13 +29,17 @@ HPC Lab Resources
 Media Posts
 -----------
 
+* `Top Considerations for HPC AI and Sustainability, HPCWire Article, 2023, <https://www.hpcwire.com/2023/06/26/top-considerations-for-hpc-ai-and-sustainability/>`
+
+* `Four Principles for Writing Energy and Carbon Efficient Software, Intel Community Blog Article, 2023 <https://community.intel.com/t5/Blogs/Thought-Leadership/Big-Ideas/Four-principles-for-writing-energy-and-carbon-efficient-software/post/1478842>`
+
 * `PowerStack: A global response to the power management problem for exascale, HIPEAC Blog Article, 2019 <https://www.hipeac.net/news/6895/powerstack-a-global-response-to-the-power-management-problem-for-exascale/>`_
 
 * `Power and Performance Optimization at Exascale, InsideHPC, March 2018, InsideHPC Podcast and article, March 2018 <https://insidehpc.com/2018/03/podcast-power-peformance-optimization-Exascale/>`_
 
-* `Energy Efficiency in the Software Stack — Cross Community Efforts, InsideHPC article, December 2017 <https://insidehpc.com/2017/12/sc17-energy-efficiency-software-stack-cross-community-efforts/>`_
+* `Energy Efficiency in the Software Stack — Cross Community Efforts, InsideHPC Article, December 2017 <https://insidehpc.com/2017/12/sc17-energy-efficiency-software-stack-cross-community-efforts/>`_
 
-* `First Global Survey of Energy and Power Aware Job Scheduling and Resource Management, InsideHPC article, November 2017 <https://insidehpc.com/2017/12/first-global-survey-energy-power-aware-job-scheduling-resource-management/>`_
+* `First Global Survey of Energy and Power Aware Job Scheduling and Resource Management, InsideHPC Article, November 2017 <https://insidehpc.com/2017/12/first-global-survey-energy-power-aware-job-scheduling-resource-management/>`_
 
 
 

--- a/service/docs/source/runtime.rst
+++ b/service/docs/source/runtime.rst
@@ -92,13 +92,13 @@ Runtime launch options.
   * Read the generated ``geopm.report`` file
   
   .. code-block:: console
-    :caption: examples using ``geopmlaunch``
+    :caption: Examples using ``geopmlaunch``
 
-    $ # Launch with srun and explore the generated geopm report
+    $ # Launch with srun and explore the generated GEOPM report
     $ geopmlaunch srun -N 1 -n 20 -- ./my-app
     $ less geopm.report
     $ # Launch with Intel mpiexec and explore the generated GEOPM report
-    $ geopmlaunch impi -N 1 -ppn 20 -- ./my-app
+    $ geopmlaunch impi -n 1 -ppn 20 -- ./my-app
     $ less geopm.report
     $ # show all options and available launchers
     $ geopmlaunch --help
@@ -119,30 +119,31 @@ Runtime launch options.
    * Both the ``geopmctl`` process and the application process must have
      the ``GEOPM_PROFILE`` environment variable set to the **same**
      value.
-   * The application process must have ``LD_PRELOAD=libgeopm.so.1`` set
+   * The application process must have ``LD_PRELOAD=libgeopm.so.2`` set
      in the environment, or the application binary must be linked
-     directly to ``libgeopm.so.1`` at compile time.
+     directly to ``libgeopm.so.2`` at compile time.
    * The ``GEOPM_REPORT`` environment variable must be set in the
      environment of the ``geopmctl`` process.
  
    .. code-block:: console
-     :caption: examples using ``geopmctl``
+     :caption: Examples using ``geopmctl``
  
      $ GEOPM_PROFILE=sleep-ten \
        GEOPM_REPORT=sleep-ten.yaml \
+       GEOPM_TRACE=sleep-ten-trace \
        geopmctl &
      $ GEOPM_PROFILE=sleep-ten \
-       LD_PRELOAD=libgeopm.so.1 \
+       LD_PRELOAD=libgeopm.so.2 \
        sleep 10
      $ cat sleep-ten.yaml
-     $ awk -F\| '{print $1, $6, $8}' sleep-ten.csv | less
+     $ awk -F\| '{print $1, $6, $8}' sleep-ten-trace* | less
 
 
-The `geopm runtime tutorial
+The `GEOPM runtime tutorial
 <https://github.com/geopm/geopm/tree/dev/tutorial#geopm-tutorial>`_ shows how
-to profile unmodified applications, select and evaluate different geopm agent
+to profile unmodified applications, select and evaluate different GEOPM agent
 algorithms, and how to add markup to an application.  The tutorial provides a
-starting point for someone trying to get familiar with the geopm runtime.
+starting point for someone trying to get familiar with the GEOPM runtime.
 
 The runtime enables complex coordination between hardware settings across all
 compute nodes used by a distributed HPC application in

--- a/service/docs/source/runtime.rst
+++ b/service/docs/source/runtime.rst
@@ -3,13 +3,19 @@ Guide for Runtime Users
 =======================
 
 The GEOPM Runtime is software designed to enhance energy efficiency of
-applications though active hardware configuration.  The architecture is
-designed to provide a secure infrastructure to support a wide range
-of tuning algorithms while solving three related challenges:
+applications through active hardware configuration.  
+
+
+User Model
+----------
+
+The architecture is designed to provide a secure infrastructure to 
+support a wide range of tuning algorithms while solving three related 
+challenges:
 
 
 1. Measuring Performance
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 The first challenge is to enable hardware tuning algorithms to derive
 a robust estimate of application performance.  This is crucial because
@@ -25,7 +31,7 @@ than if an adaptive algorithm were not applied.
 
 
 2. Hardware Configuration
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This leads to the second challenge: enabling a hardware control
 algorithm to be driven by unprivileged user input (i.e. application
@@ -36,7 +42,7 @@ is specifically designed to address these problems.
 
 
 3. Advanced Data Analysis
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The third challenge is providing a software development platform for
 control algorithms that can be safely deployed and use high level
@@ -70,37 +76,73 @@ Runtime launch options.
          trace file per host, and one report across all hosts.
    :align: center
 
-   The geopmlaunch tool is the main user interface to the GEOPM Runtime. It
+
+.. admonition:: Quick start for MPI applications
+
+   The ``geopmlaunch`` tool is the recommended user interface to launch the GEOPM Runtime for 
+   profiling and optimizing MPI applications. It
    wraps a launcher application (srun in this example), generates a summarizing
    report file, and optionally generates a time-series trace per host.
 
-.. admonition:: Quick Start
-
-  Run ``geopmlaunch`` with your application:
+   The steps for using ``geopmlaunch`` with your MPI application are:
 
   * Specify how many nodes and processes to use.
   * Run the ``geopmlaunch`` command wherever you would normally run the
-    wrapped command (e.g., ``srun``, ``mpiexec``, etc.).
+    wrapped launcher command (e.g., ``srun``, ``mpiexec``, etc.).
   * Read the generated ``geopm.report`` file
   
   .. code-block:: console
-    :caption: Examples using ``geopmlaunch``
+    :caption: examples using ``geopmlaunch``
 
-    $ # Launch with srun and explore the generated GEOPM report
+    $ # Launch with srun and explore the generated geopm report
     $ geopmlaunch srun -N 1 -n 20 -- ./my-app
     $ less geopm.report
     $ # Launch with Intel mpiexec and explore the generated GEOPM report
-    $ geopmlaunch impi -n 1 -ppn 20 -- ./my-app
+    $ geopmlaunch impi -N 1 -ppn 20 -- ./my-app
     $ less geopm.report
     $ # show all options and available launchers
     $ geopmlaunch --help
 
-  The `GEOPM Runtime tutorial
-  <https://github.com/geopm/geopm/tree/dev/tutorial#geopm-tutorial>`_ shows how
-  to profile unmodified applications, select and evaluate different GEOPM Agent
-  algorithms, and how to add markup to an application.  The tutorial provides a
-  starting point for someone trying to get familiar with the GEOPM Runtime.
 
+.. admonition:: Quick start for Non-MPI applications
+
+   In order to profile non-MPI applications, the recommended approach is to launch
+   the GEOPM runtime alongside the target application. This can be done by launching
+   the ``geopmctl`` application in the background on every host node that the non-MPI 
+   application is expected to run. After a clean or forced termination of the 
+   application being profiled, the ``geopmctl`` application is designed to terminate
+   and generate a summarizing report file, and optionally, a time-series trace per host. 
+ 
+   The following requirements must be met while launching ``geopmctl`` with your 
+   non-MPI application:
+ 
+   * Both the ``geopmctl`` process and the application process must have
+     the ``GEOPM_PROFILE`` environment variable set to the **same**
+     value.
+   * The application process must have ``LD_PRELOAD=libgeopm.so.1`` set
+     in the environment, or the application binary must be linked
+     directly to ``libgeopm.so.1`` at compile time.
+   * The ``GEOPM_REPORT`` environment variable must be set in the
+     environment of the ``geopmctl`` process.
+ 
+   .. code-block:: console
+     :caption: examples using ``geopmctl``
+ 
+     $ GEOPM_PROFILE=sleep-ten \
+       GEOPM_REPORT=sleep-ten.yaml \
+       geopmctl &
+     $ GEOPM_PROFILE=sleep-ten \
+       LD_PRELOAD=libgeopm.so.1 \
+       sleep 10
+     $ cat sleep-ten.yaml
+     $ awk -F\| '{print $1, $6, $8}' sleep-ten.csv | less
+
+
+The `geopm runtime tutorial
+<https://github.com/geopm/geopm/tree/dev/tutorial#geopm-tutorial>`_ shows how
+to profile unmodified applications, select and evaluate different geopm agent
+algorithms, and how to add markup to an application.  The tutorial provides a
+starting point for someone trying to get familiar with the geopm runtime.
 
 The runtime enables complex coordination between hardware settings across all
 compute nodes used by a distributed HPC application in
@@ -119,7 +161,7 @@ individual MPI application and enable the management of system power
 resources for multiple MPI jobs and multiple users by the system
 resource manager.
 
-The GEOPM Runtime package provides the libgeopm shared object library.
+The GEOPM Runtime package provides the *libgeopm* shared object library.
 There are several command line tools included in GEOPM which have
 dedicated manual pages.  The :doc:`geopmlaunch(1) <geopmlaunch.1>`
 command line tool is used to launch an MPI application while enabling
@@ -144,7 +186,7 @@ package which is contained in the service directory of the GEOPM
 repository.  The PlatformIO abstraction enables Agent implementations
 to be ported to different hardware platforms without modification.
 
-The libgeopm library can be called directly or indirectly within MPI
+The *libgeopm* library can be called directly or indirectly within MPI
 applications to enable application feedback for informing the control
 decisions.  The indirect calls are facilitated by GEOPM's integration
 with MPI and OpenMP through their profiling decorators, and the direct

--- a/service/docs/source/runtime.rst
+++ b/service/docs/source/runtime.rst
@@ -124,9 +124,10 @@ Runtime launch options.
      directly to ``libgeopm.so.2`` at compile time.
    * The ``GEOPM_REPORT`` environment variable must be set in the
      environment of the ``geopmctl`` process.
-   * The ``GEOPM_PROGRAM_FILTER`` environment variable can optionally be set to
-     explicitly list the program invocation name of the non-MPI processes that need
-     to be profiled.
+   * While not necessary in this example, in case of multiple extraneous processes 
+     getting launched, the optional ``GEOPM_PROGRAM_FILTER`` environment variable 
+     can be set to explicitly list the program invocation name of the specific 
+     non-MPI process that needs to be profiled.
  
    .. code-block:: console
      :caption: Examples using ``geopmctl``

--- a/service/docs/source/runtime.rst
+++ b/service/docs/source/runtime.rst
@@ -124,6 +124,9 @@ Runtime launch options.
      directly to ``libgeopm.so.2`` at compile time.
    * The ``GEOPM_REPORT`` environment variable must be set in the
      environment of the ``geopmctl`` process.
+   * The ``GEOPM_PROGRAM_FILTER`` environment variable can optionally be set to
+     explicitly list the program invocation name of the non-MPI processes that need
+     to be profiled.
  
    .. code-block:: console
      :caption: Examples using ``geopmctl``
@@ -133,6 +136,7 @@ Runtime launch options.
        GEOPM_TRACE=sleep-ten-trace \
        geopmctl &
      $ GEOPM_PROFILE=sleep-ten \
+       GEOPM_PROGRAM_FILTER=sleep \
        LD_PRELOAD=libgeopm.so.2 \
        sleep 10
      $ cat sleep-ten.yaml

--- a/service/docs/source/service_readme.rst
+++ b/service/docs/source/service_readme.rst
@@ -173,7 +173,7 @@ Opening a Session
 -----------------
 
 A client process opens a session with the GEOPM Service each time a PlatformIO
-object is created with libgeopm while the GEOPM systemd service is active.
+object is created with libgeopmd while the GEOPM systemd service is active.
 This session is initially opened in read-only mode.  Calls into the D-Bus APIs
 that modify control values:
 
@@ -217,7 +217,7 @@ Batch Server
 The GEOPM Service provides the implementation for the ServiceIOGroup
 which accesses this implementation through the DBus interface.  When a
 user program calls ``read_signal()`` or ``write_control()`` on a
-PlatformIO object provided by libgeopm and the only
+PlatformIO object provided by libgeopmd and the only
 IOGroup that provides the signal or control requested is the
 ServiceIOGroup, then each request goes through the slow D-Bus
 interface.  When a client process uses the ServiceIOGroup for batch


### PR DESCRIPTION
- Relates to #2985  from github issues


-- Adding text on GEOPM support for profiling non-MPI applications. This includes sample code snippets. 
-- This PR is also expected to fix incorrect references to libgeopm instead of libgeopmd

