### PR TITLE
Improve error messages when signal is not found

### DIFF
--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -921,7 +921,7 @@ namespace geopm
         // Special signals from PlatformIOImp are aggregated by underlying signals
         auto iogroups = find_signal_iogroup(signal_name);
         if (iogroups.empty()) {
-            throw Exception("PlatformIOImp::agg_function(): unknown how to aggregate \"" + signal_name + "\"",
+            throw Exception("PlatformIOImp::agg_function(): unknown signal \"" + signal_name + "\"",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
@@ -934,7 +934,7 @@ namespace geopm
         // PlatformIOImp forwards formatting request to underlying IOGroup
         auto iogroups = find_signal_iogroup(signal_name);
         if (iogroups.empty()) {
-            throw Exception("PlatformIOImp::format_function(): unknown how to format \"" + signal_name + "\"",
+            throw Exception("PlatformIOImp::format_function(): unknown signal \"" + signal_name + "\"",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         return iogroups.at(0)->format_function(signal_name);

--- a/service/test/PlatformIOTest.cpp
+++ b/service/test/PlatformIOTest.cpp
@@ -802,7 +802,7 @@ TEST_F(PlatformIOTest, agg_function)
     EXPECT_EQ(value, mode_func({5, 6, 7}));
 
     GEOPM_EXPECT_THROW_MESSAGE(m_platio->agg_function("INVALID"),
-                               GEOPM_ERROR_INVALID, "unknown how to aggregate");
+                               GEOPM_ERROR_INVALID, "unknown signal");
 }
 
 TEST_F(PlatformIOTest, signal_behavior)


### PR DESCRIPTION
In PlatformIO, improve the error messages in some functions when a signal is not found.

- Fixes #3158 