### PR TITLE
Add exception handling for all calls to _pid_info()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -619,6 +619,7 @@ PHONY_TARGETS = clean-local \
                 distclean-local \
                 gh_pages \
                 rpm \
+                deb \
                 # end
 
 include test/Makefile.mk

--- a/integration/test/test_multi_app.py
+++ b/integration/test/test_multi_app.py
@@ -14,6 +14,7 @@ import sys
 import unittest
 import subprocess
 import os
+from socket import gethostname
 
 import geopmpy.io
 from integration.test import util
@@ -35,7 +36,7 @@ class TestIntegration_multi_app(unittest.TestCase):
         subprocess.run(['/bin/bash', script_path],
                        timeout=cls.TIME_LIMIT, check=True)
 
-        cls._report_path = f'{cls.TEST_NAME}_report.yaml'
+        cls._report_path = f'{cls.TEST_NAME}_report.yaml-{gethostname()}'
         cls._report = geopmpy.io.RawReport(cls._report_path)
         cls._node_names = cls._report.host_names()
 

--- a/integration/test/test_multi_app.sh
+++ b/integration/test/test_multi_app.sh
@@ -23,6 +23,7 @@ GEOPM_TRACE=${TEST_NAME}_trace.csv \
 GEOPM_TRACE_PROFILE=${TEST_NAME}_trace_profile.csv \
 GEOPM_REPORT_SIGNALS=TIME@package \
 GEOPM_NUM_PROC=2 \
+GEOPM_CTL_LOCAL=true \
 geopmctl &
 
 # geopmbench

--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -428,7 +428,7 @@ endif
 
 clean-local: $(CLEAN_LOCAL_TARGETS)
 
-PHONY_TARGETS = clean-local-python doxygen
+PHONY_TARGETS = clean-local-python doxygen rpm deb
 
 # INCLUDES
 check_PROGRAMS =

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -507,7 +507,7 @@ namespace geopm
             std::cerr << "." << std::endl;
         }
 
-        if (!found_inactive_cpu) {
+        if (!found_inactive_cpu && ! is_slow_monitor) {
             std::cerr << "Warning: <geopm> ApplicationSampler::sampler_cpu(): "
                       << "GEOPM will run on the same HW thread (oversubscribe) as the "
                       << "Application." << std::endl;

--- a/src/ApplicationSampler.cpp
+++ b/src/ApplicationSampler.cpp
@@ -507,7 +507,7 @@ namespace geopm
             std::cerr << "." << std::endl;
         }
 
-        if (!found_inactive_cpu && ! is_slow_monitor) {
+        if (!found_inactive_cpu && !is_slow_monitor) {
             std::cerr << "Warning: <geopm> ApplicationSampler::sampler_cpu(): "
                       << "GEOPM will run on the same HW thread (oversubscribe) as the "
                       << "Application." << std::endl;


### PR DESCRIPTION
- A process may terminate while a callback is being executed.
- In these cases warn to syslog
- Do not check if a PID is active when destroying resources (batch server, and profiling)
- Fixes #3179

