### PR TITLE
Make use of cpuid.h optional at configure time

### DIFF
--- a/geopm-runtime.spec.in
+++ b/geopm-runtime.spec.in
@@ -53,7 +53,6 @@ BuildRequires: python-rpm-macros
 %define python_major_version 3
 
 Requires: libgeopm2 = %{version}
-ExclusiveArch: x86_64
 
 %description
 

--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -220,6 +220,8 @@ libgeopmd_la_SOURCES = $(include_HEADERS) \
                        src/ConstConfigIOGroup.cpp \
                        src/ConstConfigIOGroup.hpp \
                        src/Control.hpp \
+                       src/Cpuid.cpp \
+                       src/Cpuid.hpp \
                        src/CpuinfoIOGroup.cpp \
                        src/CpuinfoIOGroup.hpp \
                        src/DCGMDevicePool.hpp \

--- a/service/configure.ac
+++ b/service/configure.ac
@@ -482,6 +482,10 @@ if test "x$enable_io_uring" = "x1" ; then
         [#define _DEFAULT_SOURCE
          #define _POSIX_C_SOURCE 200809L
          #include <liburing.h>])
+    AC_CHECK_LIB([uring], [io_uring_free_probe], [liburing_has_free=1], [liburing_has_free=0])
+    if test "x$liburing_has_free" = "x1"; then
+        AC_DEFINE([GEOPM_IO_URING_HAS_FREE], [ ], [Use io_uring_free_probe instead of free])
+    fi
 fi
 
 AC_CHECK_HEADERS([fcntl.h limits.h stddef.h stdint.h stdlib.h string.h sys/ioctl.h unistd.h])

--- a/service/configure.ac
+++ b/service/configure.ac
@@ -482,6 +482,11 @@ if test "x$enable_io_uring" = "x1" ; then
         [#define _DEFAULT_SOURCE
          #define _POSIX_C_SOURCE 200809L
          #include <liburing.h>])
+
+    # Newer versions of liburing provide an function to release probe
+    # resources, but with older versions the user must call free(3) to
+    # release the resources.  This check sets a preprocessor define
+    # to identify which is required.
     AC_CHECK_LIB([uring], [io_uring_free_probe], [liburing_has_free=1], [liburing_has_free=0])
     if test "x$liburing_has_free" = "x1"; then
         AC_DEFINE([GEOPM_IO_URING_HAS_FREE], [ ], [Use io_uring_free_probe instead of free])

--- a/service/configure.ac
+++ b/service/configure.ac
@@ -155,6 +155,28 @@ else
   ENABLE_RAWMSR=False
 fi
 
+AC_ARG_ENABLE([cpuid],
+  [AS_HELP_STRING([--disable-cpuid], [Disable direct use of standard msr(4) device driver])],
+[if test "x$enable_cpuid" = "xno" ; then
+  enable_cpuid="0"
+else
+  enable_cpuid="1"
+fi
+],
+[enable_cpuid="1"]
+)
+
+AC_SUBST([enable_cpuid])
+AM_CONDITIONAL([ENABLE_CPUID], [test "x$enable_cpuid" = "x1"])
+
+if test "x$enable_cpuid" = "x1" ; then
+  ENABLE_CPUID=True
+  AC_DEFINE([GEOPM_ENABLE_CPUID], [ ], [Enable use of the cpuid.h interfaces])
+else
+  ENABLE_CPUID=False
+fi
+
+
 AC_ARG_WITH([bash-completion-dir], [AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
             [Install the bash auto-completion script in this directory. @<:@default=yes@:>@])])
 if test "x$with_bash_completion_dir" = "x"; then
@@ -391,6 +413,12 @@ AC_CHECK_LIB([z], [crc32], [], [
 AC_CHECK_HEADER([zlib.h], [], [
     echo "missing zlib.h: Required for crc32 interface"
     exit -1])
+
+if test "x$enable_cpuid" = "x1" ; then
+    AC_CHECK_HEADER([cpuid.h], [], [
+        echo "missing cpuid.h: cpuid interface may be disabled with the --disable-cpuid option"
+        exit -1])
+fi
 
 if test "x$enable_systemd" = "x1" ; then
     AC_CHECK_LIB([systemd], [sd_bus_open_system], [], [

--- a/service/debian/rules
+++ b/service/debian/rules
@@ -4,14 +4,17 @@ DESTDIR = $(CURDIR)/debian/tmp
 prefix = /usr
 SOURCES_DIR = $(CURDIR)/../SOURCES
 
+DPKG_EXPORT_BUILDFLAGS := 1
 include /usr/share/dpkg/default.mk
 include /usr/share/dpkg/buildtools.mk
+include /usr/share/dpkg/architecture.mk
 
 %:
 	dh $@ --with  python3 --buildsystem=pybuild
 
 override_dh_auto_configure:
 	test -f configure || ./autogen.sh
+	if [ "$(DEB_BUILD_ARCH)" != "amd64" ]; then CPUID_OPTION="--disable-cpuid"; fi; \
 	./configure \
           --prefix=$(prefix) \
           --includedir=$(prefix)/include \
@@ -19,7 +22,9 @@ override_dh_auto_configure:
           --mandir=$(prefix)/share/man \
           --libdir=$(prefix)/lib/$(DEB_HOST_MULTIARCH) \
           --with-bash-completion-dir=/etc/bash_completion.d \
-          --enable-nvml
+          --enable-nvml \
+          $(CPUID_OPTION)
+
 
 override_dh_auto_test:
 	# make check # TODO Fix issue #2999

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -63,7 +63,7 @@ BuildRequires: python-rpm-macros
 %endif
 
 %define compdir %(pkg-config --variable=completionsdir bash-completion)
-%if "x%{compdir}" == "x"
+%if "x%{?compdir}" == "x"
 %define compdir "%{_sysconfdir}/bash_completion.d"
 %endif
 
@@ -75,7 +75,6 @@ BuildRequires: python-rpm-macros
 
 Requires: python%{python3_pkgversion}-geopmdpy = %{version}
 Requires: libgeopmd2 = %{version}
-ExclusiveArch: x86_64
 
 %description
 
@@ -122,6 +121,10 @@ Group: System/Libraries
 %define io_uring_option --disable-io-uring
 %else
 BuildRequires: liburing-devel
+%endif
+
+%if "%{_arch}" != "x86_64"
+%define cpuid_option --disable-cpuid
 %endif
 
 %description -n libgeopmd2
@@ -185,6 +188,7 @@ CC=gcc CXX=g++ \
             --with-bash-completion-dir=%{compdir} \
             %{?level_zero_option} \
             %{?io_uring_option} \
+            %{?cpuid_option} \
             || ( cat config.log && false )
 
 CFLAGS= CXXFLAGS= CC=gcc CXX=g++ \

--- a/service/src/Cpuid.cpp
+++ b/service/src/Cpuid.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include "Cpuid.hpp"
+
+#ifdef GEOPM_ENABLE_CPUID
+#include <cpuid.h>
+#include <cmath>
+
+namespace geopm
+{
+    class CpuidImp : public Cpuid
+    {
+        public:
+            CpuidImp() = default;
+            virtual ~CpuidImp() = default;
+            int cpuid(void) const override;
+            bool is_hwp_supported(void) const override;
+            double freq_sticker(void) const override;
+            rdt_info_s rdt_info(void) const override;
+            uint32_t pmc_bit_width(void) const override;
+    };
+
+    std::unique_ptr<Cpuid> Cpuid::make_unique(void)
+    {
+        return std::make_unique<CpuidImp>();
+    }
+
+    int CpuidImp::cpuid(void) const
+    {
+        uint32_t key = 1; //processor features
+        uint32_t proc_info = 0;
+        uint32_t model;
+        uint32_t family;
+        uint32_t ext_model;
+        uint32_t ext_family;
+        uint32_t ebx, ecx, edx;
+        const uint32_t model_mask = 0xF0;
+        const uint32_t family_mask = 0xF00;
+        const uint32_t extended_model_mask = 0xF0000;
+        const uint32_t extended_family_mask = 0xFF00000;
+
+        __get_cpuid(key, &proc_info, &ebx, &ecx, &edx);
+
+        model = (proc_info & model_mask) >> 4;
+        family = (proc_info & family_mask) >> 8;
+        ext_model = (proc_info & extended_model_mask) >> 16;
+        ext_family = (proc_info & extended_family_mask) >> 20;
+
+        if (family == 6) {
+            model+=(ext_model << 4);
+        }
+        else if (family == 15) {
+            model+=(ext_model << 4);
+            family+=ext_family;
+        }
+
+        return ((family << 8) + model);
+    }
+
+    bool CpuidImp::is_hwp_supported(void) const
+    {
+        uint32_t leaf = 6; //thermal and power management features
+        uint32_t eax = 0, ebx = 0, ecx = 0, edx = 0;
+        const uint32_t hwp_mask = 0x80;
+        bool supported = false;
+        __get_cpuid(leaf, &eax, &ebx, &ecx, &edx);
+
+        supported = (bool)((eax & hwp_mask) >> 7);
+        return supported;
+    }
+
+    Cpuid::rdt_info_s CpuidImp::rdt_info(void) const
+    {
+        uint32_t leaf, subleaf = 0;
+        uint32_t eax = 0, ebx = 0, ecx = 0, edx = 0;
+        bool supported = false;
+        uint32_t max, scale = 0;
+
+        leaf = 0x0F;
+        subleaf = 0;
+
+        __cpuid_count(leaf, subleaf, eax, ebx, ecx, edx);
+        supported = (bool)((edx >> 1) & 1);
+        max = ebx;
+
+        if (supported == true) {
+            subleaf = 1;
+            eax = 0;
+            ebx = 0;
+            ecx = 0;
+            edx = 0;
+            __cpuid_count(leaf, subleaf, eax, ebx, ecx, edx);
+            scale = ebx;
+        }
+
+        rdt_info_s rdt = {
+            .rdt_support = supported,
+            .rmid_bit_width = (uint32_t)ceil(log2((double)max + 1)),
+            .mbm_scalar = scale
+        };
+
+        return rdt;
+    }
+
+    uint32_t CpuidImp::pmc_bit_width(void) const
+    {
+        uint32_t leaf, subleaf = 0;
+        uint32_t eax, ebx, ecx, edx = 0;
+
+        leaf = 0x0A;
+        subleaf = 0;
+
+        __cpuid_count(leaf, subleaf, eax, ebx, ecx, edx);
+
+        // SDM vol 3b, section 18 specifies where to find how many PMC bits are
+        // available
+        return (eax >> 16) & 0xff;
+    }
+
+    double CpuidImp::freq_sticker(void) const
+    {
+        double result = NAN;
+        uint32_t leaf = 0x16; //processor frequency info
+        uint32_t eax = 0, ebx = 0, ecx = 0, edx = 0;
+        const uint32_t sticker_mask = 0xFFFF;
+        const uint32_t unit_factor = 1e6;
+
+        __get_cpuid(leaf, &eax, &ebx, &ecx, &edx);
+
+        result = (eax & sticker_mask) * unit_factor;
+
+        return result;
+    }
+}
+
+#else
+
+namespace geopm
+{
+    class CpuidNull : public Cpuid
+    {
+        public:
+            CpuidNull() = default;
+            virtual ~CpuidNull() = default;
+            int cpuid(void) const override;
+            bool is_hwp_supported(void) const override;
+            double freq_sticker(void) const override;
+            rdt_info_s rdt_info(void) const override;
+            uint32_t pmc_bit_width(void) const override;
+    };
+
+    std::unique_ptr<Cpuid> Cpuid::make_unique(void)
+    {
+        return std::make_unique<CpuidNull>();
+    }
+
+    int CpuidNull::cpuid(void) const
+    {
+        return 0;
+    }
+
+    bool CpuidNull::is_hwp_supported(void) const
+    {
+        return false;
+    }
+
+    Cpuid::rdt_info_s CpuidNull::rdt_info(void) const
+    {
+        rdt_info_s rdt = {
+            .rdt_support = false,
+            .rmid_bit_width = 0,
+            .mbm_scalar = 0
+        };
+
+        return rdt;
+    }
+
+    uint32_t CpuidNull::pmc_bit_width(void) const
+    {
+        return 0;
+    }
+
+    double CpuidNull::freq_sticker(void) const
+    {
+        return 0.0;
+    }
+}
+
+#endif

--- a/service/src/Cpuid.hpp
+++ b/service/src/Cpuid.hpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef CPUID_HPP_INCLUDE
+#define CPUID_HPP_INCLUDE
+
+#include <memory>
+
+namespace geopm
+{
+    class Cpuid
+    {
+        public:
+            struct rdt_info_s
+            {
+                bool rdt_support;
+                uint32_t rmid_bit_width;
+                uint32_t mbm_scalar;
+            };
+
+            static std::unique_ptr<Cpuid> make_unique(void);
+            Cpuid() = default;
+            virtual ~Cpuid() = default;
+            virtual int cpuid(void) const = 0;
+            virtual bool is_hwp_supported(void) const = 0;
+            virtual double freq_sticker(void) const = 0;
+            virtual rdt_info_s rdt_info(void) const = 0;
+            virtual uint32_t pmc_bit_width(void) const = 0;
+    };
+}
+
+#endif

--- a/service/src/CpuinfoIOGroup.hpp
+++ b/service/src/CpuinfoIOGroup.hpp
@@ -19,7 +19,8 @@ namespace geopm
         public:
             CpuinfoIOGroup();
             CpuinfoIOGroup(const std::string &cpu_freq_min_path,
-                           const std::string &cpu_freq_max_path);
+                           const std::string &cpu_freq_max_path,
+                           double cpu_freq_sticker);
             virtual ~CpuinfoIOGroup() = default;
             /// @return the list of signal names provided by this IOGroup.
             std::set<std::string> signal_names(void) const override;

--- a/service/src/IOGroup.cpp
+++ b/service/src/IOGroup.cpp
@@ -89,6 +89,7 @@ namespace geopm
         // service is not active then loading the ServiceIOGroup will
         // fail.
         if (geopm::has_cap_sys_admin()) {
+#ifdef GEOPM_ENABLE_CPUID
 #ifdef GEOPM_ENABLE_RAWMSR
             // Only use /dev/cpu/*/msr if configured with
             // --enable-rawmsr and msr-safe driver is not available.
@@ -97,6 +98,7 @@ namespace geopm
                 register_plugin(MSRIOGroup::plugin_name(),
                                 MSRIOGroup::make_plugin);
             }
+#endif
 #endif
             register_plugin(SSTIOGroup::plugin_name(),
                             SSTIOGroup::make_plugin);
@@ -112,6 +114,7 @@ namespace geopm
             register_plugin(NVMLIOGroup::plugin_name(),
                             NVMLIOGroup::make_plugin);
 #endif
+#ifdef GEOPM_ENABLE_CPUID
 #ifdef GEOPM_ENABLE_RAWMSR
             // Always try to load msr-safe version of IOGroup unless
             // raw msr access has already been selected.
@@ -121,6 +124,7 @@ namespace geopm
                 register_plugin(MSRIOGroup::plugin_name(),
                                 MSRIOGroup::make_plugin_safe);
             }
+#endif
         }
 #ifdef GEOPM_ENABLE_SYSTEMD
         else { // not UID 0

--- a/service/src/IOUringImp.cpp
+++ b/service/src/IOUringImp.cpp
@@ -2,13 +2,16 @@
  * Copyright (c) 2015 - 2022, Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
+#include "config.h"
+
 #include "IOUringImp.hpp"
 
 #include "geopm/Exception.hpp"
 #include "geopm/Helper.hpp"
-#include "liburing.h"
 
 #include <memory>
+#include <liburing.h>
 
 namespace geopm
 {
@@ -101,7 +104,11 @@ namespace geopm
 
     bool IOUringImp::is_supported()
     {
+#ifdef GEOPM_IO_URING_HAS_FREE
+        std::unique_ptr<io_uring_probe, decltype(&io_uring_free_probe)> probe(io_uring_get_probe(), io_uring_free_probe);
+#else
         std::unique_ptr<io_uring_probe, decltype(&free)> probe(io_uring_get_probe(), free);
+#endif
         if (!probe) {
             return false;
         }

--- a/service/src/PlatformTopo.cpp
+++ b/service/src/PlatformTopo.cpp
@@ -13,7 +13,6 @@
 #include <sys/sysinfo.h>
 #include <sys/time.h>
 #include <unistd.h>
-#include <cpuid.h>
 #include <string.h>
 #include <errno.h>
 #include <limits.h>
@@ -31,38 +30,13 @@
 #include "geopm/Helper.hpp"
 #include "GPUTopo.hpp"
 #include "geopm/ServiceProxy.hpp"
+#include "Cpuid.hpp"
 
 
 int geopm_read_cpuid(void)
 {
-    uint32_t key = 1; //processor features
-    uint32_t proc_info = 0;
-    uint32_t model;
-    uint32_t family;
-    uint32_t ext_model;
-    uint32_t ext_family;
-    uint32_t ebx, ecx, edx;
-    const uint32_t model_mask = 0xF0;
-    const uint32_t family_mask = 0xF00;
-    const uint32_t extended_model_mask = 0xF0000;
-    const uint32_t extended_family_mask = 0xFF00000;
-
-    __get_cpuid(key, &proc_info, &ebx, &ecx, &edx);
-
-    model = (proc_info & model_mask) >> 4;
-    family = (proc_info & family_mask) >> 8;
-    ext_model = (proc_info & extended_model_mask) >> 16;
-    ext_family = (proc_info & extended_family_mask) >> 20;
-
-    if (family == 6) {
-        model+=(ext_model << 4);
-    }
-    else if (family == 15) {
-        model+=(ext_model << 4);
-        family+=ext_family;
-    }
-
-    return ((family << 8) + model);
+    static const auto cpuid_obj = geopm::Cpuid::make_unique();
+    return cpuid_obj->cpuid();
 }
 
 static volatile unsigned g_is_popen_complete = 0;
@@ -676,7 +650,7 @@ namespace geopm
         geopm_time_real(&current_time);
 
         unsigned int last_boot_time = current_time.t.tv_sec - si.uptime;
-        if (file_stat.st_mtime < last_boot_time) {
+        if (static_cast<unsigned int>(file_stat.st_mtime) < last_boot_time) {
             return false; // file is older than last boot
         }
         else {

--- a/service/src/PlatformTopo.cpp
+++ b/service/src/PlatformTopo.cpp
@@ -523,6 +523,11 @@ namespace geopm
 
         for (size_t i = 0; i < values.size(); ++i) {
             auto it = lscpu_map.find(keys[i]);
+            if (it == lscpu_map.end() && keys[i] == "Core(s) per socket") {
+                keys[i] = "Core(s) per cluster";
+                keys[i+1] = "Cluster(s)";
+                it = lscpu_map.find(keys[i]);
+            }
             if (it == lscpu_map.end()) {
                 throw Exception("PlatformTopoImp: parsing lscpu output, key not found: \"" + keys[i] + "\"",
                                 GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);

--- a/service/src/geopm/MSRIOGroup.hpp
+++ b/service/src/geopm/MSRIOGroup.hpp
@@ -17,6 +17,7 @@
 
 #include "IOGroup.hpp"
 #include "geopm_time.h"
+#include "Cpuid.hpp"
 
 namespace geopm
 {
@@ -25,6 +26,7 @@ namespace geopm
     class Signal;
     class Control;
     class SaveControl;
+    class Cpuid;
 
     /// @brief IOGroup that provides signals and controls based on MSRs.
     class MSRIOGroup : public IOGroup
@@ -45,7 +47,7 @@ namespace geopm
             MSRIOGroup(bool use_msr_safe);
             MSRIOGroup(const PlatformTopo &platform_topo,
                        std::shared_ptr<MSRIO> msrio,
-                       int cpuid,
+                       std::shared_ptr<Cpuid> cpuid,
                        int num_cpu,
                        std::shared_ptr<SaveControl> save_control);
             virtual ~MSRIOGroup() = default;
@@ -94,8 +96,6 @@ namespace geopm
             /// @return String formatted to be written to an msr-safe
             ///         allowlist file.
             static std::string msr_allowlist(int cpuid);
-            /// @brief Get the cpuid of the current platform.
-            static int cpuid(void);
             static std::string plugin_name(void);
             static std::unique_ptr<IOGroup> make_plugin(void);
             static std::unique_ptr<IOGroup> make_plugin_safe(void);
@@ -208,7 +208,7 @@ namespace geopm
             const PlatformTopo &m_platform_topo;
             std::shared_ptr<MSRIO> m_msrio;
             int m_save_restore_ctx;
-            int m_cpuid;
+            std::shared_ptr<Cpuid> m_cpuid;
             int m_num_cpu;
             bool m_is_active;
             bool m_is_read;
@@ -219,31 +219,14 @@ namespace geopm
             std::shared_ptr<geopm_time_s> m_time_zero;
             std::shared_ptr<double> m_time_batch;
 
-            /// @brief Return the Intel Hardware P-States
-            ///        enabled information
-            bool get_hwp_enabled(void);
             bool m_is_hwp_enabled;
 
-            struct rdt_info
-            {
-                bool rdt_support;
-                uint32_t rmid_bit_width;
-                uint32_t mbm_scalar;
-            };
-            rdt_info m_rdt_info;
+            Cpuid::rdt_info_s m_rdt_info;
 
             uint32_t m_pmc_bit_width;
 
             int m_derivative_window;
             double m_sleep_time;
-
-            /// @brief Return the Intel Resource Director Technology
-            ///        support information
-            static rdt_info get_rdt_info(void);
-
-            /// @brief Return the Intel Performance Monitoring Counter
-            ///        support information
-            static uint32_t get_pmc_bit_width(void);
 
             // All available signals: map from name to signal_info.
             // The signals vector is over the indices for the domain.

--- a/service/test/CpuinfoIOGroupTest.cpp
+++ b/service/test/CpuinfoIOGroupTest.cpp
@@ -10,8 +10,7 @@
 #include <memory>
 #include <cmath>
 
-#define GEOPM_TEST
-#include "src/CpuinfoIOGroup.cpp"
+#include "CpuinfoIOGroup.hpp"
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -452,6 +452,7 @@ test_geopm_test_SOURCES = test/GPUTopoNullTest.cpp \
                           test/MSRIOTest.cpp \
                           test/MSRFieldControlTest.cpp \
                           test/MSRFieldSignalTest.cpp \
+                          test/MockCpuid.hpp \
                           test/MockGPUTopo.hpp \
                           test/MockBatchClient.hpp \
                           test/MockBatchStatus.hpp \

--- a/service/test/Makefile.mk
+++ b/service/test/Makefile.mk
@@ -275,6 +275,7 @@ GTEST_TESTS = test/gtest_links/GPUTopoNullTest.default_config \
               test/gtest_links/PlatformIOTest.write_control_override \
               test/gtest_links/PlatformIOTest.write_control_agg \
               test/gtest_links/PlatformIOTest.write_control_agg_sum \
+              test/gtest_links/PlatformTopoTest.arm_num_domain \
               test/gtest_links/PlatformTopoTest.bdx_domain_idx \
               test/gtest_links/PlatformTopoTest.bdx_domain_idx_service \
               test/gtest_links/PlatformTopoTest.bdx_domain_idx_fallback \

--- a/service/test/MockCpuid.hpp
+++ b/service/test/MockCpuid.hpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2015 - 2023, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOCKCPUID_HPP_INCLUDE
+#define MOCKCPUID_HPP_INCLUDE
+
+#include "gmock/gmock.h"
+
+#include "Cpuid.hpp"
+
+
+class MockCpuid : public geopm::Cpuid {
+    public:
+        MOCK_METHOD(int, cpuid, (), (override, const));
+        MOCK_METHOD(bool, is_hwp_supported, (), (override, const));
+        MOCK_METHOD(double, freq_sticker, (), (override, const));
+        MOCK_METHOD(Cpuid::rdt_info_s, rdt_info, (), (override, const));
+        MOCK_METHOD(uint32_t, pmc_bit_width, (), (override, const));
+};
+
+#endif

--- a/service/test/PlatformTopoTest.cpp
+++ b/service/test/PlatformTopoTest.cpp
@@ -50,6 +50,7 @@ class PlatformTopoTest : public :: testing :: Test
         std::string m_no0x_lscpu_str;
         std::string m_no_numa_lscpu_str;
         std::string m_spr_lscpu_str;
+        std::string m_arm_lscpu_str;
         std::string m_gpu_str;
         std::string m_gpu_lscpu_str;
         std::string m_lscpu_str;
@@ -299,6 +300,37 @@ void PlatformTopoTest::SetUp()
         "GPU chip10 CPU(s): 170,172,174,176,178,180,182,184,186,188,190,192,194,196,198,200,202\n"
         "GPU chip11 CPU(s): 171,173,175,177,179,181,183,185,187,189,191,193,195,197,199,201,203\n";
     m_gpu_lscpu_str = m_spr_lscpu_str + m_gpu_str;
+    m_arm_lscpu_str =
+        "Architecture:                       aarch64\n"
+        "CPU op-mode(s):                     32-bit, 64-bit\n"
+        "Byte Order:                         Little Endian\n"
+        "CPU(s):                             8\n"
+        "On-line CPU(s) mask:                ff\n"
+        "Vendor ID:                          ARM\n"
+        "Model name:                         Neoverse-N1\n"
+        "Model:                              1\n"
+        "Thread(s) per core:                 1\n"
+        "Core(s) per cluster:                8\n"
+        "Socket(s):                          -\n"
+        "Cluster(s):                         1\n"
+        "Stepping:                           r3p1\n"
+        "BogoMIPS:                           50.08\n"
+        "Flags:                              fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs\n"
+        "NUMA node(s):                       1\n"
+        "NUMA node0 CPU(s):                  ff\n"
+        "Vulnerability Gather data sampling: Not affected\n"
+        "Vulnerability Itlb multihit:        Not affected\n"
+        "Vulnerability L1tf:                 Not affected\n"
+        "Vulnerability Mds:                  Not affected\n"
+        "Vulnerability Meltdown:             Not affected\n"
+        "Vulnerability Mmio stale data:      Not affected\n"
+        "Vulnerability Retbleed:             Not affected\n"
+        "Vulnerability Spec rstack overflow: Not affected\n"
+        "Vulnerability Spec store bypass:    Vulnerable\n"
+        "Vulnerability Spectre v1:           Mitigation; __user pointer sanitization\n"
+        "Vulnerability Spectre v2:           Mitigation; CSV2, but not BHB\n"
+        "Vulnerability Srbds:                Not affected\n"
+        "Vulnerability Tsx async abort:      Not affected\n";
     m_do_unlink = false;
 }
 
@@ -387,6 +419,23 @@ TEST_F(PlatformTopoTest, gpu_num_domain)
     EXPECT_EQ(12, topo.num_domain(GEOPM_DOMAIN_GPU_CHIP));
 
     EXPECT_THROW(topo.num_domain(GEOPM_DOMAIN_INVALID), geopm::Exception);
+}
+
+TEST_F(PlatformTopoTest, arm_num_domain)
+{
+    write_lscpu(m_arm_lscpu_str);
+    PlatformTopoImp topo(m_lscpu_file_name, nullptr);
+    EXPECT_EQ(1, topo.num_domain(GEOPM_DOMAIN_BOARD));
+    EXPECT_EQ(1, topo.num_domain(GEOPM_DOMAIN_PACKAGE));
+    EXPECT_EQ(8, topo.num_domain(GEOPM_DOMAIN_CORE));
+    EXPECT_EQ(8, topo.num_domain(GEOPM_DOMAIN_CPU));
+    EXPECT_EQ(1, topo.num_domain(GEOPM_DOMAIN_MEMORY));
+    EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_PACKAGE_INTEGRATED_MEMORY));
+    EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_NIC));
+    EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_PACKAGE_INTEGRATED_NIC));
+    EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_GPU));
+    EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_PACKAGE_INTEGRATED_GPU));
+    EXPECT_EQ(0, topo.num_domain(GEOPM_DOMAIN_GPU_CHIP));
 }
 
 TEST_F(PlatformTopoTest, ppc_num_domain)

--- a/src/Admin.cpp
+++ b/src/Admin.cpp
@@ -6,7 +6,6 @@
 #include "config.h"
 
 #include <cmath>
-#include <cpuid.h>
 #include <memory>
 #include <sstream>
 
@@ -18,6 +17,7 @@
 #include "geopm/Helper.hpp"
 #include "geopm/MSRIOGroup.hpp"
 #include "OptionParser.hpp"
+#include "geopm/PlatformTopo.hpp"
 
 
 namespace geopm
@@ -25,7 +25,7 @@ namespace geopm
     Admin::Admin()
         : Admin(geopm::environment().default_config_path(),
                 geopm::environment().override_config_path(),
-                MSRIOGroup::cpuid())
+                geopm_read_cpuid())
     {
 
     }

--- a/src/Comm.cpp
+++ b/src/Comm.cpp
@@ -8,7 +8,6 @@
 #include "Comm.hpp"
 
 #include <inttypes.h>
-#include <cpuid.h>
 #include <string>
 #include <sstream>
 #include <dlfcn.h>


### PR DESCRIPTION
merge after #3296 because this PR removes the ExclusiveArch flag from the spec files.