### PR TITLE
Fix SysfsIOGroup batch write

### DIFF
--- a/libgeopmd/src/SysfsIOGroup.hpp
+++ b/libgeopmd/src/SysfsIOGroup.hpp
@@ -68,6 +68,7 @@ namespace geopm
             const geopm::PlatformTopo &m_platform_topo;
             /// Whether any signal has been pushed
             bool m_do_batch_read;
+            bool m_do_batch_write;
             /// Whether read_batch() has been called at least once
             bool m_is_batch_read;
             bool m_is_batch_write;


### PR DESCRIPTION
- Relates to #3388.
- IOGroup was initializing IOUring during batch_write(), and on certain systems this resulted in an exception being thrown.