### PR TITLE
Give better warning message when controller does not connect

### DIFF
--- a/src/ApplicationIO.cpp
+++ b/src/ApplicationIO.cpp
@@ -57,11 +57,6 @@ namespace geopm
         if (m_is_connected) {
             return result;
         }
-        double timeout = m_timeout;
-        // TODO: This is a temporary work around until issue #2987 is resolved
-        if (timeout < 0.0) {
-            timeout = 60.0;
-        }
         struct geopm_time_s time_zero;
         struct geopm_time_s time_curr;
         geopm_time(&time_zero);
@@ -80,13 +75,14 @@ namespace geopm
             }
             clock_nanosleep(CLOCK_REALTIME, 0, &delay, NULL);
             geopm_time(&time_curr);
-        } while (!m_is_connected && geopm_time_diff(&time_zero, &time_curr) < timeout);
+        } while (!m_is_connected && geopm_time_diff(&time_zero, &time_curr) < m_timeout);
 
         if (!m_is_connected) {
-            std::cerr << "Warning: <geopm> Timeout while trying to detect the application. "
-                      << "This can happen if the application has a very short duration." << std::endl;
+            std::cerr << "Warning: <geopm> Timeout while trying to detect the application. Possible causes:\n"
+                      << "         1. Application processes have a very short duration\n"
+                      << "         2. GEOPM_PROGRAM_FILTER is not set correctly in the application environment (does not match program invocation name)\n"
+                      << "         3. GEOPM_NUM_PROC is set to more processes than are created with matching program invocation names." << std::endl;
         }
-
 #ifdef GEOPM_DEBUG
         std::cout << "Info: <geopm> Controller will profile PIDs: ";
         for (auto pid : m_profile_pids) {

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -259,6 +259,7 @@ namespace geopm
         , m_do_policy(do_policy)
         , m_init_control(std::move(init_control))
         , m_do_init_control(do_init_control)
+        , m_do_restore(false)
     {
         if (m_num_send_down > 0 && !(m_do_policy || m_do_endpoint)) {
             throw Exception("Controller(): at least one of policy or endpoint path"
@@ -292,7 +293,9 @@ namespace geopm
 
     Controller::~Controller()
     {
-        m_platform_io.restore_control();
+        if (m_do_restore) {
+            m_platform_io.restore_control();
+        }
     }
 
     void Controller::create_agents(void)
@@ -365,6 +368,7 @@ namespace geopm
         m_application_sampler.update(curr_time);
         create_agents();
         m_platform_io.save_control();
+        m_do_restore = true;
         m_init_control->write_controls();
         init_agents();
         m_reporter->init();

--- a/src/Controller.hpp
+++ b/src/Controller.hpp
@@ -171,6 +171,7 @@ namespace geopm
 
             std::shared_ptr<InitControl> m_init_control;
             bool m_do_init_control;
+            bool m_do_restore;
     };
 }
 #endif

--- a/test/ControllerTest.cpp
+++ b/test/ControllerTest.cpp
@@ -170,9 +170,6 @@ void ControllerTest::SetUp()
     m_policy_tracer_ptr = m_policy_tracer.get();
     m_profile_tracer = std::make_shared<MockProfileTracer>();
     m_init_control = std::make_shared<MockInitControl>();
-
-    // called during clean up
-    EXPECT_CALL(m_platform_io, restore_control());
 }
 
 void ControllerTest::TearDown()


### PR DESCRIPTION
- Do not call restore_control in destructor when connection fails
- Resolves #2987
- Remove work around for negative timeout values
- Profiling only occurs when the GEOPM_PROGRAM_FILTER matches, so now profiling is default off.
