### PR TITLE
Run the GEOPM service as an unprivileged user

### DIFF
--- a/service/geopmdpy/__main__.py
+++ b/service/geopmdpy/__main__.py
@@ -3,7 +3,7 @@
 #
 
 from dasbus.loop import EventLoop
-from dasbus.connection import SystemMessageBus
+from dasbus.connection import SessionMessageBus,SystemMessageBus
 from signal import signal
 from signal import SIGTERM
 import sys
@@ -37,7 +37,7 @@ def main():
     system_files.secure_make_dirs(system_files.GEOPM_SERVICE_RUN_PATH,
                                   perm_mode=system_files.GEOPM_SERVICE_RUN_PATH_PERM)
     _loop = EventLoop()
-    _bus = SystemMessageBus()
+    _bus = SessionMessageBus()
     with RestorableFileWriter(
         ALLOW_WRITES_PATH, ALLOW_WRITES_BACKUP_PATH,
         warning_handler=lambda warning: print('Warning <geopm-service>', warning,
@@ -48,6 +48,8 @@ def main():
             geopm_service = service.GEOPMService()
             geopm_service.topo_rm_cache()
             _bus.publish_object("/io/github/geopm", geopm_service)
+            ## see gi.repository.GLib.Error: g-io-error-quark: Could not connect: No such file or directory (1)
+            ## on the below line? Don't forget to start a session bus. E.g., `export $(dbus-launch)`
             _bus.register_service("io.github.geopm")
             _loop.run()
         finally:

--- a/service/geopmdpy/access.py
+++ b/service/geopmdpy/access.py
@@ -11,7 +11,7 @@ import os
 import tempfile
 import subprocess # nosec
 from argparse import ArgumentParser
-from dasbus.connection import SystemMessageBus
+from dasbus.connection import SystemMessageBus,SessionMessageBus
 from dasbus.error import DBusError
 from geopmdpy import system_files
 
@@ -432,7 +432,7 @@ def main():
 
     try:
         geopm_proxy = (DirectAccessProxy() if args.direct
-                       else SystemMessageBus().get_proxy('io.github.geopm', '/io/github/geopm'))
+                       else SessionMessageBus().get_proxy('io.github.geopm', '/io/github/geopm'))
         acc = Access(geopm_proxy)
         output = acc.run(args.write, args.all, args.controls, args.group,
                          args.default, args.delete, args.dry_run, args.force,

--- a/service/geopmdpy/service.py
+++ b/service/geopmdpy/service.py
@@ -22,7 +22,7 @@ from . import pio
 from . import topo
 from . import dbus_xml
 from . import system_files
-from dasbus.connection import SystemMessageBus
+from dasbus.connection import SessionMessageBus,SystemMessageBus
 try:
     from dasbus.server.interface import accepts_additional_arguments
 except ImportError as ee:
@@ -67,7 +67,8 @@ class PlatformService(object):
         returned.
 
         The values are securely read from files located in
-        /etc/geopm using the secure_read_file() interface.
+        GEOPM_CONFIG_PATH (default /etc/geopm) using the secure_read_file()
+        interface.
 
         If no secure file exist for the specified group, then two
         empty lists are returned.
@@ -93,7 +94,7 @@ class PlatformService(object):
         updated.
 
         The values are securely written atomically to files located in
-        /etc/geopm using the secure_make_dirs() and
+        GEOPM_CONFIG_PATH (default /etc/geopm) using the secure_make_dirs() and
         secure_make_file() interfaces.
 
         Args:
@@ -117,7 +118,7 @@ class PlatformService(object):
         of allowed signal are updated.
 
         The values are securely written atomically to files located in
-        /etc/geopm using the secure_make_dirs() and
+        GEOPM_CONFIG_PATH (default /etc/geopm) using the secure_make_dirs() and
         secure_make_file() interfaces.
 
         Args:
@@ -139,7 +140,7 @@ class PlatformService(object):
         of allowed control are updated.
 
         The values are securely written atomically to files located in
-        /etc/geopm using the secure_make_dirs() and
+        GEOPM_CONFIG_PATH (default /etc/geopm) using the secure_make_dirs() and
         secure_make_file() interfaces.
 
         Args:
@@ -935,8 +936,8 @@ class GEOPMService(object):
     def __init__(self):
         self._topo = TopoService()
         self._platform = PlatformService()
-        self._dbus_proxy = SystemMessageBus().get_proxy('org.freedesktop.DBus',
-                                                        '/org/freedesktop/DBus')
+        self._dbus_proxy = SessionMessageBus().get_proxy('org.freedesktop.DBus',
+                                                         '/org/freedesktop/DBus')
 
     def TopoGetCache(self):
         return self._topo.get_cache()

--- a/service/geopmdpy_test/TestPlatformService.py
+++ b/service/geopmdpy_test/TestPlatformService.py
@@ -447,7 +447,7 @@ class TestPlatformService(unittest.TestCase):
         topo_service = TopoService(topo=topo)
 
         mock_open = mock.mock_open(read_data='data')
-        cache_file = '/run/geopm/geopm-topo-cache'
+        cache_file = '/tmp/rungeopm/geopm-topo-cache'
         with mock.patch('builtins.open', mock_open):
             cache_data = topo_service.get_cache()
             self.assertEqual('data', cache_data)

--- a/service/io.github.geopm.xml
+++ b/service/io.github.geopm.xml
@@ -56,7 +56,7 @@ then the default lists of allowed signals and controls are
 returned.
 
 The values are securely read from files located in
-/etc/geopm using the secure_read_file() interface.
+/tmp/etcgeopm using the secure_read_file() interface.
 
 If no secure file exist for the specified group, then two
 empty lists are returned.
@@ -93,7 +93,7 @@ then the default lists of allowed signals and controls are
 updated.
 
 The values are securely written atomically to files located in
-/etc/geopm using the secure_make_dirs() and
+/tmp/etcgeopm using the secure_make_dirs() and
 secure_make_file() interfaces.
           </doc:para>
         </doc:description>
@@ -122,7 +122,7 @@ then the default lists of allowed signals and controls are
 updated.
 
 The values are securely written atomically to files located in
-/etc/geopm using the secure_make_dirs() and
+/tmp/etcgeopm using the secure_make_dirs() and
 secure_make_file() interfaces.
           </doc:para>
         </doc:description>
@@ -151,7 +151,7 @@ then the default lists of allowed signals and controls are
 updated.
 
 The values are securely written atomically to files located in
-/etc/geopm using the secure_make_dirs() and
+/tmp/etcgeopm using the secure_make_dirs() and
 secure_make_file() interfaces.
           </doc:para>
         </doc:description>

--- a/service/src/BatchServer.hpp
+++ b/service/src/BatchServer.hpp
@@ -95,7 +95,7 @@ namespace geopm
 
         protected:
             static constexpr const char* M_SHMEM_PREFIX =
-                "/run/geopm/batch-buffer-";
+                "/tmp/rungeopm/batch-buffer-";
     };
 
     class BatchServerImp : public BatchServer

--- a/service/src/BatchStatus.hpp
+++ b/service/src/BatchStatus.hpp
@@ -68,7 +68,7 @@ namespace geopm
             // This is the single place where the server prefix is located,
             // which is also accessed by BatchStatusTest.
             static constexpr const char* M_DEFAULT_FIFO_PREFIX =
-                "/run/geopm/batch-status-";
+                "/tmp/rungeopm/batch-status-";
     };
 
     class BatchStatusServer : public BatchStatusImp

--- a/service/src/IOGroup.cpp
+++ b/service/src/IOGroup.cpp
@@ -89,7 +89,8 @@ namespace geopm
         // service enabling save/restore by geopmd.  If the geopm
         // service is not active then loading the ServiceIOGroup will
         // fail.
-        if (geopm::has_cap_sys_admin()) {
+        bool is_service = get_env("GEOPM_IS_SERVICE") == "1";
+        if (is_service) {
             // May want to give this higher priority than the non-safe
             // msr driver once it is considered more stable.
             register_plugin(CpufreqSysfsDriver::plugin_name(),

--- a/service/src/PlatformTopo.cpp
+++ b/service/src/PlatformTopo.cpp
@@ -76,7 +76,7 @@ static int geopm_topo_popen(const char *cmd, FILE **fid)
 namespace geopm
 {
     const std::string PlatformTopoImp::M_CACHE_FILE_NAME = "/tmp/geopm-topo-cache-" + std::to_string(getuid());
-    const std::string PlatformTopoImp::M_SERVICE_CACHE_FILE_NAME = "/run/geopm/geopm-topo-cache";
+    const std::string PlatformTopoImp::M_SERVICE_CACHE_FILE_NAME = "/tmp/rungeopm/geopm-topo-cache";
 
     const PlatformTopo &platform_topo(void)
     {
@@ -424,7 +424,8 @@ namespace geopm
 
     void PlatformTopoImp::create_cache(void)
     {
-        if (geopm::has_cap_sys_admin()) {
+        // TODO: Make the user say which to use.
+        if (true/*geopm::has_cap_sys_admin()*/) {
             PlatformTopoImp::create_cache(M_SERVICE_CACHE_FILE_NAME);
         }
         else {

--- a/service/src/SDBus.cpp
+++ b/service/src/SDBus.cpp
@@ -50,7 +50,7 @@ namespace geopm
         , m_dbus_interface("io.github.geopm")
         , m_dbus_timeout_usec(0)
     {
-        int err = sd_bus_open_system(&m_bus);
+        int err = sd_bus_open(&m_bus);
         if (err < 0) {
             throw Exception("ServiceProxy: Failed to open system bus",
                             GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);

--- a/service/src/ServiceIOGroup.cpp
+++ b/service/src/ServiceIOGroup.cpp
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <climits>
+#include <iostream>
 #include <cstring>
 #include <unistd.h>
 #include "geopm/Agg.hpp"

--- a/service/src/geopm_shmem.cpp
+++ b/service/src/geopm_shmem.cpp
@@ -23,7 +23,7 @@ namespace geopm
             // The status key is a shared resource
             id = uid;
         }
-        result << "/run/geopm/profile-" << id << "-" << shm_key;
+        result << "/tmp/rungeopm/profile-" << id << "-" << shm_key;
         return result.str();
     }
 


### PR DESCRIPTION
This is a hard-coded prototype demonstrating what code needs to be touched (not a proposal for actual changes to be made) if we want to optionally run geopmd as a regular user, which may simplify some testing workflows.

Summary of key changes is:
* We need to be able to customize our /etc and /run paths (either at build time, or at run time should be fine)
* We need to be able to select between system dbus and session dbus
* There are several "am I privileged" checks in the code. Some of those are truly intended as privilege checks, but some of them are "am I a client or am I the service" checks. Those need to be separated out. This draft makes a guess, but I'm not sure if I got it completely right.

Usage:
* Configure with something to put the GEOPM config path on a user-writable location `GEOPM_CONFIG_PATH=/tmp/etcgeopm ./configure ...`
* On a compute node, stop any actual instances of the geopm service `system stop geopm`
* On the compute node, start a dbus session: `dbus-launch`. Note the env vars it prints out.
* Export the env vars printed by dbus-launch. These need to be exported where you run the service, as well as where you run any clients (e.g., geopmread)
* Run geopmd as `GEOPM_IS_SERVICE=1 geopmd`
* Run geopm clients as normal
