### PR TITLE
Reduce GEOPM startup time

### DIFF
--- a/service/src/PlatformIO.cpp
+++ b/service/src/PlatformIO.cpp
@@ -422,8 +422,12 @@ namespace geopm
                 if (domain_type == ii->signal_domain_type(signal_name)) {
                     bool do_push_signal = false;
                     try {
-                        // Attempt to read before pushing to ensure batch reads will succeed
-                        (void)ii->read_signal(signal_name, domain_type, domain_idx);
+                        if (m_pushed_signal_names.find(signal_name) == m_pushed_signal_names.end()) {
+                            // Attempt to read before pushing to ensure batch reads will succeed
+                            (void)ii->read_signal(signal_name, domain_type, domain_idx);
+                        } // else: as an optimization, avoid reading the signal if it has been
+                          // successfully read before for some domain-domain_idx combination
+
                         do_push_signal = true;
                     }
                     catch (const geopm::Exception &ex) {
@@ -440,6 +444,7 @@ namespace geopm
                         result = m_active_signal.size();
                         m_existing_signal[sig_tup] = result;
                         m_active_signal.emplace_back(ii, group_signal_idx);
+                        m_pushed_signal_names.insert(signal_name);
                     }
                 }
                 else {

--- a/service/src/PlatformIOImp.hpp
+++ b/service/src/PlatformIOImp.hpp
@@ -8,6 +8,7 @@
 
 #include <list>
 #include <map>
+#include <set>
 
 #include "geopm/PlatformIO.hpp"
 #include "geopm_pio.h"
@@ -145,6 +146,7 @@ namespace geopm
                                     std::unique_ptr<CombinedControl> > > m_combined_control;
             bool m_do_restore;
             std::map<int, std::shared_ptr<BatchServer> > m_batch_server;
+            std::set<std::string> m_pushed_signal_names;
             static const std::map<const std::string, const std::string> m_signal_descriptions;
             static const std::map<const std::string, const std::string> m_control_descriptions;
     };

--- a/service/test/PlatformIOTest.cpp
+++ b/service/test/PlatformIOTest.cpp
@@ -36,6 +36,7 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::SetArgReferee;
 using ::testing::AtLeast;
+using ::testing::AtMost;
 using ::testing::Throw;
 using ::testing::Not;
 using ::testing::IsEmpty;
@@ -273,13 +274,13 @@ TEST_F(PlatformIOTest, push_signal)
 TEST_F(PlatformIOTest, push_signal_agg)
 {
     EXPECT_CALL(*m_topo, is_nested_domain(GEOPM_DOMAIN_CPU,
-                                         GEOPM_DOMAIN_PACKAGE));
+                                          GEOPM_DOMAIN_PACKAGE));
     EXPECT_CALL(*m_topo, domain_nested(GEOPM_DOMAIN_CPU, GEOPM_DOMAIN_PACKAGE, 0));
 
     EXPECT_CALL(*m_control_iogroup, signal_domain_type("FREQ")).Times(AtLeast(1));
+    EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, _)).Times(AtMost(1));
     for (auto cpu : m_cpu_set0) {
         EXPECT_CALL(*m_control_iogroup, push_signal("FREQ", GEOPM_DOMAIN_CPU, cpu));
-        EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, cpu));
     }
     EXPECT_CALL(*m_control_iogroup, agg_function("FREQ"))
         .WillOnce(Return(geopm::Agg::average));
@@ -489,15 +490,15 @@ TEST_F(PlatformIOTest, sample_not_active)
 TEST_F(PlatformIOTest, sample_agg)
 {
     EXPECT_CALL(*m_topo, is_nested_domain(GEOPM_DOMAIN_CPU,
-                                         GEOPM_DOMAIN_PACKAGE));
+                                          GEOPM_DOMAIN_PACKAGE));
     EXPECT_CALL(*m_topo, domain_nested(GEOPM_DOMAIN_CPU, GEOPM_DOMAIN_PACKAGE, 0));
     EXPECT_CALL(*m_control_iogroup, signal_domain_type("FREQ")).Times(AtLeast(1));
     EXPECT_CALL(*m_control_iogroup, agg_function("FREQ"))
         .WillOnce(Return(geopm::Agg::average));
+    EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, _)).Times(AtMost(1));
     for (auto cpu : m_cpu_set0) {
         EXPECT_CALL(*m_control_iogroup, push_signal("FREQ", GEOPM_DOMAIN_CPU, cpu))
             .WillOnce(Return(cpu));
-        EXPECT_CALL(*m_control_iogroup, read_signal("FREQ", GEOPM_DOMAIN_CPU, cpu));
     }
     int freq_idx = m_platio->push_signal("FREQ", GEOPM_DOMAIN_PACKAGE, 0);
 


### PR DESCRIPTION
Introduce minor optimization in PlatformIO push_signal() to avoid checking/reading signals if they have already been verified before for a domain idx.

- Relates to #3015
- Fixes #3239
