### PR TITLE
Address RPM issues on rocky and centos

### DIFF
--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -117,7 +117,7 @@ Group: System/Libraries
 
 # Lets GEOPM batch its IO operations to reduce syscall overhead in IOGroups
 # with a lot of reads/writes per GEOPM batch operation.
-%if %{defined disable_io_uring}
+%if %{defined disable_io_uring} || 0%{?centos_ver} == 8
 %define io_uring_option --disable-io-uring
 %else
 BuildRequires: liburing-devel

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -163,6 +163,7 @@ the implementation for the geopmd service daemon and interfaces for
 configuring the service.
 
 # Steps for all packages
+%global debug_package %{nil}
 %prep
 %setup
 

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -224,8 +224,6 @@ ln -s -r %{buildroot}%{_sbindir}/service %{buildroot}%{_sbindir}/rcgeopm
 %service_add_post geopm.service
 %endif
 
-%post -n libgeopmd2 -p /sbin/ldconfig
-
 %preun -n geopm-service
 %if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
 %systemd_preun geopm.service
@@ -239,8 +237,6 @@ ln -s -r %{buildroot}%{_sbindir}/service %{buildroot}%{_sbindir}/rcgeopm
 %else
 %service_del_postun geopm.service
 %endif
-
-%postun -n libgeopmd2 -p /sbin/ldconfig
 
 # Installed files
 

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -21,7 +21,7 @@ Name: geopm-service
 Version: @VERSION@
 Release: 1
 License: BSD-3-Clause
-%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
 # Deprecated for RHEL and CentOS
 Group: System Environment/Daemons
 %else
@@ -52,9 +52,9 @@ Requires: level-zero >= 1.8.1
 %endif
 %if 0%{?suse_version} || 0%{?rocky_ver}
 BuildRequires: fdupes
+%endif
 BuildRequires: systemd-rpm-macros
 BuildRequires: python-rpm-macros
-%endif
 
 %if %{defined suse_version}
 %define docdir %{_defaultdocdir}/geopm-service
@@ -90,7 +90,7 @@ is installed with this package.
 %package devel
 
 Summary: Global Extensible Open Power Manager Service - development
-%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
 # Deprecated for RHEL and CentOS
 Group: Development/Libraries
 %else
@@ -108,7 +108,7 @@ libgeopmd.so shared object symbolic link.
 %package -n libgeopmd2
 
 Summary: Provides libgeopmd shared object library
-%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
 # Deprecated for RHEL and CentOS
 Group: System Environment/Libraries
 %else
@@ -135,7 +135,7 @@ library which provides C and C++ interfaces.
 %package -n python%{python3_pkgversion}-geopmdpy
 
 Summary: The geopmdpy Python package for the GEOPM Service
-%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
 # Deprecated for RHEL and CentOS
 Group: System Environment/Libraries
 %else
@@ -218,21 +218,21 @@ ln -s -r %{buildroot}%{_sbindir}/service %{buildroot}%{_sbindir}/rcgeopm
 %endif
 
 %post -n geopm-service
-%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
 %systemd_post geopm.service
 %else
 %service_add_post geopm.service
 %endif
 
 %preun -n geopm-service
-%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
 %systemd_preun geopm.service
 %else
 %service_del_preun geopm.service
 %endif
 
 %postun -n geopm-service
-%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
 %systemd_postun_with_restart geopm.service
 %else
 %service_del_postun geopm.service

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -50,7 +50,7 @@ BuildRequires: level-zero
 BuildRequires: level-zero-devel
 Requires: level-zero >= 1.8.1
 %endif
-%if 0%{?suse_version} || 0%{?rocky_ver}
+%if 0%{?suse_version}
 BuildRequires: fdupes
 %endif
 BuildRequires: systemd-rpm-macros

--- a/service/geopm-service.spec.in
+++ b/service/geopm-service.spec.in
@@ -21,7 +21,7 @@ Name: geopm-service
 Version: @VERSION@
 Release: 1
 License: BSD-3-Clause
-%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
 # Deprecated for RHEL and CentOS
 Group: System Environment/Daemons
 %else
@@ -50,7 +50,7 @@ BuildRequires: level-zero
 BuildRequires: level-zero-devel
 Requires: level-zero >= 1.8.1
 %endif
-%if 0%{?suse_version}
+%if 0%{?suse_version} || 0%{?rocky_ver}
 BuildRequires: fdupes
 BuildRequires: systemd-rpm-macros
 BuildRequires: python-rpm-macros
@@ -90,7 +90,7 @@ is installed with this package.
 %package devel
 
 Summary: Global Extensible Open Power Manager Service - development
-%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
 # Deprecated for RHEL and CentOS
 Group: Development/Libraries
 %else
@@ -108,7 +108,7 @@ libgeopmd.so shared object symbolic link.
 %package -n libgeopmd2
 
 Summary: Provides libgeopmd shared object library
-%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
 # Deprecated for RHEL and CentOS
 Group: System Environment/Libraries
 %else
@@ -135,7 +135,7 @@ library which provides C and C++ interfaces.
 %package -n python%{python3_pkgversion}-geopmdpy
 
 Summary: The geopmdpy Python package for the GEOPM Service
-%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
 # Deprecated for RHEL and CentOS
 Group: System Environment/Libraries
 %else
@@ -218,7 +218,7 @@ ln -s -r %{buildroot}%{_sbindir}/service %{buildroot}%{_sbindir}/rcgeopm
 %endif
 
 %post -n geopm-service
-%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
 %systemd_post geopm.service
 %else
 %service_add_post geopm.service
@@ -227,14 +227,14 @@ ln -s -r %{buildroot}%{_sbindir}/service %{buildroot}%{_sbindir}/rcgeopm
 %post -n libgeopmd2 -p /sbin/ldconfig
 
 %preun -n geopm-service
-%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
 %systemd_preun geopm.service
 %else
 %service_del_preun geopm.service
 %endif
 
 %postun -n geopm-service
-%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver}
 %systemd_postun_with_restart geopm.service
 %else
 %service_del_postun geopm.service


### PR DESCRIPTION
- Fixes #3313.
- Disable iouring support on CentOS 8.  The version available from the powertools repo has configure time errors within liburing.h.