### PR TITLE
Consolidate geopm configuration directories

### DIFF
--- a/service/README.rst
+++ b/service/README.rst
@@ -134,8 +134,8 @@ have enhanced access.  The default lists are stored in:
 
 .. code-block::
 
-   /etc/geopm-service/0.DEFAULT_ACCESS/allowed_signals
-   /etc/geopm-service/0.DEFAULT_ACCESS/allowed_controls
+   /etc/geopm/0.DEFAULT_ACCESS/allowed_signals
+   /etc/geopm/0.DEFAULT_ACCESS/allowed_controls
 
 
 Each Unix group name ``<GROUP>`` that has extended permissions can
@@ -143,9 +143,17 @@ maintain one or both of the files
 
 .. code-block::
 
-   /etc/geopm-service/<GROUP>/allowed_signals
-   /etc/geopm-service/<GROUP>/allowed_controls
+   /etc/geopm/<GROUP>/allowed_signals
+   /etc/geopm/<GROUP>/allowed_controls
 
+
+.. note::
+
+   Before GEOPM 3.0, service configuration files were stored in
+   ``/etc/geopm-service``. Since version 3.0, they are stored in
+   ``/etc/geopm``. Version 3.0 ignores the old file location if the new
+   location exists. If the service uses a configuration from the old location,
+   then a deprecation warning is emitted.
 
 Any missing files are inferred to be empty lists, including the
 default access files.  A signal or control will not be available to
@@ -184,7 +192,7 @@ service is configured to support are recorded to a save directory in:
 
 .. code-block::
 
-   /run/geopm-service/SAVE_FILES
+   /run/geopm/SAVE_FILES
 
 
 When a write mode session ends, all of these saved controls are

--- a/service/debian/geopm-service.postinst
+++ b/service/debian/geopm-service.postinst
@@ -1,2 +1,2 @@
 #/bin/bash
-mkdir -p -m 711 /run/geopm-service
+mkdir -p -m 711 /run/geopm

--- a/service/debian/rules
+++ b/service/debian/rules
@@ -31,7 +31,7 @@ override_dh_auto_install:
 	install -Dp -m644 geopm.service $(DESTDIR)$(prefix)/lib/systemd/system/geopm.service
 	install -Dp -m644 io.github.geopm.conf $(DESTDIR)$(prefix)/share/dbus-1/system.d/io.github.geopm.conf
 	install -Dp -m644 io.github.geopm.xml $(DESTDIR)$(prefix)/share/dbus-1/interfaces/io.github.geopm.xml
-	mkdir -p -m 711 $(DESTDIR)/etc/geopm-service
+	mkdir -p -m 711 $(DESTDIR)/etc/geopm
 	rm -f $(DESTDIR)$(prefix)/lib/*/libgeopmd.la
 	install -d $(DESTDIR)$(prefix)/sbin
 	ln -s -r $(DESTDIR)$(prefix)/sbin/service $(DESTDIR)$(prefix)/sbin/rcgeopm

--- a/service/docs/source/GEOPM_CXX_MAN_MSRIOGroup.3.rst
+++ b/service/docs/source/GEOPM_CXX_MAN_MSRIOGroup.3.rst
@@ -256,19 +256,15 @@ Enum Type
 Environment
 -----------
 
-If the ``GEOPM_PLUGIN_PATH`` environment variable is set to a
+If the ``GEOPM_MSR_CONFIG_PATH`` environment variable is set to a
 colon-separated list of paths, the paths will be checked for files
-starting with ``msr_`` and ending in ``.json``.  The default plugin path
+starting with ``msr_`` and ending in ``.json``.  The ``/etc/geopm`` directory
 will also be searched.  The ``MSRIOGroup`` will attempt to load additional
 MSR definitions from any JSON file it finds. The files must follow this
 schema:
 
 .. literalinclude:: ../../json_schemas/msrs.schema.json
     :language: json
-
-Refer to the documentation for ``--geopm-plugin-path`` in
-:doc:`geopmlaunch(1) <geopmlaunch.1>`.
-
 
 
 See Also

--- a/service/docs/source/admin.rst
+++ b/service/docs/source/admin.rst
@@ -27,16 +27,16 @@ GEOPM Service Files
 In addition to the files provided by the installation packages, the
 GEOPM Service may create and modify files while active.  The files
 created by the GEOPM Service are located within two directories.  The
-files in ``/etc/geopm-service`` hold the access control lists.  These
+files in ``/etc/geopm`` hold the access control lists.  These
 files persist across reboots and restarts of the service.  The files
-in ``/run/geopm-service`` track information about clients that are
+in ``/run/geopm`` track information about clients that are
 actively using the service.  These files save the state of the GEOPM
 Service and if the service is stopped for any reason the files will be
 used when the service is started again.  The files in ``/run`` are
 erased upon reboot.
 
-All files and directories within ``/etc/geopm-service`` or
-``/run/geopm-service`` are created by the GEOPM Service with
+All files and directories within ``/etc/geopm`` or
+``/run/geopm`` are created by the GEOPM Service with
 restricted access permissions and root ownership.  The GEOPM Service
 will not read any file or directory if they are modified to have more
 permissive access restrictions, non-root ownership, or if they are

--- a/service/docs/source/geopm.7.rst
+++ b/service/docs/source/geopm.7.rst
@@ -353,6 +353,9 @@ GEOPM Environment Variables
   The control loop period in seconds, if not specified this is determined by
   the Agent. See the ``--geopm-period`` :ref:`option description <geopm-period option>`
   in :doc:`geopmlaunch(1) <geopmlaunch.1>` for details.
+``GEOPM_MSR_CONFIG_PATH``
+  The colon-separated list of search paths for additional MSR definitions. See
+  :doc:`geopm_pio_msr(7) <geopm_pio_msr.7>` for more details.
 
 Other Environment Variables
 ---------------------------

--- a/service/docs/source/geopm_pio_msr.7.rst
+++ b/service/docs/source/geopm_pio_msr.7.rst
@@ -17,15 +17,26 @@ CPU. The MSR IOGroup will declare a set of common signals and controls,
 including MSRs for CPU performance, temperature and power.
 
 Additional MSRs can be specified via configuration files. If the
-``GEOPM_PLUGIN_PATH`` environment variable is set, the paths specified there
-will be checked for any JSON files prefixed with ``msr_``. The default plugin
-path will also be searched. The files must follow this schema:
+``GEOPM_MSR_CONFIG_PATH`` environment variable is set, the paths specified there
+will be checked for any JSON files prefixed with ``msr_``. The ``/etc/geopm``
+directory will also be searched. The files must follow this schema:
 
 .. literalinclude:: ../../json_schemas/msrs.schema.json
     :language: json
 
 For an example of an MSR configuration file, please see:
 `<msr_reasons.json> <https://github.com/geopm/geopm/blob/dev/examples/custom_msr/msr_reasons.json>`_
+
+.. note::
+
+   Before GEOPM 3.0, MSR configuration files were stored near the GEOPM
+   library objects (e.g., in ``/usr/lib64/geopm``), and discovered in the
+   search paths from the ``GEOPM_PLUGIN_PATH`` environment variable. Since
+   version 3.0, GEOPM additionally searches ``/etc/geopm`` and locations from
+   the ``GEOPM_MSR_CONFIG_PATH`` environment variable. Future releases may
+   stop searching the library and plugin paths for MSR configuration data.
+   If GEOPM uses a configuration from the old location, then a deprecation
+   warning is emitted.
 
 This guide includes a list of signals and controls that are more commonly
 available. Use geopmread and geopmwrite to query the full set of signals and

--- a/service/docs/source/geopm_topo.3.rst
+++ b/service/docs/source/geopm_topo.3.rst
@@ -149,7 +149,7 @@ interface.
   file will be used by any calls to the other ``geopm_topo_*()`` functions
   documented here as well as any use of the GEOPM runtime.  If a privileged
   user is making this call (i.e. root or via sudo), the file path will be
-  ``/run/geopm-service/geopm-topo-cache`` and the permissions will be
+  ``/run/geopm/geopm-topo-cache`` and the permissions will be
   ``-rw-r--r--``, i.e. 644.  If a non-privileged user makes this call file path
   will be ``/tmp/geopm-topo-cache-<UID>`` and the permissions will be
   ``-rw-------``, i.e. 600.  If the file exists from the current boot cycle and

--- a/service/docs/source/geopmaccess.1.rst
+++ b/service/docs/source/geopmaccess.1.rst
@@ -48,7 +48,7 @@ Get Help or Version
 Description
 -----------
 
-The GEOPM service uses the ``/etc/geopm-service`` directory to store
+The GEOPM service uses the ``/etc/geopm`` directory to store
 files that control which signals and controls may be accessed by a
 user through the service.  The purpose of the ``geopmaccess`` command
 line tool is to enable reading and writing of these access list files.
@@ -143,10 +143,10 @@ access list: the default behavior when writing equivalent to the
 Shared File Systems
 ~~~~~~~~~~~~~~~~~~~
 
-There are use cases where the ``/etc/geopm-service`` directory must be
+There are use cases where the ``/etc/geopm`` directory must be
 configured on a system where the signals and controls available at
 configuration-time do not match what is available at run-time.  This
-is particularly common when the ``/etc/geopm-service`` directory is
+is particularly common when the ``/etc/geopm`` directory is
 located on a shared file system to support distributed servers.
 
 The ``-n`` / ``--dry-run`` option may be specified to check the
@@ -155,14 +155,14 @@ validity of a configuration at run-time without modifying files in the
 to standard input, however no files are opened for writing.
 
 The ``-F`` / ``--force`` option enables the creation of access
-lists in ``/etc/geopm-service`` without checking that the names in the
+lists in ``/etc/geopm`` without checking that the names in the
 access list correspond to signals or controls supported by the active
 GEOPM Service.  This enables the creation of the configuration file on
 a system where the GEOPM Service does not support some signals or
 controls.
 
 Note that having signal or control names in an access list in
-``/etc/geopm-service`` which are not valid on a particular system is
+``/etc/geopm`` which are not valid on a particular system is
 not an error.  This enables access list files to be mounted on
 multiple systems which may have non-overlapping support.
 
@@ -302,7 +302,7 @@ Supporting Heterogeneous Clusters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This example demonstrates how to create and check access lists when
-the ``/etc/geopm-service`` directory must be modified on a system with
+the ``/etc/geopm`` directory must be modified on a system with
 incomplete support for signals and controls.
 
 In this example, the access lists created contain all signals and
@@ -336,7 +336,7 @@ and combine access lists when writing to a shared mount point.
     geopmaccess --write --dry-run < system2-signals.txt
     geopmaccess --write --controls --dry-run < system2-controls.txt
 
-    # Log onto node where /etc/geopm-service is writable
+    # Log onto node where /etc/geopm is writable
     ssh admin-system
 
     # Combine the created lists, duplicates are okay

--- a/service/docs/source/geopmread.1.rst
+++ b/service/docs/source/geopmread.1.rst
@@ -107,7 +107,7 @@ Options
                 does not exist or if the existing cache is from a previous boot
                 cycle.  If a privileged user requests this option (e.g. root or
                 if invoked with sudo) the file path will be
-                ``/run/geopm-service/geopm-topo-cache`` and the permissions will
+                ``/run/geopm/geopm-topo-cache`` and the permissions will
                 be ``-rw-r--r--``, i.e. **644**.  If a non-privileged user requests
                 this option the file path will be ``/tmp/geopm-topo-cache-<UID>``
                 and the permissions will be ``-rw-------``, i.e. **600**.  If the

--- a/service/docs/source/geopmwrite.1.rst
+++ b/service/docs/source/geopmwrite.1.rst
@@ -107,7 +107,7 @@ Options
                 does not exist or if the existing cache is from a previous boot
                 cycle.  If a privileged user requests this option (e.g. root or
                 if invoked with sudo) the file path will be
-                ``/run/geopm-service/geopm-topo-cache`` and the permissions will
+                ``/run/geopm/geopm-topo-cache`` and the permissions will
                 be ``-rw-r--r--``, i.e. **644**.  If a non-privileged user requests
                 this option the file path will be ``/tmp/geopm-topo-cache-<UID>``
                 and the permissions will be ``-rw-------``, i.e. **600**.  If the

--- a/service/docs/source/security.rst
+++ b/service/docs/source/security.rst
@@ -100,7 +100,7 @@ configuration settings to disk prior to enabling a user session to
 write. When the user's write session terminates, all configuration
 settings are restored to their previous value. The storage location
 for the saved state is in the directory
-``/run/geopm-service/SAVE_FILES``.
+``/run/geopm/SAVE_FILES``.
 
 Note that all configuration settings are restored regardless of
 whether or not they were adjusted during the session through the
@@ -172,7 +172,7 @@ rights of this batch server are verified prior to its creation, and
 the user may then interact with this batch server through faster
 mechanisms than DBus provides. In particular, the user interfaces with
 the batch server over inter-process shared memory and FIFO special files,
-both of which are created in ``/run/geopm-service``.
+both of which are created in ``/run/geopm``.
 
 The DBus interface provides a layer of security that is leveraged
 throughout Linux services to verify the user identity of requests made
@@ -325,8 +325,8 @@ System files
 The state used to manage access permissions, track open sessions, and
 store control settings for reset is stored in system files. The files
 controlling access permissions are located in the
-``/etc/geopm-service`` directory. The state required to support active
-user sessions is stored in ``/run/geopm-service``. Protecting
+``/etc/geopm`` directory. The state required to support active
+user sessions is stored in ``/run/geopm``. Protecting
 these files is paramount to the integrity of the GEOPM Service
 security model.  In general these files have root access permissions
 only, and are modified by calling into GEOPM Service interfaces, or by
@@ -480,7 +480,7 @@ permissions.
 
 By default, directories are created with 0o700 permissions (i.e. rwx
 only for the owner). Some directories, for example
-``/run/geopm-service``, also require execution permissions (i.e.
+``/run/geopm``, also require execution permissions (i.e.
 0o711). For more details on how directories are created and default
 permissions, please see the :ref:`system_files.py <geopmdpy.7:geopmdpy.system_files>`
 documentation

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -190,7 +190,7 @@ rm -f $(find %{buildroot}/%{_libdir} -name '*.a'; \
 install -Dp -m644 geopm.service %{buildroot}%{_unitdir}/geopm.service
 install -Dp -m644 io.github.geopm.conf %{buildroot}%{_datadir}/dbus-1/system.d/io.github.geopm.conf
 install -Dp -m644 io.github.geopm.xml %{buildroot}%{_datadir}/dbus-1/interfaces/io.github.geopm.xml
-mkdir -p %{buildroot}%{_sysconfdir}/geopm-service
+mkdir -p %{buildroot}%{_sysconfdir}/geopm
 mkdir -p %{buildroot}%{_sbindir}
 ln -s -r %{buildroot}%{_sbindir}/service %{buildroot}%{_sbindir}/rcgeopm
 %if 0%{?suse_version}

--- a/service/geopmdpy/__main__.py
+++ b/service/geopmdpy/__main__.py
@@ -11,7 +11,7 @@ from . import service
 from geopmdpy.restorable_file_writer import RestorableFileWriter
 
 ALLOW_WRITES_PATH = '/sys/module/msr/parameters/allow_writes'
-ALLOW_WRITES_BACKUP_PATH = '/run/geopm-service/msr-saved-allow-writes'
+ALLOW_WRITES_BACKUP_PATH = '/run/geopm/msr-saved-allow-writes'
 
 _bus = None
 _loop = None

--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -45,8 +45,8 @@ class PlatformService(object):
         self._RUN_PATH = system_files.GEOPM_SERVICE_RUN_PATH
         self._SAVE_DIR = 'SAVE_FILES'
         self._WATCH_INTERVAL_SEC = 1
-        self._active_sessions = system_files.ActiveSessions()
-        self._access_lists = system_files.AccessLists()
+        self._active_sessions = system_files.ActiveSessions(self._RUN_PATH)
+        self._access_lists = system_files.AccessLists(system_files.get_config_path())
         for client_pid in self._active_sessions.get_clients():
             is_active = self.check_client(client_pid)
             if is_active:
@@ -66,7 +66,7 @@ class PlatformService(object):
         returned.
 
         The values are securely read from files located in
-        /etc/geopm-service using the secure_read_file() interface.
+        /etc/geopm using the secure_read_file() interface.
 
         If no secure file exist for the specified group, then two
         empty lists are returned.
@@ -92,7 +92,7 @@ class PlatformService(object):
         updated.
 
         The values are securely written atomically to files located in
-        /etc/geopm-service using the secure_make_dirs() and
+        /etc/geopm using the secure_make_dirs() and
         secure_make_file() interfaces.
 
         Args:
@@ -116,7 +116,7 @@ class PlatformService(object):
         of allowed signal are updated.
 
         The values are securely written atomically to files located in
-        /etc/geopm-service using the secure_make_dirs() and
+        /etc/geopm using the secure_make_dirs() and
         secure_make_file() interfaces.
 
         Args:
@@ -138,7 +138,7 @@ class PlatformService(object):
         of allowed control are updated.
 
         The values are securely written atomically to files located in
-        /etc/geopm-service using the secure_make_dirs() and
+        /etc/geopm using the secure_make_dirs() and
         secure_make_file() interfaces.
 
         Args:
@@ -851,7 +851,7 @@ class TopoService(object):
 
         """
         self._topo.create_cache()
-        with open('/run/geopm-service/geopm-topo-cache') as fid:
+        with open(os.path.join(system_files.GEOPM_SERVICE_RUN_PATH, 'geopm-topo-cache')) as fid:
             result = fid.read()
         return result
 

--- a/service/geopmdpy/topo.py
+++ b/service/geopmdpy/topo.py
@@ -203,12 +203,12 @@ def create_cache():
     functions in the topo module as well as any use of the GEOPM
     runtime.  File permissions of the cache file are set to
     "-rw-r--r--", i.e. 644. The path for the cache file is
-    /run/geopm-service/geopm-topo-cache.  If this file is older than
+    /run/geopm/geopm-topo-cache.  If this file is older than
     the last boot it will be regenerated.  If the file exists but has
     improper permissions is will be regenerated.  If the file has been
     created since the last boot with the correct permissions, no
     operation will be performed.  To force the creation of a new cache
-    file call os.unlink('/run/geopm-service/geopm-topo-cache') prior
+    file call os.unlink('/run/geopm/geopm-topo-cache') prior
     to calling this function.
 
     """

--- a/service/geopmdpy_test/Makefile.mk
+++ b/service/geopmdpy_test/Makefile.mk
@@ -6,6 +6,7 @@ EXTRA_DIST += geopmdpy_test/__init__.py \
               geopmdpy_test/__main__.py \
               geopmdpy_test/geopmdpy_test.sh \
               geopmdpy_test/TestAccess.py \
+              geopmdpy_test/TestConfigPath.py \
               geopmdpy_test/TestPlatformService.py \
               geopmdpy_test/TestDBusXML.py \
               geopmdpy_test/TestError.py \
@@ -93,6 +94,10 @@ GEOPMDPY_TESTS = geopmdpy_test/pytest_links/TestAccessLists.test__read_allowed_i
                  geopmdpy_test/pytest_links/TestAccess.test_write_invalid_signals_dry_run \
                  geopmdpy_test/pytest_links/TestAccess.test_edit_signals \
                  geopmdpy_test/pytest_links/TestAccess.test_delete_default_signals \
+                 geopmdpy_test/pytest_links/TestConfigPath.test_no_existing_config_paths \
+                 geopmdpy_test/pytest_links/TestConfigPath.test_only_latest_config_path_exists \
+                 geopmdpy_test/pytest_links/TestConfigPath.test_only_legacy_config_path_exists \
+                 geopmdpy_test/pytest_links/TestConfigPath.test_multiple_config_paths_exist \
                  geopmdpy_test/pytest_links/TestRequestQueue.test_read_request_queue \
                  geopmdpy_test/pytest_links/TestRequestQueue.test_read_request_queue_invalid \
                  geopmdpy_test/pytest_links/TestRequestQueue.test_request_queue_invalid \

--- a/service/geopmdpy_test/TestActiveSessions.py
+++ b/service/geopmdpy_test/TestActiveSessions.py
@@ -140,7 +140,7 @@ class TestActiveSessions(unittest.TestCase):
                 json.dump(contents, file)
 
     def check_json_file(self, name, contents, is_valid):
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         full_file_path = os.path.join(sess_path, f'session-{name}.json')
         renamed_path = f'{full_file_path}-uuid4-INVALID'
 
@@ -233,7 +233,7 @@ class TestActiveSessions(unittest.TestCase):
         controls_2 = self.json_good_example_2['controls']
         watch_id_2 = self.json_good_example_2['watch_id']
 
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         full_file_path_1 = os.path.join(sess_path, f'session-{client_pid_1}.json')
         full_file_path_2 = os.path.join(sess_path, f'session-{client_pid_2}.json')
 
@@ -275,7 +275,7 @@ class TestActiveSessions(unittest.TestCase):
         controls = self.json_good_example['controls']
         watch_id = self.json_good_example['watch_id']
 
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         full_file_path = os.path.join(sess_path, f'session-{client_pid}.json')
 
         with mock.patch('geopmdpy.system_files.secure_make_dirs', autospec=True, specset=True) as mock_smd, \
@@ -307,7 +307,7 @@ class TestActiveSessions(unittest.TestCase):
         client_gid = 321
         profile_name = 'profile_test'
 
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         full_file_path = os.path.join(sess_path, f'session-{client_pid}.json')
 
         with mock.patch('geopmdpy.system_files.secure_make_dirs', autospec=True, specset=True) as mock_smd, \
@@ -374,7 +374,7 @@ class TestActiveSessions(unittest.TestCase):
         watch_id = json_good_example['watch_id']
         batch_pid = 8765
 
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         full_file_path = os.path.join(sess_path, f'session-{client_pid}.json')
 
         with mock.patch('geopmdpy.system_files.secure_make_dirs', autospec=True, specset=True) as mock_smd, \
@@ -411,7 +411,7 @@ class TestActiveSessions(unittest.TestCase):
 
         batch_pid = 42
         json_good_example['batch_server'] = batch_pid
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         full_file_path = os.path.join(sess_path, f"session-{client_pid}.json")
 
         session_mock = mock.create_autospec(os.stat_result, spec_set=True)
@@ -450,7 +450,7 @@ class TestActiveSessions(unittest.TestCase):
 
         batch_pid = 42
         json_good_example['batch_server'] = batch_pid
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         full_file_path = os.path.join(sess_path, f"session-{client_pid}.json")
 
         session_mock = mock.create_autospec(os.stat_result, spec_set=True)
@@ -495,7 +495,7 @@ class TestActiveSessions(unittest.TestCase):
         watch_id = json_good_example['watch_id']
         batch_pid = 8765
 
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         full_file_path = os.path.join(sess_path, f'session-{client_pid}.json')
 
         signal_shmem_key = 'geopm-service-batch-buffer-' + str(batch_pid) + '-signal'
@@ -549,7 +549,7 @@ class TestActiveSessions(unittest.TestCase):
             self.assertEqual(None, batch_pid_actual)
 
     def test_is_pid_valid(self):
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         with mock.patch('geopmdpy.system_files.secure_make_dirs', autospec=True, specset=True) as mock_smd:
             act_sess = ActiveSessions(sess_path)
             mock_smd.assert_called_once_with(sess_path, GEOPM_SERVICE_RUN_PATH_PERM)
@@ -588,7 +588,7 @@ class TestActiveSessions(unittest.TestCase):
         controls = json_good_example['controls']
         watch_id = json_good_example['watch_id']
 
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         full_file_path = os.path.join(sess_path, f'session-{client_pid}.json')
 
         with mock.patch('geopmdpy.system_files.secure_make_dirs', autospec=True, specset=True) as mock_smd, \
@@ -622,7 +622,7 @@ class TestActiveSessions(unittest.TestCase):
         controls = session_json['controls']
         watch_id = session_json['watch_id']
 
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         full_file_path = os.path.join(sess_path, f'session-{client_pid}.json')
 
         with mock.patch('geopmdpy.system_files.secure_make_dirs', autospec=True, specset=True) as mock_smd, \

--- a/service/geopmdpy_test/TestConfigPath.py
+++ b/service/geopmdpy_test/TestConfigPath.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2023, Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+import unittest
+from unittest import mock
+import os
+import tempfile
+
+from geopmdpy import system_files
+
+INITIAL_CONFIG_PATH = system_files.GEOPM_SERVICE_CONFIG_PATH
+INITIAL_LEGACY_CONFIG_PATH = system_files.LEGACY_GEOPM_SERVICE_CONFIG_PATH
+
+class TestConfigPath(unittest.TestCase):
+    def setUp(self):
+        self._temp_dir = tempfile.TemporaryDirectory('TestConfigPath')
+        system_files.GEOPM_SERVICE_CONFIG_PATH = os.path.join(
+            self._temp_dir.name, os.path.relpath(INITIAL_CONFIG_PATH, '/'))
+        system_files.LEGACY_GEOPM_SERVICE_CONFIG_PATH = os.path.join(
+            self._temp_dir.name, os.path.relpath(INITIAL_LEGACY_CONFIG_PATH, '/'))
+
+        self._expected_legacy_warning = (
+            'Warning <geopm-service> Using an old GEOPM configuration directory. '
+            f'The directory at "{system_files.LEGACY_GEOPM_SERVICE_CONFIG_PATH}" '
+            'is deprecated and may not be used in future GEOPM releases. Migrate '
+            'configuration data to the directory at '
+            f'"{system_files.GEOPM_SERVICE_CONFIG_PATH}"\n')
+
+        self._expected_multi_config_warning = (
+            'Warning <geopm-service> Detected multiple geopm configuration directories. '
+            f'The GEOPM service is using "{system_files.GEOPM_SERVICE_CONFIG_PATH}" and '
+            f'ignoring "{system_files.LEGACY_GEOPM_SERVICE_CONFIG_PATH}". The directory '
+            f'at "{system_files.LEGACY_GEOPM_SERVICE_CONFIG_PATH}" is deprecated and may '
+            'not be used in future GEOPM releases. Migrate configuration data to the '
+            f'directory at "{system_files.GEOPM_SERVICE_CONFIG_PATH}"\n')
+
+        system_files.get_config_path.cache_clear()
+
+    def tearDown(self):
+        self._temp_dir.cleanup()
+
+    def test_no_existing_config_paths(self):
+        with mock.patch('sys.stderr.write') as mock_sys_stderr_write:
+            self.assertEqual(system_files.GEOPM_SERVICE_CONFIG_PATH, system_files.get_config_path())
+            mock_sys_stderr_write.assert_not_called()
+
+    def test_only_latest_config_path_exists(self):
+        os.makedirs(system_files.GEOPM_SERVICE_CONFIG_PATH)
+        with mock.patch('sys.stderr.write') as mock_sys_stderr_write:
+            self.assertEqual(system_files.GEOPM_SERVICE_CONFIG_PATH, system_files.get_config_path())
+            mock_sys_stderr_write.assert_not_called()
+
+    def test_only_legacy_config_path_exists(self):
+        os.makedirs(system_files.LEGACY_GEOPM_SERVICE_CONFIG_PATH)
+        with mock.patch('sys.stderr.write') as mock_sys_stderr_write:
+            # Call twice. Same output both times, but only warn once.
+            self.assertEqual(system_files.LEGACY_GEOPM_SERVICE_CONFIG_PATH, system_files.get_config_path())
+            self.assertEqual(system_files.LEGACY_GEOPM_SERVICE_CONFIG_PATH, system_files.get_config_path())
+            mock_sys_stderr_write.assert_called_once_with(self._expected_legacy_warning)
+
+    def test_multiple_config_paths_exist(self):
+        os.makedirs(system_files.GEOPM_SERVICE_CONFIG_PATH)
+        os.makedirs(system_files.LEGACY_GEOPM_SERVICE_CONFIG_PATH)
+        with mock.patch('sys.stderr.write') as mock_sys_stderr_write:
+            # Call twice. Same output both times, but only warn once.
+            self.assertEqual(system_files.GEOPM_SERVICE_CONFIG_PATH, system_files.get_config_path())
+            self.assertEqual(system_files.GEOPM_SERVICE_CONFIG_PATH, system_files.get_config_path())
+            mock_sys_stderr_write.assert_called_with(self._expected_multi_config_warning)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/service/geopmdpy_test/TestPlatformService.py
+++ b/service/geopmdpy_test/TestPlatformService.py
@@ -422,7 +422,7 @@ class TestPlatformService(unittest.TestCase):
         topo_service = TopoService(topo=topo)
 
         mock_open = mock.mock_open(read_data='data')
-        cache_file = '/run/geopm-service/geopm-topo-cache'
+        cache_file = '/run/geopm/geopm-topo-cache'
         with mock.patch('builtins.open', mock_open):
             cache_data = topo_service.get_cache()
             self.assertEqual('data', cache_data)

--- a/service/geopmdpy_test/TestSecureFiles.py
+++ b/service/geopmdpy_test/TestSecureFiles.py
@@ -60,39 +60,39 @@ class TestSecureFiles(unittest.TestCase):
         self.assertEqual(os.getgid(), group_owner)
 
     def test_pre_exists(self):
-        """Usage of pre existing geopm-service directory
+        """Usage of pre existing geopm directory
 
-        Test calls secure_make_dirs() when the geopm-service
+        Test calls secure_make_dirs() when the geopm
         directory has already been created.
 
         """
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(sess_path, mode=0o700)
         secure_make_dirs(sess_path)
         self.check_dir_perms(sess_path)
 
     def test_default_creation(self):
-        """Default creation of geopm-service directory
+        """Default creation of geopm directory
 
-        Test calls secure_make_dirs() when the geopm-service
+        Test calls secure_make_dirs() when the geopm
         directory is not present.
 
         """
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         secure_make_dirs(sess_path)
         self.check_dir_perms(sess_path)
         current_umask = os.umask(self._old_umask)
         self.assertEqual(current_umask, self._old_umask)
 
     def test_creation_with_perm(self):
-        """Creation of geopm-service directory with permissions
+        """Creation of geopm directory with permissions
 
-        Test calls secure_make_dirs() when the geopm-service
+        Test calls secure_make_dirs() when the geopm
         directory is not present and specifies the permissions
         to set.
 
         """
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         perm_mode = 0o711
         secure_make_dirs(sess_path, perm_mode)
         self.check_dir_perms(sess_path, perm_mode)
@@ -102,13 +102,13 @@ class TestSecureFiles(unittest.TestCase):
     def test_creation_link_not_dir(self):
         """The path specified is a link not a directory.
 
-        Test calls secure_make_dirs() when the geopm-service
+        Test calls secure_make_dirs() when the geopm
         provided path is not a directory, but a link. It asserts that
         a warning message is printed to standard error and that a
         new directory is created while the link is renamed.
 
         """
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service-link'
+        sess_path = f'{self._TEMP_DIR.name}/geopm-link'
         os.symlink('/tmp', sess_path)
         with mock.patch('os.path.islink', wraps=os.path.islink) as mock_os_path_islink, \
              mock.patch('uuid.uuid4', return_value='uuid4'), \
@@ -127,13 +127,13 @@ class TestSecureFiles(unittest.TestCase):
     def test_creation_file_not_dir(self):
         """The path specified is a file not a directory.
 
-        Test calls secure_make_dirs() when the geopm-service
+        Test calls secure_make_dirs() when the geopm
         provided path is not a directory, but a file. It asserts that
         a warning message is printed to standard error and that a
         new directory is created while the file is renamed.
 
         """
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service.txt'
+        sess_path = f'{self._TEMP_DIR.name}/geopm.txt'
         filename = Path(sess_path)
         filename.touch(exist_ok=True)
 
@@ -153,13 +153,13 @@ class TestSecureFiles(unittest.TestCase):
     def test_creation_bad_perms(self):
         """Directory exists with bad permissions
 
-        Test calls secure_make_dirs() when the geopm-service
+        Test calls secure_make_dirs() when the geopm
         directory is present with wrong permissions.  It asserts that
         a warning message is printed to standard error and that the
         permissions are changed.
 
         """
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(sess_path, mode=0o755)
 
         with mock.patch('os.stat', wraps=os.stat) as mock_os_stat, \
@@ -184,13 +184,13 @@ class TestSecureFiles(unittest.TestCase):
     def test_creation_bad_user_owner(self):
         """Directory exists with wrong user owner
 
-        Test calls secure_make_dirs() when the geopm-service
+        Test calls secure_make_dirs() when the geopm
         directory is present with wrong ownership.  It asserts that
         a warning message is printed to standard error and that the
         ownership is changed.
 
         """
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(sess_path, mode=0o700)
 
         bad_user = mock.create_autospec(os.stat_result, spec_set=True)
@@ -220,13 +220,13 @@ class TestSecureFiles(unittest.TestCase):
     def test_creation_bad_group_owner(self):
         """Directory exists with wrong group owner
 
-        Test calls secure_make_dirs() when the geopm-service
+        Test calls secure_make_dirs() when the geopm
         directory is present with wrong ownership.  It asserts that
         a warning message is printed to standard error and that the
         ownership is changed.
 
         """
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(sess_path, mode=0o700)
 
         bad_group = mock.create_autospec(os.stat_result, spec_set=True)
@@ -275,7 +275,7 @@ class TestSecureFiles(unittest.TestCase):
         when there are any errors creating the directories.
         """
         perm_mode = self._old_umask
-        sess_path = f'{self._TEMP_DIR.name}/geopm-service'
+        sess_path = f'{self._TEMP_DIR.name}/geopm'
         with mock.patch('os.makedirs', side_effect=Exception('Unable to create directories!')), \
              self.assertRaises(Exception):
             secure_make_dirs(sess_path, perm_mode)
@@ -285,11 +285,11 @@ class TestSecureFiles(unittest.TestCase):
     def test_read_file_not_exists(self):
         """File to be securely read in does not exist!
 
-        Creates the geopm-service directory, but does not create the file within.
+        Creates the geopm directory, but does not create the file within.
         Calls secure_read_file() with a non existent file path.
 
         """
-        dir_path = f'{self._TEMP_DIR.name}/geopm-service'
+        dir_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(dir_path, mode=0o700)
         self.check_dir_perms(dir_path)
         file_name = "stuff.json"
@@ -305,11 +305,11 @@ class TestSecureFiles(unittest.TestCase):
     def test_read_file_is_directory(self):
         """File to be securely read in is actually a directory!
 
-        Creates the geopm-service directory, and creates another directory within.
+        Creates the geopm directory, and creates another directory within.
         Calls secure_read_file() with a directory instead of a file.
 
         """
-        dir_path = f'{self._TEMP_DIR.name}/geopm-service'
+        dir_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(dir_path, mode=0o700)
         self.check_dir_perms(dir_path)
         file_name = "stuff.json"
@@ -329,11 +329,11 @@ class TestSecureFiles(unittest.TestCase):
     def test_read_file_is_link(self):
         """File to be securely read in is actually a link!
 
-        Creates the geopm-service directory, and creates a link within.
+        Creates the geopm directory, and creates a link within.
         Calls secure_read_file() with a link instead of a file.
 
         """
-        dir_path = f'{self._TEMP_DIR.name}/geopm-service'
+        dir_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(dir_path, mode=0o700)
         self.check_dir_perms(dir_path)
         file_name = "stuff.json"
@@ -361,11 +361,11 @@ class TestSecureFiles(unittest.TestCase):
     def test_read_file_is_fifo(self):
         """File to be securely read in is actually a fifo!
 
-        Creates the geopm-service directory, and creates a fifo within.
+        Creates the geopm directory, and creates a fifo within.
         Calls secure_read_file() with a fifo instead of a file.
 
         """
-        dir_path = f'{self._TEMP_DIR.name}/geopm-service'
+        dir_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(dir_path, mode=0o700)
         self.check_dir_perms(dir_path)
         file_name = "stuff.json"
@@ -394,11 +394,11 @@ class TestSecureFiles(unittest.TestCase):
     def test_read_file_bad_permissions(self):
         """File to be securely read in has wrong permissions.
 
-        Creates the geopm-service directory, and creates a regular file with wrong permissions within.
+        Creates the geopm directory, and creates a regular file with wrong permissions within.
         Calls secure_read_file() with that file.
 
         """
-        dir_path = f'{self._TEMP_DIR.name}/geopm-service'
+        dir_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(dir_path, mode=0o700)
         self.check_dir_perms(dir_path)
         file_name = "stuff.json"
@@ -435,11 +435,11 @@ class TestSecureFiles(unittest.TestCase):
     def test_read_file_bad_user_owner(self):
         """File to be securely read in has wrong user owner.
 
-        Creates the geopm-service directory, and creates a regular file with wrong user owner within.
+        Creates the geopm directory, and creates a regular file with wrong user owner within.
         Calls secure_read_file() with that file.
 
         """
-        dir_path = f'{self._TEMP_DIR.name}/geopm-service'
+        dir_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(dir_path, mode=0o700)
         self.check_dir_perms(dir_path)
         file_name = "stuff.json"
@@ -480,11 +480,11 @@ class TestSecureFiles(unittest.TestCase):
     def test_read_file_bad_group_owner(self):
         """File to be securely read in has wrong group owner.
 
-        Creates the geopm-service directory, and creates a regular file with wrong group owner within.
+        Creates the geopm directory, and creates a regular file with wrong group owner within.
         Calls secure_read_file() with that file.
 
         """
-        dir_path = f'{self._TEMP_DIR.name}/geopm-service'
+        dir_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(dir_path, mode=0o700)
         self.check_dir_perms(dir_path)
         file_name = "stuff.json"
@@ -525,11 +525,11 @@ class TestSecureFiles(unittest.TestCase):
     def test_read_valid_file(self):
         """Opens and reads in a valid file which passes all checks.
 
-        Creates the geopm-service directory, and creates a regular file within, and write the contents to it.
+        Creates the geopm directory, and creates a regular file within, and write the contents to it.
         Calls secure_read_file() with that file, verifying that the contents match.
 
         """
-        dir_path = f'{self._TEMP_DIR.name}/geopm-service'
+        dir_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(dir_path, mode=0o700)
         self.check_dir_perms(dir_path)
         file_name = "stuff.json"
@@ -561,11 +561,11 @@ class TestSecureFiles(unittest.TestCase):
     def test_secure_make_file(self):
         """Opens and reads in a valid file which passes all checks.
 
-        Creates the geopm-service directory, and creates a regular file within, and write the contents to it.
+        Creates the geopm directory, and creates a regular file within, and write the contents to it.
         Calls secure_read_file() with that file, verifying that the contents match.
 
         """
-        dir_path = f'{self._TEMP_DIR.name}/geopm-service'
+        dir_path = f'{self._TEMP_DIR.name}/geopm'
         os.mkdir(dir_path, mode=0o700)
         self.check_dir_perms(dir_path)
         file_name = "stuff.json"

--- a/service/integration/check_session_clean.sh
+++ b/service/integration/check_session_clean.sh
@@ -47,15 +47,15 @@ fi
 
 SESSION_PID=$1
 
-SESSION_FILE="/run/geopm-service/session-${SESSION_PID}.json"
+SESSION_FILE="/run/geopm/session-${SESSION_PID}.json"
 # fifo files for the batch status
-BATCH_STATUS_IN="/run/geopm-service/batch-status-${SESSION_PID}-in"
-BATCH_STATUS_OUT="/run/geopm-service/batch-status-${SESSION_PID}-out"
+BATCH_STATUS_IN="/run/geopm/batch-status-${SESSION_PID}-in"
+BATCH_STATUS_OUT="/run/geopm/batch-status-${SESSION_PID}-out"
 # shared memory keys
-SHMEM_KEY_SIGNAL="/run/geopm-service/batch-buffer-${SESSION_PID}-signal"
-SHMEM_KEY_CONTROL="/run/geopm-service/batch-buffer-${SESSION_PID}-control"
-SHMEM_KEY_STATUS="/run/geopm-service/profile-$(id -u)-status"
-SHMEM_KEY_RECORD_LOG="/run/geopm-service/profile-${SESSION_PID}-record-log"
+SHMEM_KEY_SIGNAL="/run/geopm/batch-buffer-${SESSION_PID}-signal"
+SHMEM_KEY_CONTROL="/run/geopm/batch-buffer-${SESSION_PID}-control"
+SHMEM_KEY_STATUS="/run/geopm/profile-$(id -u)-status"
+SHMEM_KEY_RECORD_LOG="/run/geopm/profile-${SESSION_PID}-record-log"
 
 check_file ${SESSION_FILE}
 check_file ${BATCH_STATUS_IN}

--- a/service/integration/get_batch_server.py
+++ b/service/integration/get_batch_server.py
@@ -17,7 +17,7 @@ if os.getuid() != 0:
 session_pid=int(sys.argv[1])
 if session_pid < 0 or not psutil.pid_exists(session_pid):
      raise RuntimeError(f'{session_pid} is not a valid PID')
-with open(f'/run/geopm-service/session-{session_pid}.json') as fid:
+with open(f'/run/geopm/session-{session_pid}.json') as fid:
      server_pid = json.loads(fid.read()).get('batch_server')
 if server_pid is not None:
      print(server_pid)

--- a/service/integration/open_pbs/geopm_install_pbs_power_limit.sh
+++ b/service/integration/open_pbs/geopm_install_pbs_power_limit.sh
@@ -6,7 +6,7 @@
 RESOURCE="geopm-node-power-limit"
 HOOK="geopm_power_limit"
 REMOVE_OPT="--remove"
-SAVED_CONTROLS_BASE_DIR="/run/geopm-pbs-hooks"
+SAVED_CONTROLS_BASE_DIR="/run/geopm/pbs-hooks"
 
 print_usage() {
     echo "

--- a/service/integration/open_pbs/geopm_power_limit.py
+++ b/service/integration/open_pbs/geopm_power_limit.py
@@ -23,7 +23,7 @@ from geopmdpy import pio
 from geopmdpy import system_files
 
 
-_SAVED_CONTROLS_PATH = "/run/geopm-pbs-hooks/SAVE_FILES"
+_SAVED_CONTROLS_PATH = "/run/geopm/pbs-hooks/SAVE_FILES"
 _SAVED_CONTROLS_FILE = _SAVED_CONTROLS_PATH + "/power-limit-save-control.json"
 _POWER_LIMIT_RESOURCE = "geopm-node-power-limit"
 

--- a/service/io.github.geopm.xml
+++ b/service/io.github.geopm.xml
@@ -56,7 +56,7 @@ then the default lists of allowed signals and controls are
 returned.
 
 The values are securely read from files located in
-/etc/geopm-service using the secure_read_file() interface.
+/etc/geopm using the secure_read_file() interface.
 
 If no secure file exist for the specified group, then two
 empty lists are returned.
@@ -93,7 +93,7 @@ then the default lists of allowed signals and controls are
 updated.
 
 The values are securely written atomically to files located in
-/etc/geopm-service using the secure_make_dirs() and
+/etc/geopm using the secure_make_dirs() and
 secure_make_file() interfaces.
           </doc:para>
         </doc:description>
@@ -122,7 +122,7 @@ then the default lists of allowed signals and controls are
 updated.
 
 The values are securely written atomically to files located in
-/etc/geopm-service using the secure_make_dirs() and
+/etc/geopm using the secure_make_dirs() and
 secure_make_file() interfaces.
           </doc:para>
         </doc:description>
@@ -151,7 +151,7 @@ then the default lists of allowed signals and controls are
 updated.
 
 The values are securely written atomically to files located in
-/etc/geopm-service using the secure_make_dirs() and
+/etc/geopm using the secure_make_dirs() and
 secure_make_file() interfaces.
           </doc:para>
         </doc:description>

--- a/service/src/BatchServer.hpp
+++ b/service/src/BatchServer.hpp
@@ -95,7 +95,7 @@ namespace geopm
 
         protected:
             static constexpr const char* M_SHMEM_PREFIX =
-                "/run/geopm-service/batch-buffer-";
+                "/run/geopm/batch-buffer-";
     };
 
     class BatchServerImp : public BatchServer

--- a/service/src/BatchStatus.hpp
+++ b/service/src/BatchStatus.hpp
@@ -68,7 +68,7 @@ namespace geopm
             // This is the single place where the server prefix is located,
             // which is also accessed by BatchStatusTest.
             static constexpr const char* M_DEFAULT_FIFO_PREFIX =
-                "/run/geopm-service/batch-status-";
+                "/run/geopm/batch-status-";
     };
 
     class BatchStatusServer : public BatchStatusImp

--- a/service/src/PlatformTopo.cpp
+++ b/service/src/PlatformTopo.cpp
@@ -102,7 +102,7 @@ static int geopm_topo_popen(const char *cmd, FILE **fid)
 namespace geopm
 {
     const std::string PlatformTopoImp::M_CACHE_FILE_NAME = "/tmp/geopm-topo-cache-" + std::to_string(getuid());
-    const std::string PlatformTopoImp::M_SERVICE_CACHE_FILE_NAME = "/run/geopm-service/geopm-topo-cache";
+    const std::string PlatformTopoImp::M_SERVICE_CACHE_FILE_NAME = "/run/geopm/geopm-topo-cache";
 
     const PlatformTopo &platform_topo(void)
     {

--- a/service/src/geopm/MSRIOGroup.hpp
+++ b/service/src/geopm/MSRIOGroup.hpp
@@ -112,9 +112,18 @@ namespace geopm
             /// @brief Return the JSON string for the MSR data
             ///        associated with the given cpuid.
             static std::string platform_data(int cpu_id);
+
+            enum MsrConfigWarningPreference_e {
+                SILENCE_CONFIG_DEPRECATION_WARNING,
+                EMIT_CONFIG_DEPRECATION_WARNING,
+            };
             /// @brief Returns the filenames for user-defined MSRs if
             ///        found in the plugin path.
-            static std::set<std::string> msr_data_files(void);
+            /// @param [in] emit_config_deprecation_warning Whether to emit a warning
+            ///        if MSR config files are found while searching the plugin
+            ///        path instead of while searching config file locations.
+            static std::set<std::string> msr_data_files(
+                    MsrConfigWarningPreference_e warning_preference = SILENCE_CONFIG_DEPRECATION_WARNING);
             /// @brief Override the default description for a signal.
             ///        If signal is not available, does nothing.
             void set_signal_description(const std::string &name,

--- a/service/src/geopm_shmem.cpp
+++ b/service/src/geopm_shmem.cpp
@@ -23,7 +23,7 @@ namespace geopm
             // The status key is a shared resource
             id = uid;
         }
-        result << "/run/geopm-service/profile-" << id << "-" << shm_key;
+        result << "/run/geopm/profile-" << id << "-" << shm_key;
         return result.str();
     }
 


### PR DESCRIPTION
- Resolves #2914
- Use `/etc/geopm` instead of `/etc/geopm-service`
- Use `/run/geopm` instead of `/run/geopm-service`
- Read MSRIOGroup's json files from a new environment variable separate from the plugin path, with a default search location in `/etc/geopm`
- Continue reading from old file locations for `/etc` and MSR files, but emit warnings that those locations may not be read in future releases.