### PR TITLE
Fix coverage make target

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -221,6 +221,7 @@ if test "x$enable_coverage" = "x1" ; then
   EXTRA_LDFLAGS="$EXTRA_LDFLAGS --coverage -lgcov"
 fi
 AC_SUBST([enable_coverage])
+AM_CONDITIONAL([ENABLE_COVERAGE], [test "x$enable_coverage" = "x1"])
 
 if test "x$enable_asan" = "x1" ; then
   EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -fsanitize=address -fno-omit-frame-pointer -mllvm -asan-use-private-alias=1"

--- a/configure.ac
+++ b/configure.ac
@@ -580,8 +580,9 @@ AC_COMPILE_IFELSE([
 
 [EXTRA_CFLAGS="$EXTRA_CFLAGS -Wall -Wextra -Werror -Wno-unused-parameter -Wformat -Wformat-security $NO_FASTMATH -fPIC -fPIE"]
 [EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -Wall -Wextra -Werror -Wno-unused-parameter -Wformat -Wformat-security $NO_FASTMATH -fPIC -fPIE"]
-[LDFLAGS_NOPIE="$EXTRA_LDFLAGS -Wl,-z,relro,-z,now,-z,noexecstack"]
-[EXTRA_LDFLAGS="$LDFLAGS_NOPIE -pie"]
+[EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-z,relro,-z,now,-z,noexecstack"]
+[LDFLAGS_NOPIE="$EXTRA_LDFLAGS $AM_LDFLAGS"]
+[EXTRA_LDFLAGS="$EXTRA_LDFLAGS -pie"]
 [EXTRA_FFLAGS="$EXTRA_FFLAGS $NO_FASTMATH -fPIC"]
 if test ! -z "$FC" && $FC --version | grep "GNU Fortran" > /dev/null; then
 [EXTRA_FFLAGS="$EXTRA_FFLAGS -fno-range-check"]

--- a/integration/apps/nasft/nasft/Makefile.mk
+++ b/integration/apps/nasft/nasft/Makefile.mk
@@ -21,7 +21,7 @@ if ENABLE_OPENMP
                                   # end
 
     integration_apps_nasft_nasft_nas_ft_LDADD = libgeopm.la libgeopmfort.la $(MPI_FCLIBS) $(MPI_CXXLIBS)
-    integration_apps_nasft_nasft_nas_ft_LDFLAGS = $(AM_LDFLAGS) $(MPI_LDFLAGS) $(OPENMP_CFLAGS)
+    integration_apps_nasft_nasft_nas_ft_LDFLAGS = $(LDFLAGS_NOPIE) $(MPI_LDFLAGS) $(OPENMP_CFLAGS)
     integration_apps_nasft_nasft_nas_ft_FCFLAGS = -std=legacy -fopenmp -msse4.2 $(MPI_FCFLAGS) $(OPENMP_CFLAGS) -O3
     integration_apps_nasft_nasft_nas_ft_FFLAGS =  -fopenmp -msse4.2 $(MPI_FFLAGS) $(OPENMP_CFLAGS) -O3
 if HAVE_IFX

--- a/service/configure.ac
+++ b/service/configure.ac
@@ -209,6 +209,7 @@ if test "x$enable_coverage" = "x1" ; then
   EXTRA_LDFLAGS="$EXTRA_LDFLAGS --coverage -lgcov"
 fi
 AC_SUBST([enable_coverage])
+AM_CONDITIONAL([ENABLE_COVERAGE], [test "x$enable_coverage" = "x1"])
 
 if test "x$enable_asan" = "x1" ; then
   EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -fsanitize=address -fno-omit-frame-pointer -mllvm -asan-use-private-alias=1"

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -505,10 +505,14 @@ $(GTEST_TESTS): test/gtest_links/%:
 	rm -f $@
 	ln -s $(abs_srcdir)/test/geopm_test.sh $@
 
-init-coverage:
+init-coverage: all
 	lcov --no-external --capture --initial --directory src --output-file coverage-service-initial.info
 
-coverage: | init-coverage check
+if ENABLE_COVERAGE
+check: init-coverage
+endif
+
+coverage: init-coverage check
 	lcov --no-external --capture --directory src --output-file coverage-service.info
 	lcov -a coverage-service-initial.info -a coverage-service.info --output-file coverage-service-combined.info
 	genhtml coverage-service-combined.info --output-directory coverage-service --legend -t $(VERSION) -f

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -632,10 +632,14 @@ $(GTEST_TESTS): test/gtest_links/%:
 	rm -f $@
 	ln -s $(abs_builddir)/test/geopm_test.sh $@
 
-init-coverage:
+init-coverage: all
 	lcov --no-external --capture --initial --directory src --output-file coverage-base-initial.info
 
-coverage: | init-coverage check
+if ENABLE_COVERAGE
+check: init-coverage
+endif
+
+coverage: init-coverage check
 	lcov --no-external --capture --directory src --output-file coverage-base.info
 	lcov -a coverage-base-initial.info -a coverage-base.info --output-file coverage-base-combined.info
 	lcov --remove coverage-base-combined.info "$$(realpath $$(pwd))/src/geopm_pmpi_fortran.c" --output-file coverage-base-combined-filtered.info


### PR DESCRIPTION
- Multi threaded builds were still failing because the init-coverage step was firing before the build was complete.
- The previous usage of order-only-prerequisites for the coverage target were incorrect.
- https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html