### PR TITLE
Do not make assumptions about the fd number

### DIFF
--- a/service/test/SecurePathTest.cpp
+++ b/service/test/SecurePathTest.cpp
@@ -46,17 +46,19 @@ TEST_F(SecurePathTest, umask)
 {
     mode_t test_perms = (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH); // 0o644
     chmod(m_file_name.c_str(), test_perms);
+    std::string fd_path = "";
 
     // Assert write permissions for the group/world are not set
     {
         SecurePath sp (m_file_name, (S_IWGRP | S_IWOTH), true);
-        EXPECT_EQ("/proc/self/fd/3", sp.secure_path());
+        EXPECT_TRUE(geopm::string_begins_with(sp.secure_path(), "/proc/self/fd"));
+        fd_path = sp.secure_path();
     }
 
     // When not enforcing, umask is ignored
     {
         SecurePath sp (m_file_name, (S_IWUSR), false);
-        EXPECT_EQ("/proc/self/fd/3", sp.secure_path());
+        EXPECT_EQ(fd_path, sp.secure_path());
     }
 
     // When enforcing, an exception is generated


### PR DESCRIPTION
- Resolves an issue where this test was falling over in the nightlies because the cronjob uses flock while invoking the script that ultimately runs ```make check```.  This was causing another fd to be present in ```/proc/self/status``` which made this test fail.