### PR TITLE
Remove the topo cache when service starts up

### DIFF
--- a/service/geopm.service
+++ b/service/geopm.service
@@ -12,6 +12,8 @@ After=msr-safe.service
 [Service]
 Environment=PYTHONUNBUFFERED=true
 Environment=ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
+Environment=ZES_ENABLE_SYSMAN=1
+
 Type=dbus
 BusName=io.github.geopm
 ExecStart=/usr/bin/geopmd

--- a/service/geopmdpy/__main__.py
+++ b/service/geopmdpy/__main__.py
@@ -45,7 +45,9 @@ def main():
         try:
             if not os.path.exists('/dev/cpu/msr_batch'):
                 writer.backup_and_try_update('on\n')
-            _bus.publish_object("/io/github/geopm", service.GEOPMService())
+            geopm_service = service.GEOPMService()
+            geopm_service.topo_rm_cache()
+            _bus.publish_object("/io/github/geopm", geopm_service)
             _bus.register_service("io.github.geopm")
             _loop.run()
         finally:

--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -884,6 +884,7 @@ class TopoService(object):
 
         """
         self._topo = topo
+        self._topo_path = os.path.join(system_files.GEOPM_SERVICE_RUN_PATH, 'geopm-topo-cache')
 
     def get_cache(self):
         """Return the contents of the PlatformTopo cache file.
@@ -899,10 +900,18 @@ class TopoService(object):
 
         """
         self._topo.create_cache()
-        with open(os.path.join(system_files.GEOPM_SERVICE_RUN_PATH, 'geopm-topo-cache')) as fid:
+        with open(self._topo_path) as fid:
             result = fid.read()
         return result
 
+    def rm_cache(self):
+        """Remove an existing cache file if it exists
+
+        """
+        try:
+            os.unlink(self._topo_path)
+        except FileNotFoundError:
+            pass
 
 class GEOPMService(object):
     """The dasbus service object that is published.
@@ -1025,6 +1034,12 @@ class GEOPMService(object):
     # TODO: This method should check credentials
     def PlatformPopProfileRegionNames(self, profile_name):
         return self._platform.pop_profile_region_names(profile_name)
+
+    def topo_rm_cache(self):
+        """Remove an existing topo cache file if it exists
+
+        """
+        self._topo.rm_cache()
 
     def _get_user(self, call_info):
         """Use DBus proxy object to derive the user name that owns the client

--- a/service/src/LevelZero.cpp
+++ b/service/src/LevelZero.cpp
@@ -16,11 +16,6 @@
 
 #include "LevelZeroImp.hpp"
 
-static void __attribute__((constructor)) geopm_levelzero_init(void)
-{
-    setenv("ZES_ENABLE_SYSMAN", "1", 1);
-}
-
 namespace geopm
 {
     const LevelZero &levelzero()


### PR DESCRIPTION
- Since environment variables can impact how LevelZero reports topology, make sure to clear off any topo file when the service starts up
- Set environment variables in service file, not in lib init scripts
