### PR TITLE
Fix restore for CpufreqDriver when using JSON

### DIFF
--- a/service/src/SaveControl.cpp
+++ b/service/src/SaveControl.cpp
@@ -78,10 +78,12 @@ namespace geopm
     {
         std::vector<std::map<std::string, Json> > json_settings;
         for (const auto &ss : settings) {
-            json_settings.push_back({{"name", ss.name},
-                                     {"domain_type", ss.domain_type},
-                                     {"domain_idx", ss.domain_idx},
-                                     {"setting", ss.setting}});
+            if (std::isfinite(ss.setting)) {
+                json_settings.push_back({{"name", ss.name},
+                                         {"domain_type", ss.domain_type},
+                                         {"domain_idx", ss.domain_idx},
+                                         {"setting", ss.setting}});
+            }
         }
         Json json_obj(json_settings);
         return json_obj.dump();
@@ -142,12 +144,12 @@ namespace geopm
          }
     }
 
-    std::set<std::string> SaveControlImp::unsaved_controls(void) const
+    std::set<std::string> SaveControlImp::unsaved_controls(const std::set<std::string> &all_controls) const
     {
-        std::set<std::string> result;
+        std::set<std::string> result = all_controls;
         for (const auto &ss : settings()) {
-            if (!std::isfinite(ss.setting)) {
-                result.insert(ss.name);
+            if (std::isfinite(ss.setting)) {
+                result.erase(ss.name);
             }
         }
         return result;

--- a/service/src/SaveControl.hpp
+++ b/service/src/SaveControl.hpp
@@ -118,7 +118,7 @@ namespace geopm
             ///
             /// @param io_group [in] An IOGroup that implements controls
             virtual void restore(IOGroup &io_group) const = 0;
-            virtual std::set<std::string> unsaved_controls(void) const = 0;
+            virtual std::set<std::string> unsaved_controls(const std::set<std::string> &all_controls) const = 0;
     };
 
     class SaveControlImp : public SaveControl
@@ -132,7 +132,7 @@ namespace geopm
             std::vector<m_setting_s> settings(void) const override;
             void write_json(const std::string &save_path) const override;
             void restore(IOGroup &io_group) const override;
-            std::set<std::string> unsaved_controls(void) const override;
+            std::set<std::string> unsaved_controls(const std::set<std::string> &all_controls) const override;
 
             static std::string json(const std::vector<m_setting_s> &settings);
             static std::vector<m_setting_s> settings(const std::string &json_string);

--- a/service/src/SysfsIOGroup.cpp
+++ b/service/src/SysfsIOGroup.cpp
@@ -412,18 +412,20 @@ namespace geopm
 
     void SysfsIOGroup::save_control(void)
     {
-        if (!control_names().empty() && m_control_saver == nullptr) {
+        auto cnames = control_names();
+        if (!cnames.empty() && m_control_saver == nullptr) {
             m_control_saver = SaveControl::make_unique(*this);
-            m_unsaved_controls = m_control_saver->unsaved_controls();
+            m_unsaved_controls = m_control_saver->unsaved_controls(cnames);
         }
     }
 
     void SysfsIOGroup::save_control(const std::string &save_path)
     {
-        if (!control_names().empty()) {
+        auto cnames = control_names();
+        if (!cnames.empty()) {
             if (m_control_saver == nullptr) {
                 m_control_saver = SaveControl::make_unique(*this);
-                m_unsaved_controls = m_control_saver->unsaved_controls();
+                m_unsaved_controls = m_control_saver->unsaved_controls(cnames);
             }
             m_control_saver->write_json(save_path);
         }
@@ -438,9 +440,10 @@ namespace geopm
 
     void SysfsIOGroup::restore_control(const std::string &save_path)
     {
-        if (!control_names().empty() && m_control_saver == nullptr) {
+        auto cnames = control_names();
+        if (!cnames.empty() && m_control_saver == nullptr) {
             m_control_saver = SaveControl::make_unique(geopm::read_file(save_path));
-            m_unsaved_controls = m_control_saver->unsaved_controls();
+            m_unsaved_controls = m_control_saver->unsaved_controls(cnames);
         }
         if (m_control_saver != nullptr) {
             m_control_saver->restore(*this);

--- a/service/test/MockSaveControl.hpp
+++ b/service/test/MockSaveControl.hpp
@@ -19,7 +19,7 @@ class MockSaveControl : public geopm::SaveControl
         MOCK_METHOD(std::vector<m_setting_s>, settings, (), (const, override));
         MOCK_METHOD(void, write_json, (const std::string &save_path), (const, override));
         MOCK_METHOD(void, restore, (geopm::IOGroup &io_group), (const, override));
-        MOCK_METHOD(std::set<std::string>, unsaved_controls, (), (const, override));
+        MOCK_METHOD(std::set<std::string>, unsaved_controls, (const std::set<std::string> &all_controls), (const, override));
 };
 
 #endif


### PR DESCRIPTION
- The NAN values get represented as null in the JSON.
- When the files are parsed back in null is represented as 0 rather than NaN.
- Avoid this issue by not writing NaN values to JSON and change implemenation for unsaved_controls().
- Relates to #3311