### PR TITLE
Make geopmctl_main a cpp file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -484,7 +484,7 @@ ompt_source_files = src/OMPT.cpp \
                     src/ompt_callback.cpp \
                     # end
 
-geopmctl_SOURCES = src/geopmctl_main.c
+geopmctl_SOURCES = src/geopmctl_main.cpp
 
 if ENABLE_MPI
     libgeopm_la_SOURCES +=$(mpi_source_files)

--- a/src/Controller.hpp
+++ b/src/Controller.hpp
@@ -14,6 +14,12 @@
 #include <map>
 #include <set>
 
+
+extern "C"
+{
+    int geopmctl_main(int argc, char **argv);
+}
+
 namespace geopm
 {
     class Comm;

--- a/src/geopmctl_main.cpp
+++ b/src/geopmctl_main.cpp
@@ -17,15 +17,11 @@
 
 #include "geopm_version.h"
 #include "geopm_error.h"
+#include "Controller.hpp"
 
 enum geopmctl_const {
     GEOPMCTL_STRING_LENGTH = 128,
 };
-
-extern "C"
-{
-    int geopmctl_main(int argc, char **argv);
-}
 
 int main(int argc, char **argv)
 {

--- a/src/geopmctl_main.cpp
+++ b/src/geopmctl_main.cpp
@@ -22,7 +22,10 @@ enum geopmctl_const {
     GEOPMCTL_STRING_LENGTH = 128,
 };
 
-int geopmctl_main(int argc, char **argv);
+extern "C"
+{
+    int geopmctl_main(int argc, char **argv);
+}
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
- Resolves linking issues when building inside spack.
- Relates to #1874.