### PR TITLE
Two fixes for the spec files

### DIFF
--- a/geopm-runtime.spec.in
+++ b/geopm-runtime.spec.in
@@ -52,7 +52,6 @@ BuildRequires: python-rpm-macros
 
 %define python_major_version 3
 
-Requires: python%{python3_pkgversion}-geopmpy = %{version}
 Requires: libgeopm2 = %{version}
 ExclusiveArch: x86_64
 

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -117,7 +117,7 @@ Group: System/Libraries
 
 # Lets GEOPM batch its IO operations to reduce syscall overhead in IOGroups
 # with a lot of reads/writes per GEOPM batch operation.
-%if %{defined disable_io_uring} || ! %{defined suse_version}
+%if %{defined disable_io_uring}
 %define io_uring_option --disable-io-uring
 %else
 BuildRequires: liburing-devel


### PR DESCRIPTION
- Use liburing on non-SUSE linux builds
- Do not make python3-geopmdpy a requirement for the geopm-service package
- These are both required to enable Rocky Linux