### PR TITLE
Revert "Remove automatic python dependency tracking to avoid dependencies not available in yum"

### DIFF
--- a/geopm-runtime.spec.in
+++ b/geopm-runtime.spec.in
@@ -58,8 +58,6 @@ Prefix: %{_prefix}
 %define compdir "%{_sysconfdir}/bash_completion.d"
 %endif
 
-%{?python_disable_dependency_generator}
-
 %description
 @BLURB@
 

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -78,8 +78,6 @@ BuildRequires: python-rpm-macros
 Requires: python%{python3_pkgversion}-geopmdpy = %{version}
 Requires: libgeopmd2 = %{version}
 
-%{?python_disable_dependency_generator}
-
 %description
 
 The GEOPM Service provides a user-level interface to read telemetry


### PR DESCRIPTION
- This reverts commit a87068a6cd11ec793a4f442b23d9f3ae0ffe4b39.
- The fix for this problem was to change setup.py in 9c61afc4b419a5062b27501435482930bd1b0d42
