### PR TITLE
Updates to geopmlaunch's man page to reflect changed default

### DIFF
--- a/service/docs/source/geopmlaunch.1.rst
+++ b/service/docs/source/geopmlaunch.1.rst
@@ -264,17 +264,28 @@ GEOPM Options
 --geopm-ctl CONTROL_MODE  .. _geopm-ctl option:
 
                           Use the GEOPM runtime and launch GEOPM with one of
-                          three ``CONTROL_MODE``\ s: *process*, *pthread* or
-                          *application*.
+                          three ``CONTROL_MODE``\ s: *application*, *process*,
+                          or *pthread*.
+
+                          When used with ``srun``, the *application* method of
+                          launch must be called inside an existing allocation
+                          made with ``salloc`` or ``sbatch`` and the command
+                          must request all the compute nodes assigned to the
+                          allocation. This method is the default if the
+                          ``--geopm-ctl`` option is not provided.
+
+                          When invoked with non-MPI applications, the *process*
+                          and *pthread* methods will silently fail to launch geopm.
+                          Only the *application* method will launch geopm with
+                          non-MPI applications.
 
                           The *process* method allocates one extra MPI process
-                          per node for the GEOPM controller, and this is the
-                          default method if the ``--geopm-ctl`` option is not
-                          provided. The *process* method can be used in the
-                          widest variety of cases, but some systems require
-                          that each MPI process be assigned the same number of
-                          CPUs which may waste resources by assigning more than
-                          one CPU to the GEOPM controller process.
+                          per node for the GEOPM controller. The *process* method
+                          can be used in the widest variety of cases, but some
+                          systems require that each MPI process be assigned the
+                          same number of CPUs which may waste resources by
+                          assigning more than one CPU to the GEOPM controller
+                          process.
 
                           The *pthread* method spawns a thread from one MPI
                           process per node to run the GEOPM controller.  The
@@ -284,12 +295,6 @@ GEOPM Options
                           *pthread* option requires support for
                           ``MPI_THREAD_MULTIPLE``, which is not enabled at many
                           sites.
-
-                          The *application* method of launch is not compatible
-                          with ``aprun``; with ``srun``, the call must be made
-                          inside an existing allocation made with ``salloc`` or
-                          ``sbatch`` and the command must request all the
-                          compute nodes assigned to the allocation.
 
                           The ``--geopm-ctl`` option is used by the launcher to
                           set the ``GEOPM_CTL`` environment variable.  The command

--- a/service/docs/source/overview.rst
+++ b/service/docs/source/overview.rst
@@ -529,11 +529,11 @@ setting up the necessary environment settings and directly calling ``geopmctl``.
 
 ``geopmlaunch`` will bring up the Runtime alongside your application using one
 of three launch methods: ``process``, ``pthread``, or ``application``.  The
-``process`` launch method (default when unspecified) will attempt to launch the
-main entity of the Runtime, the Controller, as an extra rank in the MPI gang.
-The ``application`` launch method will launch the Controller as a separate
-application (useful for non-MPI applications).  For more information, see the
-``--geopm-ctl`` :ref:`option description <geopm-ctl option>`.
+``process`` launch method will attempt to launch the main entity of the
+Runtime, the Controller, as an extra rank in the MPI gang.  The ``application``
+launch method (default when unspecified) will launch the Controller as a
+separate application (useful for non-MPI applications).  For more information,
+see the ``--geopm-ctl`` :ref:`option description <geopm-ctl option>`.
 
 Using ``geopmlaunch`` with MPI Applications
 """""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
Also noted that non-MPI apps can only be used with the application control mode and removed the note about aprun.