### PR TITLE
Implement ServiceIOGroup save/restore

### DIFF
--- a/service/geopmdpy/dbus_xml.py
+++ b/service/geopmdpy/dbus_xml.py
@@ -385,6 +385,16 @@ def geopm_dbus_xml(TopoService=None, PlatformService=None):
         </doc:description>
       </doc:doc>
     </method>
+    <method name="PlatformRestoreControl">
+     <doc:doc>
+        <doc:description>
+          <doc:summary>{PlatformRestoreControl_short_description}
+          </doc:summary>
+          <doc:para>{PlatformRestoreControl_long_description}
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </method>
     <method name="PlatformStartProfile">
       <arg direction="in" name="profile_name" type="s">
         <doc:doc>
@@ -483,6 +493,7 @@ def geopm_dbus_xml(TopoService=None, PlatformService=None):
         PlatformStopBatch = google.parse(PlatformService.stop_batch.__doc__)
         PlatformReadSignal = google.parse(PlatformService.read_signal.__doc__)
         PlatformWriteControl = google.parse(PlatformService.write_control.__doc__)
+        PlatformRestoreControl = google.parse(PlatformService.restore_control.__doc__)
         PlatformStartProfile = google.parse(PlatformService.start_profile.__doc__)
         PlatformStopProfile = google.parse(PlatformService.stop_profile.__doc__)
         PlatformGetProfilePids = google.parse(PlatformService.get_profile_pids.__doc__)
@@ -556,6 +567,8 @@ def geopm_dbus_xml(TopoService=None, PlatformService=None):
             PlatformWriteControl_params3_description=PlatformWriteControl.params[3].description,
             PlatformWriteControl_short_description=PlatformWriteControl.short_description,
             PlatformWriteControl_long_description=PlatformWriteControl.long_description,
+            PlatformRestoreControl_short_description=PlatformRestoreControl.short_description,
+            PlatformRestoreControl_long_description=PlatformRestoreControl.long_description,
             PlatformStartProfile_params2_description=PlatformStartProfile.params[2].description,
             PlatformStartProfile_short_description=PlatformStartProfile.short_description,
             PlatformStartProfile_long_description=PlatformStartProfile.long_description,

--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -676,8 +676,7 @@ class PlatformService(object):
         self._pio.write_control(control_name, domain, domain_idx, setting)
 
     def restore_control(self, client_pid):
-        """Restore the state of all controls recorded at the start of a
-        session.
+        """Restore all controls recorded at the start of a session.
 
         For the session associated to the given process, restore the state
         of all controls, which is recorded at the beginning of the session.

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -39,6 +39,7 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestAccessLists.test__read_allowed_i
                  geopmdpy_test/pytest_links/TestAccessLists.test_set_group_access_empty \
                  geopmdpy_test/pytest_links/TestAccessLists.test_set_group_access_named \
                  geopmdpy_test/pytest_links/TestAccessLists.test_get_names \
+                 geopmdpy_test/pytest_links/TestPlatformService.test_close_already_closed \
                  geopmdpy_test/pytest_links/TestPlatformService.test_close_session_invalid \
                  geopmdpy_test/pytest_links/TestPlatformService.test_close_session_read \
                  geopmdpy_test/pytest_links/TestPlatformService.test_close_session_write \
@@ -47,8 +48,12 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestAccessLists.test__read_allowed_i
                  geopmdpy_test/pytest_links/TestPlatformService.test_lock_control \
                  geopmdpy_test/pytest_links/TestPlatformService.test_open_session \
                  geopmdpy_test/pytest_links/TestPlatformService.test_open_session_twice \
+                 geopmdpy_test/pytest_links/TestPlatformService.test_read_already_closed \
                  geopmdpy_test/pytest_links/TestPlatformService.test_read_signal \
                  geopmdpy_test/pytest_links/TestPlatformService.test_read_signal_invalid \
+                 geopmdpy_test/pytest_links/TestPlatformService.test_restore_already_closed \
+                 geopmdpy_test/pytest_links/TestPlatformService.test_restore_control \
+                 geopmdpy_test/pytest_links/TestPlatformService.test_restore_write_blocked \
                  geopmdpy_test/pytest_links/TestPlatformService.test_start_batch \
                  geopmdpy_test/pytest_links/TestPlatformService.test_start_batch_invalid \
                  geopmdpy_test/pytest_links/TestPlatformService.test_start_batch_write_blocked \

--- a/service/io.github.geopm.xml
+++ b/service/io.github.geopm.xml
@@ -635,11 +635,9 @@ range.
     <method name="PlatformRestoreControl">
      <doc:doc>
         <doc:description>
-          <doc:summary>Restore the state of all controls recorded at the start of a
+          <doc:summary>Restore all controls recorded at the start of a session.
           </doc:summary>
-          <doc:para>session.
-
-For the session associated to the given process, restore the state
+          <doc:para>For the session associated to the given process, restore the state
 of all controls, which is recorded at the beginning of the session.
 
 Raises

--- a/service/io.github.geopm.xml
+++ b/service/io.github.geopm.xml
@@ -632,6 +632,24 @@ range.
         </doc:description>
       </doc:doc>
     </method>
+    <method name="PlatformRestoreControl">
+     <doc:doc>
+        <doc:description>
+          <doc:summary>Restore the state of all controls recorded at the start of a
+          </doc:summary>
+          <doc:para>session.
+
+For the session associated to the given process, restore the state
+of all controls, which is recorded at the beginning of the session.
+
+Raises
+    RuntimeError: If client_pid does not have an open session or
+                  if a different client currently has an open
+                  session in write mode
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </method>
     <method name="PlatformStartProfile">
       <arg direction="in" name="profile_name" type="s">
         <doc:doc>

--- a/service/src/ServiceIOGroup.cpp
+++ b/service/src/ServiceIOGroup.cpp
@@ -296,12 +296,13 @@ namespace geopm
 
     void ServiceIOGroup::save_control(void)
     {
-        // Proxy, so no direct save/restore
+        // Implementation not required as ServiceIOGroup works with the service, which manages
+        // sessions and saving controls.
     }
 
     void ServiceIOGroup::restore_control(void)
     {
-        // Proxy, so no direct save/restore
+        m_service_proxy->platform_restore_control();
     }
 
     std::function<double(const std::vector<double> &)> ServiceIOGroup::agg_function(const std::string &signal_name) const

--- a/service/src/ServiceProxy.cpp
+++ b/service/src/ServiceProxy.cpp
@@ -104,6 +104,11 @@ namespace geopm
         (void)m_bus->call_method("PlatformCloseSession");
     }
 
+    void ServiceProxyImp::platform_close_session_admin(int client_pid)
+    {
+        m_bus->call_method("PlatformCloseSessionAdmin", client_pid);
+    }
+
     void ServiceProxyImp::platform_start_batch(const std::vector<struct geopm_request_s> &signal_config,
                                                const std::vector<struct geopm_request_s> &control_config,
                                                int &server_pid,
@@ -155,6 +160,11 @@ namespace geopm
                                  domain,
                                  domain_idx,
                                  setting);
+    }
+
+    void ServiceProxyImp::platform_restore_control()
+    {
+        m_bus->call_method("PlatformRestoreControl");
     }
 
     std::string ServiceProxyImp::topo_get_cache(void)

--- a/service/src/geopm/ServiceProxy.hpp
+++ b/service/src/geopm/ServiceProxy.hpp
@@ -97,6 +97,9 @@ namespace geopm
             /// @brief Calls the PlatformCloseSession API defined in
             ///        the io.github.geopm D-Bus namespace.
             virtual void platform_close_session(void) = 0;
+            /// @brief Calls the PlatformCloseSessionAdmin API defined in
+            ///        the io.github.geopm D-Bus namespace.
+            virtual void platform_close_session_admin(int client_pid) = 0;
             /// @brief Calls the PlatformStartBatch API defined in the
             ///        io.github.geopm D-Bus namespace.
             /// @param signal_config [in] Vector of signal requests
@@ -144,6 +147,9 @@ namespace geopm
                                                 int domain,
                                                 int domain_idx,
                                                 double setting) = 0;
+            /// @brief Calls the PlatformRestoreControl API defined in the
+            ///        io.github.geopm D-Bus namespace.
+            virtual void platform_restore_control() = 0;
             /// @brief Calls the TopoGetCache API defined in the
             ///        io.github.geopm D-Bus namespace.
             /// @return The string buffer defining the system topology
@@ -166,6 +172,7 @@ namespace geopm
             std::vector<control_info_s> platform_get_control_info(const std::vector<std::string> &control_names) override;
             void platform_open_session(void) override;
             void platform_close_session(void) override;
+            void platform_close_session_admin(int client_pid) override;
             void platform_start_batch(const std::vector<struct geopm_request_s> &signal_config,
                                       const std::vector<struct geopm_request_s> &control_config,
                                       int &server_pid,
@@ -178,6 +185,7 @@ namespace geopm
                                         int domain,
                                         int domain_idx,
                                         double setting) override;
+            void platform_restore_control() override;
             std::string topo_get_cache(void) override;
             void platform_start_profile(const std::string &profile_name) override;
             void platform_stop_profile(const std::vector<std::string> &region_names) override;

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -335,6 +335,8 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/ServiceProxyTest.platform_get_control_info \
               test/gtest_links/ServiceProxyTest.platform_open_session \
               test/gtest_links/ServiceProxyTest.platform_close_session \
+              test/gtest_links/ServiceProxyTest.platform_close_session_admin \
+              test/gtest_links/ServiceProxyTest.platform_restore_control \
               test/gtest_links/ServiceProxyTest.platform_start_batch \
               test/gtest_links/ServiceProxyTest.platform_stop_batch \
               test/gtest_links/ServiceProxyTest.platform_read_signal \

--- a/service/test/MockServiceProxy.hpp
+++ b/service/test/MockServiceProxy.hpp
@@ -22,6 +22,7 @@ class MockServiceProxy : public geopm::ServiceProxy
                     (const std::vector<std::string> &control_names), (override));
         MOCK_METHOD(void, platform_open_session, (), (override));
         MOCK_METHOD(void, platform_close_session, (), (override));
+        MOCK_METHOD(void, platform_close_session_admin, (int client_pid), (override));
         MOCK_METHOD(void, platform_start_batch,
                     (const std::vector<struct geopm_request_s> &signal_config,
                      const std::vector<struct geopm_request_s> &control_config,
@@ -33,6 +34,7 @@ class MockServiceProxy : public geopm::ServiceProxy
         MOCK_METHOD(void, platform_write_control,
                     (const std::string &control_name, int domain,
                      int domain_idx, double setting), (override));
+        MOCK_METHOD(void, platform_restore_control, (), (override));
         MOCK_METHOD(std::string, topo_get_cache,
                     (), (override));
         MOCK_METHOD(void, platform_start_profile, (const std::string &profile_name),

--- a/service/test/ServiceIOGroupTest.cpp
+++ b/service/test/ServiceIOGroupTest.cpp
@@ -290,8 +290,9 @@ TEST_F(ServiceIOGroupTest, save_control)
 
 TEST_F(ServiceIOGroupTest, restore_control)
 {
-    /// These are noops, make sure mock objects are not called into
-    /// We want it to fail if it tries to open the non-existent file path.
+    EXPECT_CALL(*m_proxy, platform_restore_control());
     m_serviceio_group->restore_control();
+    /// This is a noop, make sure mock objects are not called into
+    /// We want it to fail if it tries to open the non-existent file path.
     m_serviceio_group->restore_control("/bad/file/path");
 }

--- a/service/test/ServiceProxyTest.cpp
+++ b/service/test/ServiceProxyTest.cpp
@@ -194,6 +194,13 @@ TEST_F(ServiceProxyTest, platform_close_session)
     m_proxy->platform_close_session();
 }
 
+TEST_F(ServiceProxyTest, platform_close_session_admin)
+{
+    int client_pid = 1234;
+    EXPECT_CALL(*m_bus, call_method("PlatformCloseSessionAdmin", client_pid));
+    m_proxy->platform_close_session_admin(client_pid);
+}
+
 TEST_F(ServiceProxyTest, platform_start_batch)
 {
     std::vector<geopm_request_s> signal_config = {geopm_request_s {1, 0, "CPU_FREQUENCY"},
@@ -255,6 +262,12 @@ TEST_F(ServiceProxyTest, platform_write_control)
 {
     EXPECT_CALL(*m_bus, call_method("PlatformWriteControl", "frequency", 1, 2, 1.0e9));
     m_proxy->platform_write_control("frequency", 1, 2, 1.0e9);
+}
+
+TEST_F(ServiceProxyTest, platform_restore_control)
+{
+    EXPECT_CALL(*m_bus, call_method("PlatformRestoreControl"));
+    m_proxy->platform_restore_control();
 }
 
 TEST_F(ServiceProxyTest, topo_get_cache)


### PR DESCRIPTION
Fix bug in controller where controls accessed through the service are not restored. Add DBus API to restore controls (called by ServiceIOGroup) to allow controller to trigger controls to be restored.

- Fixes #2892 