### PR TITLE
Update documentation for web page

### DIFF
--- a/docs/source/geopmaccess.1.rst
+++ b/docs/source/geopmaccess.1.rst
@@ -5,6 +5,13 @@ geopmaccess(1) -- Access management for the GEOPM Service
 Synopsis
 --------
 
+.. code-block:: none
+
+    geopmaccess [-h] [-v] [-c] [-u | -g GROUP | -a | -l | -s] [-w | -e | -D] [-n | -F] [-x]
+
+Access management for the GEOPM Service. Command line tool for reading and
+writing the access management lists for the GEOPM Service signals and controls.
+
 Read Access List
 ~~~~~~~~~~~~~~~~
 
@@ -33,7 +40,6 @@ Remove Access List
 
     geopmaccess -D [-c] [-g GROUP]
 
-
 Get Help or Version
 ~~~~~~~~~~~~~~~~~~~
 
@@ -45,33 +51,73 @@ Get Help or Version
 Description
 -----------
 
-The GEOPM service uses the ``/etc/geopm`` directory to store
-files that control which signals and controls may be accessed by a
-user through the service.  The purpose of the ``geopmaccess`` command
-line tool is to enable reading and writing of these access list files.
+The GEOPM service uses the ``/etc/geopm`` directory to store files that control
+which signals and controls may be accessed by a user through the service.  The
+purpose of the ``geopmaccess`` command line tool is to enable reading and
+writing of these access list files.
 
 
 Options
 ~~~~~~~
--c, --controls  Command applies to controls not signals
--u, --default   Print the default user access list
--g, --group     Read or write the access list for a specific Unix GROUP
--a, --all       Print all signals or controls supported by the service system
--w, --write     Use standard input to write an access list
--e, --edit      Edit an access list using EDITOR environment variable, default
-                ``vi``
--D, --delete    Remove an access list for default user or a particular Unix Group
--n, --dry-run   Do error checking on all user input, but do not modify
-                configuration files
--F, --force     Write access list without validating GEOPM Service support for
-                names
--l, --log       Print a log of all signals or controls that have been accessed
-                since the service was last restarted.
--s, --msr-safe  Print the minimal msr-safe allowlist required by GEOPM.
--h, --help      Print brief summary of the command line usage information, then
-                exit
--v, --version   Print version of :doc:`geopm(7) <geopm.7>` to standard output,
-                then exit
+
+-h, --help  .. _help option:
+
+    Print help message and exit
+
+-v, --version  .. _version option:
+
+    Print version and exit
+
+-c, --controls  .. _controls option:
+
+    Command applies to controls not signals
+
+-u, --default  .. _default option:
+
+    Print the default user access list
+
+-g GROUP, --group GROUP  .. _group option:
+
+    Read or write the access list for a specific Unix GROUP
+
+-a, --all  .. _all option:
+
+    Print all signals or controls supported by the service system
+
+-l, --log  .. _log option:
+
+    Print list of used signals or controls used since last restart of the
+    service
+
+-s, --msr-safe  .. _msr-safe option:
+
+    Generate an allowlist for msr-safe
+
+-w, --write  .. _write option:
+
+    Use standard input to write an access list. Implies -u unless -g is
+    provided.
+
+-e, --edit  .. _edit option:
+
+    Edit an access list using EDITOR environment variable, default vi
+
+-D, --delete  .. _delete option:
+
+    Remove an access list for default user or a particular Unix Group
+
+-n, --dry-run  .. _dry-run option:
+
+    Do error checking on all user input, but do not modify configuration files
+
+-F, --force  .. _force option:
+
+    Write access list without validating GEOPM Service support for names
+
+-x, --direct  .. _direct option:
+
+    Write directly to files, do not use DBus
+
 
 Query Access
 ~~~~~~~~~~~~

--- a/docs/source/geopmsession.1.rst
+++ b/docs/source/geopmsession.1.rst
@@ -5,6 +5,14 @@ geopmsession(1) -- Command line interface for the GEOPM service batch read featu
 Synopsis
 --------
 
+.. code-block:: none
+
+    geopmsession [-h] [-v] [-t TIME] [-p PERIOD] [--pid PID] [--print-header]
+
+Command line interface for the geopm service batch read features. This command
+can be used to read signals by opening a session with the geopm service.
+
+
 Read a signal
 ~~~~~~~~~~~~~
 
@@ -49,11 +57,33 @@ signals requested though standard input is made and the results are
 printed to the screen.
 
 Options
-~~~~~~~
--h, --help                  show this help message and exit
--t TIME, --time TIME        Total run time of the session to be opened in seconds
--p PERIOD, --period PERIOD  When used with a read mode session reads all values
-                            out periodically with the specified period in seconds
+-------
+
+-h, --help  .. _help option:
+
+    Print help message and exit
+
+-v, --version  .. _version option:
+
+    Print version and exit
+
+-t TIME, --time TIME  .. _time option:
+
+    Total run time of the session to be opened in seconds
+
+-p PERIOD, --period PERIOD  .. _period option:
+
+    When used with a read mode session reads all values out periodically with
+    the specified period in seconds
+
+--pid PID  .. _pid option:
+
+    Stop the session when the given process PID ends
+
+--print-header  .. _header option:
+
+    Print a CSV header before printing any sampled values
+
 
 Examples
 --------

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -821,7 +821,7 @@ controller process to connect to the application process and generate a report:
 3. The ``GEOPM_REPORT`` environment variable must be set in the environment of
    the ``geopmctl`` process.
 4. The ``GEOPM_PROGRAM_FILTER`` environment variable is required and explicitly
-   lists the program invovation names of any process to be profiled. All other
+   lists the program invocation names of any process to be profiled. All other
    programs will not be affected by ``LD_PRELOAD`` of ``libgeopm.so``.  For this
    reason a user will typically set these two environment variables together.
    This is especially important when profiling programs within a bash script.

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -794,61 +794,61 @@ option to ``geopmlaunch``.  For more information about ``geompmlaunch`` see:
 :doc:`geopmlaunch.1`.  For more information about the reports, see:
 :doc:`geopm_report.7`.
 
-Profiling Non-MPI Applications
-""""""""""""""""""""""""""""""
 
-The ``geopmlaunch(1)`` command may not be best suited for your needs
-if you are running a non-MPI application, or if you are running an MPI
-application but the launch command is embedded in scripts that are
-difficult to modify.  Instead of using ``geopmlaunch(1)``, the
-user may use the ``geopmctl(1)`` application in conjunction with
-environment variables that control the GEOPM Runtime behavior.
+Profiling Applications without ``geopmlaunch``
+""""""""""""""""""""""""""""""""""""""""""""""
 
-In this simple example we run the ``sleep(1)`` command for 10 seconds
-and monitor the system during its execution.  Rather than using the
-``geopmlaunch`` tool as in the above example, we will run the
-``geopmctl`` command in the background while the application of
-interest is executing.  There are four requirements to enable the
-GEOPM controller process to connect to the application process and
-generate a report:
+The ``geopmlaunch(1)`` command may not be best suited for your needs if you are
+running a non-MPI application, or if you are running an MPI application but the
+launch command is embedded in scripts that are difficult to modify.  Instead of
+using ``geopmlaunch(1)``, the user may use the ``geopmctl(1)`` application in
+conjunction with environment variables that control the GEOPM Runtime behavior.
 
-1. Both the ``geopmctl`` process and the application process must have
-   the ``GEOPM_PROFILE`` environment variable set to the **same**
-   value or both environments may leave this variable unset.
-2. The application process must have ``LD_PRELOAD=libgeopm.so.2`` set
-   in the environment or the application binary must be linked
-   directly to ``libgeopm.so.2`` at compile time.
-3. The ``GEOPM_REPORT`` environment variable must be set in the
-   environment of the ``geopmctl`` process.
-4. The ``GEOPM_PROGRAM_FILTER`` environment variable is required and
-   explicitly lists the program invovation names of any process to be
-   profiled. All other programs will not be affected by ``LD_PRELOAD``
-   of ``libgeopm.so``.  For this reason a user will typically set
-   these two environment variables together.  This is especially
-   important when profiling programs within a bash script.
+In this simple example we run the ``sleep(1)`` command for 10 seconds and
+monitor the system during its execution.  Rather than using the ``geopmlaunch``
+tool as in the above example, we will run the ``geopmctl`` command in the
+background while the application of interest is executing.  The ``geopmctl`` MPI
+application should be launched with one process per compute node when executing
+the runtime on multiple nodes.  There are five requirements to enable the GEOPM
+controller process to connect to the application process and generate a report:
 
-In addition to generating a report in YAML format, the example below
-showcases two optional features of the GEOPM Runtime:
+1. Both the ``geopmctl`` process and the application process must have the
+   ``GEOPM_PROFILE`` environment variable set to the **same** value or both
+   environments may leave this variable unset.
+2. The application process must have ``LD_PRELOAD=libgeopm.so.2`` set in the
+   environment or the application binary must be linked directly to
+   ``libgeopm.so.2`` at compile time.
+3. The ``GEOPM_REPORT`` environment variable must be set in the environment of
+   the ``geopmctl`` process.
+4. The ``GEOPM_PROGRAM_FILTER`` environment variable is required and explicitly
+   lists the program invovation names of any process to be profiled. All other
+   programs will not be affected by ``LD_PRELOAD`` of ``libgeopm.so``.  For this
+   reason a user will typically set these two environment variables together.
+   This is especially important when profiling programs within a bash script.
+5. The ``GEOPM_NUM_PROCESS`` variable must be set in the ``geopmctl``
+   environment if there is more than one process to be tracked on each compute
+   node.
 
-1. **CSV Trace File**: By setting the ``GEOPM_TRACE`` environment
-   variable, you can generate a trace file in CSV format.
+In addition to generating a report in YAML format, the example below showcases
+two optional features of the GEOPM Runtime:
+
+1. **CSV Trace File**: By setting the ``GEOPM_TRACE`` environment variable, you
+   can generate a trace file in CSV format.
 2. **Sampling Period Adjustment**: The ``GEOPM_PERIOD`` environment variable
    allows you to modify the controller's sampling period. For instance, setting
    it to 200 milliseconds, up from the default 5 milliseconds, results in
    approximately 50 rows of samples in the trace file (calculated as five
    samples per second over ten seconds).
-3. **Disable Network Use** The ``GEOPM_CTL_LOCAL`` environment
-   variable may be set which disables all intra-node communication
-   between the controllers on each node, thereby generating a unique
-   report file per host node over which the application processes are
-   launched.
+3. **Disable Network Use** The ``GEOPM_CTL_LOCAL`` environment variable may be
+   set which disables all intra-node communication between the controllers on
+   each node, thereby generating a unique report file per host node over which
+   the application processes are launched.
 
 These three options together will inform the GEOPM runtime controller
-(``geopmctl``) to profile the ``sleep`` utility and generate a CSV trace
-file with approximately 50 rows of samples (five per-second for ten seconds).
-In the provided example, the ``awk`` command extracts specific columns: time
-since application start (column 1), CPU energy (column 6), and CPU power
-(column 8).
+(``geopmctl``) to profile the ``sleep`` utility and generate a CSV trace file
+with approximately 50 rows of samples (five per-second for ten seconds).  In the
+provided example, the ``awk`` command extracts specific columns: time since
+application start (column 1), CPU energy (column 6), and CPU power (column 8).
 
 .. code-block:: bash
 

--- a/docs/source/requires.rst
+++ b/docs/source/requires.rst
@@ -85,36 +85,36 @@ local Python package bin directory to your path for access to the
 The MSR Driver
 ^^^^^^^^^^^^^^
 
-Access to MSRs enhances the capability of the GEOPM Access Service in terms of
-hardware telemetry and controls. While the GEOPM Service can function without
-access to MSRs, it provides a limited set of hardware features. For the GEOPM
-Runtime to function correctly, these MSR-related hardware features are
-necessary. Hence, MSR support is a hard requirement for the GEOPM Runtime.
+Access to MSRs enhances the capabilities of the GEOPM Access Service by
+providing additional hardware telemetry and controls. While the **GEOPM Access
+Service** can function without access to MSRs, it provides a limited set of CPU
+features. For the **GEOPM Runtime** to function correctly, these MSR-related
+CPU features are necessary. Hence, MSR support is a hard requirement for
+the GEOPM Runtime which may be relaxed in a future release.
 
-The msr-safe kernel driver provides two key features. Firstly, it offers a low
-latency interface for reading and writing many MSR values at once through an
-`ioctl(2) <https://man7.org/linux/man-pages/man2/ioctl.2.html>`_ system call,
-possibly improving the performance of GEOPM Runtime or other MSR usages.
+One of two drivers may be used by the GEOPM Access Service to enable the MSR
+features: the standard Linux (in-tree) MSR driver or the msr-safe kernel driver
+maintained by LLNL.  The msr-safe driver is preferred by GEOPM if both kernel
+modules are loaded because it provides low latency interface for reading and
+writing many MSR values at once through an `ioctl(2)
+<https://man7.org/linux/man-pages/man2/ioctl.2.html>`_ system call, possibly
+improving the performance of GEOPM Runtime or other MSR usages.
 
-Secondly, the msr-safe kernel driver enables user-level read and write
-operations of the model-specific registers (MSRs) with access controlled by the
-system administrator.  This feature is mandatory if the GEOPM Access Service is
-not active on the system. Alternatively, the access can also be managed by the
-system administrator using the GEOPM Access Service, if active.
-
-The msr-safe kernel driver code can be found `here
+The msr-safe kernel driver source code can be found `here
 <https://github.com/LLNL/msr-safe>`__.  It's distributed with the `OpenSUSE
 Hardware Repository <https://download.opensuse.org/repositories/hardware/>`_ and
 can be installed from the RPMs provided there.  For more information about the
-necessary configuration of msr-safe see: :ref:`geopmaccess.1:Configuring msr-safe`.
+necessary configuration of msr-safe see: :ref:`geopmaccess.1:Configuring
+msr-safe` and :ref:`overview:admin-configuration`.  Note that subsequent to
+v1.7.0 of msr-safe, it is required that the msr-safe allow list be configured
+prior to starting the GEOPM Access Service.
 
-In the absence of both the msr-safe kernel driver and the GEOPM Systemd Service,
-root users may access MSRs using the standard MSR driver. This can be loaded
-with the command:
+In the absence of the msr-safe kernel driver, users may access MSRs using the
+standard Linux MSR driver. This can be loaded with the command:
 
 .. code-block:: bash
 
     modprobe msr
 
-The standard MSR driver must also be loaded to enable MSR access through the
-GEOPM Systemd Service when msr-safe is not installed.
+The standard MSR driver be loaded to enable MSR access through the GEOPM Systemd
+Service when msr-safe is not installed.

--- a/docs/source/requires.rst
+++ b/docs/source/requires.rst
@@ -105,7 +105,7 @@ The msr-safe kernel driver source code can be found `here
 Hardware Repository <https://download.opensuse.org/repositories/hardware/>`_ and
 can be installed from the RPMs provided there.  For more information about the
 necessary configuration of msr-safe see: :ref:`geopmaccess.1:Configuring
-msr-safe` and :ref:`overview:admin-configuration`.  Note that subsequent to
+msr-safe` and :ref:`overview:admin configuration`.  Note that subsequent to
 v1.7.0 of msr-safe, it is required that the msr-safe allow list be configured
 prior to starting the GEOPM Access Service.
 

--- a/docs/source/requires.rst
+++ b/docs/source/requires.rst
@@ -1,21 +1,20 @@
 Requirements
 ============
 
-The GEOPM Service library depend on several external dependencies for
-enabling certain features. However, most of them are readily available
-in standard Linux distributions. If you intend to use only the GEOPM
-Service, all the required dependencies can be found on this page. For
-users of the GEOPM Runtime, refer to its dedicated documentation :doc:`here
-<runtime>` for the necessary external
+The GEOPM Service library depends on several external dependencies for enabling
+certain features. However, most of them are readily available in standard Linux
+distributions. If you intend to use only the GEOPM Service, all the required
+dependencies can be found on this page. For users of the GEOPM Runtime, refer to
+its dedicated documentation :doc:`here <runtime>` for the necessary external
 dependencies.
 
 Build Requirements
 ------------------
 
-To run the GEOPM Service build, the packages listed below are
-required. All these packages are available in standard Linux
-distributions and can be installed using commands specific to
-RPM-based or Debian-based Linux distributions.
+To run the GEOPM Service build, the packages listed below are required. All
+these packages are available in standard Linux distributions and can be
+installed using commands specific to RPM-based or Debian-based Linux
+distributions.
 
 Upstream RHEL and CentOS Package Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,82 +55,66 @@ Upstream Ubuntu Package Requirements
 Systemd Library Requirement
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``systemd-devel`` package can be omitted in the building sequence
-with the ``--disable-systemd`` option. Note that this is mandatory for
-older Linux distributions like CentOS 7.  However, disabling
-``libsystemd`` means the user-space loaded PlatformIO interface won't
-access signals or controls from the GEOPM Systemd Service. The
-``--disable-systemd`` option doesn't impact the GEOPM user unless the
-GEOPM Systemd Service is installed and active on the running Linux OS.
+The ``systemd-devel`` package can be omitted in the building sequence with the
+``--disable-systemd`` option. Note that this is mandatory for older Linux
+distributions like CentOS 7.  However, disabling ``libsystemd`` means the
+user-space loaded PlatformIO interface won't access signals or controls from the
+GEOPM Systemd Service. The ``--disable-systemd`` option doesn't impact the GEOPM
+user unless the GEOPM Systemd Service is installed and active on the running
+Linux OS.
 
 Sphinx Requirement
 ^^^^^^^^^^^^^^^^^^
 
-The Sphinx python package is essential for generate man pages and HTML
-documentation. For the build to function correctly, the man pages must
-be generated. These man pages are included in the distribution tarball
-created by the ``make dist`` target, hence, building using this
-archive doesn't particularly require Sphinx. The requirement can be
-satisfied by PIP if there are issues installing the RPM packages for
-sphinx:
+The Sphinx python package is essential for generation of man pages and HTML
+documentation.  The source and build infrastrucure for this documentation is
+located in the ``docs`` subdirectory of the Git repository. The Sphinx
+requirement can be satisfied by PIP if there are issues installing the OS
+distribution packages:
 
 .. code-block:: bash
 
     python3 -m pip install --user sphinx sphinx_rtd_theme sphinxemoji
     export PATH=$HOME/.local/bin:$PATH
 
-These commands install Sphinx into your user's local Python packages
-and add the local Python package bin directory to your path for access
-to the sphinx-build script.
+These commands install Sphinx into your user's local Python packages and add the
+local Python package bin directory to your path for access to the
+``sphinx-build`` script.
 
-Run Requirements
-----------------
-
-There are runtime requirements for both the GEOPM Service and the
-GEOPM Runtime. These requirements relate to the MSR driver and the
-configuration of systemd.
-
-Access to MSRs enhances the capability of the GEOPM Service in terms
-of hardware telemetry and controls. While the GEOPM Service can
-function without access to MSRs, it provides a limited set of hardware
-features. For the GEOPM Runtime to function correctly, these
-MSR-related hardware features are necessary. Hence, MSR support is a
-hard requirement for the GEOPM Runtime.
-
-Erroneous settings for systemd can cause inter-process communication
-issues for both the GEOPM Service and the GEOPM Runtime.
 
 The MSR Driver
 ^^^^^^^^^^^^^^
 
-The msr-safe kernel driver provides two key features. Firstly, it
-offers a low latency interface for reading and writing many MSR values
-at once through an `ioctl(2)
-<https://man7.org/linux/man-pages/man2/ioctl.2.html>`_ system call,
-possibly improving the performance of GEOPM Runtime or other MSR
-usages.
+Access to MSRs enhances the capability of the GEOPM Access Service in terms of
+hardware telemetry and controls. While the GEOPM Service can function without
+access to MSRs, it provides a limited set of hardware features. For the GEOPM
+Runtime to function correctly, these MSR-related hardware features are
+necessary. Hence, MSR support is a hard requirement for the GEOPM Runtime.
+
+The msr-safe kernel driver provides two key features. Firstly, it offers a low
+latency interface for reading and writing many MSR values at once through an
+`ioctl(2) <https://man7.org/linux/man-pages/man2/ioctl.2.html>`_ system call,
+possibly improving the performance of GEOPM Runtime or other MSR usages.
 
 Secondly, the msr-safe kernel driver enables user-level read and write
-operations of the model-specific registers (MSRs) with access
-controlled by the system administrator.  This feature is mandatory if
-the GEOPM Service is not active on the system. Alternatively, the
-access can also be managed by the system administrator using the GEOPM
-Service, if active.
+operations of the model-specific registers (MSRs) with access controlled by the
+system administrator.  This feature is mandatory if the GEOPM Access Service is
+not active on the system. Alternatively, the access can also be managed by the
+system administrator using the GEOPM Access Service, if active.
 
 The msr-safe kernel driver code can be found `here
 <https://github.com/LLNL/msr-safe>`__.  It's distributed with the `OpenSUSE
-Hardware Repository <https://download.opensuse.org/repositories/hardware/>`_
-and can be installed from the RPMs provided there.  For more information about
-the necessary configuration of msr-safe see: :ref:`geopmaccess.1:Configuring
-msr-safe`.
+Hardware Repository <https://download.opensuse.org/repositories/hardware/>`_ and
+can be installed from the RPMs provided there.  For more information about the
+necessary configuration of msr-safe see: :ref:`geopmaccess.1:Configuring msr-safe`.
 
-In the absence of both the msr-safe kernel driver and the GEOPM
-Systemd Service, root users may access MSRs using the standard MSR
-driver. This can be loaded with the command:
+In the absence of both the msr-safe kernel driver and the GEOPM Systemd Service,
+root users may access MSRs using the standard MSR driver. This can be loaded
+with the command:
 
 .. code-block:: bash
 
     modprobe msr
 
-The standard MSR driver must also be loaded to enable MSR access
-through the GEOPM Systemd Service when msr-safe is not installed.
+The standard MSR driver must also be loaded to enable MSR access through the
+GEOPM Systemd Service when msr-safe is not installed.

--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -2,7 +2,9 @@ User Guide for GEOPM Runtime
 ============================
 
 The GEOPM Runtime is software designed to enhance energy efficiency of
-applications through active hardware configuration.
+applications through active hardware configuration. See
+:doc:`Getting Started Guide <overview:straight-ruler-use-the-runtime-to-measure-application-performance>`
+for information on how to begin using the GEOPM Runtime.
 
 User Model
 ----------
@@ -65,84 +67,6 @@ documentation.
 .. figure:: https://geopm.github.io/images/geopm-runtime-usage.svg
    :alt: An illustration of geopmlaunch running on 2 servers, generating a trace file per host, and one report across all hosts.
    :align: center
-
-.. admonition:: Quick start for MPI applications
-
-   The ``geopmlaunch`` tool is the recommended user interface for GEOPM Runtime. It wraps a launcher application
-   (like srun in this example), generates a summarizing report file, and optionally generates a time-series trace for each host.
-
-   The steps for using ``geopmlaunch`` with your MPI application are:
-
-  * Specify how many nodes and processes to use.
-  * Run the ``geopmlaunch`` command wherever you would normally run the
-    wrapped launcher command (e.g., ``srun``, ``mpiexec``, etc.).
-  * Read the generated ``geopm.report`` file
-
-  .. code-block:: console
-    :caption: Examples using ``geopmlaunch``
-
-    # Launch with srun and examine the generated GEOPM report
-    $ geopmlaunch srun -N 1 -n 20 -- ./my-app
-    $ less geopm.report
-    # Launch with Intel mpiexec and examine the generated GEOPM report
-    $ geopmlaunch impi -n 1 -ppn 20 -- ./my-app
-    $ less geopm.report
-    # Display all options and available launchers
-    $ geopmlaunch --help
-
-.. admonition:: Quick start for Non-MPI applications
-
-   In order to profile non-MPI applications, the recommended approach is to launch
-   the GEOPM runtime alongside the target application. This can be done by launching
-   the ``geopmctl`` application in the background on every host node that the non-MPI
-   application is expected to run. After a clean or forced termination of the
-   application being profiled, the ``geopmctl`` application is designed to terminate
-   and generate a summarizing report file, and optionally, a time-series trace per host.
-
-   The following requirements must be met while launching ``geopmctl`` with your
-   non-MPI application:
-
-   * Both the ``geopmctl`` process and the application process must have
-     the ``GEOPM_PROFILE`` environment variable set to the **same**
-     value.
-   * The application process must have ``LD_PRELOAD=libgeopm.so.2`` set
-     in the environment, or the application binary must be linked
-     directly to ``libgeopm.so.2`` at compile time.
-   * The ``GEOPM_REPORT`` environment variable must be set in the
-     environment of the ``geopmctl`` process.
-   * While not necessary in this example, in case of multiple extraneous processes
-     getting launched, the optional ``GEOPM_PROGRAM_FILTER`` environment variable
-     can be set to explicitly list the program invocation name of the specific
-     non-MPI process that needs to be profiled.
-   * While optional in this example, in case of launching non-MPI applications across
-     multiple nodes, the ``GEOPM_CTL_LOCAL`` environment variable should be set in order
-     to generate a unique GEOPM report file for each host node. This disables all
-     intra-process MPI communication between the GEOPM controllers.
-
-   .. code-block:: console
-     :caption: Examples using ``geopmctl``
-
-     $ GEOPM_PROFILE=sleep-ten \
-       GEOPM_REPORT=sleep-ten.yaml \
-       GEOPM_CTL_LOCAL=true \
-       GEOPM_TRACE=sleep-ten-trace \
-       GEOPM_PROGRAM_FILTER=sleep \
-       geopmctl &
-     $ GEOPM_PROFILE=sleep-ten \
-       LD_PRELOAD=libgeopm.so.2 \
-       sleep 10
-     $ cat sleep-ten.yaml
-     $ awk -F\| '{print $1, $6, $8}' sleep-ten-trace* | less
-
-The `GEOPM Environment Variables
-<https://geopm.github.io/geopm.7.html#geopm-environment-variables>`_ section
-includes a complete listing of the environment variables accepted by the GEOPM runtime.
-
-The `GEOPM runtime tutorial
-<https://github.com/geopm/geopm/tree/dev/tutorial#geopm-tutorial>`_ shows how
-to profile unmodified applications, select and evaluate different GEOPM agent
-algorithms (see below), and how to add markup to an application.  The tutorial
-provides a starting point for someone trying to get familiar with the GEOPM runtime.
 
 GEOPM *agents* can exploit this hierarchical control system to optimize
 various objective functions. Examples include maximizing application

--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -3,7 +3,7 @@ User Guide for GEOPM Runtime
 
 The GEOPM Runtime is software designed to enhance energy efficiency of
 applications through active hardware configuration. See
-:doc:`Getting Started Guide <overview:straight-ruler-use-the-runtime-to-measure-application-performance>`
+:ref:`Getting Started Guide <overview:|:straight_ruler:| Use the Runtime to Measure Application Performance>`
 for information on how to begin using the GEOPM Runtime.
 
 User Model

--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -221,8 +221,8 @@ interfere with performance optimization objectives of GEOPM Agents. To achieve
 optimal performance when deploying a GEOPM Agent that controls CPU frequency or
 power limits it's recommended that the generic scaling govermernor ``userspace``
 is selected while the GEOPM Agent is active.  If ``userspace`` is not available
-on your system, it may be preferred to select ``performance`` mode of the
-acpi-cpufreq driver.
+on your system, it may be preferred to select ``performance`` mode while the
+GEOPM Agent is active.
 
 For more information, see the Linux Kernel documentation on
 `generic scaling governors <https://docs.kernel.org/admin-guide/pm/cpufreq.html#generic-scaling-governors>`_.

--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -292,10 +292,13 @@ For additional information, please contact the GEOPM team.
 Linux Power Management
 ^^^^^^^^^^^^^^^^^^^^^^
 
-It's crucial to note that other Linux mechanisms for CPU power management can
-interfere with optimization objectives of GEOPM agents. When deploying an agent
-that controls CPU frequency or power limits, it's recommended that the generic
-scaling govermernor ``userspace`` is selected.
+It's important to note that other Linux mechanisms for CPU power management may
+interfere with performance optimization objectives of GEOPM Agents. To achieve
+optimal performance when deploying a GEOPM Agent that controls CPU frequency or
+power limits it's recommended that the generic scaling govermernor ``userspace``
+is selected while the GEOPM Agent is active.  If ``userspace`` is not available
+on your system, it may be preferred to select ``performance`` mode of the
+acpi-cpufreq driver.
 
 For more information, see the Linux Kernel documentation on
 `generic scaling governors <https://docs.kernel.org/admin-guide/pm/cpufreq.html#generic-scaling-governors>`_.
@@ -355,7 +358,7 @@ CPU Affinity Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When using the ``geopmlaunch`` wrapper, the user may optionally provide the
-``--geopm-affinity-enable`` command-line option is provided (see
+``--geopm-affinity-enable`` command-line option (see
 :doc:`geopmlaunch(1)<geopmlaunch.1>`). This will enable hardware metrics to be
 more accurately measured on a per-application-region basis by restricting
 process migration.

--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -304,10 +304,10 @@ For more information, see the Linux Kernel documentation on
 Using Slurm to control the Linux CPU governor
 """""""""""""""""""""""""""""""""""""""""""""
 
-When the `userspace` or `performance` mode is selected, the driver will not
+When the ``userspace`` or ``performance`` mode is selected, the driver will not
 interfere with GEOPM. On SLURM-based systems, the :ref:`GEOPM launch wrapper
 <runtime:geopm application launch wrapper>` will attempt to set the scaling
-governor to "performance" automatically, eliminating the need to manually set
+governor to ``performance`` automatically, eliminating the need to manually set
 the governor. On older versions of SLURM, the desired governors must be listed
 explicitly in ``/etc/slurm.conf``. Specifically, SLURM 15.x requires the
 following option:
@@ -320,11 +320,11 @@ For more on SLURM configuration, please see the `slurm.conf manual
 <https://slurm.schedmd.com/slurm.conf.html>`_. On non-SLURM systems, the
 scaling governor should still be manually set through some other mechanism
 to ensure proper GEOPM behavior. The following command will set the governor
-to performance:
+to ``userspace``:
 
 .. code-block:: bash
 
-   echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+   echo userspace | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 
 Launching the GEOPM Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -219,7 +219,7 @@ Linux Power Management
 It's important to note that other Linux mechanisms for CPU power management may
 interfere with performance optimization objectives of GEOPM Agents. To achieve
 optimal performance when deploying a GEOPM Agent that controls CPU frequency or
-power limits it's recommended that the generic scaling govermernor ``userspace``
+power limits it's recommended that the generic scaling governor ``userspace``
 is selected while the GEOPM Agent is active.  If ``userspace`` is not available
 on your system, it may be preferred to select ``performance`` mode while the
 GEOPM Agent is active.

--- a/geopmdpy/geopmdpy/__init__.py
+++ b/geopmdpy/geopmdpy/__init__.py
@@ -3,3 +3,7 @@
 #
 
 from .version import version as __version__
+__version_str__ = f"""\
+GEOPM version {__version__}
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.
+"""

--- a/geopmdpy/geopmdpy/__main__.py
+++ b/geopmdpy/geopmdpy/__main__.py
@@ -10,6 +10,7 @@ import sys
 import os
 from . import service
 from . import system_files
+from . import __version_str__
 from geopmdpy.restorable_file_writer import RestorableFileWriter
 
 ALLOW_WRITES_PATH = '/sys/module/msr/parameters/allow_writes'
@@ -32,6 +33,9 @@ def stop():
 
 
 def main():
+    if sys.argv[1] == '--version':
+        print(__version_str__)
+        return 0
     signal(SIGTERM, term_handler)
     global _bus, _loop
     system_files.secure_make_dirs(system_files.GEOPM_SERVICE_RUN_PATH,

--- a/geopmdpy/geopmdpy/access.py
+++ b/geopmdpy/geopmdpy/access.py
@@ -16,6 +16,7 @@ from dasbus.error import DBusError
 from geopmdpy import system_files
 from . import gffi
 from . import error
+from . import __version_str__
 
 gffi.gffi.cdef("""
 int geopm_allowlist(size_t result_max,
@@ -436,6 +437,8 @@ def main():
 
     err = 0
     parser = ArgumentParser(description=main.__doc__)
+    parser.add_argument('-v', '--version', dest='version', action='store_true',
+                        help='Print version and exit')
     parser.add_argument('-c', '--controls', dest='controls', action='store_true', default=False,
                         help='Command applies to controls not signals')
     parser_group_ugals = parser.add_mutually_exclusive_group(required=False)
@@ -471,6 +474,9 @@ def main():
         parser.error('Must specify either --group or --default with --direct.')
 
     try:
+        if args.version:
+            print(__version_str__)
+            return 0
         geopm_proxy = (DirectAccessProxy() if args.direct
                        else SystemMessageBus().get_proxy('io.github.geopm', '/io/github/geopm'))
         acc = Access(geopm_proxy)

--- a/geopmdpy/geopmdpy/session.py
+++ b/geopmdpy/geopmdpy/session.py
@@ -14,6 +14,7 @@ from argparse import ArgumentParser
 from . import topo
 from . import pio
 from . import loop
+from . import __version_str__
 
 
 class Session:
@@ -331,6 +332,8 @@ def main():
     """
     err = 0
     parser = ArgumentParser(description=main.__doc__)
+    parser.add_argument('-v', '--version', dest='version', action='store_true',
+                        help='Print version and exit')
     parser.add_argument('-t', '--time', dest='time', type=float, default=0.0,
                         help='Total run time of the session to be opened in seconds')
     parser.add_argument('-p', '--period', dest='period', type=float, default = 0.0,
@@ -341,6 +344,9 @@ def main():
                         help='Print a CSV header before printing any sampled values')
     args = parser.parse_args()
     try:
+        if args.version:
+            print(__version_str__)
+            return 0
         sess = Session()
         sess.run(run_time=args.time, period=args.period, pid=args.pid, print_header=args.print_header)
     except RuntimeError as ee:


### PR DESCRIPTION
- Relates to #3385
- [x] Read through all existing documentation and re-word/re-flow as necessary to match the new directory structure of the source repository.
- [x] Documentation about things like "you MUST use the performance cpufreq governor" can be removed/relaxed.  We're not *just* concerned with HPC anymore.  Similarly, CPU affinity requirements.
- [x] HPC specific doc would be nice that discusses CPU governors, rank-to-CPU affinity, OpenMP, MPI, etc.