### PR TITLE
Remove administrative interface from ServiceProxy

### DIFF
--- a/service/src/ServiceProxy.cpp
+++ b/service/src/ServiceProxy.cpp
@@ -104,11 +104,6 @@ namespace geopm
         (void)m_bus->call_method("PlatformCloseSession");
     }
 
-    void ServiceProxyImp::platform_close_session_admin(int client_pid)
-    {
-        m_bus->call_method("PlatformCloseSessionAdmin", client_pid);
-    }
-
     void ServiceProxyImp::platform_start_batch(const std::vector<struct geopm_request_s> &signal_config,
                                                const std::vector<struct geopm_request_s> &control_config,
                                                int &server_pid,

--- a/service/src/geopm/ServiceProxy.hpp
+++ b/service/src/geopm/ServiceProxy.hpp
@@ -97,9 +97,6 @@ namespace geopm
             /// @brief Calls the PlatformCloseSession API defined in
             ///        the io.github.geopm D-Bus namespace.
             virtual void platform_close_session(void) = 0;
-            /// @brief Calls the PlatformCloseSessionAdmin API defined in
-            ///        the io.github.geopm D-Bus namespace.
-            virtual void platform_close_session_admin(int client_pid) = 0;
             /// @brief Calls the PlatformStartBatch API defined in the
             ///        io.github.geopm D-Bus namespace.
             /// @param signal_config [in] Vector of signal requests
@@ -172,7 +169,6 @@ namespace geopm
             std::vector<control_info_s> platform_get_control_info(const std::vector<std::string> &control_names) override;
             void platform_open_session(void) override;
             void platform_close_session(void) override;
-            void platform_close_session_admin(int client_pid) override;
             void platform_start_batch(const std::vector<struct geopm_request_s> &signal_config,
                                       const std::vector<struct geopm_request_s> &control_config,
                                       int &server_pid,

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -337,7 +337,6 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/ServiceProxyTest.platform_get_control_info \
               test/gtest_links/ServiceProxyTest.platform_open_session \
               test/gtest_links/ServiceProxyTest.platform_close_session \
-              test/gtest_links/ServiceProxyTest.platform_close_session_admin \
               test/gtest_links/ServiceProxyTest.platform_restore_control \
               test/gtest_links/ServiceProxyTest.platform_start_batch \
               test/gtest_links/ServiceProxyTest.platform_stop_batch \

--- a/service/test/MockServiceProxy.hpp
+++ b/service/test/MockServiceProxy.hpp
@@ -22,7 +22,6 @@ class MockServiceProxy : public geopm::ServiceProxy
                     (const std::vector<std::string> &control_names), (override));
         MOCK_METHOD(void, platform_open_session, (), (override));
         MOCK_METHOD(void, platform_close_session, (), (override));
-        MOCK_METHOD(void, platform_close_session_admin, (int client_pid), (override));
         MOCK_METHOD(void, platform_start_batch,
                     (const std::vector<struct geopm_request_s> &signal_config,
                      const std::vector<struct geopm_request_s> &control_config,

--- a/service/test/ServiceProxyTest.cpp
+++ b/service/test/ServiceProxyTest.cpp
@@ -194,13 +194,6 @@ TEST_F(ServiceProxyTest, platform_close_session)
     m_proxy->platform_close_session();
 }
 
-TEST_F(ServiceProxyTest, platform_close_session_admin)
-{
-    int client_pid = 1234;
-    EXPECT_CALL(*m_bus, call_method("PlatformCloseSessionAdmin", client_pid));
-    m_proxy->platform_close_session_admin(client_pid);
-}
-
 TEST_F(ServiceProxyTest, platform_start_batch)
 {
     std::vector<geopm_request_s> signal_config = {geopm_request_s {1, 0, "CPU_FREQUENCY"},


### PR DESCRIPTION
- No current use case for calling into administrative APIs from C++.  The ServiceProxy does not currently give access to the other administrative DBus interfaces, like access list control.
- Fixes #3152
