### PR TITLE
Moved GPU-CA unit tests out from behind beta flag

### DIFF
--- a/scripts/test/TestAgent.py
+++ b/scripts/test/TestAgent.py
@@ -32,10 +32,9 @@ class TestAgent(unittest.TestCase):
     def test_agent_names(self):
         agent_names = set(geopmpy.agent.names())
         expected_agent_names = {'power_balancer', 'power_governor',
-                                'frequency_map', 'monitor'}
+                                'frequency_map', 'monitor', 'gpu_activity'}
         if geopmpy.version.__beta__:
             expected_agent_names.add('cpu_activity')
-            expected_agent_names.add('gpu_activity')
             expected_agent_names.add('ffnet')
         self.assertEqual(expected_agent_names, agent_names)
 

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -213,6 +213,15 @@ GTEST_TESTS = test/gtest_links/AccumulatorTest.empty \
               test/gtest_links/FrequencyTimeBalancerTest.negative_time_spent_in_balancing_regions \
               test/gtest_links/FrequencyTimeBalancerTest.selects_high_priority_critical_path \
               test/gtest_links/FrequencyTimeBalancerTest.selects_low_priority_critical_path \
+              test/gtest_links/GPUActivityAgentTest.name \
+              test/gtest_links/GPUActivityAgentTest.validate_policy \
+              test/gtest_links/GPUActivityAgentTest.adjust_platform_high \
+              test/gtest_links/GPUActivityAgentTest.adjust_platform_medium \
+              test/gtest_links/GPUActivityAgentTest.adjust_platform_low \
+              test/gtest_links/GPUActivityAgentTest.adjust_platform_zero \
+              test/gtest_links/GPUActivityAgentTest.adjust_platform_signal_out_of_bounds_high \
+              test/gtest_links/GPUActivityAgentTest.adjust_platform_signal_out_of_bounds_low \
+              test/gtest_links/GPUActivityAgentTest.invalid_fe \
               test/gtest_links/InitControlTest.parse_valid_file \
               test/gtest_links/InitControlTest.parse_valid_file_2 \
               test/gtest_links/InitControlTest.parse_empty_file \
@@ -412,15 +421,6 @@ if ENABLE_BETA
                    test/gtest_links/FFNetAgentTest.validate_badsize_policy \
                    test/gtest_links/FFNetAgentTest.validate_empty_policy \
                    test/gtest_links/FFNetAgentTest.validate_good_policy\
-                   test/gtest_links/GPUActivityAgentTest.name \
-                   test/gtest_links/GPUActivityAgentTest.validate_policy \
-                   test/gtest_links/GPUActivityAgentTest.adjust_platform_high \
-                   test/gtest_links/GPUActivityAgentTest.adjust_platform_medium \
-                   test/gtest_links/GPUActivityAgentTest.adjust_platform_low \
-                   test/gtest_links/GPUActivityAgentTest.adjust_platform_zero \
-                   test/gtest_links/GPUActivityAgentTest.adjust_platform_signal_out_of_bounds_high \
-                   test/gtest_links/GPUActivityAgentTest.adjust_platform_signal_out_of_bounds_low \
-                   test/gtest_links/GPUActivityAgentTest.invalid_fe \
                    test/gtest_links/PolicyStoreImpTest.self_consistent \
                    test/gtest_links/PolicyStoreImpTest.table_precedence \
                    test/gtest_links/PolicyStoreImpTest.update_policy \
@@ -489,6 +489,7 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
                           test/FrequencyGovernorTest.cpp \
                           test/FrequencyMapAgentTest.cpp \
                           test/FrequencyTimeBalancerTest.cpp \
+                          test/GPUActivityAgentTest.cpp \
                           test/InitControlTest.cpp \
                           test/LocalNeuralNetTest.cpp \
                           test/MockAgent.hpp \
@@ -573,7 +574,6 @@ test_geopm_test_SOURCES = test/AccumulatorTest.cpp \
 beta_test_sources = test/CPUActivityAgentTest.cpp \
                     test/DaemonTest.cpp \
                     test/FFNetAgentTest.cpp \
-                    test/GPUActivityAgentTest.cpp \
                     test/MockPolicyStore.hpp \
                     test/PolicyStoreImpTest.cpp \
                     # end


### PR DESCRIPTION
- Relates to #3097 feature request from github issues
- Fixes #3097 change request from github issues.

Fixup on moving GPU-CA outside the beta flag, the unit tests were not moved along with the agent. 