### PR TITLE
Bring back reverted MSRIOGroup change with fix bug

### DIFF
--- a/service/configure.ac
+++ b/service/configure.ac
@@ -134,6 +134,27 @@ else
   ENABLE_LIBCAP=False
 fi
 
+AC_ARG_ENABLE([rawmsr],
+  [AS_HELP_STRING([--disable-rawmsr], [Disable direct use of standard msr(4) device driver])],
+[if test "x$enable_rawmsr" = "xno" ; then
+  enable_rawmsr="0"
+else
+  enable_rawmsr="1"
+fi
+],
+[enable_rawmsr="1"]
+)
+
+AC_SUBST([enable_rawmsr])
+AM_CONDITIONAL([ENABLE_RAWMSR], [test "x$enable_rawmsr" = "x1"])
+
+if test "x$enable_rawmsr" = "x1" ; then
+  ENABLE_RAWMSR=True
+  AC_DEFINE([GEOPM_ENABLE_RAWMSR], [ ], [Enable direct use of standard msr(4) device driver])
+else
+  ENABLE_RAWMSR=False
+fi
+
 AC_ARG_WITH([bash-completion-dir], [AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
             [Install the bash auto-completion script in this directory. @<:@default=yes@:>@])])
 if test "x$with_bash_completion_dir" = "x"; then
@@ -530,4 +551,5 @@ AC_MSG_RESULT([io_uring           : ${enable_io_uring}])
 AC_MSG_RESULT([asan               : ${enable_asan}])
 AC_MSG_RESULT([fuzz               : ${enable_fuzz}])
 AC_MSG_RESULT([libcap             : ${enable_libcap}])
+AC_MSG_RESULT([rawmsr             : ${enable_rawmsr}])
 AC_MSG_RESULT([===============================================================================])

--- a/service/src/MSRIO.cpp
+++ b/service/src/MSRIO.cpp
@@ -28,18 +28,13 @@
 
 namespace geopm
 {
-    std::unique_ptr<MSRIO> MSRIO::make_unique(void)
+    std::unique_ptr<MSRIO> MSRIO::make_unique(int driver_type)
     {
-        return geopm::make_unique<MSRIOImp>();
+        return std::make_unique<MSRIOImp>(std::make_unique<MSRPath>(driver_type));
     }
 
-    std::shared_ptr<MSRIO> MSRIO::make_shared(void)
-    {
-        return std::make_shared<MSRIOImp>();
-    }
-
-    MSRIOImp::MSRIOImp()
-        : MSRIOImp(platform_topo().num_domain(GEOPM_DOMAIN_CPU), std::make_shared<MSRPath>(), nullptr, nullptr)
+    MSRIOImp::MSRIOImp(std::shared_ptr<MSRPath> path)
+        : MSRIOImp(platform_topo().num_domain(GEOPM_DOMAIN_CPU), path, nullptr, nullptr)
     {
 
     }
@@ -493,10 +488,8 @@ namespace geopm
 
     void MSRIOImp::open_msr(int cpu_idx)
     {
-        for (int fallback_idx = 0;
-             m_file_desc[cpu_idx] == -1;
-             ++fallback_idx) {
-            std::string path = m_path->msr_path(cpu_idx, fallback_idx);
+        if (m_file_desc[cpu_idx] == -1) {
+            std::string path = m_path->msr_path(cpu_idx);
             m_file_desc[cpu_idx] = open(path.c_str(), O_RDWR);
         }
         struct stat stat_buffer;

--- a/service/src/MSRIO.hpp
+++ b/service/src/MSRIO.hpp
@@ -15,6 +15,12 @@ namespace geopm
     class MSRIO
     {
         public:
+            enum m_driver_e {
+                M_DRIVER_MSRSAFE,
+                M_DRIVER_MSR,
+                M_NUM_DRIVER,
+            };
+
             MSRIO() = default;
             virtual ~MSRIO() = default;
             /// @brief Read from a single MSR on a CPU.
@@ -127,10 +133,7 @@ namespace geopm
             virtual void write_batch(int batch_ctx) = 0;
             /// @brief Returns a unique_ptr to a concrete object
             ///        constructed using the underlying implementation
-            static std::unique_ptr<MSRIO> make_unique(void);
-            /// @brief Returns a shared_ptr to a concrete object
-            ///        constructed using the underlying implementation
-            static std::shared_ptr<MSRIO> make_shared(void);
+            static std::unique_ptr<MSRIO> make_unique(int driver_type);
     };
 }
 

--- a/service/src/MSRIOGroup.cpp
+++ b/service/src/MSRIOGroup.cpp
@@ -140,8 +140,10 @@ namespace geopm
         return msr_config_paths;
     }
 
-    MSRIOGroup::MSRIOGroup()
-        : MSRIOGroup(platform_topo(), std::make_shared<MSRIOImp>(), cpuid(), geopm_sched_num_cpu(), nullptr)
+    MSRIOGroup::MSRIOGroup(bool use_msr_safe)
+        : MSRIOGroup(platform_topo(),
+                     MSRIO::make_unique(use_msr_safe ? MSRIO::M_DRIVER_MSRSAFE : MSRIO::M_DRIVER_MSR),
+                     cpuid(), geopm_sched_num_cpu(), nullptr)
     {
 
     }
@@ -1084,7 +1086,12 @@ namespace geopm
 
     std::unique_ptr<IOGroup> MSRIOGroup::make_plugin(void)
     {
-        return geopm::make_unique<MSRIOGroup>();
+        return geopm::make_unique<MSRIOGroup>(false);
+    }
+
+    std::unique_ptr<IOGroup> MSRIOGroup::make_plugin_safe(void)
+    {
+        return geopm::make_unique<MSRIOGroup>(true);
     }
 
     void MSRIOGroup::enable_fixed_counters(void)

--- a/service/src/MSRIOImp.hpp
+++ b/service/src/MSRIOImp.hpp
@@ -19,7 +19,8 @@ namespace geopm
     class MSRIOImp : public MSRIO
     {
         public:
-            MSRIOImp();
+            MSRIOImp() = delete;
+            MSRIOImp(std::shared_ptr<MSRPath> path);
             MSRIOImp(int num_cpu, std::shared_ptr<MSRPath> path,
                      std::shared_ptr<IOUring> batch_reader,
                      std::shared_ptr<IOUring> batch_writer);

--- a/service/src/MSRPath.cpp
+++ b/service/src/MSRPath.cpp
@@ -8,20 +8,33 @@
 #include <sstream>
 
 #include "MSRPath.hpp"
+#include "MSRIO.hpp"
 #include "geopm/Exception.hpp"
 
 namespace geopm
 {
-    std::string MSRPath::msr_path(int cpu_idx,
-                                  int fallback_idx)
+
+    MSRPath::MSRPath()
+        : MSRPath(MSRIO::M_DRIVER_MSRSAFE)
+    {
+
+    }
+
+    MSRPath::MSRPath(int driver_type)
+        : m_driver_type(driver_type)
+    {
+
+    }
+
+    std::string MSRPath::msr_path(int cpu_idx) const
     {
         std::ostringstream path_ss;
         path_ss << "/dev/cpu/" << cpu_idx;
-        switch (fallback_idx) {
-            case M_FALLBACK_MSRSAFE:
+        switch (m_driver_type) {
+            case MSRIO::M_DRIVER_MSRSAFE:
                 path_ss << "/msr_safe";
                 break;
-            case M_FALLBACK_MSR:
+            case MSRIO::M_DRIVER_MSR:
                 path_ss << "/msr";
                 break;
             default:
@@ -32,7 +45,7 @@ namespace geopm
         return path_ss.str();
     }
 
-    std::string MSRPath::msr_batch_path(void)
+    std::string MSRPath::msr_batch_path(void) const
     {
         return "/dev/cpu/msr_batch";
     }

--- a/service/src/MSRPath.hpp
+++ b/service/src/MSRPath.hpp
@@ -13,17 +13,13 @@ namespace geopm
     class MSRPath
     {
         public:
-            enum m_fallback_e {
-                M_FALLBACK_MSRSAFE,
-                M_FALLBACK_MSR,
-                M_NUM_FALLBACK,
-            };
-
-            MSRPath() = default;
+            MSRPath();
+            MSRPath(int driver_type);
             virtual ~MSRPath() = default;
-            virtual std::string msr_path(int cpu_idx,
-                                         int fallback_idx);
-            virtual std::string msr_batch_path(void);
+            virtual std::string msr_path(int cpu_idx) const;
+            virtual std::string msr_batch_path(void) const;
+        private:
+            const int m_driver_type;
     };
 }
 

--- a/service/src/geopm/MSRIOGroup.hpp
+++ b/service/src/geopm/MSRIOGroup.hpp
@@ -41,7 +41,8 @@ namespace geopm
                 M_CPUID_SPR = 0x68F,
             };
 
-            MSRIOGroup();
+            MSRIOGroup() = delete;
+            MSRIOGroup(bool use_msr_safe);
             MSRIOGroup(const PlatformTopo &platform_topo,
                        std::shared_ptr<MSRIO> msrio,
                        int cpuid,
@@ -97,6 +98,7 @@ namespace geopm
             static int cpuid(void);
             static std::string plugin_name(void);
             static std::unique_ptr<IOGroup> make_plugin(void);
+            static std::unique_ptr<IOGroup> make_plugin_safe(void);
         private:
             /// @brief Parse the given JSON string and update the
             ///        allowlist data map.

--- a/service/test/MSRIOTest.cpp
+++ b/service/test/MSRIOTest.cpp
@@ -56,8 +56,8 @@ class MSRIOMockFiles
 class MockMSRPath : public MSRPath
 {
     public:
-        MOCK_METHOD(std::string, msr_path, (int cpu_idx, int fallback_idx), (override));
-        MOCK_METHOD(std::string, msr_batch_path, (), (override));
+        MOCK_METHOD(std::string, msr_path, (int cpu_idx), (const, override));
+        MOCK_METHOD(std::string, msr_batch_path, (), (const, override));
 };
 
 MSRIOMockFiles::MSRIOMockFiles(int num_cpu)
@@ -651,7 +651,7 @@ void MSRIOTest::SetUp(void)
     m_path = std::make_shared<MockMSRPath>();
     m_batch_io = std::make_shared<MockIOUring>();
     for (int cpu_idx = 0; cpu_idx != m_num_cpu; ++cpu_idx) {
-        EXPECT_CALL(*m_path, msr_path(cpu_idx, 0))
+        EXPECT_CALL(*m_path, msr_path(cpu_idx))
             .WillOnce(Return(m_files->test_dev_path()[cpu_idx]));
     }
     EXPECT_CALL(*m_path, msr_batch_path()).WillOnce(Return("NO_FILE_HERE"));


### PR DESCRIPTION
- Load either the IOGroup for raw msr or msr-safe, but not both.
- Relates to #3291 