### PR TITLE
improve readability and flow of secure_make_dirs

### DIFF
--- a/service/geopmdpy/system_files.py
+++ b/service/geopmdpy/system_files.py
@@ -86,44 +86,43 @@ def _directory_permissions_are_correct(directory, perm_mode):
 
     set_perm_mode = stat.S_IMODE(st.st_mode)
     correct_permissions = set_perm_mode == perm_mode
-
-    user_owner = st.st_uid
-    correct_owner = user_owner == os.getuid()
-
-    group_owner = st.st_gid
-    correct_group = group_owner == os.getgid()
-
-    if correct_permissions and correct_owner and correct_group:
-        return True
     if not correct_permissions:
         sys.stderr.write(f'Warning: <geopm-service> {path} has wrong permissions, expected {oct(perm_mode)}\n')
         sys.stderr.write(f'Warning: <geopm-service> the wrong permissions were {oct(set_perm_mode)}\n')
+
+    user_owner = st.st_uid
+    correct_owner = user_owner == os.getuid()
     if not correct_owner:
         sys.stderr.write(f'Warning: <geopm-service> {path} has wrong user owner\n')
         sys.stderr.write(f'Warning: <geopm-service> the wrong user owner was {user_owner}\n')
+
+    group_owner = st.st_gid
+    correct_group = group_owner == os.getgid()
     if not correct_group:
         sys.stderr.write(f'Warning: <geopm-service> {path} has wrong group owner\n')
         sys.stderr.write(f'Warning: <geopm-service> the wrong group owner was {group_owner}\n')
-    return False
+
+    return correct_permissions and correct_owner and correct_group
 
 
 def _is_already_secure_directory(candidate_dir, perm_mode):
     """Helper function to check if a path is a directory with the correct permissions and ownership
     """
     path = candidate_dir
+    is_secure_directory = False
     # If it's a link
     if os.path.islink(path):
         sys.stderr.write(f'Warning: <geopm-service> {path} is a symbolic link\n')
         sys.stderr.write(f'Warning: <geopm-service> the symbolic link points to {os.readlink(path)}\n')
-        return False
     # If it's a directory
-    if os.path.isdir(path):
+    elif os.path.isdir(path):
         if _directory_permissions_are_correct(path, perm_mode):
-            return True
+          is_secure_directory = True
+    # Don't know what it is, definitely not a directory
     else:
         sys.stderr.write(f'Warning: <geopm-service> {path} is not a directory\n')
     # default condition: path is not a secure directory
-    return False
+    return is_secure_directory
 
 
 def secure_make_dirs(path, perm_mode=0o700):

--- a/service/geopmdpy_test/TestAccessLists.py
+++ b/service/geopmdpy_test/TestAccessLists.py
@@ -370,8 +370,9 @@ default
             self._access_lists = AccessLists(CONFIG_PATH.name)
 
             calls = [
-                mock.call(f'Warning: <geopm-service> {CONFIG_PATH.name} has wrong permissions, it will be renamed to {renamed_path}\n'),
-                mock.call('Warning: <geopm-service> the wrong permissions were 0o755\n')
+                mock.call(f'Warning: <geopm-service> {CONFIG_PATH.name} has wrong permissions, expected 0o700\n'),
+                mock.call('Warning: <geopm-service> the wrong permissions were 0o755\n'),
+                mock.call(f'Warning: <geopm-service> renamed invalid path {CONFIG_PATH.name} to {renamed_path}\n')
             ]
             mock_err.assert_has_calls(calls)
 

--- a/service/geopmdpy_test/TestSecureFiles.py
+++ b/service/geopmdpy_test/TestSecureFiles.py
@@ -170,8 +170,9 @@ class TestSecureFiles(unittest.TestCase):
             secure_make_dirs(sess_path)
             renamed_path = f'{sess_path}-uuid4-INVALID'
             calls = [
-                mock.call(f'Warning: <geopm-service> {sess_path} has wrong permissions, it will be renamed to {renamed_path}\n'),
-                mock.call(f'Warning: <geopm-service> the wrong permissions were 0o755\n')
+                mock.call(f'Warning: <geopm-service> {sess_path} has wrong permissions, expected 0o700\n'),
+                mock.call(f'Warning: <geopm-service> the wrong permissions were 0o755\n'),
+                mock.call(f'Warning: <geopm-service> renamed invalid path {sess_path} to {renamed_path}\n')
             ]
             mock_sys_stderr_write.assert_has_calls(calls)
             # os.stat() is also called internally by system functions like maybe os.path.islink()
@@ -206,8 +207,9 @@ class TestSecureFiles(unittest.TestCase):
             secure_make_dirs(sess_path)
             renamed_path = f'{sess_path}-uuid4-INVALID'
             calls = [
-                mock.call(f'Warning: <geopm-service> {sess_path} has wrong user owner, it will be renamed to {renamed_path}\n'),
-                mock.call(f'Warning: <geopm-service> the wrong user owner was {bad_user.st_uid}\n')
+                mock.call(f'Warning: <geopm-service> {sess_path} has wrong user owner\n'),
+                mock.call(f'Warning: <geopm-service> the wrong user owner was {bad_user.st_uid}\n'),
+                mock.call(f'Warning: <geopm-service> renamed invalid path {sess_path} to {renamed_path}\n')
             ]
             mock_sys_stderr_write.assert_has_calls(calls)
             # os.stat() is also called internally by system functions like maybe os.path.islink()
@@ -242,8 +244,9 @@ class TestSecureFiles(unittest.TestCase):
             secure_make_dirs(sess_path)
             renamed_path = f'{sess_path}-uuid4-INVALID'
             calls = [
-                mock.call(f'Warning: <geopm-service> {sess_path} has wrong group owner, it will be renamed to {renamed_path}\n'),
-                mock.call(f'Warning: <geopm-service> the wrong group owner was {bad_group.st_gid}\n')
+                mock.call(f'Warning: <geopm-service> {sess_path} has wrong group owner\n'),
+                mock.call(f'Warning: <geopm-service> the wrong group owner was {bad_group.st_gid}\n'),
+                mock.call(f'Warning: <geopm-service> renamed invalid path {sess_path} to {renamed_path}\n')
             ]
             mock_sys_stderr_write.assert_has_calls(calls)
             # os.stat() is also called internally by system functions like maybe os.path.islink()

--- a/service/geopmdpy_test/TestSecureFiles.py
+++ b/service/geopmdpy_test/TestSecureFiles.py
@@ -116,8 +116,9 @@ class TestSecureFiles(unittest.TestCase):
             secure_make_dirs(sess_path)
             renamed_path = f'{sess_path}-uuid4-INVALID'
             calls = [
-                mock.call(f'Warning: <geopm-service> {sess_path} is a symbolic link, the link will be renamed to {renamed_path}\n'),
-                mock.call(f'Warning: <geopm-service> the symbolic link points to /tmp\n')
+                mock.call(f'Warning: <geopm-service> {sess_path} is a symbolic link\n'),
+                mock.call(f'Warning: <geopm-service> the symbolic link points to /tmp\n'),
+                mock.call(f'Warning: <geopm-service> renamed invalid path {sess_path} to {renamed_path}\n')
             ]
             mock_sys_stderr_write.assert_has_calls(calls)
             mock_os_path_islink.assert_called_once_with(sess_path)
@@ -143,8 +144,11 @@ class TestSecureFiles(unittest.TestCase):
              mock.patch('sys.stderr.write', return_value=None) as mock_sys_stderr_write:
             secure_make_dirs(sess_path)
             renamed_path = f'{sess_path}-uuid4-INVALID'
-            msg = f'Warning: <geopm-service> {sess_path} is not a directory, it will be renamed to {renamed_path}\n'
-            mock_sys_stderr_write.assert_called_once_with(msg)
+            calls = [
+                mock.call(f'Warning: <geopm-service> {sess_path} is not a directory\n'),
+                mock.call(f'Warning: <geopm-service> renamed invalid path {sess_path} to {renamed_path}\n')
+            ]
+            mock_sys_stderr_write.assert_has_calls(calls)
             mock_os_path_islink.assert_called_once_with(sess_path)
             mock_os_path_isdir.assert_called_once_with(sess_path)
         self.assertTrue(os.path.exists(renamed_path))


### PR DESCRIPTION
- Fixes #3148 change request from github issues.

> The implementation for the secure directories feature was modified because it is difficult to review the nested logic in the secure_make_dirs function. It is important that this code is readable since this type of file manipulation does not lend itself very well to static analysis. I think some improvements could be made to improve readability and help avoid security issues introduced in future code changes.

A common pattern that I apply in my own secure code development is to `return False` at the end of a function which serves as a secure condition check. This helps when auditing occurrences of truthful returns from the function, and helps to mitigate future bugs introduced in the function body that could allow the control flow to reach the end of the check.
