### PR TITLE
Add upstream openmp.m4 macro from fossies

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = googletest-release*,autom4te.cache,./service/docs/build,./service/contrib,libtool*,ltmain*,./integration/apps/*/*,./.git,./ChangeLog,*.patch,./test/ProfileTableTest.cpp,configure,config.*,depcomp,*.spec
-ignore-words-list = atleast,clos,fom,warmup,affinitize,affinitized,whis
+ignore-words-list = atleast,clos,fom,warmup,affinitize,affinitized,whis,ois

--- a/COPYING-TPP
+++ b/COPYING-TPP
@@ -425,3 +425,37 @@ CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
 SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+6. Autoconf OpenMP Macro
+
+# This file is part of Autoconf.			-*- Autoconf -*-
+# Programming languages support.
+# Copyright (C) 2001-2012 Free Software Foundation, Inc.
+# Copyright (C) 2015-2023 R Core Team
+
+# This file is part of Autoconf.  This program is free
+# software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# Under Section 7 of GPL version 3, you are granted additional
+# permissions described in the Autoconf Configure Script Exception,
+# version 3.0, as published by the Free Software Foundation.
+#
+# You should have received a copy of the GNU General Public License
+# and a copy of the Autoconf Configure Script Exception along with
+# this program; see the files COPYINGv3 and COPYING.EXCEPTION
+# respectively.  If not, see <https://www.gnu.org/licenses/>.
+
+# Written by David MacKenzie, with help from
+# Akim Demaille, Paul Eggert,
+# Franc,ois Pinard, Karl Berry, Richard Pixley, Ian Lance Taylor,
+# Roland McGrath, Noah Friedman, david d zuhn, and many others.

--- a/Makefile.am
+++ b/Makefile.am
@@ -179,12 +179,14 @@ EXTRA_DIST = $(TUTORIAL_DIST) \
              autogen.sh \
              configure.ac \
              copying_headers/MANIFEST.apache2-llvm \
+             copying_headers/MANIFEST.autoconf_macro \
              copying_headers/MANIFEST.BSD3-llnl \
              copying_headers/MANIFEST.compile_flag \
              copying_headers/MANIFEST.EXEMPT \
              copying_headers/MANIFEST.MIT-dropbox \
              copying_headers/MANIFEST.NAS \
              copying_headers/header.apache2-llvm \
+             copying_headers/header.autoconf_macro \
              copying_headers/header.BSD3-intel \
              copying_headers/header.BSD3-llnl \
              copying_headers/header.compile_flag \
@@ -209,6 +211,7 @@ EXTRA_DIST = $(TUTORIAL_DIST) \
              indicators/index.html \
              indicators/indicators.py \
              m4/ax_check_compile_flag.m4 \
+             m4/openmp.m4 \
              pull_request_template.md \
              geopm-runtime.spec \
              geopm-runtime.spec.in \

--- a/configure.ac
+++ b/configure.ac
@@ -362,7 +362,7 @@ fi
 fi
 
 AC_LANG_PUSH([C++])
-AC_OPENMP
+R_OPENMP
 AC_LANG_POP([C++])
 
 if test "x$enable_openmp" = "xno" ; then

--- a/copying_headers/MANIFEST.EXEMPT
+++ b/copying_headers/MANIFEST.EXEMPT
@@ -7,12 +7,14 @@ COPYING-TPP
 docs
 .codespellrc
 copying_headers/header.apache2-llvm
+copying_headers/header.autoconf_macro
 copying_headers/header.BSD3-intel
 copying_headers/header.BSD3-llnl
 copying_headers/header.compile_flag
 copying_headers/header.MIT-dropbox
 copying_headers/header.NAS
 copying_headers/MANIFEST.apache2-llvm
+copying_headers/MANIFEST.autoconf_macro
 copying_headers/MANIFEST.BSD3-intel
 copying_headers/MANIFEST.BSD3-llnl
 copying_headers/MANIFEST.compile_flag

--- a/copying_headers/MANIFEST.autoconf_macro
+++ b/copying_headers/MANIFEST.autoconf_macro
@@ -1,0 +1,1 @@
+m4/openmp.m4

--- a/copying_headers/header.autoconf_macro
+++ b/copying_headers/header.autoconf_macro
@@ -1,0 +1,29 @@
+# This file is part of Autoconf.			-*- Autoconf -*-
+# Programming languages support.
+# Copyright (C) 2001-2012 Free Software Foundation, Inc.
+# Copyright (C) 2015-2023 R Core Team
+
+# This file is part of Autoconf.  This program is free
+# software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# Under Section 7 of GPL version 3, you are granted additional
+# permissions described in the Autoconf Configure Script Exception,
+# version 3.0, as published by the Free Software Foundation.
+#
+# You should have received a copy of the GNU General Public License
+# and a copy of the Autoconf Configure Script Exception along with
+# this program; see the files COPYINGv3 and COPYING.EXCEPTION
+# respectively.  If not, see <https://www.gnu.org/licenses/>.
+
+# Written by David MacKenzie, with help from
+# Akim Demaille, Paul Eggert,
+# Franc,ois Pinard, Karl Berry, Richard Pixley, Ian Lance Taylor,
+# Roland McGrath, Noah Friedman, david d zuhn, and many others.

--- a/examples/comd/0001-Marked-up-CoMD-code-for-use-with-GEOPM.patch
+++ b/examples/comd/0001-Marked-up-CoMD-code-for-use-with-GEOPM.patch
@@ -56,7 +56,7 @@ index 0000000..9537bab
 +### own.  If you need any -L or -l switches to get C standard libraries
 +### (such as -lm for the math library) put them in C_LIB.
 +CC = mpicc
-+CFLAGS = -std=c99 -qopenmp
++CFLAGS = -std=c99 -fiopenmp
 +OPTFLAGS = -g -O5
 +INCLUDES = 
 +C_LIB = -lm -lgeopm
@@ -298,7 +298,7 @@ index 0000000..db71722
 +### own.  If you need any -L or -l switches to get C standard libraries
 +### (such as -lm for the math library) put them in C_LIB.
 +CC = mpicc
-+CFLAGS = -std=c99 -fopenmp
++CFLAGS = -std=c99 -fiopenmp
 +CFLAGS_no_omp = -std=c99
 +OPTFLAGS = -g -O3
 +INCLUDES = 
@@ -313,7 +313,7 @@ index 0000000..db71722
 +### A place to specify any other include or library switches your
 +### platform requires.
 +OTHER_LIB = -L$(GEO_INSTALL_PATH)/lib \
-+			-Xlinker -rpath $(GEO_INSTALL_PATH)/lib -lgeopm -fopenmp
++			-Xlinker -rpath $(GEO_INSTALL_PATH)/lib -lgeopm -fiopenmp
 +OTHER_INCLUDE = -I$(GEO_INSTALL_PATH)/include
 +
 +#########################################
@@ -361,7 +361,7 @@ index 0000000..db71722
 +	${CC} ${CFLAGS} -c $< -o $@
 +
 +${CoMD_EXE}: ${BIN_DIR} CoMD_info.h ${OBJECTS} 
-+	${CC} ${CFLAGS_no_omp} -o comd.no_power ${OBJECTS} ${LDFLAGS} -fopenmp
++	${CC} ${CFLAGS_no_omp} -o comd.no_power ${OBJECTS} ${LDFLAGS} -fiopenmp
 +	${CC} ${CFLAGS_no_omp} -o comd.geo ${OBJECTS} ${LDFLAGS} 
 +	cp comd.no_power ../bin/
 +	cp comd.geo ../bin/

--- a/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
+++ b/integration/apps/amg/0001-Insert-calls-to-geopm-profile-APIs-in-the-AMG-timing.patch
@@ -39,8 +39,8 @@ index b73ccce..1397d5b 100644
  #CC = mpixlc_r
  
  # set compile flags here
-@@ -51,3 +51,7 @@ INCLUDE_CFLAGS = -O2 -DTIMER_USE_MPI -DHYPRE_USING_OPENMP -fopenmp -DHYPRE_HOPSC
- INCLUDE_LFLAGS = -lm -fopenmp
+@@ -51,3 +51,7 @@ INCLUDE_CFLAGS = -O2 -DTIMER_USE_MPI -DHYPRE_USING_OPENMP -fiopenmp -DHYPRE_HOPSC
+ INCLUDE_LFLAGS = -lm -fiopenmp
  #INCLUDE_LFLAGS = -lm 
  
 +# Add CFLAGS for geopm

--- a/integration/apps/hpcg/0002-Use-build-environment-vars.patch
+++ b/integration/apps/hpcg/0002-Use-build-environment-vars.patch
@@ -25,7 +25,7 @@ index 38b0f73..bff2726 100644
  #
 -CXX          = mpiicpc
 +CXX          = $(MPICXX)
- CXXFLAGS     = -xCORE-AVX2 -qopenmp -std=c++11 $(HPCG_DEFS)
+ CXXFLAGS     = -xCORE-AVX2 -fiopenmp -std=c++11 $(HPCG_DEFS)
  ifeq (yes, $(DBG))
    CXXFLAGS  += -O0 -g -DHPCG_DEBUG
 diff --git a/setup/Make.IMPI_IOMP_SKX b/setup/Make.IMPI_IOMP_SKX
@@ -38,7 +38,7 @@ index 9325d71..edc99cd 100644
  #
 -CXX          = mpiicpc
 +CXX          = $(MPICXX)
- CXXFLAGS     = -xCORE-AVX512 -qopt-zmm-usage=high -qopenmp -std=c++11 $(HPCG_DEFS)
+ CXXFLAGS     = -xCORE-AVX512 -qopt-zmm-usage=high -fiopenmp -std=c++11 $(HPCG_DEFS)
  ifeq (yes, $(DBG))
    CXXFLAGS  += -O0 -g -DHPCG_DEBUG
 -- 

--- a/integration/apps/hpl_netlib/0002-Changed-LAinc-lib-to-the-correct-paths-and-openmp-fl.patch
+++ b/integration/apps/hpl_netlib/0002-Changed-LAinc-lib-to-the-correct-paths-and-openmp-fl.patch
@@ -2,7 +2,7 @@ From 4a214908473fa022e407974591b8faaab22a2526 Mon Sep 17 00:00:00 2001
 From: Fuat Keceli <fuat.keceli@intel.com>
 Date: Fri, 9 Oct 2020 08:54:30 -0700
 Subject: [PATCH 2/4] Changed LAinc/lib to the correct paths and -openmp flag
- to -qopenmp
+ to -fiopenmp
 
 #  Copyright (c) 2015 - 2023, Intel Corporation
 #  SPDX-License-Identifier: BSD-3-Clause
@@ -35,7 +35,7 @@ index 47661c2..205a459 100644
  CC       = mpiicc
  CCNOOPT  = $(HPL_DEFS)
 -OMP_DEFS = -openmp
-+OMP_DEFS = -qopenmp
++OMP_DEFS = -fiopenmp
  CCFLAGS  = $(HPL_DEFS) -O3 -w -ansi-alias -i-static -z noexecstack -z relro -z now -nocompchk -Wall
  #
  # On some platforms,  it is necessary  to use the Fortran linker to find

--- a/integration/apps/hpl_netlib/0004-Replaced-mpicc-with-the-environment-variable.patch
+++ b/integration/apps/hpl_netlib/0004-Replaced-mpicc-with-the-environment-variable.patch
@@ -23,7 +23,7 @@ index 87d7191..36403d4 100644
 -CC       = mpiicc
 +CC       = $(MPICC)
  CCNOOPT  = $(HPL_DEFS)
- OMP_DEFS = -qopenmp
+ OMP_DEFS = -fiopenmp
  CCFLAGS  = $(HPL_DEFS) -O3 -w -ansi-alias -i-static -z noexecstack -z relro -z now -nocompchk -Wall
 -- 
 1.8.3.1

--- a/integration/apps/minife/0002-Enable-MPI-in-Intel-build.patch
+++ b/integration/apps/minife/0002-Enable-MPI-in-Intel-build.patch
@@ -20,7 +20,7 @@ index 390f163..df085d9 100644
 --- a/src/Makefile.intel.openmp
 +++ b/src/Makefile.intel.openmp
 @@ -19,13 +19,13 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
- CFLAGS = -O3 -fopenmp
+ CFLAGS = -O3 -fiopenmp
  CXXFLAGS = $(CFLAGS)
  
 -CPPFLAGS = -I. -I../utils -I../fem $(MINIFE_TYPES) $(MINIFE_MATRIX_TYPE)

--- a/integration/apps/minife/0003-Link-GEOPM.patch
+++ b/integration/apps/minife/0003-Link-GEOPM.patch
@@ -21,8 +21,8 @@ index df085d9..1f1a964 100644
  
  #-----------------------------------------------------------------------
  
--CFLAGS = -O3 -fopenmp
-+CFLAGS = -O3 -fopenmp $(GEOPM_CFLAGS)
+-CFLAGS = -O3 -fiopenmp
++CFLAGS = -O3 -fiopenmp $(GEOPM_CFLAGS)
  CXXFLAGS = $(CFLAGS)
  
  CPPFLAGS = -I. -I../utils -I../fem $(MINIFE_TYPES) $(MINIFE_MATRIX_TYPE) -DHAVE_MPI

--- a/integration/apps/nasft/nasft/Makefile.mk
+++ b/integration/apps/nasft/nasft/Makefile.mk
@@ -22,8 +22,8 @@ if ENABLE_OPENMP
 
     integration_apps_nasft_nasft_nas_ft_LDADD = libgeopm.la libgeopmfort.la $(MPI_FCLIBS) $(MPI_CXXLIBS)
     integration_apps_nasft_nasft_nas_ft_LDFLAGS = $(LDFLAGS_NOPIE) $(MPI_LDFLAGS) $(OPENMP_CFLAGS)
-    integration_apps_nasft_nasft_nas_ft_FCFLAGS = -std=legacy -fopenmp -msse4.2 $(MPI_FCFLAGS) $(OPENMP_CFLAGS) -O3
-    integration_apps_nasft_nasft_nas_ft_FFLAGS =  -fopenmp -msse4.2 $(MPI_FFLAGS) $(OPENMP_CFLAGS) -O3
+    integration_apps_nasft_nasft_nas_ft_FCFLAGS = -std=legacy -fiopenmp -msse4.2 $(MPI_FCFLAGS) $(OPENMP_CFLAGS) -O3
+    integration_apps_nasft_nasft_nas_ft_FFLAGS =  -fiopenmp -msse4.2 $(MPI_FFLAGS) $(OPENMP_CFLAGS) -O3
 if HAVE_IFX
     integration_apps_nasft_nasft_nas_ft_FCFLAGS += -std=legacy -xAVX -shared-intel -mcmodel=medium -fpic
     integration_apps_nasft_nasft_nas_ft_FFLAGS += -xAVX -shared-intel -mcmodel=medium -fpic

--- a/integration/apps/nekbone/0002-Use-AVX2.patch
+++ b/integration/apps/nekbone/0002-Use-AVX2.patch
@@ -18,14 +18,14 @@ diff --git a/test/example1/makenek-intel b/test/example1/makenek-intel
 index fa6e4f3..a5cce80 100755
 --- a/test/example1/makenek-intel
 +++ b/test/example1/makenek-intel
-@@ -35,8 +35,8 @@ USR_LFLAGS="-qopenmp -mcmodel=medium -shared-intel"
+@@ -35,8 +35,8 @@ USR_LFLAGS="-fiopenmp -mcmodel=medium -shared-intel"
  #G="-g"
  
  # optimization flags
--OPT_FLAGS_STD="-qopenmp -O3 -g -xHost -mcmodel=medium -shared-intel"
--OPT_FLAGS_MAG="-qopenmp -O3 -g -xHost -mcmodel=medium -shared-intel"
-+OPT_FLAGS_STD="-qopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
-+OPT_FLAGS_MAG="-qopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
+-OPT_FLAGS_STD="-fiopenmp -O3 -g -xHost -mcmodel=medium -shared-intel"
+-OPT_FLAGS_MAG="-fiopenmp -O3 -g -xHost -mcmodel=medium -shared-intel"
++OPT_FLAGS_STD="-fiopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
++OPT_FLAGS_MAG="-fiopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
  
  ###############################################################################
  # DONT'T TOUCH WHAT FOLLOWS !!!

--- a/integration/apps/nekbone/0003-Link-w-GEOPM.patch
+++ b/integration/apps/nekbone/0003-Link-w-GEOPM.patch
@@ -35,15 +35,15 @@ index a5cce80..82ec388 100755
  #USR="foo.o"
  
  # linking flags
--USR_LFLAGS="-qopenmp -mcmodel=medium -shared-intel"
-+USR_LFLAGS="-qopenmp -mcmodel=medium -shared-intel ${GEOPM_LDFLAGS} ${GEOPM_LDLIBS} ${GEOPM_FORTRAN_LDLIBS}"
+-USR_LFLAGS="-fiopenmp -mcmodel=medium -shared-intel"
++USR_LFLAGS="-fiopenmp -mcmodel=medium -shared-intel ${GEOPM_LDFLAGS} ${GEOPM_LDLIBS} ${GEOPM_FORTRAN_LDLIBS}"
  
  # generic compiler flags
 -#G="-g"
 +G="-DGEOPM -I${GEOPM_ROOT}/include"
  
  # optimization flags
- OPT_FLAGS_STD="-qopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
+ OPT_FLAGS_STD="-fiopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
 -- 
 2.23.0
 

--- a/integration/apps/nekbone/0008-Add-barriers-to-collective-calls.patch
+++ b/integration/apps/nekbone/0008-Add-barriers-to-collective-calls.patch
@@ -56,7 +56,7 @@ index e8ba84e..eb80bf5 100755
 --- a/test/example1/makenek-intel
 +++ b/test/example1/makenek-intel
 @@ -32,7 +32,10 @@ PPLIST="TIMERS CGTIMERS NITER=2000"
- USR_LFLAGS="-qopenmp -mcmodel=medium -shared-intel ${GEOPM_LDFLAGS} ${GEOPM_LDLIBS} ${GEOPM_FORTRAN_LDLIBS}"
+ USR_LFLAGS="-fiopenmp -mcmodel=medium -shared-intel ${GEOPM_LDFLAGS} ${GEOPM_LDLIBS} ${GEOPM_FORTRAN_LDLIBS}"
  
  # generic compiler flags
 -G="-DGEOPM -I${GEOPM_ROOT}/include"
@@ -66,7 +66,7 @@ index e8ba84e..eb80bf5 100755
 +fi
  
  # optimization flags
- OPT_FLAGS_STD="-qopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
+ OPT_FLAGS_STD="-fiopenmp -O3 -g -xCORE-AVX2 -mcmodel=medium -shared-intel"
 -- 
 2.23.0
 

--- a/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
+++ b/integration/apps/pennant/0001-Fixed-Makefile-to-GEOPM-and-Intel-conventions.patch
@@ -17,7 +17,7 @@ index 83cf0b2..e05e812 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -19,10 +19,10 @@ BINARY := $(BUILDDIR)/$(PRODUCT)
- #CXXFLAGS_OPENMP := -fopenmp
+ #CXXFLAGS_OPENMP := -fiopenmp
  
  # intel flags:
 -CXX := icpc
@@ -25,7 +25,7 @@ index 83cf0b2..e05e812 100644
  CXXFLAGS_DEBUG := -g
  CXXFLAGS_OPT := -O3 -fast -fno-alias
 -CXXFLAGS_OPENMP := -openmp
-+CXXFLAGS_OPENMP := -qopenmp
++CXXFLAGS_OPENMP := -fiopenmp
  
  # pgi flags:
  #CXX := pgCC

--- a/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
+++ b/integration/apps/pennant/0002-Added-geopm-epoch-markup.patch
@@ -17,7 +17,7 @@ diff --git a/Makefile b/Makefile
 index e05e812..a0611ef 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -36,6 +36,12 @@ CXXFLAGS_OPENMP := -qopenmp
+@@ -36,6 +36,12 @@ CXXFLAGS_OPENMP := -fiopenmp
  CXXFLAGS := $(CXXFLAGS_OPT)
  #CXXFLAGS := $(CXXFLAGS_DEBUG)
  

--- a/m4/openmp.m4
+++ b/m4/openmp.m4
@@ -1,0 +1,104 @@
+# This file is part of Autoconf.			-*- Autoconf -*-
+# Programming languages support.
+# Copyright (C) 2001-2012 Free Software Foundation, Inc.
+# Copyright (C) 2015-2023 R Core Team
+
+# This file is part of Autoconf.  This program is free
+# software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# Under Section 7 of GPL version 3, you are granted additional
+# permissions described in the Autoconf Configure Script Exception,
+# version 3.0, as published by the Free Software Foundation.
+#
+# You should have received a copy of the GNU General Public License
+# and a copy of the Autoconf Configure Script Exception along with
+# this program; see the files COPYINGv3 and COPYING.EXCEPTION
+# respectively.  If not, see <https://www.gnu.org/licenses/>.
+
+# Written by David MacKenzie, with help from
+# Akim Demaille, Paul Eggert,
+# Franc,ois Pinard, Karl Berry, Richard Pixley, Ian Lance Taylor,
+# Roland McGrath, Noah Friedman, david d zuhn, and many others.
+
+# [a small part, modified for clang and Intel in 2015,6, Solaris in 2017.]
+# [Change for Intel preferring -fiopenmp and deprecating -fopenmp in 2023.]
+
+# _AC_LANG_OPENMP is a language-dependent program defined in c.m4 in
+# the autoconf library.  And this is a modification of its AC_OPENMP
+
+# R_OPENMP
+# --------
+# Check which options need to be passed to the C compiler to support OpenMP.
+# Set the OPENMP_CFLAGS / OPENMP_CXXFLAGS / OPENMP_FFLAGS variable to these
+# options.
+# The options are necessary at compile time (so the #pragmas are understood)
+# and at link time (so the appropriate library is linked with).
+# This macro takes care to not produce redundant options if $CC $CFLAGS already
+# supports OpenMP. It also is careful to not pass options to compilers that
+# misinterpret them; for example, most compilers accept "-openmp" and create
+# an output file called 'penmp' rather than activating OpenMP support.
+AC_DEFUN([R_OPENMP],
+[
+  OPENMP_[]_AC_LANG_PREFIX[]FLAGS=
+  AC_ARG_ENABLE([openmp],
+    [AS_HELP_STRING([--disable-openmp], [do not use OpenMP])])
+  if test "$enable_openmp" != no; then
+    AC_CACHE_CHECK([for $[]_AC_CC[] option to support OpenMP],
+      [ac_cv_prog_[]_AC_LANG_ABBREV[]_openmp],
+      [AC_LINK_IFELSE([_AC_LANG_OPENMP],
+	 [ac_cv_prog_[]_AC_LANG_ABBREV[]_openmp='none needed'],
+	 [ac_cv_prog_[]_AC_LANG_ABBREV[]_openmp='unsupported'
+	  dnl Try these flags:
+	  dnl   GCC >= 4.2, clang >= 3.8, flang-new -fopenmp
+	  dnl   clang 3.7.x	      -fopenmp=libomp
+	  dnl   (-fopenmp was accepted but does not work)
+	  dnl   Oracle C, Fortran     -xopenmp
+          dnl   (also accepts -fopenmp as from 12.4, but does not work in 12.5)
+	  dnl   'Classic' Intel C, Fortran      -qopenmp
+	  dnl   Intel                 -openmp (deprecated)
+          dnl   (https://software.intel.com/en-us/node/581863,
+	  dnl    https://software.intel.com/en-us/node/525020)
+	  dnl   2023 Intel: prefers -fiopenmp
+	  dnl   SGI C, PGI C          -mp
+	  dnl   Tru64 Compaq C        -omp
+	  dnl   IBM C (AIX, Linux)    -qsmp=omp
+          dnl   Cray CCE              -homp
+          dnl   NEC SX                -Popenmp
+          dnl   Lahey Fortran (Linux) --openmp
+	  dnl   Classic flang          -mp, also -fopenmp
+	  dnl If in this loop a compiler is passed an option that it doesn't
+	  dnl understand or that it misinterprets, the AC_LINK_IFELSE test
+	  dnl will fail (since we know that it failed without the option),
+	  dnl therefore the loop will continue searching for an option, and
+	  dnl no output file called 'penmp' or 'mp' is created.
+	  dnl Sept 2017: Solaris needs -xopenmp tested before -fopenmp
+	  for ac_option in -xopenmp -fiopenmp -fopenmp -qopenmp \
+                           -openmp -mp -omp -qsmp=omp -homp \
+			   -fopenmp=libomp \
+                           -Popenmp --openmp; do
+	    ac_save_[]_AC_LANG_PREFIX[]FLAGS=$[]_AC_LANG_PREFIX[]FLAGS
+	    _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $ac_option"
+	    AC_LINK_IFELSE([_AC_LANG_OPENMP],
+	      [ac_cv_prog_[]_AC_LANG_ABBREV[]_openmp=$ac_option])
+	    _AC_LANG_PREFIX[]FLAGS=$ac_save_[]_AC_LANG_PREFIX[]FLAGS
+	    if test "$ac_cv_prog_[]_AC_LANG_ABBREV[]_openmp" != unsupported; then
+	      break
+	    fi
+	  done])])
+    case $ac_cv_prog_[]_AC_LANG_ABBREV[]_openmp in #(
+      "none needed" | unsupported)
+	;; #(
+      *)
+	OPENMP_[]_AC_LANG_PREFIX[]FLAGS=$ac_cv_prog_[]_AC_LANG_ABBREV[]_openmp ;;
+    esac
+  fi
+  AC_SUBST([OPENMP_]_AC_LANG_PREFIX[FLAGS])
+])

--- a/test_hw/Makefile
+++ b/test_hw/Makefile
@@ -6,7 +6,7 @@
 CFLAGS_EXTRA = -std=c99 -D_POSIX_C_SOURCE=200809L -O3 -lrt -qmkl=parallel
 
 rapl_pkg_limit_test: rapl_pkg_limit_test.c
-	icx $(CFLAGS_EXTRA) $(CFLAGS) $(LDFLAGS) $(LIBS) -qopenmp $^ -o $@
+	icx $(CFLAGS_EXTRA) $(CFLAGS) $(LDFLAGS) $(LIBS) -fiopenmp $^ -o $@
 
 check: rapl_pkg_limit_test
 	./rapl_pkg_limit_test 150

--- a/tutorial/tutorial_build_intel.sh
+++ b/tutorial/tutorial_build_intel.sh
@@ -8,7 +8,7 @@
 
 # OMP_FLAGS: Flags for enabling OpenMP
 if [ ! "$OMP_FLAGS" ]; then
-    OMP_FLAGS="-qopenmp"
+    OMP_FLAGS="-fiopenmp"
 fi
 
 export CC=${CC:-icx}


### PR DESCRIPTION
- Origin: https://fossies.org/linux/R/m4/openmp.m4
- Intel requires -fiopenmp and warns when -fopenmp is provided.
- Fixes build issue with the following signature:

```
icpx: error: Use of '-qopenmp' recommended over '-fopenmp' [-Werror,-Wrecommended-option]
```

- Fixes #3318