### PR TITLE
Documentation revisions for v3

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,6 +1,5 @@
-
-Guide for Contributors
-======================
+GEOPM Contributor Guide
+=======================
 
 This file describes how to contribute to the GEOPM project.  All
 feedback is appreciated.

--- a/service/docs/source/admin.rst
+++ b/service/docs/source/admin.rst
@@ -1,6 +1,5 @@
-
-Guide for Service Administrators
-================================
+Service Administrators
+======================
 
 This guide covers GEOPM's integration with the Linux OS, directories
 influenced by GEOPM, the utilization of files within those directories, and a

--- a/service/docs/source/admin.rst
+++ b/service/docs/source/admin.rst
@@ -2,12 +2,10 @@
 Guide for Service Administrators
 ================================
 
-This documentation covers some of the aspects of the GEOPM Service
-that are important to system administrators.  These include how the
-GEOPM Service is integrated with the Linux OS, which directories are
-created and modified by the GEOPM Service, how the files in those
-directories are used, and a command line tool to configure the GEOPM
-Service.  Additional information is available on other pages:
+This guide covers GEOPM's integration with the Linux OS, directories
+influenced by GEOPM, the utilization of files within those directories, and a
+command-line tool for configuring the GEOPM Service. For further details,
+explore the subsequent sections:
 
 - :doc:`Install Guide <install>`
 - :doc:`Security Guide <security>`
@@ -16,42 +14,45 @@ Service.  Additional information is available on other pages:
 Linux Integration
 -----------------
 
-The GEOPM Service integrates with the Linux OS through Systemd as a
-unit that is installed with the geopm-service RPM.  The ``sytemctl``
-command can be used to interact with the ``geopm`` Systemd Unit.
+The GEOPM Service integrates seamlessly with the Linux OS through Systemd. It
+is packaged within the geopm-service binary package, and administrators can install it
+using their respective package management systems. Use ``systemctl``
+to interact with ``geopm`` Systemd Unit.
 
 
 GEOPM Service Files
 -------------------
 
-In addition to the files provided by the installation packages, the
-GEOPM Service may create and modify files while active.  The files
-created by the GEOPM Service are located within two directories.  The
-files in ``/etc/geopm`` hold the access control lists.  These
-files persist across reboots and restarts of the service.  The files
-in ``/run/geopm`` track information about clients that are
-actively using the service.  These files save the state of the GEOPM
-Service and if the service is stopped for any reason the files will be
-used when the service is started again.  The files in ``/run`` are
-erased upon reboot.
+Beyond the files that come with the installation packages, the GEOPM Service
+may generate and modify additional files during its active state. These files
+are housed within two primary directories:
 
-All files and directories within ``/etc/geopm`` or
-``/run/geopm`` are created by the GEOPM Service with
-restricted access permissions and root ownership.  The GEOPM Service
-will not read any file or directory if they are modified to have more
-permissive access restrictions, non-root ownership, or if they are
-replaced by a symbolic link or other non-regular file.  If these
-checks fail, the file or directory will be renamed to include a UUID
-string and a warning is printed in the syslog.  These renamed files or
-directories enable an administrator to perform an investigation into
-problem, but they will not be used by the GEOPM Service in any way.
+- ``/etc/geopm``: This directory contains configuration files, including access
+  control lists. Files here persist across both reboots and service restarts.
 
-It is recommended that these GEOPM Service system files are always
-manipulated using GEOPM tools like ``geopmaccess``, however, any
-administrator that manipulates the GEOPM system files without using a
-GEOPM interface should be aware of the permission and ownership
-requirements for these files.  For more information about the GEOPM
-security model please refer to the `Security Guide <security.html>`_.
+- ``/run/geopm``: This directory contains files that monitor data about clients
+  actively engaging the service, files that help maintain the GEOPM Service's
+  state, and files that are used by GEOPM's save/restore mechanism. Should the
+  service halt unexpectedly, these files aid in its subsequent restart. However,
+  remember that the ``/run`` directory's contents get deleted upon a system reboot.
+
+Furthermore, the GEOPM Service ensures robust security measures:
+
+- Both ``/etc/geopm`` and ``/run/geopm`` directories and their contained files
+  are established with restricted access permissions and root ownership.
+
+- The service will avoid reading any file or directory if there's a relaxation
+  in access restrictions, non-root ownership, or if they're substituted by
+  symbolic links or non-standard files. Should these conditions not be met, the
+  affected file or directory will be renamed with a UUID and a warning will be
+  dispatched to the syslog. While these renamed entities can assist an
+  administrator in investigations, they are otherwise ignored by the GEOPM Service.
+
+For seamless operation and security, it's advised to manage the GEOPM Service
+system files using GEOPM tools like ``geopmaccess``. However, administrators
+opting to handle GEOPM system files outside of a GEOPM interface should be
+vigilant of the necessary permission and ownership criteria. Delve deeper into
+the GEOPM security intricacies by referring to the `Security Guide <security.html>`_.
 
 
 Configuring Access Lists

--- a/service/docs/source/build.rst
+++ b/service/docs/source/build.rst
@@ -1,25 +1,28 @@
 Source Build Guide
 ==================
 
-This documentation is providing build instructions for administrators who are
+This documentation provides build instructions for administrators who are
 interested in installing the GEOPM Service based on a checkout from the GEOPM
 git repository. Following these instructions will assist users in creating RPM
-packages compatible with various Linux distributions.
+or debian (DEB) packages compatible with various Linux distributions.
 
-We have tested packages created through this process on CentOS 8, RHEL 8, and
-SLES 15 SP2 Linux distributions. Feedback from installations on other
-distributions such as Fedora, openSUSE Leap, and Ubuntu would be greatly
+We have tested packages created through this process on SLES 15 SP3 and SP4,
+as well as Ubuntu jammy 22.04.  Feedback from installations on other
+distributions such as CentOS, openSUSE Leap, and Fedora would be greatly
 appreciated.
 
-GEOPM Service installation is available via both RPM and deb packages. These
+GEOPM Service installation is available via both RPM and DEB packages. These
 packages provide cross-Linux-distribution compatibility for the installation of
 the systemd service and facilitate a clean uninstallation process.
 
-Building GEOPM Service RPMs
------------------------------
+The GEOPM service build system provides support for packaging for:
 
-The GEOPM service build system is provides support for packaging for CentOS 8,
-RHEL 8, and SLES 15 SP2.
+* SLES 15 SP3 and SP4
+* CentOS 8 amd 9-Stream
+* Ubuntu 22.04 jammy
+
+Building GEOPM Service RPMs
+---------------------------
 
 Use the following bash commands:
 
@@ -40,36 +43,91 @@ These commands create the GEOPM service RPM files in your rpmbuild directory:
     $HOME/rpmbuild/RPMS/x86_64/python3-geopmdpy-<VERSION>-1.x86_64.rpm
     $HOME/rpmbuild/RPMS/x86_64/libgeopmd2-<VERSION>-1.x86_64.rpm
 
+Building GEOPM Service DEBs
+---------------------------
+
+Use the following bash commands:
+
+.. code-block:: bash
+
+    git clone git@github.com:geopm/geopm.git
+    cd geopm/service
+    ./autogen.sh
+    ./configure
+    make deb
+
+These commands create the GEOPM service DEB files in your current working directory, e.g.:
+
+.. code-block:: bash
+
+    $HOME/geopm/service/geopm-service_<VERSION>-1_amd64.deb
+    $HOME/geopm/service/libgeopmd2_<VERSION>-1_amd64.deb
+    $HOME/geopm/service/libgeopmd-dev_<VERSION>-1_amd64.deb
+    $HOME/geopm/service/python3-geopmdpy_<VERSION>-1_amd64.deb
+
+.. note::
+
+   Because the GEOPM Python modules are still packaged with ``setuptools``, you
+   must use the package manager installed version of python3-setuptools when
+   issuing ``make deb``.  At the of this writing that is version ``59.6.0``.
+
+   If you have a newer version of ``setuptools`` installed via ``pip``, you can
+   use the following to remove it: ``python3 -m pip uninstall setuptools``
+
+   Alternatively you can force the usage of the system version of ``setuptools``
+   with: ``SETUPTOOLS_USE_DISTUTILS=stdlib make deb``
+
+   For more information see:
+
+   https://bugs.launchpad.net/ubuntu/+source/dput/+bug/2018519
+
+   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003252
 
 Installing and Running the GEOPM Service
-------------------------------------------------
+----------------------------------------
 
-Post following the aforementioned instructions, install the RPM files by
-executing the `install_service.sh` script located within `service/integration`
-subdirectory of the GEOPM repository.
+Once the packaging is complete, install the RPM files by issuing your OS's
+packaging manager (i.e. zypper or yum):
 
 .. code-block:: bash
 
-    cd geopm/service
-    sudo ./integration/install_service.sh $(cat VERSION) $USER
+   $ sudo zypper install --allow-unsigned-rpm \
+     $HOME/rpmbuild/RPMS/x86_64/geopm-service-<VERSION>-1.x86_64.rpm \
+     $HOME/rpmbuild/RPMS/x86_64/geopm-service-devel-<VERSION>-1.x86_64.rpm \
+     $HOME/rpmbuild/RPMS/x86_64/python3-geopmdpy-<VERSION>-1.x86_64.rpm \
+     $HOME/rpmbuild/RPMS/x86_64/libgeopmd2-<VERSION>-1.x86_64.rpm
+
+Or the DEB files by issuing:
+
+.. code-block:: bash
+
+   $ cd geopm/service
+   $ sudo apt install \
+     ./geopm-service_<VERSION>-1_amd64.deb \
+     ./libgeopmd2_<VERSION>-1_amd64.deb \
+     ./libgeopmd-dev_<VERSION>-1_amd64.deb \
+     ./python3-geopmdpy_<VERSION>-1_amd64.deb
+
+To start the GEOPM service and check its status issue:
+
+.. code-block:: bash
+
+    sudo systemctl start geopm
     systemctl status geopm
 
-Installation of the GEOPM Service Development Package
---------------------------------------------------------------------
-
-For system administrators looking to enable system users to link to the C or
-C++ interfaces provided by libgeopmd.so, consider installing the GEOPM Service
-Development Package, which provides C and C++ header files. Manual installation
-is mandatory as it is not part of the running `install_service.sh` script
-explained in the previous section.
-
 Removal of the GEOPM Service
---------------------------------------
+----------------------------
 
-To stop the GEOPM service and remove the RPMs from your system, simply pass use the
-`--remove` option with the installer script detailed in the previous section:
+To stop the GEOPM service and remove the RPMs from your system, use your OS's
+package manager:
 
 .. code-block:: bash
 
-    cd geopm/service
-    sudo ./integration/install_service.sh --remove
+    sudo zypper remove geopm-service libgeopmd2 geopm-service-devel python3-geopmdpy
+
+Or for the DEB packages by issuing:
+
+.. code-block:: bash
+
+    sudo systemctl stop geopm
+    sudo apt remove geopm-service libgeopmd2 libgeopmd-dev python3-geopmdpy

--- a/service/docs/source/build.rst
+++ b/service/docs/source/build.rst
@@ -1,5 +1,5 @@
-Source Build Guide
-==================
+Source Builds
+=============
 
 This documentation provides build instructions for administrators who are
 interested in installing the GEOPM Service based on a checkout from the GEOPM

--- a/service/docs/source/build.rst
+++ b/service/docs/source/build.rst
@@ -4,14 +4,14 @@ Source Builds
 This documentation provides build instructions for administrators who are
 interested in installing the GEOPM Service based on a checkout from the GEOPM
 git repository. Following these instructions will assist users in creating RPM
-or debian (DEB) packages compatible with various Linux distributions.
+or debian packages compatible with various Linux distributions.
 
 We have tested packages created through this process on SLES 15 SP3 and SP4,
 as well as Ubuntu jammy 22.04.  Feedback from installations on other
 distributions such as CentOS, openSUSE Leap, and Fedora would be greatly
 appreciated.
 
-GEOPM Service installation is available via both RPM and DEB packages. These
+GEOPM Service installation is available via both RPM and debian packages. These
 packages provide cross-Linux-distribution compatibility for the installation of
 the systemd service and facilitate a clean uninstallation process.
 
@@ -43,8 +43,8 @@ These commands create the GEOPM service RPM files in your rpmbuild directory:
     $HOME/rpmbuild/RPMS/x86_64/python3-geopmdpy-<VERSION>-1.x86_64.rpm
     $HOME/rpmbuild/RPMS/x86_64/libgeopmd2-<VERSION>-1.x86_64.rpm
 
-Building GEOPM Service DEBs
----------------------------
+Building GEOPM Service Debian Packages
+--------------------------------------
 
 Use the following bash commands:
 
@@ -56,7 +56,8 @@ Use the following bash commands:
     ./configure
     make deb
 
-These commands create the GEOPM service DEB files in your current working directory, e.g.:
+These commands create the GEOPM service debian packages  in your current working
+directory, e.g.:
 
 .. code-block:: bash
 

--- a/service/docs/source/build.rst
+++ b/service/docs/source/build.rst
@@ -1,29 +1,27 @@
+Source Build Guide
+==================
 
-Guide to Source Builds
-======================
+This documentation is providing build instructions for administrators who are
+interested in installing the GEOPM Service based on a checkout from the GEOPM
+git repository. Following these instructions will assist users in creating RPM
+packages compatible with various Linux distributions.
 
-These are build instructions for an administrator that would like to
-install the GEOPM Service based on a checkout of the GEOPM git
-repository.  Following these instructions will enable the user to
-create RPM packages that can be installed on several Linux
-distributions.
+We have tested packages created through this process on CentOS 8, RHEL 8, and
+SLES 15 SP2 Linux distributions. Feedback from installations on other
+distributions such as Fedora, openSUSE Leap, and Ubuntu would be greatly
+appreciated.
 
-Packages created through this process have been tested on the CentOS 8,
-RHEL 8, and SLES 15 SP2 Linux distributions.  We welcome feedback
-from testing on other distributions like Fedora, openSUSE Leap, and
-Ubuntu (note there is currently no .deb support).
-
-Installing the GEOPM Service relies on the RPM packaging system.  The
-RPM packaging system enables some cross-Linux-distribution
-compatibility for the installation of the systemd service, and
-provides a clean mechanism for uninstall.
-
+GEOPM Service installation is available via both RPM and deb packages. These
+packages provide cross-Linux-distribution compatibility for the installation of
+the systemd service and facilitate a clean uninstallation process.
 
 Building GEOPM Service RPMs
----------------------------
+-----------------------------
 
-Support for packaging for CentOS 8, RHEL 8, and SLES 15 SP2 is provided
-by the GEOPM service build system.
+The GEOPM service build system is provides support for packaging for CentOS 8,
+RHEL 8, and SLES 15 SP2.
+
+Use the following bash commands:
 
 .. code-block:: bash
 
@@ -33,9 +31,7 @@ by the GEOPM service build system.
     ./configure
     make rpm
 
-
-These commands create the GEOPM service RPM files in your rpmbuild
-directory:
+These commands create the GEOPM service RPM files in your rpmbuild directory:
 
 .. code-block:: bash
 
@@ -45,12 +41,12 @@ directory:
     $HOME/rpmbuild/RPMS/x86_64/libgeopmd2-<VERSION>-1.x86_64.rpm
 
 
-Installing and Starting the GEOPM Service
------------------------------------------
+Installing and Running the GEOPM Service
+------------------------------------------------
 
-After following the instructions above, install the RPM files by
-executing the ``install_service.sh`` script located in the
-``service/integration`` sub-directory of the GEOPM repository.
+Post following the aforementioned instructions, install the RPM files by
+executing the `install_service.sh` script located within `service/integration`
+subdirectory of the GEOPM repository.
 
 .. code-block:: bash
 
@@ -58,24 +54,20 @@ executing the ``install_service.sh`` script located in the
     sudo ./integration/install_service.sh $(cat VERSION) $USER
     systemctl status geopm
 
+Installation of the GEOPM Service Development Package
+--------------------------------------------------------------------
 
-Installing the GEOPM Service Development Package
-------------------------------------------------
+For system administrators looking to enable system users to link to the C or
+C++ interfaces provided by libgeopmd.so, consider installing the GEOPM Service
+Development Package, which provides C and C++ header files. Manual installation
+is mandatory as it is not part of the running `install_service.sh` script
+explained in the previous section.
 
-A system administrator that would like to enable users of the system to
-link to the C or C++ interfaces provided by libgeopmd.so should
-install the GEOPM Service Development Package.  This provides the C
-and C++ header files.  Installation of this package must be done
-manually as it is **not** installed as part of running the
-``install_service.sh`` script documented above.
+Removal of the GEOPM Service
+--------------------------------------
 
-
-Removing the GEOPM Service
---------------------------
-
-To stop the GEOPM service and uninstall the RPMs from the system,
-simply pass the ``--remove`` option to the installer script used in
-the previous section:
+To stop the GEOPM service and remove the RPMs from your system, simply pass use the
+`--remove` option with the installer script detailed in the previous section:
 
 .. code-block:: bash
 

--- a/service/docs/source/client.rst
+++ b/service/docs/source/client.rst
@@ -1,21 +1,19 @@
+Service Clients Guide
+=====================
 
-Guide for Service Clients
-=========================
+The GEOPM Service enhances the PlatformIO interfaces by ensures
+reliability and quality.  Users of the GEOPM service can
+utilize the PlatformIO capabilities through different interfaces
+such as C, C++, Python, and command line tools. The system
+administrator can manage user access rights through using the ``geopmaccess``
+command line tool. PlatformTopo is an abstraction that outlines the
+system's hardware.
 
-The GEOPM Service facilitates the PlatformIO interfaces by providing
-security and quality guarantees.  Clients of the GEOPM service may
-access the PlatformIO features through a variety of interfaces
-including C, C++, Python, and command line tools.  The administrator
-of the system may manage client access rights through the
-``geopmaccess`` command line tool.  PlatformIO uses the PlatformTopo
-abstraction to define the hardware available on the system.
-
-A high level overview of the PlatformIO abstraction is described in
-the :doc:`geopm_pio(7) <geopm_pio.7>` man page.  This page and the
-pages linked within describe all signals and controls that are available
-through this interface.  A client may read the signals or write the
-controls described in the overview with the interfaces listed below.
-
+An comprehensive overview of the PlatformIO abstraction is outlined in
+the :doc:`geopm_pio(7) <geopm_pio.7>` man page. This page along with
+the linked pages describe all signals and controls available
+through this interface. Clients can read the signals or utilizes the
+controls explained in the overview with the interfaces provided below.
 
 
 Language Bindings
@@ -41,7 +39,7 @@ Python3 API
 
 Command Line Tools
 ------------------
-- Read one value: :doc:`geopmread(1) <geopmread.1>`
-- Write one value: :doc:`geopmwrite(1) <geopmwrite.1>`
+- Read a single value: :doc:`geopmread(1) <geopmread.1>`
+- Write a single value: :doc:`geopmwrite(1) <geopmwrite.1>`
 - Read time series of values :doc:`geopmsession(1) <geopmsession.1>`
-- Access management :doc:`geopmaccess(1) <geopmaccess.1>`
+- Manage access :doc:`geopmaccess(1) <geopmaccess.1>`

--- a/service/docs/source/client.rst
+++ b/service/docs/source/client.rst
@@ -1,5 +1,5 @@
-Service Clients Guide
-=====================
+Service Clients
+===============
 
 The GEOPM Service enhances the PlatformIO interfaces by ensures
 reliability and quality.  Users of the GEOPM service can

--- a/service/docs/source/devel.rst
+++ b/service/docs/source/devel.rst
@@ -211,7 +211,7 @@ Preprocessor usage should be reserved for expressing configure time
 options.
 
 The number of columns in a source file should not exceed 70 or 80 before
-wrapping the line.  Exceptions are allowed when it is required for compliation
+wrapping the line.  Exceptions are allowed when it is required for compilation
 or similar.  In general, follow the style in the file you are modifying.
 
 Pre-Commit Checks

--- a/service/docs/source/devel.rst
+++ b/service/docs/source/devel.rst
@@ -1,5 +1,5 @@
-GEOPM Developer Guide
-=====================
+Guide for GEOPM Developers
+==========================
 
 If you wish to modify the source code in the GEOPM git repository, this
 guide provide instructions for the process. The GEOPM repository utilizes

--- a/service/docs/source/devel.rst
+++ b/service/docs/source/devel.rst
@@ -103,8 +103,10 @@ options and environment variables are listed below:
 - Service configure script
 
 * ``--enable-nvml``: Adds support for the Nvidia NVML library
+* ``--enable-dcgm``: Adds support for the Nvidia DCGM library
 * ``--enable-levelzero``: Adds support for OneAPI LevelZero
 * ``--disable-systemd``: Excludes GEOPM service access from PlatformIO
+* ``--disable-io-uring``: Disable support for libiouring for batch IO operations
 
 - Base configure script
 
@@ -112,6 +114,7 @@ options and environment variables are listed below:
 * ``--disable-mpi``: Excludes MPI dependencies from the base directory build
 * ``--disable-fortran``: Excludes Fortran dependencies from the base directory build
 * ``--disable-openmp``: Excludes OpenMP dependencies from the base directory build
+* ``--disable-geopmd-local``: Use system installed geopmd package, do not use local service build
 * ``export FC=``: Set the Fortran compiler with an environment variable
 * ``export F77=``: Set the Fortran 77 compiler with an environment variable
 * ``export MPICC=``: Set the MPI C compiler wrapper with an environment variable
@@ -126,20 +129,22 @@ the following variables prior to configuring the base build of the GEOPM reposit
 
 .. code-block:: bash
 
-    export CC=icc
-    export CXX=icpc
-    export FC=ifort
-    export F77=ifort
+    export CC=icx
+    export CXX=icpx
+    export FC=ifx
+    export F77=ifx
+    export F90=ifx
     export MPICC=mpiicc
     export MPICXX=mpiicpc
+    export MPIFORT=mpiifort
     export MPIFC=mpiifort
     export MPIF77=mpiifort
+    export MPIFR90=mpiifort
 
 We recommend using the system compiler toolchain for compiling the
 GEOPM service when creating an installed RPM.  The ``make rpm`` target
 of the service directory uses the geopm-service spec file to ensure
 that the system GCC toolchain is used to create the RPM.
-
 
 Coverage Instructions
 ---------------------
@@ -172,7 +177,6 @@ which runs the corresponding unit tests and produces a coverage report in
 Note that all tests must pass in order to generate a coverage report.
 Any help in increasing code coverage levels is appreciated.
 
-
 Coding Style
 ------------
 
@@ -185,7 +189,6 @@ using astyle with the following options:
 .. code-block::
 
    astyle --style=linux --indent=spaces=4 -y -S -C -N
-
 
 Note that astyle is not perfect (in particular it is confused by C++11
 initializer lists), and some versions of astyle will format the code
@@ -202,6 +205,10 @@ statically to the compilation unit.
 Avoid preprocessor macros as much as possible (use enum not #define).
 Preprocessor usage should be reserved for expressing configure time
 options.
+
+The number of columns in a source file should not exceed 70 or 80 before
+wrapping the line.  Exceptions are allowed when it is required for compliation
+or similar.  In general, follow the style in the file you are modifying.
 
 Pre-Commit Checks
 -----------------
@@ -227,7 +234,6 @@ committing the new file to git, and rerunning the autogen.sh script.
 Files for which a license comment is not appropriate should be listed
 in copying_headers/MANIFEST.EXEMPT.  Any new installed files should
 also be added to geopm-runtime.spec.in or service/geopm-service.spec.in.
-
 
 Creating Manuals
 ----------------

--- a/service/docs/source/devel.rst
+++ b/service/docs/source/devel.rst
@@ -1,97 +1,73 @@
+GEOPM Developer Guide
+=====================
 
-Guide for GEOPM Developers
-==========================
+If you wish to modify the source code in the GEOPM git repository, this
+guide provide instructions for the process. The GEOPM repository utilizes
+two separate autotools-based build systems, used for compiling, testing,
+and installing software components designed with C++ and Python.
 
-These are instructions for a developer that would like to modify the
-source code in the GEOPM git repository.  The GEOPM repository
-contains two independent autotools based build systems that are used
-to compile, test and install software components written in C++ and
-Python.  The ``service`` subdirectory of the GEOPM repository contains
-all files related to the GEOPM systemd service including the build
-system and all source code for the software components.  The base
-directory of the GEOPM git repository is populated with a build system
-that supports all software components not located in the ``service``
-directory.  The base build depends solely on components in the
-``service`` directory that are installed by the service build
-including: the ``libgeopmd.so`` library, the C and C++ public
-interface header files for that library, and the ``geopmdpy`` Python
-module.
+The `service` subdirectory of the GEOPM repository houses all the files
+related to the GEOPM systemd services, including the build system and all
+the source codes. In contrast, the base directory of the same repository
+supports all software components not located in the `service` directory and
+relies solely on the components within the `service` directory installed
+by the service build.
 
-Prior to following the build steps, it's recommended to get familiar with
-the build requirements for the :doc:`GEOPM service<requires>` and the
-:doc:`GEOPM HPC runtime<runtime>`.
+Before proceeding with the build steps, it's advisable to familiarize
+yourself with the build requirements for the :doc:`GEOPM service<requires>`
+and :doc:`GEOPM HPC runtime<runtime>`.
 
 Developer Build Process
 -----------------------
 
-The basic procedure for building all of the software in the GEOPM
-repository is to run the following commands within the base of the GEOPM
-repository:
+To build all the software in the GEOPM repository, run the following commands
+within the base directory of the GEOPM repository:
 
 .. code-block:: bash
 
-    # Build the geopm-service package
     cd service/
     ./autogen.sh
     ./configure
     make
-
-    # Optionally, build the GEOPM HPC runtime package
     cd ..
     ./autogen.sh
     ./configure
     make
 
-
-After the build is complete, a developer may wish to execute the unit
-tests.  Each of the two builds has a ``check`` target for their
-makefiles.  The test programs may be built separately from the
-``check`` target by specifying the ``checkprogs`` make target.
+Upon successful build completion, if you wish to execute unit tests,
+each build has a `check` target in the makefiles. Alternatively, the test
+programs can be built separately using the `checkprogs` target.
 
 .. code-block:: bash
 
-    # Run the geopm-service package unit tests
     cd service/
     make checkprogs
     make check
-
-    # Optionally run the GEOPM HPC runtime package unit tests
     cd ..
     make checkprogs
     make check
 
-
-The developer may be interested in installing the build artifacts to a
-separate directory.  In this case, the build process differs slightly:
-some extra options will be provided to configure.
+If you want to install the build artifacts into a separate directory, you'll
+need to provide some additional options to configure during the build process.
 
 .. code-block:: bash
 
-    # Define the install location
     GEOPM_INSTALL=$HOME/build/geopm
-
-    # Build the geopm-service package
     cd service/
     ./autogen.sh
     ./configure --prefix=$GEOPM_INSTALL
     make
     make install
-
-    # Optionally, build the GEOPM HPC runtime package
     cd ..
     ./autogen.sh
     ./configure --prefix=$GEOPM_INSTALL --with-geopmd=$GEOPM_INSTALL
     make
     make install
 
-
-The libraries, binaries and python tools will not be installed into
-the standard system paths if GEOPM is built from source and configured
-with the ``--prefix`` option.  In this case, it is required that the
-user augment their environment to specify the installed location.  If
-the configure option is specified as above. then the following
-modifications to the user's environment should be made prior to
-running any GEOPM tools:
+When building from source and configured with the `--prefix` option, the
+libraries, binaries, and Python tools will not install into the standard
+system paths. At this point, you must modify your environment to specify
+the installed location.
 
 .. code-block:: bash
 
@@ -99,99 +75,49 @@ running any GEOPM tools:
     export PATH=$GEOPM_INSTALL/bin:$PATH
     export PYTHONPATH=$(ls -d $GEOPM_INSTALL/lib/python*/site-packages | tail -n1):$PYTHONPATH
 
-
-Use a PYTHONPATH that points to the site-packages created by the geopm
-build.  The version created is for whichever version of python 3 was
-used in the configure step.  If a different version of python is
-desired, override the default with the --with-python option in the
-configure script.
-
+If desired, you can specify a different Python version using the
+`--with-python` option in the configure script.
 
 Configuring the Build
 ---------------------
 
-There are many options that may be passed to each of the two configure
-scripts that are part of the GEOPM repository build system.  Two
-scripts called ``autogen.sh`` are provided, one in the base of the
-GEOPM repository and the other in the service directory.  Each of
-these scripts manage the GEOPM version that is embedded in the build
-artifacts, and create the two ``configure`` scripts using the
-autotools package.
+Several options can be passed to each of the two configure scripts that
+determine the build process. The files managed by the scripts are responsible
+for GEOPM's version embedding in build artifacts and create two `configure`
+scripts using the autotools package.
 
-Running the configure scripts generates a number of output files,
-including the ``Makefile`` that is used for the rest of the build
-steps.  The ``configure`` scripts accept a large number of command line
-options, and environment variables that affect the behavior.
-Each configure script will provide user documentation through the
-``./configure --help`` command.  Some important options and
-environment variables are listed below.
+The configure scripts output several files, including the `Makefile` used
+for further build steps. These scripts also accept various command line
+options and environmental variables that customize behavior. For detailed
+user documentation, refer to the `./configure --help` command. Some notable
+options and environment variables are listed below:
 
-Both configure scripts
-^^^^^^^^^^^^^^^^^^^^^^
+- Both configure scripts
 
-* ``--prefix``
-  Path prefix for install artifacts
+* ``--prefix``: Path prefix for install artifacts
+* ``--enable-debug``: Enable verbose error and warning messaging while disabling optimization.
+* ``--enable-coverage``: Enable coverage report generation with gcov
+* ``export CC=``: Set the C compiler with environment variable
+* ``export CXX=``: Set the C++ compiler with environment variable
 
-* ``--enable-debug``
-  Create more verbose error and warning messaging and disable
-  optimization.
+- Service configure script
 
-* ``--enable-coverage``
-  Enable coverage report generation with gcov
+* ``--enable-nvml``: Adds support for the Nvidia NVML library
+* ``--enable-levelzero``: Adds support for OneAPI LevelZero
+* ``--disable-systemd``: Excludes GEOPM service access from PlatformIO
 
-* ``export CC=``
-  Set the C compiler with environment variable
+- Base configure script
 
-* ``export CXX=``
-  Set the C++ compiler with environment variable
-
-
-Service configure script
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-* ``--enable-nvml``
-  Add support for the Nvidia NVML library
-
-* ``--enable-levelzero``
-  Add support for OneAPI LevelZero
-
-* ``--disable-systemd``
-  Do not build GEOPM Service access into PlatformIO
-
-
-Base configure script
-^^^^^^^^^^^^^^^^^^^^^
-
-* ``--with-geopmd=``
-  Provide install location of the service build
-
-* ``--disable-mpi``
-  Build the base directory without MPI dependencies
-
-* ``--disable-fortran``
-  Build the base directory without fortran dependencies
-
-* ``--disable-openmp``
-  Build the base directory without OpenMP dependencies
-
-* ``export FC=``
-  Set the Fortran compiler with environment variable
-
-* ``export F77=``
-  Set the Fortran 77 compiler with environment variable
-
-* ``export MPICC=``
-  Set the MPI C compiler wrapper with environment variable
-
-* ``export MPICXX=``
-  Set the MPI C++ compiler wrapper with environment variable
-
-* ``export MPIFC=``
-  Set the Fortran compiler wrapper with environment variable
-
-* ``export MPIF77=``
-  Set the Fortran 77 compiler wrapper with environment variable
-
+* ``--with-geopmd=``: Specify the installation location of the service build
+* ``--disable-mpi``: Excludes MPI dependencies from the base directory build
+* ``--disable-fortran``: Excludes Fortran dependencies from the base directory build
+* ``--disable-openmp``: Excludes OpenMP dependencies from the base directory build
+* ``export FC=``: Set the Fortran compiler with an environment variable
+* ``export F77=``: Set the Fortran 77 compiler with an environment variable
+* ``export MPICC=``: Set the MPI C compiler wrapper with an environment variable
+* ``export MPICXX=``: Set the MPI C++ compiler wrapper with an environment variable
+* ``export MPIFC=``: Set the Fortran compiler wrapper with environmental variable
+* ``export MPIF77=``: Set the Fortran 77 compiler
 
 Intel Compiler and MPI Toolchain
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/service/docs/source/devel.rst
+++ b/service/docs/source/devel.rst
@@ -1,5 +1,5 @@
-Guide for GEOPM Developers
-==========================
+GEOPM Developer Guide
+=====================
 
 If you wish to modify the source code in the GEOPM git repository, this
 guide provide instructions for the process. The GEOPM repository utilizes
@@ -124,6 +124,10 @@ options and environment variables are listed below:
 
 Intel Compiler and MPI Toolchain
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. TODO this section and runtime->Build Requirements need to be refactored.
+   IMO all this text belongs in the runtime.rst.
+
 To enable the use of the Intel toolchain for both the compiler and MPI support, export
 the following variables prior to configuring the base build of the GEOPM repository:
 

--- a/service/docs/source/docu.rst
+++ b/service/docs/source/docu.rst
@@ -1,27 +1,25 @@
-Guide for GEOPM Documentation
-=============================
-These are the style guidelines for writing or modifying rst source files for
-GEOPM.  See :ref:`devel:Creating Manuals` section of the :doc:`Guide for GEOPM
-Developers <devel>` for information on how to add the new files to the build
-properly.
+GEOPM Documentation Guidelines
+==============================
 
-Some of these rules (:ref:`section ordering <docu:Section Ordering>` and the
-property list in :ref:`low-level signals/controls <docu:Signals/Controls (low
-level)>`) can be tested with the ``geopmlint`` Sphinx builder. Run ``make
-docs_geopmlint`` to run those checks. Edit
-``service/docs/source/_ext/geopmlint.py`` if you need to modify those checks.
+This guide outline the style specifications for writing or amending reStructuredText (rst) source files for
+the GEOPM project. Please refer to the :ref:`devel:Creating Manuals` section in the :doc:`Guide for GEOPM
+Developers <devel>` for detailed instructions on properly adding new files to the build.
+
+Certain rules such as :ref:`section ordering <docu:Section Ordering>` and the
+property list mentioned in :ref:`low-level signals/controls <docu:Signals/Controls (low
+level)>`, can be verified using the ``geopmlint`` Sphinx builder. Execute ``make
+docs_geopmlint`` command to perform those checks. If it's necessary to alter these checks,
+modify ``service/docs/source/_ext/geopmlint.py``.
 
 Whitespace
 ----------
-Minimize the amount of whitespace (carriage returns, spaces, and indentation)
-present in the source file.  Only use the necessary amount of whitespace to
-satisfy the rst compiler for what you are trying to do.
+Strive to reduce the usage of whitespace (carriage returns, spaces, and indentation)
+present in the source file. Use only the necessary amount of whitespace required by the rs compiler for your goal.
 
 Sections
 --------
-Follow the `Sphinx Documentation for Sections
-<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections>`_,
-namely:
+Adhere the `Sphinx Documentation for Sections
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections>`, explicitly:
 
   * ``=`` for page titles
   * ``-`` for sections within a page
@@ -30,7 +28,7 @@ namely:
 
 Section Ordering
 ----------------
-For chapter 7 man pages of IOGroups, follow the following ordering:
+For Chapter 7 man pages related to IOGroups, follow the following sequence:
 
 1. Description
 2. Requirements
@@ -45,24 +43,24 @@ For chapter 7 man pages of IOGroups, follow the following ordering:
 
 Signals/Controls (low level)
 ----------------------------
-Use the following code as an example:
+Use the following code as an illustration:
 
 .. code-block:: rst
 
    ``PROFILE::TIME_HINT_UNKNOWN``
-       The total amount of time that a CPU was measured to be running with this
-       hint value on the Linux logical CPU specified.
+       The aggregate time that a CPU was monitored while working with this
+       specific hint value on the designated Linux logical CPU.
 
        * **Aggregation**: average
        * **Domain**: cpu
        * **Format**: double
        * **Unit**: seconds
 
-That block will render as follows:
+This will appear as:
 
 ``PROFILE::TIME_HINT_UNKNOWN``
-    The total amount of time that a CPU was measured to be running with this
-    hint value on the Linux logical CPU specified.
+    The aggregate time that a CPU was monitored while working with this
+    specific hint value on the designated Linux logical CPU.
 
     * **Aggregation**: average
     * **Domain**: cpu
@@ -72,66 +70,66 @@ That block will render as follows:
 MSR Signals and controls
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Document MSRs in their respective ``msr_data_*.json`` files. Use the
-``geopm-msr-json`` directive to insert the formatted documentation from a json
-definition into a ``rst`` file. For example:
+MSRs should be documented in their related ``msr_data_*.json`` file. Apply the
+``geopm-msr-json`` to extract the formatted documentation from a JSON
+definition into a ``rst`` file. See the examples below:
 
 .. code-block:: rst
-   :caption: Render all MSRs in a json file
+   :caption: All MSRs in a json file
 
    .. geopm-msr-json:: ../json_data/msr_data_arch.json
 
 .. code-block:: rst
-   :caption: Render only signals from a json file
+   :caption: Only signals from a json file
 
    .. geopm-msr-json:: ../json_data/msr_data_arch.json
       :no-controls:
 
 .. code-block:: rst
-   :caption: Render only controls from a json file
+   :caption: Only controls from a json file
 
    .. geopm-msr-json:: ../json_data/msr_data_arch.json
       :no-signals:
 
-If you need to modify the output format of the ``geopm-msr-json`` directive,
-edit the ``GeopmMsrJson`` class in the
+To change the output format of the ``geopm-msr-json`` directive,
+revise the ``GeopmMsrJson`` class in the
 ``service/docs/source/_ext/geopm_rst_extensions.py`` Sphinx extension.
 
 Aliases
 -------
-The IOGroup specific chapter 7 pages should document how the high level
-alias relates to the signals or controls provided by said IOGroup.
-Use the following code as an example for 1-to-1 mappings:
+The Chapter 7 pages particular to IOGroup should describe how the high-level
+alias corresponds to the signals or controls provided by that IOGroup.
+This is an example of a direct 1-to-1 mapping:
 
 .. code-block:: rst
 
    ``CPU_FREQUENCY_MAX_AVAIL``
-       Maps to ``MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0``
+       Corresponds to ``MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0``
 
-That block will render as follows:
+It will display as:
 
 ``CPU_FREQUENCY_MAX_AVAIL``
-    Maps to ``MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0``
+    Corresponds to ``MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0``
 
-If the alias does not directly map, then a further explanation of how the alias
-is implemented is provided in the IOGroup specific page.
+If the alias does not have a straightforward mapping, then an expanded explanation of how the alias
+is implemented should be provided in the IOGroup specific page.
 
-The :doc:`geopm_pio(7) <geopm_pio.7>` page should document the high level alias
-in detail with full sentences.  Use the following code as an example:
+The :doc:`geopm_pio(7) <geopm_pio.7>` page should explain the high-level alias
+in full sentence descriptions. Here's an example:
 
 .. code-block:: rst
 
    ``CPU_FREQUENCY_MAX_AVAIL``
-       Maximum processor frequency.
+       Maximum available processor frequency.
 
-That block will render as follows:
+It will render as:
 
 ``CPU_FREQUENCY_MAX_AVAIL``
-    Maximum processor frequency.
+    Maximum available processor frequency.
 
 Examples
 --------
-See the following pages for examples of the style to follow:
+For style reference, consult the following pages:
 
 :doc:`geopm_pio_profile(7) <geopm_pio_profile.7>`,
 :doc:`geopm_pio(3) <geopm_pio.3>`,

--- a/service/docs/source/docu.rst
+++ b/service/docs/source/docu.rst
@@ -18,7 +18,7 @@ Whitespace
 
 Strive to minimize the usage of whitespace (carriage returns, spaces, and
 indentation) in the source file. Use only the necessary amount of whitespace
-as required for readability or by the rs compiler for your goal.
+as required for readability or by the reStructuredText compiler for your goal.
 
 Columns in a Line
 -----------------

--- a/service/docs/source/docu.rst
+++ b/service/docs/source/docu.rst
@@ -24,7 +24,7 @@ Columns in a Line
 -----------------
 
 The number of columns in a source file should not exceed 70 or 80 before
-wrapping the line.  Exceptions are allowed when it is required for compliation
+wrapping the line.  Exceptions are allowed when it is required for compilation
 or similar.  In general, follow the style in the file you are modifying.
 
 Sections

--- a/service/docs/source/docu.rst
+++ b/service/docs/source/docu.rst
@@ -1,25 +1,38 @@
 GEOPM Documentation Guidelines
 ==============================
 
-This guide outline the style specifications for writing or amending reStructuredText (rst) source files for
-the GEOPM project. Please refer to the :ref:`devel:Creating Manuals` section in the :doc:`Guide for GEOPM
-Developers <devel>` for detailed instructions on properly adding new files to the build.
+This guide outlines the style specifications for writing or amending
+reStructuredText (rst) source files for the GEOPM project. Please refer to the
+:ref:`devel:Creating Manuals` section in the :doc:`Guide for GEOPM Developers
+<devel>` for detailed instructions on properly adding new files to the build.
 
 Certain rules such as :ref:`section ordering <docu:Section Ordering>` and the
-property list mentioned in :ref:`low-level signals/controls <docu:Signals/Controls (low
-level)>`, can be verified using the ``geopmlint`` Sphinx builder. Execute ``make
-docs_geopmlint`` command to perform those checks. If it's necessary to alter these checks,
-modify ``service/docs/source/_ext/geopmlint.py``.
+property list mentioned in :ref:`low-level signals/controls
+<docu:Signals/Controls (low level)>`, can be verified using the ``geopmlint``
+Sphinx builder. Execute ``make docs_geopmlint`` command to perform these checks.
+If it's necessary to alter these checks, modify
+``service/docs/source/_ext/geopmlint.py``.
 
 Whitespace
 ----------
-Strive to reduce the usage of whitespace (carriage returns, spaces, and indentation)
-present in the source file. Use only the necessary amount of whitespace required by the rs compiler for your goal.
+
+Strive to minimize the usage of whitespace (carriage returns, spaces, and
+indentation) in the source file. Use only the necessary amount of whitespace
+as required for readability or by the rs compiler for your goal.
+
+Columns in a Line
+-----------------
+
+The number of columns in a source file should not exceed 70 or 80 before
+wrapping the line.  Exceptions are allowed when it is required for compliation
+or similar.  In general, follow the style in the file you are modifying.
 
 Sections
 --------
-Adhere the `Sphinx Documentation for Sections
-<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections>`, explicitly:
+
+Adhere to the `Sphinx Documentation for Sections
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections>`,
+explicitly:
 
   * ``=`` for page titles
   * ``-`` for sections within a page
@@ -71,7 +84,7 @@ MSR Signals and controls
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 MSRs should be documented in their related ``msr_data_*.json`` file. Apply the
-``geopm-msr-json`` to extract the formatted documentation from a JSON
+``geopm-msr-json`` directive to extract the formatted documentation from a JSON
 definition into a ``rst`` file. See the examples below:
 
 .. code-block:: rst
@@ -97,7 +110,7 @@ revise the ``GeopmMsrJson`` class in the
 
 Aliases
 -------
-The Chapter 7 pages particular to IOGroup should describe how the high-level
+The Chapter 7 pages particular to an IOGroup should describe how the high-level
 alias corresponds to the signals or controls provided by that IOGroup.
 This is an example of a direct 1-to-1 mapping:
 
@@ -111,8 +124,9 @@ It will display as:
 ``CPU_FREQUENCY_MAX_AVAIL``
     Corresponds to ``MSR::TURBO_RATIO_LIMIT:MAX_RATIO_LIMIT_0``
 
-If the alias does not have a straightforward mapping, then an expanded explanation of how the alias
-is implemented should be provided in the IOGroup specific page.
+If the alias does not have a straightforward mapping, then an expanded
+explanation of how the alias is implemented should be provided in the IOGroup
+specific page.
 
 The :doc:`geopm_pio(7) <geopm_pio.7>` page should explain the high-level alias
 in full sentence descriptions. Here's an example:

--- a/service/docs/source/geopm_pio_msr.7.rst
+++ b/service/docs/source/geopm_pio_msr.7.rst
@@ -96,7 +96,7 @@ Skylake (SKX) Signals
     of PCNT divided by the derivative of ACNT over 8 samples.
 
     *  **Aggregation**: average
-    *  **Domain**: matches MSR::PPERF:PCNT
+    *  **Domain**: cpu
     *  **Format**: double
     *  **Unit**: none
 

--- a/service/docs/source/geopm_pio_nvml.7.rst
+++ b/service/docs/source/geopm_pio_nvml.7.rst
@@ -129,6 +129,7 @@ Signals
 
 ``NVML::GPU_CORE_FREQUENCY_STEP``
     The Streaming Multiprocessor frequency step size in hertz.  The average step size is provided in the case where the step size is variable.
+
     *  **Aggregation**: expect_same
     *  **Domain**: gpu
     *  **Format**: double

--- a/service/docs/source/index.rst
+++ b/service/docs/source/index.rst
@@ -3,7 +3,6 @@
 Welcome to GEOPM
 ================
 
-
 The Global Extensible Open Power Manager (GEOPM) serves as a framework for
 investigating energy and power optimizations geared towards heterogeneous
 platforms. It offers a whole range of built-in functions. A basic use case
@@ -33,4 +32,3 @@ To get the latest source code clone the git repository:
    contrib
    devel
    reference
-

--- a/service/docs/source/index.rst
+++ b/service/docs/source/index.rst
@@ -4,27 +4,25 @@ Welcome to GEOPM
 ================
 
 
-The Global Extensible Open Power Manager (GEOPM) is a framework for exploring
-power and energy optimizations targeting heterogeneous platforms. The GEOPM
-package provides many built-in features. A simple use case is reading hardware
-counters and setting hardware controls with platform independent syntax using
-a command line tool on a particular compute node. An advanced use case is
-dynamically coordinating hardware settings across all compute nodes used by a
-distributed application in response to the application's behavior and requests
-from the resource manager.
-
+The Global Extensible Open Power Manager (GEOPM) serves as a framework for
+investigating energy and power optimizations geared towards heterogeneous
+platforms. It offers a whole range of built-in functions. A basic use case
+could be reading hardware counters and configuring hardware controls using a
+command line tool on a specific compute node with platform independent syntax.
+On the other hand, an advanced example includes dynamically synchronizing
+hardware settings across all compute nodes of a distributed application in
+response to the application's behavior and requests from the resource manager.
 
 .. image:: https://geopm.github.io/images/github-button.png
    :target: https://github.com/geopm/geopm
    :width: 200
    :alt: View on Github
 
-For access to the latest source code clone the git repo:
+To get the latest source code clone the git repository:
 
 .. code-block:: bash
 
     $ git clone https://github.com/geopm/geopm.git
-
 
 .. toctree::
    :maxdepth: 1
@@ -35,3 +33,4 @@ For access to the latest source code clone the git repo:
    contrib
    devel
    reference
+

--- a/service/docs/source/install.rst
+++ b/service/docs/source/install.rst
@@ -1,115 +1,91 @@
+Service Installation Guide
+==========================
 
-Guide to Service Installation
-=============================
+Each time specified branches hosted on GitHub are updated, continuous
+integration generates packages for numerous Linux distributions. This
+process is uses GitHub Actions, combined with the OpenSUSE Build Service
+(OBS). Here are the packages curated by OBS:
 
-Continuous integration creates packages for a variety of Linux
-distributions each time certain branches hosted on GitHub are updated.
-This is supported by GitHub Actions, in conjunction with the OpenSUSE
-Build Service (OBS).
+- ``geopm-service``: Sets up and enables the geopm systemd service.
+- ``libgeopmd2``: Provides the library that supports the PlatformIO interface.
+- ``python3-geopmdpy``: Houses the implementation of geopmd, CLI utilities, and bindings for PlatformIO.
+- ``geopm-service-devel``: Provides headers and man pages for C and C++ APIs supportable by ``libgeopmd2``.
 
-Packages built by OBS:
+Besides these routinely curated packages, the download repositories also grant
+access to ``python3-dasbus`` version 1.6. This version is a prerequisite
+for ``python3-geopmdpy``, but not included by the supported Linux distributions.
 
-- ``geopm-service``:
-   Installs and activates the geopm systemd service
-- ``libgeopmd2``:
-   Provides the library that supports the PlatformIO interface
-- ``python3-geopmdpy``:
-   Implementation of geopmd, CLI tools, and bindings for PlatformIO
-- ``geopm-service-devel``:
-   Headers and man pages for C and C++ APIs provided by ``libgeopmd2``
-
-In addition to these packages that are built each time a tracked
-branch is updated, the download repositories also provide
-``python3-dasbus`` version 1.6.  This version of dasbus is required by
-``python3-geopmdpy``, and is not provided by the supported Linux
-distributions.
-
-Installing the ``geopm-service`` package will also install the
-``libgeopmd2``, ``python3-geopmdpy`` and ``python3-dasbus`` dependency
-packages.  The ``geopm-service-devel`` package must be explicitly
-installed if it is required by the user.
+Installation of ``geopm-service`` will involve the dependency packages:
+``libgeopmd2``, ``python3-geopmdpy`` and ``python3-dasbus``. However, explicit
+installation is obligatory for anyone seeking to use ``geopm-service-devel``.
 
 
-Level Zero Prerequisite
------------------------
+Prerequisites for Level Zero
+----------------------------
 
-Before installing the GEOPM Service packages, the ``level-zero``
-package must be installed.  This package enables GEOPM's support for
-GPU metrics and controls.  The ``level-zero`` package is not currently
-provided upstream by the Linux distributions that GEOPM supports.
-Please follow the
-`Intel(R) GPGPU software package installation guide for Linux <https://dgpu-docs.intel.com/installation-guides/index.html>`__
-to install the ``level-zero`` package on your system.  The linked
-guide shows how to add the OS appropriate package management
-repository to your system.  Once the repository has been added, use
-``yum`` or ``zypper`` to install the ``level-zero`` package.  Only the
-``level-zero`` package is required, there is no GEOPM requirement to
-install any of the other packages mentioned in the guides linked
-above.  Installing the ``level-zero-devel`` package will enable the
-user to build GEOPM from source with GPU support if that is desired.
+Before you install the GEOPM Service packages, ensure you have the
+``level-zero`` package. This package supports GEOPM for GPU metrics and
+controls. Currently, none of the Linux distributions supporting GEOPM
+provide this package upstream.
+
+To install ``level-zero``, use the `Intel(R)
+GPGPU software package installation guide for Linux
+<https://dgpu-docs.intel.com/installation-guides/index.html>`__. Once
+added your system's OS appropriate package management repository,
+you can use ``yum`` or ``zypper`` to install the package. Note that the
+``level-zero-devel`` package is optional unless building GEOPM from source
+with GPU support is intended.
 
 
 Download Repositories
 ---------------------
 
+The ``release-v2.0`` branch logs v2.0 releases, including any potential
+hotfixes for v2.0.0. It captures the latest stable GEOPM release. The ``dev``
+branch, however, presents the most updated stable development. Builds from
+these two branches have the following download repository pages:
 
-The ``release-v2.0`` branch tracks the v2.0 release including any
-hotfix releases for v2.0.0 that could occur in the future.  This
-represents the latest stable GEOPM release.  The ``dev`` branch is the
-default branch containing the most up to date stable development.  The
-builds from these two branches have the following download repository
-pages:
-
-- Install Release Packages (``release-v2.0`` branch)
+- Release Packages Installation (``release-v2.0`` branch)
    + `geopm-service <https://software.opensuse.org/download.html?project=home%3Ageopm%3Arelease-v2.0&package=geopm-service>`__
    + `libgeopmd2 <https://software.opensuse.org/download.html?project=home%3Ageopm%3Arelease-v2.0&package=libgeopmd2>`__
    + `python3-geopmdpy <https://software.opensuse.org/download.html?project=home%3Ageopm%3Arelease-v2.0&package=python3-geopmdpy>`__
    + `geopm-service-devel <https://software.opensuse.org/download.html?project=home%3Ageopm%3Arelease-v2.0&package=geopm-service-devel>`__
 
-- Install Development Packages (``dev`` branch)
+- Development Packages Installation (``dev`` branch)
    + `geopm-service <https://software.opensuse.org/download.html?project=home%3Ageopm&package=geopm-service>`__
    + `libgeopmd2 <https://software.opensuse.org/download.html?project=home%3Ageopm&package=libgeopmd2>`__
    + `python3-geopmdpy <https://software.opensuse.org/download.html?project=home%3Ageopm&package=python3-geopmdpy>`__
    + `geopm-service-devel <https://software.opensuse.org/download.html?project=home%3Ageopm&package=geopm-service-devel>`__
 
+Use the provided links to install GEOPM Service packages on your system. The
+links will also guide you through instructions for each supported operating
+system. If you add both the development repository and the release repository
+to your package configuration, you will always receive updates from the
+development branch.
 
 
-Use these links to install the GEOPM Service packages on your system.  The
-links contain instructions and examples for each of the supported operating
-systems.
+What the Packages Don't Include
+-------------------------------
 
-Note that the development branch always provides a version which is at
-least as recent as the release branch.  For this reason, updates will
-always come from the development branch download repository if both
-the development repository and the release repository are added to
-your package configuration.
+Please note that the packages listed above do not offer the :doc:`GEOPM HPC
+Runtime <runtime>` features (e.g. :doc:`geopmlaunch(1) <geopmlaunch.1>`,
+:doc:`geopm_prof(3) <geopm_prof.3>`, :doc:`geopm_report(7) <geopm_report.7>`,
+``libgeopm.so`` and others.)
 
+The GEOPM HPC Runtime should be built against a specific implementation of
+MPI, often unique to the system running the HPC application. An exception to
+this rule is the OpenHPC distribution. We've packaged GEOPM version 1 with
+`OpenHPC releases <http://openhpc.community/downloads/>`_, and we hope to
+offer version 2 in the future.
 
-Un-packaged Features
---------------------
+The packages above don't provide support for NVIDIA GPUs with NVML or
+DCGM. This support depends on libraries not included in the OpenSUSE OBS
+build system where the GEOPM packages are curated. To enable the use of NVML,
+or DCGM, you will need to source-build the GEOPM Service, which requires
+an environment supporting the dependency libraries and headers.
 
-The packages described above do not provide the
-:doc:`GEOPM HPC Runtime <runtime>` features (e.g.
-:doc:`geopmlaunch(1) <geopmlaunch.1>`, :doc:`geopm_prof(3) <geopm_prof.3>`,
-:doc:`geopm_report(7) <geopm_report.7>`, ``libgeopm.so``, etc.).
-The GEOPM HPC Runtime must be built against a particular implementation of the
-Message Passing Interface (MPI).  Typically the implementation of MPI is
-specific to the system where the HPC application is being run.  An exception
-to this rule is the OpenHPC distribution.  GEOPM version 1 has been packaged
-with `OpenHPC releases <http://openhpc.community/downloads/>`_, and we hope to distribute version 2 with OpenHPC in the future.
-For users interested in GEOPM version 2, a source build is required.
-
-Support for NVIDIA GPUs with NVML or DCGM is also not provided by
-installing the packages described above.  Support for NVIDIA GPUs
-relies on libraries that are not bundled with the OpenSUSE OBS build
-system where the GEOPM packages are built and distributed.  A source
-build of the GEOPM Service is required to enable use of NVML, or DCGM.
-This build process must be done in an environment where the dependency
-libraries and headers are present.
-
-In order to access these GEOPM features which are not packaged, a user should
-build GEOPM from source.  The best recommendation for building GEOPM from
-source is to follow the :ref:`developer build process <devel:developer build process>`
-posted in the :doc:`developer guide <devel>`.  Note that it may be of interest
-to git checkout a git tag (e.g. ``v2.0.0``) to create a build based on a
-particular release.
+For GEOPM features not included in these packages, build GEOPM from
+source. The best instructions for this process can be found in the
+:ref:`developer build process <devel:developer build process>` within the
+:doc:`developer guide <devel>`. Keep in mind that you may need to git checkout
+a git tag (e.g. ``v2.0.0``) to create a build based on a specific release.

--- a/service/docs/source/install.rst
+++ b/service/docs/source/install.rst
@@ -1,5 +1,5 @@
-Service Installation Guide
-==========================
+Installation
+============
 
 Each time specified branches hosted on GitHub are updated, continuous
 integration generates packages for numerous Linux distributions. This

--- a/service/docs/source/install.rst
+++ b/service/docs/source/install.rst
@@ -93,12 +93,6 @@ See below for download repository information for your Linux distribution.
 SLES, OpenSUSE, and CentOS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. warning::
-
-   The following links and branches need to be double checked prior to
-   publishing.  The 3.0 configurations still need to be created on OBS, and
-   need to be mapped in GH CI.
-
 When using the below links, it is preferable to click on your desired OS and
 follow the procedure for "Add repositoriy and install manually".  If you do
 this, installing the ``geopm-service`` package will automatically install the
@@ -116,16 +110,16 @@ package manager, you must specify all of the required packages at install time
    is added.
 
 - Release Packages (``release-v3.0`` branch - Intel GPU support via levelzero)
-   + geopm-service
-   + libgeopm2
-   + python3-geopmdpy
-   + geopm-service-devel
+   + `geopm-service <https://software.opensuse.org//download.html?project=home%3Ageopm%3Arelease%3Asupplementary&package=geopm-service>`__
+   + `libgeopm2 <https://software.opensuse.org//download.html?project=home%3Ageopm%3Arelease%3Asupplementary&package=libgeopmd2>`__
+   + `python3-geopmdpy <https://software.opensuse.org//download.html?project=home%3Ageopm%3Arelease%3Asupplementary&package=python3-geopmdpy>`__
+   + `geopm-service-devel <https://software.opensuse.org//download.html?project=home%3Ageopm%3Arelease%3Asupplementary&package=geopm-service-devel>`__
 
 - Release Packages (``release-v3.0`` branch - no GPU support)
-   + geopm-service
-   + libgeopm2
-   + python3-geopmdpy
-   + geopm-service-devel
+   + `geopm-service <https://software.opensuse.org//download.html?project=home%3Ageopm%3Arelease&package=geopm-service>`__
+   + `libgeopm2 <https://software.opensuse.org//download.html?project=home%3Ageopm%3Arelease&package=libgeopmd2>`__
+   + `python3-geopmdpy <https://software.opensuse.org//download.html?project=home%3Ageopm%3Arelease&package=python3-geopmdpy>`__
+   + `geopm-service-devel <https://software.opensuse.org//download.html?project=home%3Ageopm%3Arelease&package=geopm-service-devel>`__
 
 - Development Packages (``dev`` branch - Intel GPU support via levelzero)
    + `geopm-service <https://software.opensuse.org/download.html?project=home%3Ageopm%3Asupplementary&package=geopm-service>`__

--- a/service/docs/source/install.rst
+++ b/service/docs/source/install.rst
@@ -149,30 +149,48 @@ package manager, you must specify all of the required packages at install time
 Ubuntu
 ^^^^^^
 
-Presently, there is only one configuration of GEOPM available for installation
-on Ubuntu.  It is tied to the ``dev`` branch,  built with Nvidia support only,
-and can be utilized via the following commands:
+There are 2 repostories that are maintained for GEOPM support on Ubuntu: one
+corresponding to the ``release-v3.0`` branch while the other corresponds to the
+``dev`` branch.  Both are built with Nvidia GPU support **only**.
+
+First, add the necessary upstream repository:
 
 .. code-block:: bash
 
-    # Add the upstream repo
-    $ add-apt-repository ppa:cmcantal/geopm-dev
-    $ apt update
+    # ONLY DO ONE OF THE FOLLOWING add-apt-repository COMMANDS:
+
+    # Add the release repo:
+    $ sudo add-apt-repository ppa:geopm/release
+    # OR add tre dev repo:
+    $ sudo add-apt-repository ppa:geopm/dev
+
+Then pull all the current updates, install GEOPM, start/enable the service, and
+configure the initial access lists:
+
+.. code-block:: bash
+
+    $ sudo apt update
     $ apt install geopm-service libgeopmd-dev libgeopmd2 python3-geopmdpy
     # Start and enable the service
-    $ systemctl start geopm
-    $ systemctl enable geopm
+    $ sudo systemctl start geopm
+    $ sudo systemctl enable geopm
     # Setup initial access: all users can access all signals and controls
-    $ geopmaccess -a | geopmaccess -w
-    $ geopmaccess -ac | geopmaccess -wc
+    $ sudo geopmaccess -a | sudo geopmaccess -w
+    $ sudo geopmaccess -ac | sudo geopmaccess -wc
 
-For more information see: `GEOPM repo on Launchpad
-<https://launchpad.net/~cmcantal/+archive/ubuntu/geopm-dev>`__
+For more information see:
 
-.. note::
+ * `GEOPM release repo on Launchpad
+   <https://launchpad.net/~geopm/+archive/ubuntu/release>`__
+ * `GEOPM dev repo on Launchpad
+   <https://launchpad.net/~geopm/+archive/ubuntu/dev>`__
 
-   Source builds that use ``--enable-nvml`` require the following package to be
-   installed: ``libnvidia-ml-dev``
+
+.. MOVE TO SOURCE BUILD PAGE
+.. .. note::
+
+..    Source builds that use ``--enable-nvml`` require the following package to be
+..    installed: ``libnvidia-ml-dev``
 
 ----
 

--- a/service/docs/source/install.rst
+++ b/service/docs/source/install.rst
@@ -141,7 +141,7 @@ package manager, you must specify all of the required packages at install time
 
 .. warning::
 
-   Do not add more than one of the above repostories to your system package
+   Do not add more than one of the above repositories to your system package
    manager at the same time.  Only add one, and ensure all GEOPM packages are
    completely removed from the system when changing GEOPM repo configuration in
    the package manager.
@@ -149,7 +149,7 @@ package manager, you must specify all of the required packages at install time
 Ubuntu
 ^^^^^^
 
-There are 2 repostories that are maintained for GEOPM support on Ubuntu: one
+There are 2 repositories that are maintained for GEOPM support on Ubuntu: one
 corresponding to the ``release-v3.0`` branch while the other corresponds to the
 ``dev`` branch.  Both are built with Nvidia GPU support **only**.
 
@@ -161,7 +161,7 @@ First, add the necessary upstream repository:
 
     # Add the release repo:
     $ sudo add-apt-repository ppa:geopm/release
-    # OR add tre dev repo:
+    # OR add the dev repo:
     $ sudo add-apt-repository ppa:geopm/dev
 
 Then pull all the current updates, install GEOPM, start/enable the service, and

--- a/service/docs/source/install.rst
+++ b/service/docs/source/install.rst
@@ -11,81 +11,197 @@ process is uses GitHub Actions, combined with the OpenSUSE Build Service
 - ``python3-geopmdpy``: Houses the implementation of geopmd, CLI utilities, and bindings for PlatformIO.
 - ``geopm-service-devel``: Provides headers and man pages for C and C++ APIs supportable by ``libgeopmd2``.
 
-Besides these routinely curated packages, the download repositories also grant
-access to ``python3-dasbus`` version 1.6. This version is a prerequisite
-for ``python3-geopmdpy``, but not included by the supported Linux distributions.
-
 Installation of ``geopm-service`` will involve the dependency packages:
 ``libgeopmd2``, ``python3-geopmdpy`` and ``python3-dasbus``. However, explicit
 installation is obligatory for anyone seeking to use ``geopm-service-devel``.
 
+.. note::
+
+    Besides these routinely curated packages, the download repositories also
+    grant access to ``python3-dasbus`` version 1.6. This version is a
+    prerequisite for ``python3-geopmdpy``, but it is not included by some of
+    the Linux distributions that support GEOPM.  In particular, starting with
+    SLES 15.4 the necessary ``python3-dasbus`` version is available in the
+    regular package repositories.  This support will be removed from OBS in
+    a future release.
+
+----
+
+GPU Support
+-----------
+
+In order to leverage the GEOPM Service's support for GPUs, you must install the
+necessary libraries for either Intel GPUs (levelzero) or Nvidia GPUs (NVML).
 
 Prerequisites for Level Zero
-----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Before you install the GEOPM Service packages, ensure you have the
-``level-zero`` package. This package supports GEOPM for GPU metrics and
-controls. Currently, none of the Linux distributions supporting GEOPM
-provide this package upstream.
+``levelzero`` allows GEOPM to read metrics and enact controls from Intel GPUs.
+Currently, none of the Linux distributions supporting GEOPM provide this
+package upstream.
 
-To install ``level-zero``, use the `Intel(R)
-GPGPU software package installation guide for Linux
-<https://dgpu-docs.intel.com/installation-guides/index.html>`__. Once
-added your system's OS appropriate package management repository,
-you can use ``yum`` or ``zypper`` to install the package. Note that the
-``level-zero-devel`` package is optional unless building GEOPM from source
-with GPU support is intended.
+To install ``level-zero``, use the one of the following:
 
+For up-to-date distributions (e.g. SLES 15.4 and Ubuntu 22.04):
+
+* `Intel(R) software for general purpose GPU capabilities
+  <https://dgpu-docs.intel.com/driver/installation.html>`__
+
+For older, deprecated distributions (e.g. SLES 15.3 and Ubuntu 20.04):
+
+* `Intel(R) software for general purpose GPU capabilities
+  <https://dgpu-docs.intel.com/installation-guides/index.html>`__
+
+Once added your system's OS appropriate package management repository, you can
+use ``yum``, ``zypper``, or ``apt`` to install the package.
+
+.. note::
+
+   The ``level-zero-devel`` package is optional unless building GEOPM from
+   source with GPU support.
+
+Prerequisites for NVML
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. TODO Include blurb about DCGM, where to get it, and why it's important.
+   This only makes sense if/when we build with DCGM in something that is packaged
+   on Launchpad or OBS.
+
+To build with support for Nvidia's GPUs please follow their installation guide
+for CUDA here:
+
+* `NVIDIA CUDA Installation Guide for Linux
+  <https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html>`__
+
+.. note::
+
+   Source builds that use ``--enable-nvml`` require the following package to be
+   installed: ``libnvidia-ml-dev``
+
+----
 
 Download Repositories
 ---------------------
 
-The ``release-v2.0`` branch logs v2.0 releases, including any potential
-hotfixes for v2.0.0. It captures the latest stable GEOPM release. The ``dev``
-branch, however, presents the most updated stable development. Builds from
-these two branches have the following download repository pages:
+The ``release-v3.0`` branch tracks the v3.0 GEOPM release, including any
+potential hotfixes that could occur in the future. It captures the latest
+stable GEOPM release.
 
-- Release Packages Installation (``release-v2.0`` branch)
-   + `geopm-service <https://software.opensuse.org/download.html?project=home%3Ageopm%3Arelease-v2.0&package=geopm-service>`__
-   + `libgeopmd2 <https://software.opensuse.org/download.html?project=home%3Ageopm%3Arelease-v2.0&package=libgeopmd2>`__
-   + `python3-geopmdpy <https://software.opensuse.org/download.html?project=home%3Ageopm%3Arelease-v2.0&package=python3-geopmdpy>`__
-   + `geopm-service-devel <https://software.opensuse.org/download.html?project=home%3Ageopm%3Arelease-v2.0&package=geopm-service-devel>`__
+The ``dev`` branch, however, presents the most up-to-date stable development.
+See below for download repository information for your Linux distribution.
 
-- Development Packages Installation (``dev`` branch)
+SLES, OpenSUSE, and CentOS
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+
+   The following links and branches need to be double checked prior to
+   publishing.  The 3.0 configurations still need to be created on OBS, and
+   need to be mapped in GH CI.
+
+When using the below links, it is preferable to click on your desired OS and
+follow the procedure for "Add repositoriy and install manually".  If you do
+this, installing the ``geopm-service`` package will automatically install the
+remaining dependencies (e.g. ``libgeopmd2``, etc.).  If required for source
+builds, you still must manually install ``geopm-service-devel``.
+
+While you *can* download the binary packages directly and install through your
+package manager, you must specify all of the required packages at install time
+(i.e. ``geopm-service``, ``libgeopmd2``, ``python3-geopmdpy``, and optionally
+``geopm-service-devel``).
+
+.. note::
+
+   You will not automatically pull updates and bug fixes unless the repository
+   is added.
+
+- Release Packages (``release-v3.0`` branch - Intel GPU support via levelzero)
+   + geopm-service
+   + libgeopm2
+   + python3-geopmdpy
+   + geopm-service-devel
+
+- Release Packages (``release-v3.0`` branch - no GPU support)
+   + geopm-service
+   + libgeopm2
+   + python3-geopmdpy
+   + geopm-service-devel
+
+- Development Packages (``dev`` branch - Intel GPU support via levelzero)
+   + `geopm-service <https://software.opensuse.org/download.html?project=home%3Ageopm%3Asupplementary&package=geopm-service>`__
+   + `libgeopmd2 <https://software.opensuse.org/download.html?project=home%3Ageopm%3Asupplementary&package=libgeopmd2>`__
+   + `python3-geopmdpy <https://software.opensuse.org/download.html?project=home%3Ageopm%3Asupplementary&package=python3-geopmdpy>`__
+   + `geopm-service-devel <https://software.opensuse.org/download.html?project=home%3Ageopm%3Asupplementary&package=geopm-service-devel>`__
+
+- Development Packages (``dev`` branch - no GPU support)
    + `geopm-service <https://software.opensuse.org/download.html?project=home%3Ageopm&package=geopm-service>`__
    + `libgeopmd2 <https://software.opensuse.org/download.html?project=home%3Ageopm&package=libgeopmd2>`__
    + `python3-geopmdpy <https://software.opensuse.org/download.html?project=home%3Ageopm&package=python3-geopmdpy>`__
    + `geopm-service-devel <https://software.opensuse.org/download.html?project=home%3Ageopm&package=geopm-service-devel>`__
 
-Use the provided links to install GEOPM Service packages on your system. The
-links will also guide you through instructions for each supported operating
-system. If you add both the development repository and the release repository
-to your package configuration, you will always receive updates from the
-development branch.
+.. warning::
 
+   Do not add more than one of the above repostories to your system package
+   manager at the same time.  Only add one, and ensure all GEOPM packages are
+   completely removed from the system when changing GEOPM repo configuration in
+   the package manager.
+
+Ubuntu
+^^^^^^
+
+Presently, there is only one configuration of GEOPM available for installation
+on Ubuntu.  It is tied to the ``dev`` branch,  built with Nvidia support only,
+and can be utilized via the following commands:
+
+.. code-block:: bash
+
+    # Add the upstream repo
+    $ add-apt-repository ppa:cmcantal/geopm-dev
+    $ apt update
+    $ apt install geopm-service libgeopmd-dev libgeopmd2 python3-geopmdpy
+    # Start and enable the service
+    $ systemctl start geopm
+    $ systemctl enable geopm
+    # Setup initial access: all users can access all signals and controls
+    $ geopmaccess -a | geopmaccess -w
+    $ geopmaccess -ac | geopmaccess -wc
+
+For more information see: `GEOPM repo on Launchpad
+<https://launchpad.net/~cmcantal/+archive/ubuntu/geopm-dev>`__
+
+.. note::
+
+   Source builds that use ``--enable-nvml`` require the following package to be
+   installed: ``libnvidia-ml-dev``
+
+----
 
 What the Packages Don't Include
 -------------------------------
 
-Please note that the packages listed above do not offer the :doc:`GEOPM HPC
-Runtime <runtime>` features (e.g. :doc:`geopmlaunch(1) <geopmlaunch.1>`,
+Please note that the packages listed above do not offer the :doc:`GEOPM Runtime
+<runtime>` features (e.g. :doc:`geopmlaunch(1) <geopmlaunch.1>`,
 :doc:`geopm_prof(3) <geopm_prof.3>`, :doc:`geopm_report(7) <geopm_report.7>`,
 ``libgeopm.so`` and others.)
 
-The GEOPM HPC Runtime should be built against a specific implementation of
-MPI, often unique to the system running the HPC application. An exception to
-this rule is the OpenHPC distribution. We've packaged GEOPM version 1 with
-`OpenHPC releases <http://openhpc.community/downloads/>`_, and we hope to
-offer version 2 in the future.
+For information on how to install the GEOPM Runtime, see :doc:`GEOPM Runtime
+<runtime>`.
 
-The packages above don't provide support for NVIDIA GPUs with NVML or
-DCGM. This support depends on libraries not included in the OpenSUSE OBS
-build system where the GEOPM packages are curated. To enable the use of NVML,
-or DCGM, you will need to source-build the GEOPM Service, which requires
-an environment supporting the dependency libraries and headers.
+.. MOVE THIS ALL TO A NEW RUNTIME INSTALLATION PAGE
+.. The GEOPM HPC Runtime should be built against a specific implementation of
+.. MPI, often unique to the system running the HPC application. An exception to
+.. this rule is the OpenHPC distribution. We've packaged GEOPM version 1 with
+.. `OpenHPC releases <http://openhpc.community/downloads/>`_, and we hope to
+.. offer version 2 in the future.
+
+.. The packages above don't provide support for NVIDIA GPUs with NVML or
+.. DCGM. This support depends on libraries not included in the OpenSUSE OBS
+.. build system where the GEOPM packages are curated. To enable the use of NVML,
+.. or DCGM, you will need to source-build the GEOPM Service, which requires
+.. an environment supporting the dependency libraries and headers.
 
 For GEOPM features not included in these packages, build GEOPM from
 source. The best instructions for this process can be found in the
 :ref:`developer build process <devel:developer build process>` within the
 :doc:`developer guide <devel>`. Keep in mind that you may need to git checkout
-a git tag (e.g. ``v2.0.0``) to create a build based on a specific release.
+a git tag (e.g. ``v3.0.0``) to create a build based on a specific release.

--- a/service/docs/source/install.rst
+++ b/service/docs/source/install.rst
@@ -205,19 +205,6 @@ Please note that the packages listed above do not offer the :doc:`GEOPM Runtime
 For information on how to install the GEOPM Runtime, see :doc:`GEOPM Runtime
 <runtime>`.
 
-.. MOVE THIS ALL TO A NEW RUNTIME INSTALLATION PAGE
-.. The GEOPM HPC Runtime should be built against a specific implementation of
-.. MPI, often unique to the system running the HPC application. An exception to
-.. this rule is the OpenHPC distribution. We've packaged GEOPM version 1 with
-.. `OpenHPC releases <http://openhpc.community/downloads/>`_, and we hope to
-.. offer version 2 in the future.
-
-.. The packages above don't provide support for NVIDIA GPUs with NVML or
-.. DCGM. This support depends on libraries not included in the OpenSUSE OBS
-.. build system where the GEOPM packages are curated. To enable the use of NVML,
-.. or DCGM, you will need to source-build the GEOPM Service, which requires
-.. an environment supporting the dependency libraries and headers.
-
 For GEOPM features not included in these packages, build GEOPM from
 source. The best instructions for this process can be found in the
 :ref:`developer build process <devel:developer build process>` within the

--- a/service/docs/source/overview.rst
+++ b/service/docs/source/overview.rst
@@ -51,17 +51,7 @@ General Users (non-ALCF)
 """"""""""""""""""""""""
 
 For users who are running one of our supported Linux distributions, see the
-following for installation instructions: :doc:`install`.  The GEOPM Runtime
-must be built from source and installed manually if desired.  For instructions
-on that process see: :doc:`devel`.
-
-.. note::
-
-    For usage with GPUs, please use the level-zero enabled RPMs here:
-
-    * SLES 15.3 (`v2.0.2 <https://download.opensuse.org/repositories/home:/geopm:/release-v2.0-supplementary/15.3/x86_64/>`__, `latest <https://download.opensuse.org/repositories/home:/geopm:/supplementary/15.3/x86_64/>`__)
-    * SLES 15.4 (`v2.0.2 <https://download.opensuse.org/repositories/home:/geopm:/release-v2.0-supplementary/15.4/x86_64/>`__, `latest <https://download.opensuse.org/repositories/home:/geopm:/supplementary/15.4/x86_64/>`__)
-    * CentOS 8 (`v2.0.2 <https://download.opensuse.org/repositories/home:/geopm:/release-v2.0-supplementary/CentOS_8/x86_64/>`__, `latest <https://download.opensuse.org/repositories/home:/geopm:/supplementary/CentOS_8/x86_64/>`__)
+following for installation instructions: :doc:`install`.
 
 Admin Configuration
 """""""""""""""""""

--- a/service/docs/source/overview.rst
+++ b/service/docs/source/overview.rst
@@ -1,12 +1,13 @@
 Getting Started
 ===============
 
-The GEOPM project consists of 2 layers of software that work in tandem: the
-**GEOPM Service** and the **GEOPM Runtime**.  The **GEOPM Service** provides a
-secure userspace interface to access hardware telemetry and settings while the
-**GEOPM Runtime** allows end-users to profile their application for advanced
-data analysis and optionally employ active hardware configuration algorithms to
-enhance energy efficiency.
+The GEOPM project consists of a two-tiered software structure: the **GEOPM
+Service** and the **GEOPM Runtime**. The **GEOPM Service** stands out by offering a
+secure userspace interface, facilitating access to hardware telemetry and
+configurations. On the other hand, the **GEOPM Runtime** empowers end-users to
+delve deeper into their application profiles for refined data analysis.
+Additionally, it provides the option to implement active hardware configuration
+algorithms, paving the way for enhanced energy efficiency.
 
 For in-depth information see: :doc:`service` or :doc:`runtime`.
 
@@ -69,7 +70,7 @@ After the Service has been installed, it must be configured properly before
 non-root users will be able to leverage it.
 
 To grant permissions to **all** non-root users to be able to use **all** of the
-features provided by the Service issue the following:
+features provided by the Service, execute the following commands:
 
 .. code-block:: bash
 
@@ -91,8 +92,8 @@ configuration can be found on the following pages: :doc:`admin` and
     :alt: Topology Encapsulation Diagram
     :align: center
 
-The various layers of hardware in a system are described as *domains* in GEOPM
-terminology.  GEOPM has support for the following domains:
+We refer to the different hardware layers within a system as *domains*.  GEOPM
+has support for the following domains:
 
 * Board
 * Package
@@ -118,7 +119,7 @@ module and that ``libgeopmd`` is available in your ``LD_LIBRARY_PATH``.
 The following examples leverage :doc:`geopmread <geopmread.1>` or
 :doc:`geopmwrite <geopmwrite.1>` for command-line usage, and the
 :doc:`C <geopm_topo.3>`, :doc:`C++ <GEOPM_CXX_MAN_PlatformTopo.3>`, and
-:doc:`Python <geopmdpy.7>` APIs of ``PlatformTopo`` to query for the platform
+:doc:`Python <geopmdpy.7>` APIs of ``PlatformTopo`` for the platform
 topology.
 
 .. tabs::
@@ -144,7 +145,7 @@ topology.
 
     .. code-tab:: c
 
-        // Query for the number of physical cores in the system
+        // Query the number of physical cores in the system
 
         #include <stdio.h>
         #include <geopm_topo.h>
@@ -160,7 +161,7 @@ topology.
 
     .. code-tab:: c++
 
-        // Query for the number of physical cores in the system
+        // Query the number of physical cores in the system
 
         #include <iostream>
         #include <geopm/PlatformTopo.hpp>
@@ -175,7 +176,7 @@ topology.
 
     .. code-tab:: python
 
-        # Query for the number of physical cores in the system
+        # Query the number of physical cores in the system
 
         import geopmdpy.topo as topo
 
@@ -187,16 +188,17 @@ topology.
 |:microscope:| Read Telemetry from the Platform
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In GEOPM terminology, any bit of telemetry that can be read with the Service is
-referred to as a *signal*.  Each signal has a native domain where it exists.
-For example, the current operating frequency of the CPU (i.e.
-``CPU_FREQUENCY_STATUS`` / ``MSR::PERF_STATUS:FREQ``) exists at the CPU
-domain.  Any signal can be aggregated to any domain that is more coarse (e.g.
-*package* or *board* in this case).
+We refer to any bit of telemetry that can be read with the Service as a
+*signal*.  Each signal has a native domain.  For example, the native domain of
+the current operating frequency of the CPU (i.e.  ``CPU_FREQUENCY_STATUS`` or
+``MSR::PERF_STATUS:FREQ``) is the CPU domain.  Any signal can be aggregated to
+any domain that is more coarse than its native domain; in our example, CPU
+frequency can be aggregated to the *package* or *board* domains since they are
+more coarse than the CPU domain.
 
-The following examples leverage :doc:`geopmread <geopmread.1>` and the :doc:`C
-<geopm_pio.3>`, :doc:`C++ <GEOPM_CXX_MAN_PlatformIO.3>`, and :doc:`Python
-<geopmdpy.7>` APIs for ``PlatformIO`` to facilitate reading telemetry.
+The following examples make use of :doc:`geopmread <geopmread.1>` for the command-line
+and the :doc:`C <geopm_pio.3>`, :doc:`C++ <GEOPM_CXX_MAN_PlatformIO.3>`, and :doc:`Python
+<geopmdpy.7>` APIs for ``PlatformIO`` in their respective languages.
 
 Listing All Available Signals
 """""""""""""""""""""""""""""
@@ -251,6 +253,7 @@ Reading Signals
 
         // Read the current CPU frequency for cpu 0
 
+        #include <limits.h>
         #include <stdio.h>
         #include <geopm_topo.h>
         #include <geopm_pio.h>
@@ -259,7 +262,7 @@ Reading Signals
         int main (int argc, char** argv)
         {
             double curr_frequency = 0;
-            char err_msg[1024];
+            char err_msg[PATH_MAX];
 
             int err = geopm_pio_read_signal("CPU_FREQUENCY_STATUS",
                                             GEOPM_DOMAIN_CPU,
@@ -267,7 +270,7 @@ Reading Signals
                                             &curr_frequency);
 
             if (err != 0) {
-                geopm_error_message(err, err_msg, 1024);
+                geopm_error_message(err, err_msg, PATH_MAX);
                 printf("Err msg = %s\n", err_msg);
             }
             printf("Current CPU frequency for core 0 = %f\n", curr_frequency);
@@ -309,33 +312,42 @@ Reading Signals
 Understanding Aggregation
 """""""""""""""""""""""""
 
-The telemetry that is output from ``geopmread`` or the APIs will be
-automatically aggregated based on the requested domain and the aggregation
+The telemetry that is output from ``geopmread`` or the APIs will automatically
+be aggregated based on the requested domain and the aggregation
 type.
 
 Using ``CPU_FREQUENCY_STATUS`` as an example, the output  in `Listing Signal
 Information`_ shows the native domain as ``cpu`` and the aggregation type as
 ``average``.  Notice the :ref:`topology diagram <topo-diagram>` shows that CPUs
-are contained within cores, cores are contained within packages, and packages
-are contained within the board.
+are contained within cores, cores within packages, and packages within the board.
 
-If ``CPU_FREQUENCY_STATUS`` was requested at the ``core`` domain, all of the
-CPUs associated with that core will have their frequency read, and the results
-will be averaged together.  If the signal was requested at the ``package``
-domain, all of the CPUs associated with all of the cores on that package will
-have their frequency read, and the results will be averaged together.  This
-pattern continues up to the highest level domain: ``board``.  This means if
-you wanted to read the average frequency across all packages, cores, and CPUs
-in a system, you would issue a ``geopmread`` at the ``board`` domain.
+When a ``CPU_FREQUENCY_STATUS`` request is made at the ``core`` domain, GEOPM
+reads and averages the frequencies of all CPUs linked to that core. If the
+request is at the ``package`` domain, it aggregates the frequencies of all CPUs
+across every core in that package and provides the average. This methodology
+escalates up to the broadest domain, the ``board`` domain. Thus, to obtain the
+average frequency spanning all packages, cores, and CPUs in the system, one
+would issue a `geopmread` at the ``board`` domain.
+
+On the other hand, using ``CPU_ENERGY`` as an example, the output in `Listing
+Signal Information`_ shows the native domain as ``cpu`` and the aggregation
+type as ``sum``.  When a ``CPU_ENERGY`` request is made at the ``core`` domain,
+GEOPM sums the energy consumed by all CPUs linked to that core. If the request
+is at the ``package`` domain, it sums the energy consumed by all CPUs across
+every core in that package and provides the total. This methodology escalates up
+to the broadest domain, the ``board`` domain. Thus, to obtain the total energy
+consumed by all packages, cores, and CPUs in the system, one would issue a
+`geopmread` at the ``board`` domain.
 
 For more information about aggregation types, see: :doc:`GEOPM_CXX_MAN_Agg.3`.
 
 Reading Multiple Signals
 """"""""""""""""""""""""
-In order to regularly read platform telemetry for output directly to the
-console or to a file, use the ``geopmsession`` from the command-line (which takes
-input that is similar to the arguments of ``geopmread``) or the batch read API
-from code.
+To fetch platform telemetry and output it to the console or a file:
+
+- From the command-line: Use `geopmsession`. Its input arguments are similar to `geopmread`,
+  but are taken from standard input rather than the command-line.
+- From code: Utilize the batch read API.
 
 .. tabs::
 
@@ -449,7 +461,8 @@ Capturing Telemetry Over Time
 """""""""""""""""""""""""""""
 
 ``geopmsession`` can also capture data over time with the ``-p`` and ``-t``
-options.  Examples:
+options. This behavior is easily implemented in code along with the batch read
+interface.
 
 .. tabs::
 
@@ -574,22 +587,23 @@ options.  Examples:
             print(f"{pio.sample(time_idx)},{pio.sample(freq_idx)}")
             time.sleep(1)
 
-For more information on ``geopmsession`` see :doc:`geopmsession.1`.
+Again, for more information on ``geopmsession`` see :doc:`geopmsession.1`.
 
 ----
 
 |:gear:| Enact Hardware-based Settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In GEOPM terminology, any hardware setting that can be manipulated through the
-Service is referred to as a *control*.  Similar to signals, each control has a
-native domain where it is applicable.  Any control can be disaggregated from a
-coarse domain (e.g. ``board``) to it's native domain.  See
-`Understanding Disaggregation`_ for more information.
+We refer to any hardware setting that can be manipulated through the Service as
+a *control*.  Like signals, each control has a native domain.  Any control can
+be disaggregated from a coarse domain (e.g., ``board``) to its native domain.
+See `Understanding Disaggregation`_ for more information.
 
-The following examples leverage :doc:`geopmwrite <geopmwrite.1>` and the
-:doc:`C <geopm_pio.3>`, :doc:`C++ <GEOPM_CXX_MAN_PlatformIO.3>`, and
-:doc:`Python <geopmdpy.7>` APIs for ``PlatformIO`` to enact hardware controls.
+The following examples make use of :doc:`geopmwrite <geopmwrite.1>` for the
+command-line and the :doc:`C <geopm_pio.3>`,
+:doc:`C++ <GEOPM_CXX_MAN_PlatformIO.3>`, and :doc:`Python <geopmdpy.7>`
+APIs for ``PlatformIO`` to enact hardware controls in their respective
+languages.
 
 Listing All Available Controls
 """"""""""""""""""""""""""""""
@@ -635,6 +649,7 @@ Writing Controls
 
         // Write the current CPU frequency for core 0 to 3.0 GHz
 
+        #include <limits.h>
         #include <stdio.h>
         #include <geopm_topo.h>
         #include <geopm_pio.h>
@@ -642,7 +657,7 @@ Writing Controls
 
         int main (int argc, char** argv)
         {
-            char err_msg[1024];
+            char err_msg[PATH_MAX];
 
             int err = geopm_pio_write_control("CPU_FREQUENCY_MAX_CONTROL",
                                               GEOPM_DOMAIN_CORE,
@@ -650,7 +665,7 @@ Writing Controls
                                               3.0e9);
 
             if (err != 0) {
-                geopm_error_message(err, err_msg, 1024);
+                geopm_error_message(err, err_msg, PATH_MAX);
                 printf("Err msg = %s\n", err_msg);
             }
 
@@ -700,21 +715,21 @@ one, controls can be disaggregated from a coarse domain to their native domain.
 This happens automatically with ``geopmwrite`` and the corresponding APIs.
 
 Using ``CPU_FREQUENCY_MAX_CONTROL`` as an example, the output in `Listing Control
-Information`_ shows the native domain as ``core``.  If the user desires to
+Information`_ shows the native domain as ``core``.  To
 write the same value to all the cores in a package, simply issue the request at
-the ``package`` domain, and all cores in that package will be written.
-Similarly, to write the same value to all cores in all packages, issue the
-request at the ``board`` domain.
+the ``package`` domain, and the ``CPU_FREQUENCY_MAX_CONTROL`` of all cores in
+that package will be written.  Likewise, to write the same value to all cores
+in all packages, issue the request at the ``board`` domain.
 
-To determine how the disaggregation will occur for a given control, you need to
-examine the aggregation type.  In this example, ``CPU_FREQUENCY_MAX_CONTROL``
-has an aggregation type of ``expect_same``.  When writing this control at a
-more coarse domain than the native one, this means that all the native domains
-will receive the same value as the coarse domain.  This behavior is in place
-for any other aggregation type *except* ``sum``.
+To understand the method of disaggregation for a specific control, you must
+examine its aggregation type.
 
-Controls that use ``sum`` aggregation will have the requested value distributed
-evenly across the native domain.  Taking
+For instance, ``CPU_FREQUENCY_MAX_CONTROL`` has an aggregation type labeled
+``expect_same``. When setting this control at a domain level coarser than its
+native domain, all native domains inherit the same value as the coarser domain.
+This consistent distribution applies to all aggregation types, with the
+exception of ``sum``; controls that use ``sum`` aggregation will have the
+requested value distributed evenly across the native domain.  Taking
 ``MSR::PKG_POWER_LIMIT:PL1_POWER_LIMIT`` as an example, it has the following
 information:
 
@@ -733,19 +748,21 @@ Since the ``package`` domain is contained within the ``board`` domain, writing t
 control at the ``board`` domain will evenly distribute the requested value over
 all the packages in the system.  This means that requesting a 200 W power limit
 at the ``board`` domain will result in each ``package`` receiving a limit of
-100 W.  This can be verified with ``geopmread``.
+100 W.
 
 ----
 
 |:straight_ruler:| Use the Runtime to Measure Application Performance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The GEOPM Runtime can be leveraged to gather telemetry across the execution of
-an application.  If it is desired to measure a specific part of an application,
-the application code can be annotated with GEOPM markup.  In order to use the
-Runtime with an application, 2 methods can be used: launching the application
-with ``geopmlaunch`` (for use with MPI enabled applications) or manually
-setting up the necessary environment settings and directly calling ``geopmctl``.
+The GEOPM Runtime offers capabilities for collecting telemetry throughout an
+application's execution. If you're aiming to measure a particular segment of an
+application, you can annotate the application code using GEOPM markup.
+
+To integrate the Runtime with an application, you have two options:
+
+1. **geopmlaunch**: Ideal for MPI-enabled applications. Simply launch the application using this method.
+2. **Manual Setup**: This involves configuring the necessary environment settings and directly invoking `geopmctl`.
 
 ``geopmlaunch`` will bring up the Runtime alongside your application using one
 of three launch methods: ``process``, ``pthread``, or ``application``.  The
@@ -772,7 +789,7 @@ Using ``geopmlaunch`` with MPI Applications
 
 When the run has concluded, there will be an output file from the Runtime
 called ``geopm.report`` in the current working directory.  This report file
-contains the summarized hardware telemetry over the course of the run.
+contains a summary of hardware telemetry over the course of the run.
 Time-series data is also available through the use of the ``--geopm-trace``
 option to ``geopmlaunch``.  For more information about ``geompmlaunch`` see:
 :doc:`geopmlaunch.1`.  For more information about the reports, see:
@@ -793,7 +810,7 @@ generate a report:
    the ``GEOPM_PROFILE`` environment variable set to the **same**
    value.
 2. The application process must have ``LD_PRELOAD=libgeopm.so.2`` set
-   in the environment, or the application binary must be linked
+   in the environment or the application binary must be linked
    directly to ``libgeopm.so.2`` at compile time.
 3. The ``GEOPM_REPORT`` environment variable must be set in the
    environment of the ``geopmctl`` process.
@@ -802,19 +819,26 @@ generate a report:
    generating a unique report file per host node over which the non-MPI
    application processes are launched.
 
-Beyond generating a report YAML file, we also show three of the optional
-GEOPM Runtime features.  The first is creating a CSV trace file using
-the ``GEOPM_TRACE`` environment variable.  Additionally, by using the
-``GEOPM_PERIOD`` environment variable we increase the sampling period
-of the controller to 200 milliseconds (default value is 5
-milliseconds). By using the third optional ``GEOPM_PROGRAM_FILTER`` variable,
-we can explicitly list the name of the non-MPI program invovation name
-of the non-MPI process to be profiled. These three options together will inform
-the GEOPM runtime controller (``geopmctl``) to profile the ``sleep`` utility
-and generate a CSV trace file with approximately 50 rows of samples (five
-per-second for ten seconds).  The ``awk`` command in the example selects
-the columns measuring time since application start from column 1, CPU
-energy from column 6, and CPU power from column 8.
+In addition to generating a report in YAML format, the example below
+showcases two optional features of the GEOPM Runtime:
+
+1. **CSV Trace File**: By setting the ``GEOPM_TRACE`` environment
+   variable, you can generate a trace file in CSV format.
+2. **Sampling Period Adjustment**: The ``GEOPM_PERIOD`` environment variable
+   allows you to modify the controller's sampling period. For instance, setting
+   it to 200 milliseconds, up from the default 5 milliseconds, results in
+   approximately 50 rows of samples in the trace file (calculated as five
+   samples per second over ten seconds).
+3. **Specify Invocation Name**: The optional ``GEOPM_PROGRAM_FILTER``
+   environment variable allows you to explicitly list the name of the
+   non-MPI program invovation name of the non-MPI process to be profiled.
+
+These three options together will inform the GEOPM runtime controller
+(``geopmctl``) to profile the ``sleep`` utility and generate a CSV trace
+file with approximately 50 rows of samples (five per-second for ten seconds).
+In the provided example, the ``awk`` command extracts specific columns: time
+since application start (column 1), CPU energy (column 6), and CPU power
+(column 8).
 
 .. code-block:: bash
 
@@ -831,11 +855,6 @@ energy from column 6, and CPU power from column 8.
     $ cat sleep-ten.yaml-$(hostname)
     $ awk -F\| '{print $1, $6, $8}' sleep-ten.csv-$(hostname) | less
 
-.. note::
-
-    Support for profiling non-MPI applications with the Runtime is not
-    available in v2.0.2.  This feature is available in the ``dev``
-    branch and will be included in the next release.
 
 For the full listing of the environment variables accepted by the GEOPM
 runtime, please refer to the `GEOPM Environment Variables
@@ -853,7 +872,7 @@ The Runtime supports the automatic profiling of various application regions thro
 * OpenCL Autodetection (WIP)
 
 The :doc:`GEOPM Profiling API <geopm_prof.3>` enables users to annotate
-specific sections of the target application for profiling.  Sections that are
+specific sections of the target application for profiling.  Each section that is
 annotated will show up as a separate ``Region`` in the report output files from
 the runtime.  An example app could be annotated as follows:
 
@@ -915,16 +934,20 @@ our GitHub repository <https://github.com/geopm/geopm/tree/dev/tutorial>`__.
 Breaking Down Signal/Control Names
 """"""""""""""""""""""""""""""""""
 
-Signal and control names are separated into 2 classes: *low level* and *high
-level*.  *Low level* names have the name prefixed with the ``IOGroup`` name and
-two colons (e.g. ``MSR::PERF_CTL:FREQ``).  For commonly used names or names
-that may be supported by more than one ``IOGroup``, the *high level* name (also
-referred to as an alias) may be used.  For example, the alias
-``CPU_FREQUENCY_STATUS`` maps to ``MSR::PERF_STATUS_FREQ``, and
-``CPU_FREQUENCY_MAX_CONTROL`` maps to ``MSR::PERF_CTL_FREQ``.  When using
-``geopmread`` or ``geopmwrite`` to list all the available signals and controls,
-aliases will be listed first.  Those command-line tools can also be used to
-understand what the aliases maps to.  For example:
+Signal and control names in GEOPM are categorized into two types: low-level and high-level.
+
+- **Low-Level Names**: These are prefixed with the IOGroup name followed by two
+  colons. For instance, ``MSR::PERF_CTL:FREQ`` is a low-level name.
+- **High-Level Names (Aliases)**: These are user-friendly alternatives to
+  commonly used or multi-IOGroup-supported names. For example:
+
+  * Alias ``CPU_FREQUENCY_STATUS`` corresponds to ``MSR::PERF_STATUS_FREQ``.
+
+  * Alias ``CPU_FREQUENCY_MAX_CONTROL`` is linked to ``MSR::PERF_CTL_FREQ``.
+
+When using ``geopmread`` or ``geopmwrite`` to display available signals and
+controls, aliases are presented first. These command-line tools also help
+decipher what each alias represents. For instance:
 
 .. code-block:: bash
 
@@ -961,9 +984,9 @@ For more information about the currently supported aliases and IOGroups, see:
 Using the Programmable Counters
 """""""""""""""""""""""""""""""
 
-The programmable counters available on various CPUs can be leveraged via
-``geopmread`` for command-line usages and through the use of the
-``InitControl`` feature for Runtime usages.
+The programmable counters available on various CPUs can be read with
+``geopmread`` from the command-line and through the use of the
+``InitControl`` API using the Runtime.
 
 First, determine the event code for your desired performance metric.  E.g. for
 Skylake Server, the event names and corresponding codes are listed `here
@@ -985,7 +1008,7 @@ programs the counter to track ``LONGEST_LAT_CACHE.MISS`` on CPU 0:
     $ geopmwrite MSR::IA32_PERFEVTSEL0:EN cpu 0 1
     $ geopmwrite MSR::PERF_GLOBAL_CTRL:EN_PMC0 cpu 0 1
 
-    # Read the counter. Repeat this read operation across whatever you're measuring.
+    # Read the counter. Repeat this read operation after a test scenario.
     $ geopmread MSR::IA32_PMC0:PERFCTR cpu 0
 
 To accomplish this with the Runtime, leverage the :ref:`geopm-init-control

--- a/service/docs/source/reference.rst
+++ b/service/docs/source/reference.rst
@@ -1,9 +1,8 @@
-
 Reference Manual
 ================
 
 
-This reference manual contains the GEOPM manual pages and the signal and control descriptions.
+This reference manual features the GEOPM manual pages along with detailed descriptions of signals and controls.
 
 
 GEOPM Manual Pages

--- a/service/docs/source/requires.rst
+++ b/service/docs/source/requires.rst
@@ -1,137 +1,136 @@
 Requirements
 ============
 
-The GEOPM library depend on several external dependencies for enabling
-certain features. However, most of them are readily available in standard Linux
-distributions. If you intend to use only the GEOPM Service, all the required
-dependencies can be found on this page. For users of the GEOPM HPC Runtime,
-refer to its dedicated documentation
-`here <https://geopm.github.io/runtime.html>`__ for the necessary external dependencies.
+The GEOPM Service library depend on several external dependencies for
+enabling certain features. However, most of them are readily available
+in standard Linux distributions. If you intend to use only the GEOPM
+Service, all the required dependencies can be found on this page. For
+users of the GEOPM Runtime, refer to its dedicated documentation `here
+<https://geopm.github.io/runtime.html>`__ for the necessary external
+dependencies.
 
 Build Requirements
 ------------------
 
-To run the GEOPM service build, the packages listed below are required. All these
-packages are available in standard Linux distributions and can be installed
-using commands specific to RPM-based Linux distributions.
+To run the GEOPM Service build, the packages listed below are
+required. All these packages are available in standard Linux
+distributions and can be installed using commands specific to
+RPM-based or Debian-based Linux distributions.
 
 Upstream RHEL and CentOS Package Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
-    yum install python3 python3-devel python3-gobject-base \
+    yum install gcc-c++ unzip libtool \
+                python3 python3-devel python3-gobject-base \
                 python3-sphinx python3-sphinx_rtd_theme \
-                systemd-devel
-
-
+                python3-jsonschema python3-psutil python3-cffi \
+                python3-setuptools python3-dasbus \
+                systemd-devel liburing-devel
 
 Upstream SLES and OpenSUSE Package Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
-    zypper install python3 python3-devel python3-gobject \
+    zypper install gcc-c++ unzip libtool \
+                   python3 python3-devel python3-gobject \
                    python3-Sphinx python3-sphinx_rtd_theme \
-                   systemd-devel
+                   python3-jsonschema python3-psutil python3-cffi \
+                   python3-setuptools python3-dasbus \
+                   systemd-devel liburing-devel
 
+Upstream Ubuntu Package Requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Dasbus Requirement
-^^^^^^^^^^^^^^^^^^
+.. code-block:: bash
 
-A more recent version of Dasbus (version 1.5 or later) is required for the GEOPM service.
-This version currently isn't packaged in Linux distributions. The GEOPM repository
-contains a script:
-
-``service/integration/build_dasbus.sh``
-
-that can be executed to create an RPM for Dasbus version 1.6. The script, upon
-successful execution, will direct how to install the generated RPM.
-
-The requirement for ``python-dasbus`` is specified in the geopm-service spec file. Thus,
-an RPM installation of Dasbus is essential. It is also possible to update Dasbus using
-``pip``, but in its absence, the ``python-dasbus`` requirement must be removed from the
-``service/geopm-service.spec.in`` file within the GEOPM repository prior to building
-the GEOPM service RPMs.
+    apt install g++ unzip libtool autoconf unzip \
+                python3 liburing-dev python3-gi python3-yaml \
+                python3-sphinx python3-sphinx-rtd-theme \
+                python3-jsonschema python3-psutil python3-cffi \
+                python3-setuptools python3-dasbus libsystemd-dev \
+                liburing-dev
 
 Systemd Library Requirement
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``systemd-devel`` package can be omitted in the building sequence with the
-``--disable-systemd`` option. Note that this is mandatory for older Linux distributions like CentOS 7.
-However, disabling ``libsystemd`` means the user-space loaded PlatformIO interface won't access signals
-or controls from the GEOPM Systemd Service. The ``--disable-systemd`` option doesn't impact the GEOPM user unless
-the GEOPM Systemd Service is installed and active on the running Linux OS.
+The ``systemd-devel`` package can be omitted in the building sequence
+with the ``--disable-systemd`` option. Note that this is mandatory for
+older Linux distributions like CentOS 7.  However, disabling
+``libsystemd`` means the user-space loaded PlatformIO interface won't
+access signals or controls from the GEOPM Systemd Service. The
+``--disable-systemd`` option doesn't impact the GEOPM user unless the
+GEOPM Systemd Service is installed and active on the running Linux OS.
 
 Sphinx Requirement
 ^^^^^^^^^^^^^^^^^^
 
 The Sphinx python package is essential for generate man pages and HTML
-documentation. For the build to function correctly, the man pages must be generated. These man pages are included in the distribution tarball created by the
-``make dist`` target, hence, building using this archive doesn't particularly require
-Sphinx. The requirement can be satisfied by PIP if there are issues installing the RPM
-packages for sphinx:
+documentation. For the build to function correctly, the man pages must
+be generated. These man pages are included in the distribution tarball
+created by the ``make dist`` target, hence, building using this
+archive doesn't particularly require Sphinx. The requirement can be
+satisfied by PIP if there are issues installing the RPM packages for
+sphinx:
 
 .. code-block:: bash
 
     python3 -m pip install --user sphinx sphinx_rtd_theme sphinxemoji
     export PATH=$HOME/.local/bin:$PATH
 
-These commands install Sphinx into your user's local Python packages and
-add the local Python package bin directory to your path for access to the
-sphinx-build script.
+These commands install Sphinx into your user's local Python packages
+and add the local Python package bin directory to your path for access
+to the sphinx-build script.
 
 Run Requirements
 ----------------
 
-There are runtime requirements for both the GEOPM Service and
-the GEOPM HPC Runtime. These requirements relate to the MSR driver
-and the configuration of systemd.
+There are runtime requirements for both the GEOPM Service and the
+GEOPM Runtime. These requirements relate to the MSR driver and the
+configuration of systemd.
 
-Access to MSRs enhances the capability of the GEOPM Service in terms of hardware
-telemetry and controls. While the GEOPM Service can function without access to MSRs,
-it provides a limited set of hardware features. For the GEOPM HPC Runtime to function
-correctly, these MSR-related hardware features are necessary. Hence, MSR support is a
-hard requirement for the GEOPM HPC Runtime.
+Access to MSRs enhances the capability of the GEOPM Service in terms
+of hardware telemetry and controls. While the GEOPM Service can
+function without access to MSRs, it provides a limited set of hardware
+features. For the GEOPM Runtime to function correctly, these
+MSR-related hardware features are necessary. Hence, MSR support is a
+hard requirement for the GEOPM Runtime.
 
-Erroneous settings for systemd can cause inter-process communication issues for both the
-GEOPM Service and the GEOPM HPC Runtime.
+Erroneous settings for systemd can cause inter-process communication
+issues for both the GEOPM Service and the GEOPM Runtime.
 
 The MSR Driver
 ^^^^^^^^^^^^^^
 
-The msr-safe kernel driver provides two key features. Firstly, it offers a low
-latency interface for reading and writing many MSR values at once through an
-`ioctl(2) <https://man7.org/linux/man-pages/man2/ioctl.2.html>`_ system call, possibly
-improving the performance of GEOPM HPC runtime or other MSR usages.
+The msr-safe kernel driver provides two key features. Firstly, it
+offers a low latency interface for reading and writing many MSR values
+at once through an `ioctl(2)
+<https://man7.org/linux/man-pages/man2/ioctl.2.html>`_ system call,
+possibly improving the performance of GEOPM Runtime or other MSR
+usages.
 
-Secondly, the msr-safe kernel driver enables user-level read and write operations of
-the model-specific registers (MSRs) with access controlled by the system administrator.
-This feature is mandatory if the GEOPM Service is not active on the system. Alternatively, the access can
-also be managed by the system administrator using the GEOPM Service, if active.
+Secondly, the msr-safe kernel driver enables user-level read and write
+operations of the model-specific registers (MSRs) with access
+controlled by the system administrator.  This feature is mandatory if
+the GEOPM Service is not active on the system. Alternatively, the
+access can also be managed by the system administrator using the GEOPM
+Service, if active.
 
-The msr-safe kernel driver code can be found `here <https://github.com/LLNL/msr-safe>`__.
-It's distributed with OpenHPC and can be installed from the RPMs provided there.
+The msr-safe kernel driver code can be found `here
+<https://github.com/LLNL/msr-safe>`__.  It's distributed with the
+`OpenSUSE Hardware Repository
+<https://download.opensuse.org/repositories/hardware/>`_ and can be
+installed from the RPMs provided there.
 
-In the absence of both the msr-safe kernel driver and the GEOPM Systemd Service, root users may access MSRs
-using the standard MSR driver. This can be loaded with the command:
+In the absence of both the msr-safe kernel driver and the GEOPM
+Systemd Service, root users may access MSRs using the standard MSR
+driver. This can be loaded with the command:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-    modprobe msr
+modprobe msr
 
 The standard MSR driver must also be loaded to enable MSR access
 through the GEOPM Systemd Service when msr-safe is not installed.
-
-Systemd Configuration
-^^^^^^^^^^^^^^^^^^^^^
-
-For GEOPM to utilize shared memory for communication between the Controller and the
-application, it may be necessary to alter systemd configuration. By default, systemd
-removes all inter-process communication for non-system users. This poses a problem to
-GEOPM's shared memory initialization routines.
-
-This behavior can be disabled by setting ``RemoveIPC=no`` in
-``/etc/systemd/logind.conf``. A majority of Linux distributions change the default
-setting to prevent this issue. More information can be found
-`here <https://superuser.com/a/1179962>`__.

--- a/service/docs/source/requires.rst
+++ b/service/docs/source/requires.rst
@@ -1,24 +1,19 @@
-
 Guide to Requirements
 =====================
 
-There are several external dependencies that GEOPM requires to enable
-certain features.  The requirements for the GEOPM Service features are
-all provided by commonly used Linux distributions.  A user that is
-only interested in using the GEOPM Service will find all of the
-dependencies in this page.  A user of the GEOPM HPC Runtime should
-refer to the documentation for that feature
-`here <https://geopm.github.io/runtime.html>`__ to learn
-about the external dependencies that the runtime requires.
+The GEOPM library depend on several external dependencies for enabling
+certain features. However, most of them are readily available in standard Linux
+distributions. If you intend to use only the GEOPM Service, all the required
+dependencies can be found on this page. For users of the GEOPM HPC Runtime,
+refer to its dedicated documentation
+`here <https://geopm.github.io/runtime.html>`__ for the necessary external dependencies.
 
 Build Requirements
 ------------------
 
-There are several packages that are required to run the GEOPM service
-build.  These packages are available from standard Linux distributions.
-The following commands can be used to install them using several RPM
-based Linux distributions.
-
+To run the GEOPM service build, the packages listed below are required. All these
+packages are available in standard Linux distributions and can be installed
+using commands specific to RPM-based Linux distributions.
 
 Upstream RHEL and CentOS Package Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,123 +39,99 @@ Upstream SLES and OpenSUSE Package Requirements
 Dasbus Requirement
 ^^^^^^^^^^^^^^^^^^
 
-The GEOPM service requires a more recent version of dasbus than is
-currently packaged by Linux distributions (dasbus version 1.5 or more
-recent).  The script located in the subdirectory of the GEOPM repo:
+A more recent version of Dasbus (version 1.5 or later) is required for the GEOPM service.
+This version currently isn't packaged in Linux distributions. The GEOPM repository
+contains a script:
 
 ``service/integration/build_dasbus.sh``
 
-can be executed to create the required RPM based on dasbus version 1.6.
-The script will print how to install the generated RPM upon successful
-completion.
+that can be executed to create an RPM for Dasbus version 1.6. The script, upon
+successful execution, will direct how to install the generated RPM.
 
-The ``python-dasbus`` requirement is explicitly stated in the
-geopm-service spec file.  Because of this, an RPM installation of
-dasbus is required.  Alternatively, dasbus may be updated with
-``pip``, but unless a python-dasbus RPM is installed on the system,
-the requirement must be removed from the file
-``service/geopm-service.spec.in`` in the GEOPM repo before building
+The requirement for ``python-dasbus`` is specified in the geopm-service spec file. Thus,
+an RPM installation of Dasbus is essential. It is also possible to update Dasbus using
+``pip``, but in its absence, the ``python-dasbus`` requirement must be removed from the
+``service/geopm-service.spec.in`` file within the GEOPM repository prior to building
 the GEOPM service RPMs.
-
 
 Systemd Library Requirement
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``systemd-devel`` package requirement may be omitted if the geopm
-service build is configured with the ``--disable-systemd`` option.
-This will be required on older Linux distributions like CentOS 7.  The
-effect of disabling use of ``libsystemd`` is that a user-space loaded
-PlatformIO interface will not access signals or controls provided by
-the GEOPM Systemd Service.  Providing ``--disable-systemd`` configure
-option will have no impact on the end user of GEOPM unless the GEOPM
-Systemd Service is installed and active in the running Linux OS.
-
+The ``systemd-devel`` package can be omitted in the building sequence with the
+``--disable-systemd`` option. Note that this is mandatory for older Linux distributions like CentOS 7.
+However, disabling ``libsystemd`` means the user-space loaded PlatformIO interface won't access signals
+or controls from the GEOPM Systemd Service. The ``--disable-systemd`` option doesn't impact the GEOPM user unless
+the GEOPM Systemd Service is installed and active on the running Linux OS.
 
 Sphinx Requirement
 ^^^^^^^^^^^^^^^^^^
 
-The sphinx python package is used to generate man pages and HTML
-documentation.  The generated man pages are required when running the build.
-The man pages are included in a distribution tarball created with the
-``make dist`` target, so building from such an archive does not explicitly require
-sphinx.  This requirement may also be satisfied with PIP if installing the RPM
-packages for sphinx is an issue on your system:
+The Sphinx python package is essential for generate man pages and HTML
+documentation. For the build to function correctly, the man pages must be generated. These man pages are included in the distribution tarball created by the
+``make dist`` target, hence, building using this archive doesn't particularly require
+Sphinx. The requirement can be satisfied by PIP if there are issues installing the RPM
+packages for sphinx:
 
 .. code-block:: bash
 
     python3 -m pip install --user sphinx sphinx_rtd_theme sphinxemoji
     export PATH=$HOME/.local/bin:$PATH
 
-
-These commands will install sphinx into your user's local python packages and
-add the the local python package bin directory to your path for access to the
+These commands install Sphinx into your user's local Python packages and
+add the local Python package bin directory to your path for access to the
 sphinx-build script.
-
 
 Run Requirements
 ----------------
 
-There are some time-of-use requirements for both the GEOPM Service and
-the GEOPM HPC Runtime.  These requirements relate to the MSR driver
+There are runtime requirements for both the GEOPM Service and
+the GEOPM HPC Runtime. These requirements relate to the MSR driver
 and the configuration of systemd.
 
-The use of MSRs enable many important features of the GEOPM Service
-for gathering hardware telemetry and setting hardware controls.  The
-GEOPM Service will function without access to MSRs, however it will
-provide a more restricted set of hardware features.  These MSR related
-hardware features are required for the GEOPM HPC Runtime to function
-correctly.  For this reason, MSR support is a hard requirement for the
-GEOPM HPC Runtime.
+Access to MSRs enhances the capability of the GEOPM Service in terms of hardware
+telemetry and controls. While the GEOPM Service can function without access to MSRs,
+it provides a limited set of hardware features. For the GEOPM HPC Runtime to function
+correctly, these MSR-related hardware features are necessary. Hence, MSR support is a
+hard requirement for the GEOPM HPC Runtime.
 
-There may be some problematic settings for systemd which could lead to
-inter-process communication issues for both the GEOPM Service and the
-GEOPM HPC Runtime.
-
+Erroneous settings for systemd can cause inter-process communication issues for both the
+GEOPM Service and the GEOPM HPC Runtime.
 
 The MSR Driver
 ^^^^^^^^^^^^^^
 
-The msr-safe kernel driver provides two features.  One of these is a
-performance feature providing a low latency interface for reading and
-writing many MSR values at once through an `ioctl(2) <https://man7.org/linux/man-pages/man2/ioctl.2.html>`_ system call.
-This may enable better performance of the GEOPM HPC runtime or other
-uses of MSRs, but also may not be critical depending on the
-algorithmic requirements.
+The msr-safe kernel driver provides two key features. Firstly, it offers a low
+latency interface for reading and writing many MSR values at once through an
+`ioctl(2) <https://man7.org/linux/man-pages/man2/ioctl.2.html>`_ system call, possibly
+improving the performance of GEOPM HPC runtime or other MSR usages.
 
-The other feature that the msr-safe kernel driver provides is
-user-level read and write of the model specific registers (MSRs) with
-access managed through an allowed list that is controlled by the system
-administrator.  This feature is required by the GEOPM runtime if the
-GEOPM Service is not active on the system.  Alternately, the access
-management for MSRs may be configured by the system administrator
-using the GEOPM Service if it is active.
+Secondly, the msr-safe kernel driver enables user-level read and write operations of
+the model-specific registers (MSRs) with access controlled by the system administrator.
+This feature is mandatory if the GEOPM Service is not active on the system. Alternatively, the access can
+also be managed by the system administrator using the GEOPM Service, if active.
 
-The msr-safe kernel driver is distributed with OpenHPC and can be
-installed using the RPMs distributed there.  The source code for the
-driver can be found `here <https://github.com/LLNL/msr-safe>`__.
+The msr-safe kernel driver code can be found `here <https://github.com/LLNL/msr-safe>`__.
+It's distributed with OpenHPC and can be installed from the RPMs provided there.
 
-If both the msr-safe kernel driver and the GEOPM Systemd Service are
-unavailable, then GEOPM when run by the root user may access MSRs
-through the standard msr driver.  This may be loaded with the
-following command:
+In the absence of both the msr-safe kernel driver and the GEOPM Systemd Service, root users may access MSRs
+using the standard MSR driver. This can be loaded with the command:
 
 .. code-block:: bash
 
     modprobe msr
 
-The standard msr driver must also be loaded to enable MSR access
+The standard MSR driver must also be loaded to enable MSR access
 through the GEOPM Systemd Service when msr-safe is not installed.
-
 
 Systemd Configuration
 ^^^^^^^^^^^^^^^^^^^^^
 
-In order for GEOPM to properly use shared memory to communicate
-between the Controller and the application, it may be necessary to
-alter the configuration for systemd.  The default behavior of systemd
-is to clean-up all inter-process communication for non-system users.
-This causes issues with GEOPM's initialization routines for shared
-memory.  This can be disabled by ensuring that ``RemoveIPC=no`` is set
-in ``/etc/systemd/logind.conf``.  Most Linux distributions change the
-default setting to disable this behavior.  More information can be
-found `here <https://superuser.com/a/1179962>`__.
+For GEOPM to utilize shared memory for communication between the Controller and the
+application, it may be necessary to alter systemd configuration. By default, systemd
+removes all inter-process communication for non-system users. This poses a problem to
+GEOPM's shared memory initialization routines.
+
+This behavior can be disabled by setting ``RemoveIPC=no`` in
+``/etc/systemd/logind.conf``. A majority of Linux distributions change the default
+setting to prevent this issue. More information can be found
+`here <https://superuser.com/a/1179962>`__.

--- a/service/docs/source/requires.rst
+++ b/service/docs/source/requires.rst
@@ -1,5 +1,5 @@
-Guide to Requirements
-=====================
+Requirements
+============
 
 The GEOPM library depend on several external dependencies for enabling
 certain features. However, most of them are readily available in standard Linux

--- a/service/docs/source/runtime.rst
+++ b/service/docs/source/runtime.rst
@@ -4,7 +4,6 @@ User Guide for GEOPM Runtime
 The GEOPM Runtime is for software designed to enhance energy efficiency of
 applications through active hardware configuration.
 
-
 User Model
 ----------
 
@@ -17,7 +16,7 @@ challenges:
 
 For hardware tuning algorithms, the first challenge involves generating a
 durable estimate of application performance. In energy efficiency terms,
-performance measurements are power-to-performance ratios, for example,
+performance measurements are performance-to-power ratios, for example,
 "perf per watt". Therefore, any dynamic hardware power control tuning
 that aims for energy efficiency must formulate an estimate of application
 performance. Without specific application feedback on the critical path,
@@ -44,7 +43,7 @@ for data analysis. To effectively enhance energy efficiency for certain
 applications, substantial software dependencies may be required. Control
 algorithms might lean on optimization software like machine learning
 packages or other numerical packages. The application being optimized could
-include millions of lines of code, and there may be significant interlinking
+include millions of lines of code, and there may be significant coupling
 between the application and the control algorithm. Limiting the privileges
 of the process running the control algorithm significantly reduces software
 security audit requirements.
@@ -52,12 +51,12 @@ security audit requirements.
 Introduction
 ------------
 
-GEOPM Runtime creates a bridge between GEOPM’s :doc:`application
+The GEOPM Runtime creates a bridge between GEOPM’s :doc:`application
 instrumentation interfaces <geopm_prof.3>` and :doc:`platform
 monitoring/control interfaces <geopm_pio.7>`.
 
 By default, the GEOPM Runtime presents relationships between application
-instrumentation and platform-monitoring interfaces in a report. For more
+instrumentation and platform-monitoring interfaces in a *report*. For more
 complex interactions, such as dynamic control of platform settings, different
 GEOPM *agents* can be utilized.  For more information on user-facing GEOPM
 Runtime launch options, please refer to :doc:`geopmlaunch(1)<geopmlaunch.1>`
@@ -82,13 +81,13 @@ documentation.
   .. code-block:: console
     :caption: Examples using ``geopmlaunch``
 
-    $ # Launch with srun and examine the generated GEOPM report
+    # Launch with srun and examine the generated GEOPM report
     $ geopmlaunch srun -N 1 -n 20 -- ./my-app
     $ less geopm.report
-    $ # Launch with Intel mpiexec and examine the generated GEOPM report
+    # Launch with Intel mpiexec and examine the generated GEOPM report
     $ geopmlaunch impi -n 1 -ppn 20 -- ./my-app
     $ less geopm.report
-    $ # Display all options and available launchers
+    # Display all options and available launchers
     $ geopmlaunch --help
 
 .. admonition:: Quick start for Non-MPI applications
@@ -194,14 +193,16 @@ requirements, or by providing the disable flag to the configure command
 line, users may skip particular GEOPM Runtime features enabled by these
 requirements.
 
-The GEOPM Runtime requires MPI standards, Message Passing Interface,
-version 2.2 or later. Fulfilling this requirement generally depends on the
-specific HPC resource targeted based on site-specific documentation. The
-Intel MPI implementation, OpenHPC or Spack packaging systems, or OpenMPI
-binaries distributed with most major Linux distributions satisfy this
-requirement. For RHEL and SLES Linux, the requirement can be met by installing
-the ``openmpi-devel`` package version 1.7 or later, and ``libopenmpi-dev``
-on Ubuntu.
+The GEOPM Runtime provides optional support for MPI standards, Message Passing
+Interface, version 2.2 or later.  Building the Runtime with MPI support will
+add MPI related region information to the reports as well as enable Agents that
+leverage the hierarchical communications tree (just the ``power_balancer`` at
+the time of this writing).  If building for an HPC system, target the desired
+site-specific MPI implementation.  Otherwise the Intel MPI implementation,
+OpenHPC or Spack packaging systems, or OpenMPI binaries distributed with most
+major Linux distributions satisfy this requirement. For RHEL and SLES Linux,
+the requirement can be met by installing the ``openmpi-devel`` package version
+1.7 or later, and ``libopenmpi-dev`` on Ubuntu.
 
 * Install all requirements on **RHEL** or **CentOS**
 
@@ -340,7 +341,7 @@ application and the GEOPM control thread on each compute node, and manages
 all process CPU affinity requirements. This wrapper is documented in the
 :doc:`geopmlaunch(1)<geopmlaunch.1>` man page.
 
-``Geopmlaunch`` supports various underlying MPI application launchers
+``geopmlaunch`` supports various underlying MPI application launchers
 as shown in the :doc:`geopmlaunch(1)<geopmlaunch.1>` man page. If your
 system's launch mechanism is not supported, then you must enforce affinity
 requirements, and all options to the GEOPM runtime must be passed through

--- a/service/docs/source/runtime.rst
+++ b/service/docs/source/runtime.rst
@@ -341,13 +341,13 @@ application and the GEOPM control thread on each compute node, and manages
 all process CPU affinity requirements. This wrapper is documented in the
 :doc:`geopmlaunch(1)<geopmlaunch.1>` man page.
 
-``geopmlaunch`` supports various underlying MPI application launchers
-as shown in the :doc:`geopmlaunch(1)<geopmlaunch.1>` man page. If your
-system's launch mechanism is not supported, then you must enforce affinity
+The ``geopmlaunch`` command supports various underlying MPI application
+launchers as shown in the :doc:`geopmlaunch(1)<geopmlaunch.1>` man page. If
+your system's launch mechanism is not supported, then you must enforce affinity
 requirements, and all options to the GEOPM runtime must be passed through
-environment variables. Please consult the :doc:`geopm(7)<geopm.7>` man page
-for documentation of the environment variables used by the GEOPM runtime
-that would otherwise be controlled by the wrapper script.
+environment variables. Please consult the :doc:`geopm(7)<geopm.7>` man page for
+documentation of the environment variables used by the GEOPM runtime that would
+otherwise be controlled by the wrapper script.
 
 CPU Affinity Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/service/docs/source/runtime.rst
+++ b/service/docs/source/runtime.rst
@@ -1,5 +1,5 @@
-Guide for Runtime Users
-=======================
+User Guide for GEOPM Runtime
+============================
 
 The GEOPM Runtime is for software designed to enhance energy efficiency of
 applications through active hardware configuration.

--- a/service/docs/source/runtime.rst
+++ b/service/docs/source/runtime.rst
@@ -1,8 +1,7 @@
-
 Guide for Runtime Users
 =======================
 
-The GEOPM Runtime is software designed to enhance energy efficiency of
+The GEOPM Runtime is for software designed to enhance energy efficiency of
 applications through active hardware configuration.
 
 
@@ -13,76 +12,65 @@ The architecture is designed to provide a secure infrastructure to
 support a wide range of tuning algorithms while solving three related
 challenges:
 
-
 1. Measuring Performance
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The first challenge is to enable hardware tuning algorithms to derive
-a robust estimate of application performance.  This is crucial because
-measurements of energy efficiency are expressed as ratios of
-performance to power, e.g. "perf per watt."  Any dynamic tuning of
-hardware power control parameters with a goal of energy efficiency
-must derive some estimate of application performance.  Without
-application feedback about the critical path, these performance
-estimates may be very inaccurate.  In this way, hardware tuning
-algorithms may interfere with application performance leading to
-longer run times which incur even higher energy costs per unit of work
-than if an adaptive algorithm were not applied.
-
+For hardware tuning algorithms, the first challenge involves generating a
+durable estimate of application performance. In energy efficiency terms,
+performance measurements are power-to-performance ratios, for example,
+"perf per watt". Therefore, any dynamic hardware power control tuning
+that aims for energy efficiency must formulate an estimate of application
+performance. Without specific application feedback on the critical path,
+these performance estimate might prove inaccurate, causing hardware
+tuning algorithms to potentially disrupt application performance and lead
+to elongated run times, resulting in higher energy costs per unit of work
+than without the adaptive algorithm.
 
 2. Hardware Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This leads to the second challenge: enabling a hardware control
-algorithm to be driven by unprivileged user input (i.e. application
-feedback) is a security risk.  Without proper guards in place, this
-can lead to escalation of privilege, denial of service, and impacts to
-quality of service for other users of the system.  The GEOPM Service
-is specifically designed to address these problems.
-
+The second challenge arises from allowing hardware control algorithms to
+be influenced by unprivileged user input (like application feedback), which
+presents a security risk. Not having adequate checks can result in escalated
+privileges, service denial, and impacts on other system users' quality of
+service. GEOPM Service is created specifically to mitigate these issues.
 
 3. Advanced Data Analysis
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The third challenge is providing a software development platform for
-control algorithms that can be safely deployed and use high level
-languages for data analysis.  To effectively gain energy efficiency
-with some applications, significant software dependencies may be
-required.  Control algorithms may rely on optimization software like
-machine learning packages, or other numerical packages.  The
-application being optimized may be composed of millions of lines of
-code, and there may be significant coupling between the application
-and control algorithm.  For these reasons, restricting the privileges
-of the processes running the control algorithm reduces software
-security audit requirements significantly.
-
+The third challenge is to provide a software development platform suitable for
+control algorithms that can be securely deployed and use high-level languages
+for data analysis. To effectively enhance energy efficiency for certain
+applications, substantial software dependencies may be required. Control
+algorithms might lean on optimization software like machine learning
+packages or other numerical packages. The application being optimized could
+include millions of lines of code, and there may be significant interlinking
+between the application and the control algorithm. Limiting the privileges
+of the process running the control algorithm significantly reduces software
+security audit requirements.
 
 Introduction
 ------------
 
-The GEOPM Runtime enables interactions between GEOPM's :doc:`application
-instrumentation interfaces <geopm_prof.3>` and
-:doc:`platform monitoring/control interfaces <geopm_pio.7>`.
+GEOPM Runtime creates a bridge between GEOPM’s :doc:`application
+instrumentation interfaces <geopm_prof.3>` and :doc:`platform
+monitoring/control interfaces <geopm_pio.7>`.
 
-By default, the GEOPM Runtime simply summarizes relationships between
-application instrumentation and platform-monitoring interfaces in a report.
-More complex interactions, such as dynamic control of platform settings, can
-be enabled by using different GEOPM *agents*. See the :doc:`geopmlaunch(1)
-<geopmlaunch.1>` documentation for more information about user-facing GEOPM
-Runtime launch options.
+By default, the GEOPM Runtime presents relationships between application
+instrumentation and platform-monitoring interfaces in a report. For more
+complex interactions, such as dynamic control of platform settings, different
+GEOPM *agents* can be utilized.  For more information on user-facing GEOPM
+Runtime launch options, please refer to :doc:`geopmlaunch(1)<geopmlaunch.1>`
+documentation.
 
 .. figure:: https://geopm.github.io/images/geopm-runtime-usage.svg
-   :alt: An illustration of geopmlaunch running on 2 servers, generating a
-         trace file per host, and one report across all hosts.
+   :alt: An illustration of geopmlaunch running on 2 servers, generating a trace file per host, and one report across all hosts.
    :align: center
-
 
 .. admonition:: Quick start for MPI applications
 
-   The ``geopmlaunch`` tool is the recommended user interface to launch the GEOPM Runtime for
-   profiling and optimizing MPI applications. It
-   wraps a launcher application (srun in this example), generates a summarizing
-   report file, and optionally generates a time-series trace per host.
+   The ``geopmlaunch`` tool is the recommended user interface for GEOPM Runtime. It wraps a launcher application
+   (like srun in this example), generates a summarizing report file, and optionally generates a time-series trace for each host.
 
    The steps for using ``geopmlaunch`` with your MPI application are:
 
@@ -94,15 +82,14 @@ Runtime launch options.
   .. code-block:: console
     :caption: Examples using ``geopmlaunch``
 
-    $ # Launch with srun and explore the generated GEOPM report
+    $ # Launch with srun and examine the generated GEOPM report
     $ geopmlaunch srun -N 1 -n 20 -- ./my-app
     $ less geopm.report
-    $ # Launch with Intel mpiexec and explore the generated GEOPM report
+    $ # Launch with Intel mpiexec and examine the generated GEOPM report
     $ geopmlaunch impi -n 1 -ppn 20 -- ./my-app
     $ less geopm.report
-    $ # show all options and available launchers
+    $ # Display all options and available launchers
     $ geopmlaunch --help
-
 
 .. admonition:: Quick start for Non-MPI applications
 
@@ -158,82 +145,63 @@ to profile unmodified applications, select and evaluate different GEOPM agent
 algorithms (see below), and how to add markup to an application.  The tutorial
 provides a starting point for someone trying to get familiar with the GEOPM runtime.
 
-The runtime enables complex coordination between hardware settings across all
-compute nodes used by a distributed HPC application in
-response to the application's behavior and resource manager requests. The
-dynamic coordination is implemented as a hierarchical control system
-for scalable communication and decentralized control.
+GEOPM *agents* can exploit this hierarchical control system to optimize
+various objective functions. Examples include maximizing application
+performance within a power limit (such as GEOPM :doc:`power_balancer
+agent<geopm_agent_power_balancer.7>`) or decreasing energy consumption while
+minimally affecting application performance. The control hierarchy root
+can communicate with the system resource manager to extend the hierarchy
+beyond the individual MPI application, thus facilitating multiple MPI jobs
+and multiple-user system resource management.
 
-GEOPM *agents* can utilize the hierarchical control system to optimize for
-various objective functions including maximizing global application performance
-within a power bound (e.g., the GEOPM :doc:`power_balancer agent
-<geopm_agent_power_balancer.7>`) or
-minimizing energy consumption with marginal degradation of application
-performance.  The root of the control hierarchy tree can communicate
-with the system resource manager to extend the hierarchy above the
-individual MPI application and enable the management of system power
-resources for multiple MPI jobs and multiple users by the system
-resource manager.
+The GEOPM Runtime package includes the libgeopm shared object library. GEOPM
+comes with numerous command-line tools, each with dedicated manual pages. The
+:doc:`geopmlaunch(1) <geopmlaunch.1>` command-line tool launches an MPI
+application, enabling the GEOPM runtime to create a GEOPM Controller thread on
+each compute node. The Controller loads plugins and runs the Agent algorithm
+to manage the compute application. The :doc:`geopmlaunch(1)<geopmlaunch.1>`
+command is featured in the geopmpy python package that is part of the GEOPM
+installation. For more documentation and links, please visit the :doc:`GEOPM
+overview man page <geopm.7>`.
 
-The GEOPM Runtime package provides the *libgeopm* shared object library.
-There are several command line tools included in GEOPM which have
-dedicated manual pages.  The :doc:`geopmlaunch(1) <geopmlaunch.1>`
-command line tool is used to launch an MPI application while enabling
-the GEOPM runtime to create a GEOPM Controller thread on each compute
-node.  The Controller loads plugins and executes the Agent algorithm
-to control the compute application.  The :doc:`geopmlaunch(1)
-<geopmlaunch.1>` command is part of the geopmpy python package that is
-included in the GEOPM installation.  See the :doc:`GEOPM overview man
-page <geopm.7>` for further documentation and links.
+GEOPM Runtime offers several built-in algorithms, each incorporated within an
+"Agent" implementing the :doc:`geopm::Agent(3) <GEOPM_CXX_MAN_Agent.3>` class
+interface. Developers can expand these algorithm features by creating an Agent
+plugin. An implementation of this class can be dynamically loaded at runtime
+by the GEOPM Controller. The Agent class determines what data is collected,
+how control decisions are made, and how messages are exchanged between
+Agents in the compute nodes' tree hierarchy. The GEOPM Service package,
+which resides in the service directory of the GEOPM repository, provides
+the PlatformIO interface which abstracts reading signals and writing controls
+from the Agent within a compute node. This allows Agent implementations to
+be ported to various hardware platforms without modification.
 
-The GEOPM Runtime provides some built-in algorithms, each as an
-"Agent" that implements the :doc:`geopm::Agent(3) <GEOPM_CXX_MAN_Agent.3>` class interface.
-A developer may extend these algorithm features by writing an Agent
-plugin.  A new implementation of this class can be dynamically loaded
-at runtime by the GEOPM Controller.  The Agent class defines which
-data are collected, how control decisions are made, and what messages
-are communicated between Agents in the tree hierarchy of compute
-nodes.  The reading of data and writing of controls from within a
-compute node is abstracted from the Agent through the PlatformIO
-interface.  The PlatformIO interface is provided by the GEOPM Service
-package which is contained in the service directory of the GEOPM
-repository.  The PlatformIO abstraction enables Agent implementations
-to be ported to different hardware platforms without modification.
-
-The *libgeopm* library can be called directly or indirectly within MPI
-applications to enable application feedback for informing the control
-decisions.  The indirect calls are facilitated by GEOPM's integration
-with MPI and OpenMP through their profiling decorators, and the direct
-calls are made through the :doc:`geopm_prof(3) <geopm_prof.3>` or
-:doc:`geopm_fortran(3) <geopm_fortran.3>`
-interfaces.  Marking up a compute application with profiling
-information through these interfaces can enable better integration of
-the GEOPM runtime with the compute application and more precise
-control.
-
+The libgeopm library can be called indirectly or directly within
+MPI applications, enabling application feedback to aid control
+decisions. Indirect calls are facilitated through GEOPM's integration with
+MPI and OpenMP via their profiling decorators. Direct calls are made through
+:doc:`geopm_prof(3)<geopm_prof.3>` or :doc:`geopm_fortran(3)<geopm_fortran.3>`
+interfaces. The application can be better integrated with the GEOPM runtime
+and controlled more accurately by marking up the compute application with
+profiling information obtained through these interfaces.
 
 Build Requirements
 ------------------
 
-When using the build system in the base of the GEOPM source repository
-to build the GEOPM Runtime some additional requirements must be
-met.  If the user is not interested in building the GEOPM Runtime,
-these extra build requirements may be ignored.  The user may also opt
-out of the specific GEOPM Runtime features enabled by any of these
-requirements by providing the appropriate disable flag to the base
-build configure command line.
+When building the GEOPM Runtime from source, additional requirements must
+be met. Those uninterested in building the GEOPM Runtime can ignore these
+requirements, or by providing the disable flag to the configure command
+line, users may skip particular GEOPM Runtime features enabled by these
+requirements.
 
-The GEOPM Runtime requires support for MPI, the Message Passing
-Interface, standard 2.2 or higher.  In many cases meeting this
-requirement will depend on the specific HPC resource being targeted
-based on documentation that is site specific.  The Intel MPI
-implementation may be used to meet this requirement.  The MPI
-requirement may also be met through HPC packaging systems like OpenHPC
-or Spack.  Additionally, the OpenMPI binaries are distributed with
-most major Linux distributions, and may also be used to satisfy this
-requirement.  This requirement can be met by installing the
-``openmpi-devel`` package version 1.7 or greater on RHEL and SLES
-Linux, and ``libopenmpi-dev`` on Ubuntu.
+The GEOPM Runtime requires MPI standards, Message Passing Interface,
+version 2.2 or later. Fulfilling this requirement generally depends on the
+specific HPC resource targeted based on site-specific documentation. The
+Intel MPI implementation, OpenHPC or Spack packaging systems, or OpenMPI
+binaries distributed with most major Linux distributions satisfy this
+requirement. For RHEL and SLES Linux, the requirement can be met by installing
+the ``openmpi-devel`` package version 1.7 or later, and ``libopenmpi-dev``
+on Ubuntu.
 
 * Install all requirements on **RHEL** or **CentOS**
 
@@ -257,8 +225,7 @@ Linux, and ``libopenmpi-dev`` on Ubuntu.
           libelf-dev python libsqlite3-dev
 
 
-Requirements that can be avoided by removing features with configure
-option:
+Requirements that can be avoided by removing features with configure option:
 
 * Remove MPI compiler requirement
   ``--disable-mpi``
@@ -269,271 +236,236 @@ option:
 * Remove elfutils library requirement
   ``--disable-ompt``
 
-
 For details on how to use non-standard install locations for build
-requirements see
+requirements see:
 
   .. code-block:: bash
 
     ./configure --help
 
-
-which describes some options of the form ``--with-<feature>`` that can
-be used for this purpose, e.g. ``--with-mpi-bin``.
-
+This provides options, for example ``--with-<feature>``, to be used for
+this purpose, such as ``--with-mpi-bin``.
 
 Building the GEOPM Runtime
-------------------------------
-The best recommendation for building the GEOPM Runtime is to follow
-the :ref:`developer build process <devel:developer build process>` posted in
-the :doc:`developer guide <devel>`.  This will enable the use of the GEOPM
-Service and will also provide the latest development in the GEOPM repository.
+---------------------------
 
+The best recommendation for constructing the GEOPM Runtime is to
+follow the "developer build process" referenced in the :doc:`developer
+guide<devel>`. This will enable GEOPM Service use and also provide the
+latest developments in the GEOPM repository.
 
 Run Requirements
 ----------------
-The GEOPM Runtime has several requirements at time-of-use beyond
-what is required for the GEOPM Service.  These requirements are
-outlined in the following subsections.  A user that is not interested in
-running the GEOPM Runtime may ignore these requirements.
+
+Beyond the GEOPM Service, the GEOPM Runtime requires several additional
+features at the time of use. Users uninterested in running the GEOPM Runtime
+can ignore these requirements.
 
 .. contents:: Categories of run requirements:
    :local:
 
-
 BIOS Configuration
 ^^^^^^^^^^^^^^^^^^
-If power governing or power balancing is the intended use case
-for GEOPM deployment, then there is an additional dependency on
-the BIOS being configured to support RAPL control. To check for
-BIOS support, execute the following on a compute node:
+
+If power governing or power balancing is the intended usage for GEOPM
+deployment, an additional requirement involves configuring the BIOS to
+support RAPL control. To make this check for BIOS support, execute the
+following on a compute node:
 
 .. code-block:: bash
 
     ./tutorial/admin/00_test_prereqs.sh
 
-
-If the script output contains:
+If the script output includes:
 
 .. code-block:: none
 
     WARNING: The lock bit for the PKG_POWER_LIMIT MSR is set.  The power_balancer
              and power_governor agents will not function properly until this is cleared.
 
-
 Please enable RAPL in your BIOS, and if such an option doesn't exist please
 contact your BIOS vendor to obtain a BIOS that supports RAPL.
 
 For additional information, please contact the GEOPM team.
 
-
 Linux Power Management
 ^^^^^^^^^^^^^^^^^^^^^^
-Note that other Linux mechanisms for power management can interfere
-with GEOPM, and these must be disabled.  We suggest disabling the
-intel_pstate kernel driver by modifying the kernel command line
-through grub2 or the boot loader on your system by adding:
+
+It's crucial to note that other Linux mechanisms for power management can
+interfere with GEOPM, which must be disabled. It's recommended to disable the
+``intel_pstate`` kernel driver by modifying the kernel command line through
+grub2 or your system bootloader by adding:
 
 .. code-block:: bash
 
    "intel_pstate=disable"
 
-
-The cpufreq driver will be enabled when the intel_pstate driver is
-disabled.  The cpufreq driver has several modes controlled by the
-scaling_governor sysfs entry.  When the performance mode is selected,
-the driver will not interfere with GEOPM.  For SLURM based systems the
-:ref:`GEOPM launch wrapper <runtime:geopm application launch wrapper>` will
-attempt to set the scaling governor to "performance".  This alleviates the need
-to manually set the governor.  Older versions of SLURM require the
-desired governors to be explicitly listed in ``/etc/slurm.conf``.  In
-particular, SLURM 15.x requires the following option:
+The `cpufreq` driver will be enabled when the ``intel_pstate`` driver
+is disabled. It has several modes controlled by the ``scaling_governor``
+sysfs entry. When the performance mode is selected, the driver will not
+interfere with GEOPM. On SLURM-based systems, the :ref:`GEOPM launch wrapper
+<runtime:geopm application launch wrapper>` will attempt to set the scaling
+governor to "performance" automatically, eliminating the need to manually
+set the governor. On older versions of SLURM, the desired governors must be
+listed explicitly in ``/etc/slurm.conf``. Specifically, SLURM 15.x requires
+the following option:
 
 .. code-block:: bash
 
    CpuFreqGovernors=OnDemand,Performance
 
-
-More information on SLURM configuration can be found in the `slurm.conf manual
-<https://slurm.schedmd.com/slurm.conf.html>`_.
-Non-SLURM systems must still set the scaling governor through some
-other mechanism to ensure proper GEOPM behavior.  The following
-command will set the governor to performance:
+For more on SLURM configuration, please see the `slurm.conf manual
+<https://slurm.schedmd.com/slurm.conf.html>`_. On non-SLURM systems, the
+scaling governor should still be manually set through some other mechanism
+to ensure proper GEOPM behavior. The following command will set the governor
+to performance:
 
 .. code-block:: bash
 
    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 
-
-See the Linux Kernel documentation on `cpu-freq governors
-<https://www.kernel.org/doc/Documentation/cpu-freq/governors.txt>`_ for more
-information.
-
+For more information, see the Linux Kernel documentation on `cpu-freq
+governors <https://www.kernel.org/doc/Documentation/cpu-freq/governors.txt>`_.
 
 GEOPM Application Launch Wrapper
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The GEOPM Runtime package installs the ``geopmlaunch`` command.
-The ``geopmlaunch`` command is a wrapper for the MPI launch commands like ``srun``, ``aprun``,
-and ``mpiexec``, where the wrapper script enables the GEOPM runtime.  The
-"geopmlaunch" command supports exactly the same command line interface
-as the underlying launch command, but the wrapper extends the
-interface with GEOPM specific options.  The ``geopmlaunch`` application
-launches the primary compute application and the GEOPM control thread
-on each compute node and manages the CPU affinity requirements for all
-processes.  The wrapper is documented in the :doc:`geopmlaunch(1)
-<geopmlaunch.1>` man page.
 
-There are several underlying MPI application launchers that
-``geopmlaunch`` wrapper supports.  See the :doc:`geopmlaunch(1) <geopmlaunch.1>`
-man page for information on available launchers and how to select them.  If the
-launch mechanism for your system is not supported, then affinity
-requirements must be enforced by the user and all options to the GEOPM
-runtime must be passed through environment variables.  Please consult
-the :doc:`geopm(7) <geopm.7>` man page for documentation of the environment
-variables used by the GEOPM runtime that are otherwise controlled by the
-wrapper script.
+The GEOPM Runtime package installs the ``geopmlaunch`` command. This
+command is a wrapper for MPI launch commands such as ``srun``, ``aprun``,
+and ``mpiexec``, where the wrapper script enables the GEOPM runtime. The
+``geopmlaunch`` command supports the same command-line interface as the
+underlying launch command, while extending the interface with GEOPM-specific
+options. The ``geopmlaunch`` application launches the primary compute
+application and the GEOPM control thread on each compute node, and manages
+all process CPU affinity requirements. This wrapper is documented in the
+:doc:`geopmlaunch(1)<geopmlaunch.1>` man page.
+
+``Geopmlaunch`` supports various underlying MPI application launchers
+as shown in the :doc:`geopmlaunch(1)<geopmlaunch.1>` man page. If your
+system's launch mechanism is not supported, then you must enforce affinity
+requirements, and all options to the GEOPM runtime must be passed through
+environment variables. Please consult the :doc:`geopm(7)<geopm.7>` man page
+for documentation of the environment variables used by the GEOPM runtime
+that would otherwise be controlled by the wrapper script.
 
 CPU Affinity Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-The GEOPM runtime requires that each MPI process of the application
-under control is affinitized to distinct CPUs.  This is a strict
-requirement for the runtime and must be enforced by the MPI launch
-command.  When using the geopmlaunch wrapper described in the previous
-section, these affinity requirements are handled by geopmlaunch when
-the ``--geopm-affinity-enable`` command line option is provided (see
-:doc:`geopmlaunch(1) <geopmlaunch.1>`).  Otherwise, it is required that
-the user will explicitly affinitize their application using the appropriate
-options for their desired launcher.
+
+The GEOPM runtime requires each of the application's MPI processes to
+be affinitized to different CPUs. This is a critical requirement for
+the runtime and must be enforced by the MPI launch command. When using
+the ``geopmlaunch`` wrapper, these affinity requirements are handled by
+``geopmlaunch`` when the ``--geopm-affinity-enable`` command-line option
+is provided (see :doc:`geopmlaunch(1)<geopmlaunch.1>`). Otherwise, users
+must explicitly affinitize their application using the appropriate options
+for their chosen launcher.
 
 While the GEOPM control thread connects to the application it will
-automatically affinitize itself to the highest indexed core not used
-by the application if the application is not affinitized to a CPU on
-every core.  In the case where the application is utilizing all cores
-of the system, the GEOPM control thread will be pinned to the highest
-logical CPU.
+automatically affinitize itself to the highest indexed core not used by the
+application if the application is not affinitized to a CPU on every core. If
+the application is using all cores of the system, the GEOPM control thread
+will be pinned to the highest logical CPU.
 
-There are many ways to launch an MPI application, and there is no
-single uniform way of enforcing MPI rank CPU affinities across
-different job launch mechanisms.  Additionally, OpenMP runtimes, which
-are associated with the compiler choice, have different mechanisms for
-affinitizing OpenMP threads within CPUs available to each MPI process.
-To complicate things further the GEOPM control thread can be launched
-as an application thread or a process that may be part of the primary
-MPI application or a completely separate MPI application.  For these
-reasons it is difficult to document how to correctly affinitize
-processes in all configurations.  Please refer to your site
-documentation about CPU affinity for the best solution on the system
-you are using and consider extending the geopmlaunch wrapper to
-support your system configuration (please see the :doc:`contrib`
-for information about how to share these implementations with the
-community).
+Many ways exist to launch an MPI application, and no single uniform
+way of enforcing MPI rank CPU affinities can work across all job launch
+mechanisms. OpenMP runtimes, which are linked with compiler choice, also have
+different mechanisms for affinitizing OpenMP threads within CPUs available
+to each MPI process. The GEOPM control thread can also be launched as an
+application thread or process that can either be part of the primary MPI
+application or a completely different MPI application. Due to these factors,
+it is challenging to document the correct process affinitization across all
+configurations. Please refer to your site documentation about CPU affinity for
+the best solution for your system and consider extending the ``geopmlaunch``
+wrapper to support your system configuration. For information on how to
+share these implementations with the community, refer to :doc:`contrib`.
 
 Resource Manager Integration
 ----------------------------
 
-The GEOPM Runtime package can be integrated with a compute cluster
-resource manager by modifying the resource manager daemon running on
-the cluster compute nodes.  An example of integration with the SLURM
-resource manager via a SPANK plugin can be found in the `geopm-slurm git
-repository <https://github.com/geopm/geopm-slurm>`_. The implementation
-reflects what is documented below.
+The GEOPM Runtime package can seamlessly integrate with a compute cluster
+resource manager by altering the daemon of the resource manager running on
+the cluster compute nodes. An integration example with the SLURM resource
+manager through a SPANK plugin is available in the `geopm-slurm git
+repository <https://github.com/geopm/geopm-slurm>`_. This example aligns
+with the process described below.
 
-Integration is achieved by modifying the daemon to make two
-``libgeopmd.so`` function calls prior to releasing resources to the
-user (prologue), and one call after the resources have been reclaimed
-from the user (epilogue).  In the prologue, the resource manager
-compute node daemon calls:
+To integrate, the daemon requires two ``libgeopmd.so`` function calls before
+allocating resources to the user (prologue) and one function call after
+the resources are released (epilogue). In the prologue, the daemon initiates:
 
 .. code-block:: C
 
    geopm_pio_save_control()
 
-
-which records into memory the value of all controls that can be
-written through GEOPM (see :doc:`geopm_pio(3) <geopm_pio.3>`).  The second call made in
-the prologue is:
+This function records all controllable GEOPM values into memory (refer
+to :doc:`geopm_pio(3) <geopm_pio.3>`). The next function called in the
+prologue is:
 
 .. code-block:: C
 
    geopm_agent_enforce_policy()
 
-
-and this call (see :doc:`geopm_agent(3) <geopm_agent.3>`) enforces the configured policy
-such as a power cap or a limit on CPU frequency by a one-time
-adjustment of hardware settings.  In the epilogue, the resource
-manager calls:
+As detailed in :doc:`geopm_agent(3) <geopm_agent.3>`, this function enforces
+a pre-set policy like a power cap or a CPU frequency limit by making a
+one-time hardware setting adjustment. In the epilogue, the manager triggers:
 
 .. code-block:: C
 
    geopm_pio_restore_control()
 
+This restores all GEOPM platform controls to their original state captured
+during the prologue.
 
-which will set all GEOPM platform controls back to the values read in
-the prologue.
-
-The configuration of the policy enforced in the prologue is controlled
-by the two files:
+The policy setup in the prologue relies on two configuration files:
 
 .. code-block:: bash
 
    /etc/geopm/environment-default.json
    /etc/geopm/environment-override.json
 
+These files contain JSON objects that map GEOPM environment variables to
+their respective values. The default configuration holds values for any
+unset GEOPM variable in the calling environment. Meanwhile, the override
+configuration enforces values, overriding the calling environment's
+specifications. A comprehensive list of GEOPM environment variables is
+available in the geopm(7) man page. The two primary environment variables
+that ``geopm_agent_enforce_policy()`` utilizes are ``GEOPM_AGENT`` and
+``GEOPM_POLICY``. It's important to note that ``/etc`` should be mounted on a
+local node file system, meaning the GEOPM configuration files typically become
+part of the compute node's boot image. The ``GEOPM_POLICY`` value directs
+to another JSON file, possibly located on a shared file system, dictating
+the enforced values (like the power cap in Watts or CPU frequency in Hz).
 
-which are JSON objects mapping GEOPM environment variable strings to
-string values.  The default configuration file controls values used
-when a GEOPM variable is not set in the calling environment.  The
-override configuration file enforces values for GEOPM variables
-regardless of what is specified in the calling environment.  The list
-of all GEOPM environment variables can be found in the geopm(7) man
-page.  The two GEOPM environment variables used by
-``geopm_agent_enforce_policy()`` are ``GEOPM_AGENT`` and ``GEOPM_POLICY``.
-Note that it is expected that ``/etc`` is mounted on a node-local file
-system, so the GEOPM configuration files are typically part of the
-compute node boot image.  Also note that the ``GEOPM_POLICY`` value
-specifies a path to another JSON file which may be located on a
-shared file system, and this second file controls the values enforced
-(e.g. power cap value in Watts, or CPU frequency value in Hz).
+For GEOPM's integration as the universal power management solution for
+a cluster, it's usual for a single agent algorithm with one policy to be
+applied across all compute nodes within a partition. The choice of agent
+rests upon the site's needs. For instance, if the aim is to keep the average
+CPU power draw for each node below a specific cap, the :doc:`power_balancer
+agent <geopm_agent_power_balancer.7>` is ideal. However, if the goal is to
+limit application CPU frequencies with exceptions for specific high-priority
+processes, the :doc:`frequency_map agent <geopm_agent_frequency_map.7>`
+is the best fit. Sites can also deploy a custom agent plugin. In every
+scenario, invoking ``geopm_agent_enforce_policy()`` before releasing
+compute resources ensures the enforcement of static limits impacting all
+user applications. For dynamic runtime features, users must initiate their
+MPI application using the :doc:`geopmlaunch(1) <geopmlaunch.1>` tool.
 
-When configuring a cluster to use GEOPM as the site-wide power
-management solution, it is expected that one agent algorithm with one
-policy will be applied to all compute nodes within a queue partition.
-The system administrator selects the agent based on the site
-requirements.  If the site requires that the average CPU power draw
-per compute node remains under a cap across the system, then they
-would choose the :doc:`power_balancer agent <geopm_agent_power_balancer.7>`.
-If the site would like to restrict
-applications to run below a particular CPU frequency unless they are
-executing a high priority optimized subroutine that has been granted
-permission by the site administration to run at an elevated CPU
-frequency, they would choose the :doc:`frequency_map agent
-<geopm_agent_frequency_map.7>`.  There is also the option for a site-specific
-custom agent plugin to be deployed.  In all of these use cases, calling
-``geopm_agent_enforce_policy()`` prior to releasing compute node resources to the
-end user will enforce static limits to power or CPU frequency, and these will
-impact all user applications.  In order to leverage the dynamic runtime
-features of GEOPM, the user must opt-in by launching their MPI application with
-the :doc:`geopmlaunch(1) <geopmlaunch.1>` command line tool.
-
-The following example shows how a system administrator would configure
-a system to use the power_balancer agent.  This use case will enforce
-a static power limit for applications which do not use geopmlaunch,
-and will optimize power limits to balance performance when
-geopmlaunch is used.  First, the system administrator creates the
-following JSON object in the boot image of the compute node in the
-path ``/etc/geopm/environment-override.json``:
+To illustrate, if a system administrator wants to use the ``power_balancer``
+agent, the process would involve setting a static power cap for
+apps not utilizing ``geopmlaunch``, while optimizing power caps for
+performance when ``geopmlaunch`` is in use. The administrator would
+install the following JSON object in the compute node's boot image at
+``/etc/geopm/environment-override.json``:
 
 .. code-block:: json
 
    {"GEOPM_AGENT": "power_balancer",
     "GEOPM_POLICY": "/shared_fs/config/geopm_power_balancer.json"}
 
-
-Note that the "CPU_POWER_LIMIT" value controlling the limit
-is specified in a secondary JSON file "geopm_power_balancer.json" that
-may be located on a shared file system and can be created with the
-:doc:`geopmagent(1) <geopmagent.1>` command line tool.  Locating the policy file on the
-shared file system enables the limit to be modified without changing
-the compute node boot image.  Changing the policy value will impact
-all subsequently launched GEOPM processes, but it will not change the
-behavior of already running GEOPM control processes.
+The controlling value, ``CPU_POWER_LIMIT``, is defined in a separate
+"geopm_power_balancer.json" file that could reside on a shared file
+system. This file can be generated using the :doc:`geopmagent(1)
+<geopmagent.1>` tool. By placing the policy file on a shared file system,
+you allow modifications to the limit without affecting the compute node
+boot image. Changing the policy value affects all new GEOPM processes but
+leaves running GEOPM processes untouched.

--- a/service/docs/source/security.rst
+++ b/service/docs/source/security.rst
@@ -1,5 +1,5 @@
-Guide to Service Security
-=========================
+Service Security
+================
 
 This document explains the objectives, mechanisms, assets and threats
 associated with the design of the GEOPM Service security architecture. It

--- a/service/docs/source/service.rst
+++ b/service/docs/source/service.rst
@@ -1,14 +1,15 @@
-.. GEOPM Service documentation main file
+.. Documentation main file for GEOPM Service
 
-Guide for Service Users
-=======================
+User Guide for GEOPM Service
+=============================
 
-This guide describes why and how to use the GEOPM Service, which provides a
-userspace interface to access hardware telemetry and settings. The guide
-includes sections that describe how to build and install this software
-component of the GEOPM project, how to configure this service as a system
-administrator, and how to interact with the service as an unprivileged user.
-
+This user guide outlines the functionality and usage of the GEOPM
+Service. GEOPM Service is designed to provide a user interface for accessing
+hardware telemetry and settings. This guide includes sections detailing
+the process of building and installing this software component of the GEOPM
+project. Furthermore, it explains how to configure this service from a
+system administrator's standpoint and how an unprivileged user can interact
+with it.
 
 .. toctree::
    :maxdepth: 1

--- a/service/docs/source/service_readme.rst
+++ b/service/docs/source/service_readme.rst
@@ -1,4 +1,3 @@
-
 GEOPM Service
 =============
 
@@ -7,71 +6,68 @@ Features
 
 |:penguin:| Linux Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  Linux Systemd Service with DBus interface for user-level access to
-  hardware features on heterogeneous systems
+  The Linux Systemd Service is integrated with a DBus interface, enabling
+  user-level access to hardware features on heterogeneous systems.
 
 
 |:microscope:| Hardware Telemetry
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  Users read telemetry from hardware components on heterogeneous
-  systems with a vendor agnostic interface
+  User can use a vendor-agnostic interface to read telemetry from hardware
+  components on heterogeneous systems.
 
 
 |:gear:| Hardware Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  Users configure hardware component device settings on heterogeneous
-  systems with a vendor agnostic interface
+  User-friendly vendor-agnostic interface for configuring hardware component
+  device settings on heterogeneous systems.
 
 
 |:medal_sports:| Quality of Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  GEOPM Service reverts any changes made to hardware configurations
-  after the client's Linux process session ends
+  The GEOPM Service reverts any changes made to hardware configurations once
+  the client's Linux process session concludes.
 
 
 |:lock:| Security
 ~~~~~~~~~~~~~~~~~
-  Linux system administrators manage fine-grained access permissions
-  for capabilities exposed by the GEOPM Service
+  Linux system administrators have complete control over managing fine-grained
+  access permissions for capabilities exposed by the GEOPM Service.
 
 
 |:rocket:| Performance
 ~~~~~~~~~~~~~~~~~~~~~~
-  Users may call a DBus interface to create a batch server which
-  provides a lower-latency interface with a single permissions
-  validation when server is created
+  DBus interface can be utilized by the user for the creation of a batch
+  server. The server provides a low-latency interface with a single permissions
+  validation when the server is created.
 
 
 |:electric_plug:| Extensibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  Supports extensibility for heterogeneous environments through C++
-  plugin infrastructure (IOGroups).
+  GEOPM Service supports extensibility for heterogeneous environments through
+  the C++ plugin infrastructure called IOGroups.
 
 
 Overview
 --------
 
-The GEOPM Service provides a user-level interface to read telemetry
-and configure settings of heterogeneous hardware platforms. Linux
-system administrators may manage permissions for user access to
-telemetry and configuration at a fine granularity.
+The GEOPM Service provides an interface at the user level, allowing users to
+read telemetry and configure heterogeneous hardware platforms. Linux system
+administrators can manage the permissions for user access to telemetry and
+configuration at very detailed level.
 
-Clients use the GEOPM Service DBus interface to interact with the
-service.  The GEOPM Service package provides access to the DBus
-interfaces from the command line, or programmatically with library
-interfaces for C, C++ and Python.
+The GEOPM Service DBus interface is how clients interact with the service.
+Access to the DBus interfaces can be gained from the command line or
+programmatically with library interfaces for C, C++, and Python.
 
-The service supports many simultaneous client sessions that make
-measurements, but only clients from within one Linux process session
-are granted write permission to configure hardware control values at
-any time.  When a client process session is granted write access it
-will retain that permission until the Linux session process leader of
-that client process terminates.  When the process session leader
-terminates, all hardware settings that are managed by the GEOPM Service
-are restored to the values they had prior to the first client write
-request.  See `setsid(2) <https://man7.org/linux/man-pages/man2/setsid.2.html>`_
-manual for more information about the Linux session leader process.
+The service supports multiple simultaneous client sessions for making
+measurements, however only clients from within a single Linux process session
+are given write permission to configure hardware control values at any one
+time. Upon termination of a client's process session leader, the GEOPM Service
+restores all hardware settings to their original state before the first
+client's write request.
 
+For more information about the Linux session leader process, please consult the
+`setsid(2) <https://man7.org/linux/man-pages/man2/setsid.2.html>`_ manual.
 
 *
   `Overview slides <https://geopm.github.io/pdf/geopm-service.pdf>`_
@@ -83,99 +79,57 @@ Architecture
    :target: https://geopm.github.io/pdf/geopm-service-diagram.pdf
    :alt:
 
-The architecture diagram shows the relationship between the IOGroups
-and the GEOPM Service.  IOGroups are the C++ classes that abstract
-hardware interfaces like the LevelZeroIOGroup for interfacing with
-Intel hardware through the LevelZero library API, or the MSRIOGroup
-for interacting with the Model Specific Register device driver.  These
-IOGroups provide a plugin mechanism for extending GEOPM.
+The architectural diagram shows the relationship between IOGroups and the GEOPM
+Service. IOGroups are the C++ classes that abstract hardware interfaces.
+IOGroups provide a plugin mechanism to extend GEOPM's functionality.
 
-The PlatformIO interface is a container for all IOGroups, and is the
-primary interface for users interacting with hardware through GEOPM.
-The PlatformIO interface may be accessed through language bindings
-with Python, C, and C++ as well as command line tools like
-``geopmread`` and ``geopmwrite``.  The GEOPM DBus interface,
-``io.github.geopm``, provides the secure gateway to privileged
-PlatformIO features.  The administrator uses the ``geopmaccess``
-command line tool to configure the DBus interface to enable user level
-access to any subset of the privileged PlatformIO features.
+The PlatformIO interface is a container for all IOGroups and is the main
+interface for users who interact with the hardware through the GEOPM Service.
+The PlatformIO interface can be accessed through language bindings with Python,
+C, and C++ as well as command line tools such as ``geopmread`` and
+``geopmwrite``. The GEOPM DBus interface, ``io.github.geopm``, provides a
+secure gateway to privileged PlatformIO features. The ``geopmaccess`` command line
+tool is used by the administrator to enable user level access to any subset of
+the privileged PlatformIO features.
 
 
 Status
 ------
 
-The GEOPM systemd service is a new feature for version 2.0.  The
-feature is fully tested and production ready.
+The GEOPM systemd service introduced in version 2.0 is fully tested and is now
+ready for production.
 
 
 Signals and Controls
 --------------------
 
-Each GEOPM signal and control has an associated name and a hardware
-domain.  The name is a unique string identifier defined by the IOGroup
-that provides the signal or control.  The hardware domain that
-provides the interface is represented by one of the enumerations as
-defined by PlatformTopo.  A detailed description of the signals and
-controls available on a system can be discovered with the
-``geopmaccess`` command line tool.  The description includes information
-useful for end-users, and it also provides information for system
-administrators that will help them understand what is enabled for an
-end-user when access is granted to a signal or control.
+Each signal and control in GEOPM has a unique name and a hardware domain. The
+signals and controls available on your system can be discovered with the
+``geopmaccess`` command line tool. The description includes all the necessary
+information for end users and system administrators to understand what is
+enabled when granting access to a signal or control.
 
 
 Access Management
 -----------------
 
-Access to signals and controls through the GEOPM Service is configured
-by the system administrator.  The administrator maintains a default
-access list that applies to all users of the system.  This list
-may be augmented so that users who are members of particular Unix groups may
-have enhanced access.  The default lists are stored in:
+System administrators configure the access to signals and controls through the
+GEOPM Service. The administrator maintains an access list that applies to all
+users of the system. Special Unix groups can have enhanced access.
 
-.. code-block::
-
-   /etc/geopm/0.DEFAULT_ACCESS/allowed_signals
-   /etc/geopm/0.DEFAULT_ACCESS/allowed_controls
-
-
-Each Unix group name ``<GROUP>`` that has extended permissions can
-maintain one or both of the files
-
-.. code-block::
-
-   /etc/geopm/<GROUP>/allowed_signals
-   /etc/geopm/<GROUP>/allowed_controls
-
-
-.. note::
-
-   Before GEOPM 3.0, service configuration files were stored in
-   ``/etc/geopm-service``. Since version 3.0, they are stored in
-   ``/etc/geopm``. Version 3.0 ignores the old file location if the new
-   location exists. If the service uses a configuration from the old location,
-   then a deprecation warning is emitted.
-
-Any missing files are inferred to be empty lists, including the
-default access files.  A signal or control will not be available to
-non-root users through the GEOPM Service until a system administrator
-enables access through these allow lists.  It is recommended that all
-manipulation of these files should be done through the GEOPM Service
-with the ``geopmaccess`` command line tool.
-
-By convention, all control settings can be read by requesting the
-signal that shares the same name as the control.  Note that when
-adding a control name to the access list for writing, the
-administrator is implicitly providing read access to the control
-setting as well.
+All control settings can be read by requesting the signal with the same name.
+Whenever a control name is added to the access list for writing, the
+administrator implicitly grants read access to the control setting as well.
 
 
 Opening a Session
 -----------------
 
-A client process opens a session with the GEOPM Service each time a PlatformIO
-object is created with libgeopmd while the GEOPM systemd service is active.
-This session is initially opened in read-only mode.  Calls into the D-Bus APIs
-that modify control values:
+Each time a client process opens a session with the GEOPM Service, a PlatformIO
+object is created with libgeopmd. This session starts in read-only mode. Calls
+to the DBus APIs that modify control values convert the session into write mode.
+The session retains write access until it ends. Calls into the DBus APIs that
+modify control values:
 
 .. code-block::
 
@@ -200,16 +154,6 @@ restored to the value they had when the session was converted,
 regardless of whether or not they were adjusted during the session
 through the service.
 
-In addition to saving the state of controls, the GEOPM Service will
-also lock access to controls for any other client until the
-controlling session ends.  When the controlling session ends the saved
-state is used to restore the values for all controls supported by the
-GEOPM Service to the values they had prior to enabling the client to
-modify a control.  The controlling session may end by an explicit
-D-Bus call by the client, or when the process that initiated the
-client session ends.  The GEOPM Service will poll procfs for the
-process ID.
-
 
 Batch Server
 ------------
@@ -219,9 +163,9 @@ which accesses this implementation through the DBus interface.  When a
 user program calls ``read_signal()`` or ``write_control()`` on a
 PlatformIO object provided by libgeopmd and the only
 IOGroup that provides the signal or control requested is the
-ServiceIOGroup, then each request goes through the slow D-Bus
+ServiceIOGroup, then each request goes through the slow DBus
 interface.  When a client process uses the ServiceIOGroup for batch
-operations a separate batch server process is created through the D-Bus
+operations a separate batch server process is created through the DBus
 interface.  The implementations for ``push_signal()`` and
 ``push_control()`` are used to configure the stack of signals and
 controls that will be enabled by the batch server.  This batch server
@@ -232,7 +176,7 @@ ServiceIOGroup.
 The batch server is configured to allow access to exactly the signals
 and controls that were pushed onto the stack for the ServiceIOGroup
 prior to the first ``read_batch()`` or ``write_batch()`` call.
-Through the D-Bus implementation, the GEOPM Service verifies that the
+Through the DBus implementation, the GEOPM Service verifies that the
 client user has appropriate permissions for the requested signals and
 controls.  When the first call to ``read_batch()`` or
 ``write_batch()`` is made to user's PlatformIO object, the geopmd

--- a/service/docs/source/service_readme.rst
+++ b/service/docs/source/service_readme.rst
@@ -12,8 +12,8 @@ Features
 
 |:microscope:| Hardware Telemetry
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  User can use a vendor-agnostic interface to read telemetry from hardware
-  components on heterogeneous systems.
+  Use a vendor-agnostic interface to read telemetry from hardware components on
+  heterogeneous systems.
 
 
 |:gear:| Hardware Configuration
@@ -36,9 +36,9 @@ Features
 
 |:rocket:| Performance
 ~~~~~~~~~~~~~~~~~~~~~~
-  DBus interface can be utilized by the user for the creation of a batch
-  server. The server provides a low-latency interface with a single permissions
-  validation when the server is created.
+  A DBus interface can be utilized for the creation of a batch server. The
+  server provides a low-latency interface with a single permissions validation
+  when the server is created.
 
 
 |:electric_plug:| Extensibility
@@ -115,7 +115,35 @@ Access Management
 
 System administrators configure the access to signals and controls through the
 GEOPM Service. The administrator maintains an access list that applies to all
-users of the system. Special Unix groups can have enhanced access.
+users of the system. Special Unix groups can have enhanced access.  The default
+lists are stored in:
+
+.. code-block::
+
+   /etc/geopm/0.DEFAULT_ACCESS/allowed_signals
+   /etc/geopm/0.DEFAULT_ACCESS/allowed_controls
+
+Each Unix group name ``<GROUP>`` that has extended permissions can
+maintain one or both of the files
+
+.. code-block::
+
+   /etc/geopm/<GROUP>/allowed_signals
+   /etc/geopm/<GROUP>/allowed_controls
+
+.. note::
+
+   Before GEOPM 3.0, service configuration files were stored in
+   ``/etc/geopm-service``. Since version 3.0, they are stored in
+   ``/etc/geopm``. Version 3.0 ignores the old file location if the new
+   location exists. If the service uses a configuration from the old location,
+   then a deprecation warning is emitted.
+
+Any missing files are inferred to be empty lists, including the default access
+files.  A signal or control will not be available to non-root users through the
+GEOPM Service until a system administrator enables access through these allow
+lists.  It is recommended that all manipulation of these files should be done
+through the GEOPM Service with the ``geopmaccess`` command line tool.
 
 All control settings can be read by requesting the signal with the same name.
 Whenever a control name is added to the access list for writing, the
@@ -154,6 +182,15 @@ restored to the value they had when the session was converted,
 regardless of whether or not they were adjusted during the session
 through the service.
 
+In addition to saving the state of controls, the GEOPM Service will
+also lock access to controls for any other client until the
+controlling session ends.  When the controlling session ends the saved
+state is used to restore the values for all controls supported by the
+GEOPM Service to the values they had prior to enabling the client to
+modify a control.  The controlling session may end by an explicit
+D-Bus call by the client, or when the process that initiated the
+client session ends.  The GEOPM Service will poll procfs for the
+process ID.
 
 Batch Server
 ------------

--- a/service/docs/source/use_cases.rst
+++ b/service/docs/source/use_cases.rst
@@ -1,54 +1,52 @@
-
 Primary Use Cases
 =================
 
-GEOPM comes with tools and software interfaces to access its
-features. This page outlines some of the use cases that are available
-across those interfaces.
+GEOPM comes bundles various tools and software interfaces designed for broad
+usability. This page outlines the multiple use cases catered by these
+interfaces.
 
 
 |:microscope:| Hardware Telemetry
 ---------------------------------
 
-Provide user-level access to hardware telemetry from heterogeneous components
-with high bandwidth and low latency.  Examples of the telemetry accessible on
-some systems include hardware performance counters, thermal measurements, and
-energy meters.
+This feature enables user-level access to hardware telemetry from a wide range
+of components, bridging gaps between data bandwidth and latency. Accessible
+telemetry on several systems includes hardware performance counters, thermal
+measurement data, and energy meters.
 
 
 |:gear:| Hardware Configuration
 -------------------------------
 
-Provide user-level configuration of hardware settings without impacting
-quality of service for other users of a shared system.  Examples of some
-system configurations that are possible include setting limits for CPU or GPU
-frequency, limiting power used by processors, or configuring priority cores
-for turbo frequency enhancement.
+It allows user-level hardware settings adjustment without affecting other
+users' quality of service of a shared system. Some potential system
+configurations include setting CPU or GPU frequency limits, stipulating
+processor power usage, and setting up priority cores for turbo frequency
+enhancement.
 
 
 |:compass:| Software Telemetry
 ------------------------------
 
-Collect software telemetry from distributed highly threaded applications while
-incurring a low-overhead.  Provide access to this telemetry while the
-application is active to enable online optimizations.  Interfaces to read the
-telemetry are provided as an event log with compression of data bursts and
-also a low-latency low-contention sampling interface.
+This feature collects software telemetry from highly threaded distributed
+applications, thereby ensuring low overhead. It provides access to real-time
+telemetry for enabling online optimizations. Interfaces for reading telemetry
+data come in an event log format with data burst compression and a
+low-contention, low-latency sampling interface.
 
 
 |:checkered_flag:| Runtime Tools
 --------------------------------
 
-Run a process on each compute node used by a distributed High Performance
-Computing (HPC) workload.  This process uses hardware and software telemetry
-to choose optimal settings for hardware.  The algorithm used for optimization
-is a plugin interface that can be extended to reflect site or user
-requirements.
+A process can run on every compute node used by a High Performance Computing
+(HPC) workload. Leveraging hardware and software telemetry, this process
+optimally configures hardware settings. The optimization algorithm runs on a
+plugin interface, easily extensible to cater to user- or site-specific needs.
 
 
 |:closed_lock_with_key:| Access Management
 ------------------------------------------
 
-Provide system administrators with a fine-grained access management interface
-that grants permissions to individual telemetry readings and control
-settings based on Linux user group membership.
+This feature equips system administrators with a granular access management
+interface. It allows them to allocate permissions for individual telemetry
+readings and control settings based on Linux user group membership.


### PR DESCRIPTION
This PR consists of documentation changes that I am suggesting as part of our v3 release.

Some elements (such as links to repos where the v3 binaries will be distributed) are only guesses at this point. We also expect these to be living documents, so users are encouraged to refer to the hosted version of the documents when possible (geopm.github.io).

I will try to indicate where I need another set of eyes.