### PR TITLE
Add visibility annotations to public headers

### DIFF
--- a/libgeopm/include/geopm/Agent.hpp
+++ b/libgeopm/include/geopm/Agent.hpp
@@ -15,7 +15,7 @@
 
 namespace geopm
 {
-    class Agent
+    class __attribute__((visibility("default"))) Agent
     {
         public:
             Agent() = default;
@@ -186,14 +186,14 @@ namespace geopm
             static const std::string m_policy_prefix;
     };
 
-    class AgentFactory : public PluginFactory<Agent>
+    class __attribute__((visibility("default"))) AgentFactory : public PluginFactory<Agent>
     {
         public:
             AgentFactory();
             virtual ~AgentFactory() = default;
     };
 
-    AgentFactory &agent_factory(void);
+    AgentFactory __attribute__((visibility("default"))) & agent_factory(void);
 }
 
 #endif

--- a/libgeopm/include/geopm/Agent.hpp
+++ b/libgeopm/include/geopm/Agent.hpp
@@ -6,16 +6,17 @@
 #ifndef AGENT_HPP_INCLUDE
 #define AGENT_HPP_INCLUDE
 
-#include <string>
-#include <map>
-#include <vector>
 #include <functional>
+#include <map>
+#include <string>
+#include <vector>
 
 #include "geopm/PluginFactory.hpp"
+#include "geopm_public.h"
 
 namespace geopm
 {
-    class __attribute__((visibility("default"))) Agent
+    class GEOPM_PUBLIC Agent
     {
         public:
             Agent() = default;
@@ -186,14 +187,14 @@ namespace geopm
             static const std::string m_policy_prefix;
     };
 
-    class __attribute__((visibility("default"))) AgentFactory : public PluginFactory<Agent>
+    class GEOPM_PUBLIC AgentFactory : public PluginFactory<Agent>
     {
         public:
             AgentFactory();
             virtual ~AgentFactory() = default;
     };
 
-    AgentFactory __attribute__((visibility("default"))) & agent_factory(void);
+    AgentFactory GEOPM_PUBLIC & agent_factory(void);
 }
 
 #endif

--- a/libgeopm/include/geopm/Agent.hpp
+++ b/libgeopm/include/geopm/Agent.hpp
@@ -194,7 +194,8 @@ namespace geopm
             virtual ~AgentFactory() = default;
     };
 
-    AgentFactory GEOPM_PUBLIC & agent_factory(void);
+    AgentFactory GEOPM_PUBLIC &
+        agent_factory(void);
 }
 
 #endif

--- a/libgeopm/include/geopm/Daemon.hpp
+++ b/libgeopm/include/geopm/Daemon.hpp
@@ -8,11 +8,13 @@
 
 #include <memory>
 
+#include "geopm_public.h"
+
 namespace geopm
 {
     /// Methods using the Endpoint interface in combination with other
     /// utilities to perform some system admin functions.
-    class __attribute__((visibility("default"))) Daemon
+    class GEOPM_PUBLIC Daemon
     {
         public:
             virtual ~Daemon() = default;

--- a/libgeopm/include/geopm/Daemon.hpp
+++ b/libgeopm/include/geopm/Daemon.hpp
@@ -12,7 +12,7 @@ namespace geopm
 {
     /// Methods using the Endpoint interface in combination with other
     /// utilities to perform some system admin functions.
-    class Daemon
+    class __attribute__((visibility("default"))) Daemon
     {
         public:
             virtual ~Daemon() = default;

--- a/libgeopm/include/geopm/Endpoint.hpp
+++ b/libgeopm/include/geopm/Endpoint.hpp
@@ -7,15 +7,16 @@
 #define ENDPOINT_HPP_INCLUDE
 
 #include <cstddef>
-
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
+
+#include "geopm_public.h"
 
 namespace geopm
 {
-    class __attribute__((visibility("default"))) Endpoint
+    class GEOPM_PUBLIC Endpoint
     {
         public:
             virtual ~Endpoint() = default;

--- a/libgeopm/include/geopm/Endpoint.hpp
+++ b/libgeopm/include/geopm/Endpoint.hpp
@@ -15,7 +15,7 @@
 
 namespace geopm
 {
-    class Endpoint
+    class __attribute__((visibility("default"))) Endpoint
     {
         public:
             virtual ~Endpoint() = default;

--- a/libgeopm/include/geopm/FrequencyGovernor.hpp
+++ b/libgeopm/include/geopm/FrequencyGovernor.hpp
@@ -14,7 +14,7 @@ namespace geopm
     class PlatformIO;
     class PlatformTopo;
 
-    class FrequencyGovernor
+    class __attribute__((visibility("default"))) FrequencyGovernor
     {
         public:
             FrequencyGovernor() = default;

--- a/libgeopm/include/geopm/FrequencyGovernor.hpp
+++ b/libgeopm/include/geopm/FrequencyGovernor.hpp
@@ -6,15 +6,17 @@
 #ifndef FREQUENCYGOVERNOR_HPP_INCLUDE
 #define FREQUENCYGOVERNOR_HPP_INCLUDE
 
-#include <vector>
 #include <memory>
+#include <vector>
+
+#include "geopm_public.h"
 
 namespace geopm
 {
     class PlatformIO;
     class PlatformTopo;
 
-    class __attribute__((visibility("default"))) FrequencyGovernor
+    class GEOPM_PUBLIC FrequencyGovernor
     {
         public:
             FrequencyGovernor() = default;

--- a/libgeopm/include/geopm/ModelRegion.hpp
+++ b/libgeopm/include/geopm/ModelRegion.hpp
@@ -12,7 +12,7 @@
 
 namespace geopm
 {
-    class ModelRegion
+    class __attribute__((visibility("default"))) ModelRegion
     {
         public:
             static std::unique_ptr<ModelRegion> model_region(const std::string &name,

--- a/libgeopm/include/geopm/ModelRegion.hpp
+++ b/libgeopm/include/geopm/ModelRegion.hpp
@@ -6,13 +6,15 @@
 #ifndef MODELREGION_HPP_INCLUDE
 #define MODELREGION_HPP_INCLUDE
 
-#include <string>
 #include <cstdint>
 #include <memory>
+#include <string>
+
+#include "geopm_public.h"
 
 namespace geopm
 {
-    class __attribute__((visibility("default"))) ModelRegion
+    class GEOPM_PUBLIC ModelRegion
     {
         public:
             static std::unique_ptr<ModelRegion> model_region(const std::string &name,

--- a/libgeopm/include/geopm/PlatformIOProf.hpp
+++ b/libgeopm/include/geopm/PlatformIOProf.hpp
@@ -18,9 +18,11 @@ namespace geopm
             static PlatformIO &platform_io(void);
             virtual ~PlatformIOProf() = default;
         private:
-            GEOPM_PRIVATE PlatformIOProf();
-            void GEOPM_PRIVATE print_load_warning(const std::string &io_group_name,
-                                    const std::string &what) const;
+            GEOPM_PRIVATE
+                PlatformIOProf();
+            void GEOPM_PRIVATE
+                print_load_warning(const std::string &io_group_name,
+                                   const std::string &what) const;
             PlatformIO &m_platform_io;
     };
 }

--- a/libgeopm/include/geopm/PlatformIOProf.hpp
+++ b/libgeopm/include/geopm/PlatformIOProf.hpp
@@ -8,16 +8,18 @@
 
 #include <string>
 
+#include "geopm_public.h"
+
 namespace geopm
 {
     class PlatformIO;
-    class __attribute__((visibility("default"))) PlatformIOProf {
+    class GEOPM_PUBLIC PlatformIOProf {
         public:
             static PlatformIO &platform_io(void);
             virtual ~PlatformIOProf() = default;
         private:
-            __attribute__((visibility("hidden"))) PlatformIOProf();
-            void __attribute__((visibility("hidden"))) print_load_warning(const std::string &io_group_name,
+            GEOPM_PRIVATE PlatformIOProf();
+            void GEOPM_PRIVATE print_load_warning(const std::string &io_group_name,
                                     const std::string &what) const;
             PlatformIO &m_platform_io;
     };

--- a/libgeopm/include/geopm/PlatformIOProf.hpp
+++ b/libgeopm/include/geopm/PlatformIOProf.hpp
@@ -11,13 +11,13 @@
 namespace geopm
 {
     class PlatformIO;
-    class PlatformIOProf {
+    class __attribute__((visibility("default"))) PlatformIOProf {
         public:
             static PlatformIO &platform_io(void);
             virtual ~PlatformIOProf() = default;
         private:
-            PlatformIOProf();
-            void print_load_warning(const std::string &io_group_name,
+            __attribute__((visibility("hidden"))) PlatformIOProf();
+            void __attribute__((visibility("hidden"))) print_load_warning(const std::string &io_group_name,
                                     const std::string &what) const;
             PlatformIO &m_platform_io;
     };

--- a/libgeopm/include/geopm/PowerBalancer.hpp
+++ b/libgeopm/include/geopm/PowerBalancer.hpp
@@ -8,13 +8,15 @@
 
 #include <memory>
 
+#include "geopm_public.h"
+
 namespace geopm
 {
     /// @brief Stay within a power cap but redistribute power to
     ///        optimize performance. An average per compute node power
     ///        maximum is maintained, but individual nodes will be
     ///        allowed above or below this average.
-    class __attribute__((visibility("default"))) PowerBalancer
+    class GEOPM_PUBLIC PowerBalancer
     {
         public:
             /// @brief Construct a IPowerBalancer object.

--- a/libgeopm/include/geopm/PowerBalancer.hpp
+++ b/libgeopm/include/geopm/PowerBalancer.hpp
@@ -14,7 +14,7 @@ namespace geopm
     ///        optimize performance. An average per compute node power
     ///        maximum is maintained, but individual nodes will be
     ///        allowed above or below this average.
-    class PowerBalancer
+    class __attribute__((visibility("default"))) PowerBalancer
     {
         public:
             /// @brief Construct a IPowerBalancer object.

--- a/libgeopm/include/geopm/PowerGovernor.hpp
+++ b/libgeopm/include/geopm/PowerGovernor.hpp
@@ -8,9 +8,11 @@
 
 #include <memory>
 
+#include "geopm_public.h"
+
 namespace geopm
 {
-    class __attribute__((visibility("default"))) PowerGovernor
+    class GEOPM_PUBLIC PowerGovernor
     {
         public:
             PowerGovernor() = default;

--- a/libgeopm/include/geopm/PowerGovernor.hpp
+++ b/libgeopm/include/geopm/PowerGovernor.hpp
@@ -10,7 +10,7 @@
 
 namespace geopm
 {
-    class PowerGovernor
+    class __attribute__((visibility("default"))) PowerGovernor
     {
         public:
             PowerGovernor() = default;

--- a/libgeopm/include/geopm/Profile.hpp
+++ b/libgeopm/include/geopm/Profile.hpp
@@ -6,19 +6,20 @@
 #ifndef PROFILE_HPP_INCLUDE
 #define PROFILE_HPP_INCLUDE
 
+#include "config.h"
+
 #include <cstdint>
-#include <vector>
-#include <string>
-#include <set>
-#include <memory>
-#include <stack>
 #include <map>
+#include <memory>
+#include <set>
+#include <stack>
+#include <string>
+#include <vector>
 
 #include "geopm_hash.h"
 #include "geopm_hint.h"
+#include "geopm_public.h"
 #include "geopm_time.h"
-#include "config.h"
-
 
 /****************************************/
 /* Encode/decode function for region_id */
@@ -110,7 +111,7 @@ namespace geopm
     /// for use with the geopm_prof_c structure and are named
     /// accordingly.  The geopm_prof_c structure is an opaque
     /// reference to the Profile class.
-    class __attribute__((visibility("default"))) Profile
+    class GEOPM_PUBLIC Profile
     {
         public:
             Profile() = default;
@@ -211,7 +212,7 @@ namespace geopm
     class ServiceProxy;
     class Scheduler;
 
-    class __attribute__((visibility("default"))) ProfileImp : public Profile
+    class GEOPM_PUBLIC ProfileImp : public Profile
     {
         public:
             /// @brief ProfileImp constructor.
@@ -262,10 +263,10 @@ namespace geopm
         protected:
             bool m_is_enabled;
         private:
-            void __attribute__((visibility("hidden"))) init_app_status(void);
-            void __attribute__((visibility("hidden"))) init_app_record_log(void);
+            void GEOPM_PRIVATE init_app_status(void);
+            void GEOPM_PRIVATE init_app_record_log(void);
             /// @brief Set the hint on all CPUs assigned to this process.
-            void __attribute__((visibility("hidden"))) set_hint(uint64_t hint);
+            void GEOPM_PRIVATE set_hint(uint64_t hint);
 
             /// @brief holds the string name of the profile.
             std::string m_prof_name;

--- a/libgeopm/include/geopm/Profile.hpp
+++ b/libgeopm/include/geopm/Profile.hpp
@@ -263,10 +263,13 @@ namespace geopm
         protected:
             bool m_is_enabled;
         private:
-            void GEOPM_PRIVATE init_app_status(void);
-            void GEOPM_PRIVATE init_app_record_log(void);
+            void GEOPM_PRIVATE
+                init_app_status(void);
+            void GEOPM_PRIVATE
+                init_app_record_log(void);
             /// @brief Set the hint on all CPUs assigned to this process.
-            void GEOPM_PRIVATE set_hint(uint64_t hint);
+            void GEOPM_PRIVATE
+                set_hint(uint64_t hint);
 
             /// @brief holds the string name of the profile.
             std::string m_prof_name;

--- a/libgeopm/include/geopm/Profile.hpp
+++ b/libgeopm/include/geopm/Profile.hpp
@@ -110,7 +110,7 @@ namespace geopm
     /// for use with the geopm_prof_c structure and are named
     /// accordingly.  The geopm_prof_c structure is an opaque
     /// reference to the Profile class.
-    class Profile
+    class __attribute__((visibility("default"))) Profile
     {
         public:
             Profile() = default;
@@ -211,7 +211,7 @@ namespace geopm
     class ServiceProxy;
     class Scheduler;
 
-    class ProfileImp : public Profile
+    class __attribute__((visibility("default"))) ProfileImp : public Profile
     {
         public:
             /// @brief ProfileImp constructor.
@@ -262,10 +262,10 @@ namespace geopm
         protected:
             bool m_is_enabled;
         private:
-            void init_app_status(void);
-            void init_app_record_log(void);
+            void __attribute__((visibility("hidden"))) init_app_status(void);
+            void __attribute__((visibility("hidden"))) init_app_record_log(void);
             /// @brief Set the hint on all CPUs assigned to this process.
-            void set_hint(uint64_t hint);
+            void __attribute__((visibility("hidden"))) set_hint(uint64_t hint);
 
             /// @brief holds the string name of the profile.
             std::string m_prof_name;

--- a/libgeopm/include/geopm/SampleAggregator.hpp
+++ b/libgeopm/include/geopm/SampleAggregator.hpp
@@ -7,14 +7,15 @@
 #define SAMPLEAGGREGATOR_HPP_INCLUDE
 
 #include <cstdint>
-
-#include <string>
-#include <set>
 #include <memory>
+#include <set>
+#include <string>
+
+#include "geopm_public.h"
 
 namespace geopm
 {
-    class __attribute__((visibility("default"))) SampleAggregator
+    class GEOPM_PUBLIC SampleAggregator
     {
         public:
             /// @brief Returns a unique_ptr to a concrete object

--- a/libgeopm/include/geopm/SampleAggregator.hpp
+++ b/libgeopm/include/geopm/SampleAggregator.hpp
@@ -14,7 +14,7 @@
 
 namespace geopm
 {
-    class SampleAggregator
+    class __attribute__((visibility("default"))) SampleAggregator
     {
         public:
             /// @brief Returns a unique_ptr to a concrete object

--- a/libgeopm/include/geopm_agent.h
+++ b/libgeopm/include/geopm_agent.h
@@ -21,7 +21,8 @@ extern "C" {
  *
  *  @return Zero if agent is supported, error code otherwise.
  */
-int GEOPM_PUBLIC geopm_agent_supported(const char *agent_name);
+int GEOPM_PUBLIC
+    geopm_agent_supported(const char *agent_name);
 
 /*!
  *  @brief Get number of policy parameters supported by agent.
@@ -33,9 +34,8 @@ int GEOPM_PUBLIC geopm_agent_supported(const char *agent_name);
  *
  *  @return Zero if agent is supported, error code otherwise.
  */
-int GEOPM_PUBLIC geopm_agent_num_policy(
-    const char *agent_name,
-    int *num_policy);
+int GEOPM_PUBLIC
+    geopm_agent_num_policy(const char *agent_name, int *num_policy);
 
 /*!
  *  @brief Get the name of a policy parameter.
@@ -55,11 +55,9 @@ int GEOPM_PUBLIC geopm_agent_num_policy(
  *          policy name can be stored in output string, error code
  *          otherwise.
  */
-int GEOPM_PUBLIC geopm_agent_policy_name(
-    const char *agent_name,
-    int policy_idx,
-    size_t policy_name_max,
-    char *policy_name);
+int GEOPM_PUBLIC
+    geopm_agent_policy_name(const char *agent_name, int policy_idx,
+                            size_t policy_name_max, char *policy_name);
 
 /*!
  *  @brief Create a json file to control agent policy statically.
@@ -78,11 +76,9 @@ int GEOPM_PUBLIC geopm_agent_policy_name(
  *
  *  @return Zero on success, error code on failure.
  */
-int GEOPM_PUBLIC geopm_agent_policy_json(
-    const char *agent_name,
-    const double *policy_array,
-    size_t json_string_max,
-    char *json_string);
+int GEOPM_PUBLIC
+    geopm_agent_policy_json(const char *agent_name, const double *policy_array,
+                            size_t json_string_max, char *json_string);
 
 /*!
  *  @brief Create a json file to control agent policy statically.
@@ -104,12 +100,10 @@ int GEOPM_PUBLIC geopm_agent_policy_json(
  *
  *  @return Zero on success, error code on failure.
  */
-int GEOPM_PUBLIC geopm_agent_policy_json_partial(
-    const char *agent_name,
-    size_t policy_array_size,
-    const double *policy_array,
-    size_t json_string_max,
-    char *json_string);
+int GEOPM_PUBLIC
+    geopm_agent_policy_json_partial(const char *agent_name, size_t policy_array_size,
+                                    const double *policy_array, size_t json_string_max,
+                                    char *json_string);
 
 /*!
  *  @brief The number of sampled parameters provided by agent.
@@ -121,9 +115,8 @@ int GEOPM_PUBLIC geopm_agent_policy_json_partial(
  *
  *  @return Zero on success, error code on failure.
  */
-int GEOPM_PUBLIC geopm_agent_num_sample(
-    const char *agent_name,
-    int *num_sample);
+int GEOPM_PUBLIC
+    geopm_agent_num_sample(const char *agent_name, int *num_sample);
 
 /*!
  *  @brief The name of the indexed sample value.
@@ -142,11 +135,9 @@ int GEOPM_PUBLIC geopm_agent_num_sample(
  *
  *  @return Zero if agent is supported, error code otherwise.
  */
-int GEOPM_PUBLIC geopm_agent_sample_name(
-    const char *agent_name,
-    int sample_idx,
-    size_t sample_name_max,
-    char *sample_name);
+int GEOPM_PUBLIC
+    geopm_agent_sample_name(const char *agent_name, int sample_idx,
+                            size_t sample_name_max, char *sample_name);
 
 /*!
  *  @brief The number of available agents.
@@ -155,7 +146,8 @@ int GEOPM_PUBLIC geopm_agent_sample_name(
  *
  *  @return Zero if no error occurred.  Otherwise the error code will be returned.
  */
-int GEOPM_PUBLIC geopm_agent_num_avail(int *num_agent);
+int GEOPM_PUBLIC
+    geopm_agent_num_avail(int *num_agent);
 
 /*!
  *  @brief The name of a specific agent.
@@ -173,10 +165,8 @@ int GEOPM_PUBLIC geopm_agent_num_avail(int *num_agent);
  *  @return Zero if agent_name is large enough to hold the name,
  *          error code otherwise.
  */
-int GEOPM_PUBLIC geopm_agent_name(
-    int agent_idx,
-    size_t agent_name_max,
-    char *agent_name);
+int GEOPM_PUBLIC
+    geopm_agent_name(int agent_idx, size_t agent_name_max, char *agent_name);
 
 /*!
  *  @brief Enforce a static implementation of the agent's policy.  The
@@ -185,7 +175,8 @@ int GEOPM_PUBLIC geopm_agent_name(
  *
  *  @return Zero on success, error code on failure.
  */
-int GEOPM_PUBLIC geopm_agent_enforce_policy(void);
+int GEOPM_PUBLIC
+    geopm_agent_enforce_policy(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_agent.h
+++ b/libgeopm/include/geopm_agent.h
@@ -19,7 +19,7 @@ extern "C" {
  *
  *  @return Zero if agent is supported, error code otherwise.
  */
-int geopm_agent_supported(const char *agent_name);
+int __attribute__((visibility("default"))) geopm_agent_supported(const char *agent_name);
 
 /*!
  *  @brief Get number of policy parameters supported by agent.
@@ -31,8 +31,9 @@ int geopm_agent_supported(const char *agent_name);
  *
  *  @return Zero if agent is supported, error code otherwise.
  */
-int geopm_agent_num_policy(const char *agent_name,
-                           int *num_policy);
+int __attribute__((visibility("default"))) geopm_agent_num_policy(
+    const char *agent_name,
+    int *num_policy);
 
 /*!
  *  @brief Get the name of a policy parameter.
@@ -52,10 +53,11 @@ int geopm_agent_num_policy(const char *agent_name,
  *          policy name can be stored in output string, error code
  *          otherwise.
  */
-int geopm_agent_policy_name(const char *agent_name,
-                            int policy_idx,
-                            size_t policy_name_max,
-                            char *policy_name);
+int __attribute__((visibility("default"))) geopm_agent_policy_name(
+    const char *agent_name,
+    int policy_idx,
+    size_t policy_name_max,
+    char *policy_name);
 
 /*!
  *  @brief Create a json file to control agent policy statically.
@@ -74,10 +76,11 @@ int geopm_agent_policy_name(const char *agent_name,
  *
  *  @return Zero on success, error code on failure.
  */
-int geopm_agent_policy_json(const char *agent_name,
-                            const double *policy_array,
-                            size_t json_string_max,
-                            char *json_string);
+int __attribute__((visibility("default"))) geopm_agent_policy_json(
+    const char *agent_name,
+    const double *policy_array,
+    size_t json_string_max,
+    char *json_string);
 
 /*!
  *  @brief Create a json file to control agent policy statically.
@@ -99,11 +102,12 @@ int geopm_agent_policy_json(const char *agent_name,
  *
  *  @return Zero on success, error code on failure.
  */
-int geopm_agent_policy_json_partial(const char *agent_name,
-                                    size_t policy_array_size,
-                                    const double *policy_array,
-                                    size_t json_string_max,
-                                    char *json_string);
+int __attribute__((visibility("default"))) geopm_agent_policy_json_partial(
+    const char *agent_name,
+    size_t policy_array_size,
+    const double *policy_array,
+    size_t json_string_max,
+    char *json_string);
 
 /*!
  *  @brief The number of sampled parameters provided by agent.
@@ -115,8 +119,9 @@ int geopm_agent_policy_json_partial(const char *agent_name,
  *
  *  @return Zero on success, error code on failure.
  */
-int geopm_agent_num_sample(const char *agent_name,
-                           int *num_sample);
+int __attribute__((visibility("default"))) geopm_agent_num_sample(
+    const char *agent_name,
+    int *num_sample);
 
 /*!
  *  @brief The name of the indexed sample value.
@@ -135,11 +140,11 @@ int geopm_agent_num_sample(const char *agent_name,
  *
  *  @return Zero if agent is supported, error code otherwise.
  */
-int geopm_agent_sample_name(const char *agent_name,
-                            int sample_idx,
-                            size_t sample_name_max,
-                            char *sample_name);
-
+int __attribute__((visibility("default"))) geopm_agent_sample_name(
+    const char *agent_name,
+    int sample_idx,
+    size_t sample_name_max,
+    char *sample_name);
 
 /*!
  *  @brief The number of available agents.
@@ -148,7 +153,7 @@ int geopm_agent_sample_name(const char *agent_name,
  *
  *  @return Zero if no error occurred.  Otherwise the error code will be returned.
  */
-int geopm_agent_num_avail(int *num_agent);
+int __attribute__((visibility("default"))) geopm_agent_num_avail(int *num_agent);
 
 /*!
  *  @brief The name of a specific agent.
@@ -166,9 +171,10 @@ int geopm_agent_num_avail(int *num_agent);
  *  @return Zero if agent_name is large enough to hold the name,
  *          error code otherwise.
  */
-int geopm_agent_name(int agent_idx,
-                     size_t agent_name_max,
-                     char *agent_name);
+int __attribute__((visibility("default"))) geopm_agent_name(
+    int agent_idx,
+    size_t agent_name_max,
+    char *agent_name);
 
 /*!
  *  @brief Enforce a static implementation of the agent's policy.  The
@@ -177,7 +183,7 @@ int geopm_agent_name(int agent_idx,
  *
  *  @return Zero on success, error code on failure.
  */
-int geopm_agent_enforce_policy(void);
+int __attribute__((visibility("default"))) geopm_agent_enforce_policy(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_agent.h
+++ b/libgeopm/include/geopm_agent.h
@@ -8,6 +8,8 @@
 
 #include <stddef.h>
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,7 +21,7 @@ extern "C" {
  *
  *  @return Zero if agent is supported, error code otherwise.
  */
-int __attribute__((visibility("default"))) geopm_agent_supported(const char *agent_name);
+int GEOPM_PUBLIC geopm_agent_supported(const char *agent_name);
 
 /*!
  *  @brief Get number of policy parameters supported by agent.
@@ -31,7 +33,7 @@ int __attribute__((visibility("default"))) geopm_agent_supported(const char *age
  *
  *  @return Zero if agent is supported, error code otherwise.
  */
-int __attribute__((visibility("default"))) geopm_agent_num_policy(
+int GEOPM_PUBLIC geopm_agent_num_policy(
     const char *agent_name,
     int *num_policy);
 
@@ -53,7 +55,7 @@ int __attribute__((visibility("default"))) geopm_agent_num_policy(
  *          policy name can be stored in output string, error code
  *          otherwise.
  */
-int __attribute__((visibility("default"))) geopm_agent_policy_name(
+int GEOPM_PUBLIC geopm_agent_policy_name(
     const char *agent_name,
     int policy_idx,
     size_t policy_name_max,
@@ -76,7 +78,7 @@ int __attribute__((visibility("default"))) geopm_agent_policy_name(
  *
  *  @return Zero on success, error code on failure.
  */
-int __attribute__((visibility("default"))) geopm_agent_policy_json(
+int GEOPM_PUBLIC geopm_agent_policy_json(
     const char *agent_name,
     const double *policy_array,
     size_t json_string_max,
@@ -102,7 +104,7 @@ int __attribute__((visibility("default"))) geopm_agent_policy_json(
  *
  *  @return Zero on success, error code on failure.
  */
-int __attribute__((visibility("default"))) geopm_agent_policy_json_partial(
+int GEOPM_PUBLIC geopm_agent_policy_json_partial(
     const char *agent_name,
     size_t policy_array_size,
     const double *policy_array,
@@ -119,7 +121,7 @@ int __attribute__((visibility("default"))) geopm_agent_policy_json_partial(
  *
  *  @return Zero on success, error code on failure.
  */
-int __attribute__((visibility("default"))) geopm_agent_num_sample(
+int GEOPM_PUBLIC geopm_agent_num_sample(
     const char *agent_name,
     int *num_sample);
 
@@ -140,7 +142,7 @@ int __attribute__((visibility("default"))) geopm_agent_num_sample(
  *
  *  @return Zero if agent is supported, error code otherwise.
  */
-int __attribute__((visibility("default"))) geopm_agent_sample_name(
+int GEOPM_PUBLIC geopm_agent_sample_name(
     const char *agent_name,
     int sample_idx,
     size_t sample_name_max,
@@ -153,7 +155,7 @@ int __attribute__((visibility("default"))) geopm_agent_sample_name(
  *
  *  @return Zero if no error occurred.  Otherwise the error code will be returned.
  */
-int __attribute__((visibility("default"))) geopm_agent_num_avail(int *num_agent);
+int GEOPM_PUBLIC geopm_agent_num_avail(int *num_agent);
 
 /*!
  *  @brief The name of a specific agent.
@@ -171,7 +173,7 @@ int __attribute__((visibility("default"))) geopm_agent_num_avail(int *num_agent)
  *  @return Zero if agent_name is large enough to hold the name,
  *          error code otherwise.
  */
-int __attribute__((visibility("default"))) geopm_agent_name(
+int GEOPM_PUBLIC geopm_agent_name(
     int agent_idx,
     size_t agent_name_max,
     char *agent_name);
@@ -183,7 +185,7 @@ int __attribute__((visibility("default"))) geopm_agent_name(
  *
  *  @return Zero on success, error code on failure.
  */
-int __attribute__((visibility("default"))) geopm_agent_enforce_policy(void);
+int GEOPM_PUBLIC geopm_agent_enforce_policy(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_daemon.h
+++ b/libgeopm/include/geopm_daemon.h
@@ -16,19 +16,18 @@ extern "C" {
 
 struct geopm_daemon_c;
 
-int GEOPM_PUBLIC geopm_daemon_create(
-    const char *endpoint_name,
-    const char *policystore_path,
-    struct geopm_daemon_c **daemon);
-int GEOPM_PUBLIC geopm_daemon_destroy(
-    struct geopm_daemon_c *daemon);
-int GEOPM_PUBLIC geopm_daemon_update_endpoint_from_policystore(
-    struct geopm_daemon_c *daemon,
-    double timeout);
-int GEOPM_PUBLIC geopm_daemon_stop_wait_loop(
-    struct geopm_daemon_c *daemon);
-int GEOPM_PUBLIC geopm_daemon_reset_wait_loop(
-    struct geopm_daemon_c *daemon);
+int GEOPM_PUBLIC
+    geopm_daemon_create(const char *endpoint_name, const char *policystore_path,
+                        struct geopm_daemon_c **daemon);
+int GEOPM_PUBLIC
+    geopm_daemon_destroy(struct geopm_daemon_c *daemon);
+int GEOPM_PUBLIC
+    geopm_daemon_update_endpoint_from_policystore(struct geopm_daemon_c *daemon,
+                                                  double timeout);
+int GEOPM_PUBLIC
+    geopm_daemon_stop_wait_loop(struct geopm_daemon_c *daemon);
+int GEOPM_PUBLIC
+    geopm_daemon_reset_wait_loop(struct geopm_daemon_c *daemon);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_daemon.h
+++ b/libgeopm/include/geopm_daemon.h
@@ -8,24 +8,26 @@
 
 #include <stddef.h>
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct geopm_daemon_c;
 
-int __attribute__((visibility("default"))) geopm_daemon_create(
+int GEOPM_PUBLIC geopm_daemon_create(
     const char *endpoint_name,
     const char *policystore_path,
     struct geopm_daemon_c **daemon);
-int __attribute__((visibility("default"))) geopm_daemon_destroy(
+int GEOPM_PUBLIC geopm_daemon_destroy(
     struct geopm_daemon_c *daemon);
-int __attribute__((visibility("default"))) geopm_daemon_update_endpoint_from_policystore(
+int GEOPM_PUBLIC geopm_daemon_update_endpoint_from_policystore(
     struct geopm_daemon_c *daemon,
     double timeout);
-int __attribute__((visibility("default"))) geopm_daemon_stop_wait_loop(
+int GEOPM_PUBLIC geopm_daemon_stop_wait_loop(
     struct geopm_daemon_c *daemon);
-int __attribute__((visibility("default"))) geopm_daemon_reset_wait_loop(
+int GEOPM_PUBLIC geopm_daemon_reset_wait_loop(
     struct geopm_daemon_c *daemon);
 
 #ifdef __cplusplus

--- a/libgeopm/include/geopm_daemon.h
+++ b/libgeopm/include/geopm_daemon.h
@@ -14,14 +14,19 @@ extern "C" {
 
 struct geopm_daemon_c;
 
-int geopm_daemon_create(const char *endpoint_name,
-                        const char *policystore_path,
-                        struct geopm_daemon_c **daemon);
-int geopm_daemon_destroy(struct geopm_daemon_c *daemon);
-int geopm_daemon_update_endpoint_from_policystore(struct geopm_daemon_c *daemon,
-                                                  double timeout);
-int geopm_daemon_stop_wait_loop(struct geopm_daemon_c *daemon);
-int geopm_daemon_reset_wait_loop(struct geopm_daemon_c *daemon);
+int __attribute__((visibility("default"))) geopm_daemon_create(
+    const char *endpoint_name,
+    const char *policystore_path,
+    struct geopm_daemon_c **daemon);
+int __attribute__((visibility("default"))) geopm_daemon_destroy(
+    struct geopm_daemon_c *daemon);
+int __attribute__((visibility("default"))) geopm_daemon_update_endpoint_from_policystore(
+    struct geopm_daemon_c *daemon,
+    double timeout);
+int __attribute__((visibility("default"))) geopm_daemon_stop_wait_loop(
+    struct geopm_daemon_c *daemon);
+int __attribute__((visibility("default"))) geopm_daemon_reset_wait_loop(
+    struct geopm_daemon_c *daemon);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_endpoint.h
+++ b/libgeopm/include/geopm_endpoint.h
@@ -29,8 +29,9 @@ struct geopm_endpoint_c;
  *
  *  @return Zero on success, error code on failure.
  */
-int geopm_endpoint_create(const char *endpoint_name,
-                          struct geopm_endpoint_c **endpoint);
+int __attribute__((visibility("default"))) geopm_endpoint_create(
+    const char *endpoint_name,
+    struct geopm_endpoint_c **endpoint);
 
 /*!
  *  @brief Release resources associated with endpoint.
@@ -43,7 +44,7 @@ int geopm_endpoint_create(const char *endpoint_name,
  *
  *  @return Zero on success, error code on failure.
  */
-int geopm_endpoint_destroy(struct geopm_endpoint_c *endpoint);
+int __attribute__((visibility("default"))) geopm_endpoint_destroy(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Create shmem regions within the endpoint for policy/sample
@@ -54,7 +55,7 @@ int geopm_endpoint_destroy(struct geopm_endpoint_c *endpoint);
  *
  *  @return Zero on success, error code on failure.
  */
-int geopm_endpoint_open(struct geopm_endpoint_c *endpoint);
+int __attribute__((visibility("default"))) geopm_endpoint_open(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Destroy shmem regions within the endpoint.
@@ -64,7 +65,7 @@ int geopm_endpoint_open(struct geopm_endpoint_c *endpoint);
  *
  *  @return Zero on success, error code on failure.
  */
-int geopm_endpoint_close(struct geopm_endpoint_c *endpoint);
+int __attribute__((visibility("default"))) geopm_endpoint_close(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Check if an agent has attached.
@@ -84,9 +85,10 @@ int geopm_endpoint_close(struct geopm_endpoint_c *endpoint);
  *          returned.
  *
  */
-int geopm_endpoint_agent(struct geopm_endpoint_c *endpoint,
-                         size_t agent_name_max,
-                         char *agent_name);
+int __attribute__((visibility("default"))) geopm_endpoint_agent(
+    struct geopm_endpoint_c *endpoint,
+    size_t agent_name_max,
+    char *agent_name);
 
 /*!
  *  @brief Blocks until an agent has attached or the timeout is
@@ -97,8 +99,9 @@ int geopm_endpoint_agent(struct geopm_endpoint_c *endpoint,
  *
  *  @param [in] timeout Timeout in seconds.
  */
-int geopm_endpoint_wait_for_agent_attach(struct geopm_endpoint_c *endpoint,
-                                         double timeout);
+int __attribute__((visibility("default"))) geopm_endpoint_wait_for_agent_attach(
+    struct geopm_endpoint_c *endpoint,
+    double timeout);
 
 /*!
  * @brief Stops any current wait loops the endpoint is running.
@@ -106,7 +109,8 @@ int geopm_endpoint_wait_for_agent_attach(struct geopm_endpoint_c *endpoint,
  *  @param [in] endpoint Object created by call to
  *         geopm_endpoint_create().
  */
-int geopm_endpoint_stop_wait_loop(struct geopm_endpoint_c *endpoint);
+int __attribute__((visibility("default"))) geopm_endpoint_stop_wait_loop(
+    struct geopm_endpoint_c *endpoint);
 
 /*!
  * @brief Resets the endpoint to prepare for a subsequent call to
@@ -115,7 +119,7 @@ int geopm_endpoint_stop_wait_loop(struct geopm_endpoint_c *endpoint);
  *  @param [in] endpoint Object created by call to
  *         geopm_endpoint_create().
  */
-int geopm_endpoint_reset_wait_loop(struct geopm_endpoint_c *endpoint);
+int __attribute__((visibility("default"))) geopm_endpoint_reset_wait_loop(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Check profile name for an attached job.
@@ -136,9 +140,10 @@ int geopm_endpoint_reset_wait_loop(struct geopm_endpoint_c *endpoint);
  *          returned.
  *
  */
-int geopm_endpoint_profile_name(struct geopm_endpoint_c *endpoint,
-                                size_t profile_name_max,
-                                char *profile_name);
+int __attribute__((visibility("default"))) geopm_endpoint_profile_name(
+    struct geopm_endpoint_c *endpoint,
+    size_t profile_name_max,
+    char *profile_name);
 
 /*!
  *  @brief Get the number of nodes managed by the agent.
@@ -152,8 +157,9 @@ int geopm_endpoint_profile_name(struct geopm_endpoint_c *endpoint,
  *
  *  @return Zero on success, error code on failure.
  */
-int geopm_endpoint_num_node(struct geopm_endpoint_c *endpoint,
-                            int *num_node);
+int __attribute__((visibility("default"))) geopm_endpoint_num_node(
+    struct geopm_endpoint_c *endpoint,
+    int *num_node);
 
 /*!
  *  @brief Get the hostname of the indexed compute node.
@@ -172,10 +178,11 @@ int geopm_endpoint_num_node(struct geopm_endpoint_c *endpoint,
  *
  *  @return Zero on success, error code on failure
  */
-int geopm_endpoint_node_name(struct geopm_endpoint_c *endpoint,
-                             int node_idx,
-                             size_t node_name_max,
-                             char *node_name);
+int __attribute__((visibility("default"))) geopm_endpoint_node_name(
+    struct geopm_endpoint_c *endpoint,
+    int node_idx,
+    size_t node_name_max,
+    char *node_name);
 
 /*!
  *  @brief Set the policy values for the agent to follow.
@@ -190,10 +197,10 @@ int geopm_endpoint_node_name(struct geopm_endpoint_c *endpoint,
  *
  *  @return Zero on success, error code on failure
  */
-int geopm_endpoint_write_policy(struct geopm_endpoint_c *endpoint,
-                                size_t num_policy,
-                                const double *policy_array);
-
+int __attribute__((visibility("default"))) geopm_endpoint_write_policy(
+    struct geopm_endpoint_c *endpoint,
+    size_t num_policy,
+    const double *policy_array);
 
 /*!
  *  @brief Get a sample from the agent and amount of time that has
@@ -212,10 +219,11 @@ int geopm_endpoint_write_policy(struct geopm_endpoint_c *endpoint,
  *
  *  @return Zero on success, error code on failure
  */
-int geopm_endpoint_read_sample(struct geopm_endpoint_c *endpoint,
-                               size_t num_sample,
-                               double *sample_array,
-                               double *sample_age_sec);
+int __attribute__((visibility("default"))) geopm_endpoint_read_sample(
+    struct geopm_endpoint_c *endpoint,
+    size_t num_sample,
+    double *sample_array,
+    double *sample_age_sec);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_endpoint.h
+++ b/libgeopm/include/geopm_endpoint.h
@@ -31,9 +31,8 @@ struct geopm_endpoint_c;
  *
  *  @return Zero on success, error code on failure.
  */
-int GEOPM_PUBLIC geopm_endpoint_create(
-    const char *endpoint_name,
-    struct geopm_endpoint_c **endpoint);
+int GEOPM_PUBLIC
+    geopm_endpoint_create(const char *endpoint_name, struct geopm_endpoint_c **endpoint);
 
 /*!
  *  @brief Release resources associated with endpoint.
@@ -46,7 +45,8 @@ int GEOPM_PUBLIC geopm_endpoint_create(
  *
  *  @return Zero on success, error code on failure.
  */
-int GEOPM_PUBLIC geopm_endpoint_destroy(struct geopm_endpoint_c *endpoint);
+int GEOPM_PUBLIC
+    geopm_endpoint_destroy(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Create shmem regions within the endpoint for policy/sample
@@ -57,7 +57,8 @@ int GEOPM_PUBLIC geopm_endpoint_destroy(struct geopm_endpoint_c *endpoint);
  *
  *  @return Zero on success, error code on failure.
  */
-int GEOPM_PUBLIC geopm_endpoint_open(struct geopm_endpoint_c *endpoint);
+int GEOPM_PUBLIC
+    geopm_endpoint_open(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Destroy shmem regions within the endpoint.
@@ -67,7 +68,8 @@ int GEOPM_PUBLIC geopm_endpoint_open(struct geopm_endpoint_c *endpoint);
  *
  *  @return Zero on success, error code on failure.
  */
-int GEOPM_PUBLIC geopm_endpoint_close(struct geopm_endpoint_c *endpoint);
+int GEOPM_PUBLIC
+    geopm_endpoint_close(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Check if an agent has attached.
@@ -87,10 +89,9 @@ int GEOPM_PUBLIC geopm_endpoint_close(struct geopm_endpoint_c *endpoint);
  *          returned.
  *
  */
-int GEOPM_PUBLIC geopm_endpoint_agent(
-    struct geopm_endpoint_c *endpoint,
-    size_t agent_name_max,
-    char *agent_name);
+int GEOPM_PUBLIC
+    geopm_endpoint_agent(struct geopm_endpoint_c *endpoint, size_t agent_name_max,
+                         char *agent_name);
 
 /*!
  *  @brief Blocks until an agent has attached or the timeout is
@@ -101,9 +102,8 @@ int GEOPM_PUBLIC geopm_endpoint_agent(
  *
  *  @param [in] timeout Timeout in seconds.
  */
-int GEOPM_PUBLIC geopm_endpoint_wait_for_agent_attach(
-    struct geopm_endpoint_c *endpoint,
-    double timeout);
+int GEOPM_PUBLIC
+    geopm_endpoint_wait_for_agent_attach(struct geopm_endpoint_c *endpoint, double timeout);
 
 /*!
  * @brief Stops any current wait loops the endpoint is running.
@@ -111,8 +111,8 @@ int GEOPM_PUBLIC geopm_endpoint_wait_for_agent_attach(
  *  @param [in] endpoint Object created by call to
  *         geopm_endpoint_create().
  */
-int GEOPM_PUBLIC geopm_endpoint_stop_wait_loop(
-    struct geopm_endpoint_c *endpoint);
+int GEOPM_PUBLIC
+    geopm_endpoint_stop_wait_loop(struct geopm_endpoint_c *endpoint);
 
 /*!
  * @brief Resets the endpoint to prepare for a subsequent call to
@@ -121,7 +121,8 @@ int GEOPM_PUBLIC geopm_endpoint_stop_wait_loop(
  *  @param [in] endpoint Object created by call to
  *         geopm_endpoint_create().
  */
-int GEOPM_PUBLIC geopm_endpoint_reset_wait_loop(struct geopm_endpoint_c *endpoint);
+int GEOPM_PUBLIC
+    geopm_endpoint_reset_wait_loop(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Check profile name for an attached job.
@@ -142,10 +143,9 @@ int GEOPM_PUBLIC geopm_endpoint_reset_wait_loop(struct geopm_endpoint_c *endpoin
  *          returned.
  *
  */
-int GEOPM_PUBLIC geopm_endpoint_profile_name(
-    struct geopm_endpoint_c *endpoint,
-    size_t profile_name_max,
-    char *profile_name);
+int GEOPM_PUBLIC
+    geopm_endpoint_profile_name(struct geopm_endpoint_c *endpoint, size_t profile_name_max,
+                                char *profile_name);
 
 /*!
  *  @brief Get the number of nodes managed by the agent.
@@ -159,9 +159,8 @@ int GEOPM_PUBLIC geopm_endpoint_profile_name(
  *
  *  @return Zero on success, error code on failure.
  */
-int GEOPM_PUBLIC geopm_endpoint_num_node(
-    struct geopm_endpoint_c *endpoint,
-    int *num_node);
+int GEOPM_PUBLIC
+    geopm_endpoint_num_node(struct geopm_endpoint_c *endpoint, int *num_node);
 
 /*!
  *  @brief Get the hostname of the indexed compute node.
@@ -180,11 +179,9 @@ int GEOPM_PUBLIC geopm_endpoint_num_node(
  *
  *  @return Zero on success, error code on failure
  */
-int GEOPM_PUBLIC geopm_endpoint_node_name(
-    struct geopm_endpoint_c *endpoint,
-    int node_idx,
-    size_t node_name_max,
-    char *node_name);
+int GEOPM_PUBLIC
+    geopm_endpoint_node_name(struct geopm_endpoint_c *endpoint, int node_idx,
+                             size_t node_name_max, char *node_name);
 
 /*!
  *  @brief Set the policy values for the agent to follow.
@@ -199,10 +196,9 @@ int GEOPM_PUBLIC geopm_endpoint_node_name(
  *
  *  @return Zero on success, error code on failure
  */
-int GEOPM_PUBLIC geopm_endpoint_write_policy(
-    struct geopm_endpoint_c *endpoint,
-    size_t num_policy,
-    const double *policy_array);
+int GEOPM_PUBLIC
+    geopm_endpoint_write_policy(struct geopm_endpoint_c *endpoint,
+                                size_t num_policy, const double *policy_array);
 
 /*!
  *  @brief Get a sample from the agent and amount of time that has
@@ -221,11 +217,9 @@ int GEOPM_PUBLIC geopm_endpoint_write_policy(
  *
  *  @return Zero on success, error code on failure
  */
-int GEOPM_PUBLIC geopm_endpoint_read_sample(
-    struct geopm_endpoint_c *endpoint,
-    size_t num_sample,
-    double *sample_array,
-    double *sample_age_sec);
+int GEOPM_PUBLIC
+    geopm_endpoint_read_sample(struct geopm_endpoint_c *endpoint, size_t num_sample,
+                               double *sample_array, double *sample_age_sec);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_endpoint.h
+++ b/libgeopm/include/geopm_endpoint.h
@@ -8,6 +8,8 @@
 
 #include <stddef.h>
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,7 +31,7 @@ struct geopm_endpoint_c;
  *
  *  @return Zero on success, error code on failure.
  */
-int __attribute__((visibility("default"))) geopm_endpoint_create(
+int GEOPM_PUBLIC geopm_endpoint_create(
     const char *endpoint_name,
     struct geopm_endpoint_c **endpoint);
 
@@ -44,7 +46,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_create(
  *
  *  @return Zero on success, error code on failure.
  */
-int __attribute__((visibility("default"))) geopm_endpoint_destroy(struct geopm_endpoint_c *endpoint);
+int GEOPM_PUBLIC geopm_endpoint_destroy(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Create shmem regions within the endpoint for policy/sample
@@ -55,7 +57,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_destroy(struct geopm_e
  *
  *  @return Zero on success, error code on failure.
  */
-int __attribute__((visibility("default"))) geopm_endpoint_open(struct geopm_endpoint_c *endpoint);
+int GEOPM_PUBLIC geopm_endpoint_open(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Destroy shmem regions within the endpoint.
@@ -65,7 +67,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_open(struct geopm_endp
  *
  *  @return Zero on success, error code on failure.
  */
-int __attribute__((visibility("default"))) geopm_endpoint_close(struct geopm_endpoint_c *endpoint);
+int GEOPM_PUBLIC geopm_endpoint_close(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Check if an agent has attached.
@@ -85,7 +87,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_close(struct geopm_end
  *          returned.
  *
  */
-int __attribute__((visibility("default"))) geopm_endpoint_agent(
+int GEOPM_PUBLIC geopm_endpoint_agent(
     struct geopm_endpoint_c *endpoint,
     size_t agent_name_max,
     char *agent_name);
@@ -99,7 +101,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_agent(
  *
  *  @param [in] timeout Timeout in seconds.
  */
-int __attribute__((visibility("default"))) geopm_endpoint_wait_for_agent_attach(
+int GEOPM_PUBLIC geopm_endpoint_wait_for_agent_attach(
     struct geopm_endpoint_c *endpoint,
     double timeout);
 
@@ -109,7 +111,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_wait_for_agent_attach(
  *  @param [in] endpoint Object created by call to
  *         geopm_endpoint_create().
  */
-int __attribute__((visibility("default"))) geopm_endpoint_stop_wait_loop(
+int GEOPM_PUBLIC geopm_endpoint_stop_wait_loop(
     struct geopm_endpoint_c *endpoint);
 
 /*!
@@ -119,7 +121,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_stop_wait_loop(
  *  @param [in] endpoint Object created by call to
  *         geopm_endpoint_create().
  */
-int __attribute__((visibility("default"))) geopm_endpoint_reset_wait_loop(struct geopm_endpoint_c *endpoint);
+int GEOPM_PUBLIC geopm_endpoint_reset_wait_loop(struct geopm_endpoint_c *endpoint);
 
 /*!
  *  @brief Check profile name for an attached job.
@@ -140,7 +142,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_reset_wait_loop(struct
  *          returned.
  *
  */
-int __attribute__((visibility("default"))) geopm_endpoint_profile_name(
+int GEOPM_PUBLIC geopm_endpoint_profile_name(
     struct geopm_endpoint_c *endpoint,
     size_t profile_name_max,
     char *profile_name);
@@ -157,7 +159,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_profile_name(
  *
  *  @return Zero on success, error code on failure.
  */
-int __attribute__((visibility("default"))) geopm_endpoint_num_node(
+int GEOPM_PUBLIC geopm_endpoint_num_node(
     struct geopm_endpoint_c *endpoint,
     int *num_node);
 
@@ -178,7 +180,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_num_node(
  *
  *  @return Zero on success, error code on failure
  */
-int __attribute__((visibility("default"))) geopm_endpoint_node_name(
+int GEOPM_PUBLIC geopm_endpoint_node_name(
     struct geopm_endpoint_c *endpoint,
     int node_idx,
     size_t node_name_max,
@@ -197,7 +199,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_node_name(
  *
  *  @return Zero on success, error code on failure
  */
-int __attribute__((visibility("default"))) geopm_endpoint_write_policy(
+int GEOPM_PUBLIC geopm_endpoint_write_policy(
     struct geopm_endpoint_c *endpoint,
     size_t num_policy,
     const double *policy_array);
@@ -219,7 +221,7 @@ int __attribute__((visibility("default"))) geopm_endpoint_write_policy(
  *
  *  @return Zero on success, error code on failure
  */
-int __attribute__((visibility("default"))) geopm_endpoint_read_sample(
+int GEOPM_PUBLIC geopm_endpoint_read_sample(
     struct geopm_endpoint_c *endpoint,
     size_t num_sample,
     double *sample_array,

--- a/libgeopm/include/geopm_imbalancer.h
+++ b/libgeopm/include/geopm_imbalancer.h
@@ -14,11 +14,14 @@ extern "C"
 
     /// @brief Used to set a delay frac that will sleep for the given fraction
     ///        of the region runtime.
-    int GEOPM_PUBLIC geopm_imbalancer_frac(double frac);
+    int GEOPM_PUBLIC
+        geopm_imbalancer_frac(double frac);
     /// @brief Sets the entry time for the imbalanced region.
-    int GEOPM_PUBLIC geopm_imbalancer_enter(void);
+    int GEOPM_PUBLIC
+        geopm_imbalancer_enter(void);
     /// @brief Spins until the region has been extended by the previously specified delay.
-    int GEOPM_PUBLIC geopm_imbalancer_exit(void);
+    int GEOPM_PUBLIC
+        geopm_imbalancer_exit(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_imbalancer.h
+++ b/libgeopm/include/geopm_imbalancer.h
@@ -5,6 +5,8 @@
 
 #ifndef GEOPM_IMBALANCER_H_INCLUDE
 #define GEOPM_IMBALANCER_H_INCLUDE
+
+#include "geopm_public.h"
 #ifdef __cplusplus
 extern "C"
 {
@@ -12,11 +14,11 @@ extern "C"
 
     /// @brief Used to set a delay frac that will sleep for the given fraction
     ///        of the region runtime.
-    int __attribute__((visibility("default"))) geopm_imbalancer_frac(double frac);
+    int GEOPM_PUBLIC geopm_imbalancer_frac(double frac);
     /// @brief Sets the entry time for the imbalanced region.
-    int __attribute__((visibility("default"))) geopm_imbalancer_enter(void);
+    int GEOPM_PUBLIC geopm_imbalancer_enter(void);
     /// @brief Spins until the region has been extended by the previously specified delay.
-    int __attribute__((visibility("default"))) geopm_imbalancer_exit(void);
+    int GEOPM_PUBLIC geopm_imbalancer_exit(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_imbalancer.h
+++ b/libgeopm/include/geopm_imbalancer.h
@@ -12,11 +12,11 @@ extern "C"
 
     /// @brief Used to set a delay frac that will sleep for the given fraction
     ///        of the region runtime.
-    int geopm_imbalancer_frac(double frac);
+    int __attribute__((visibility("default"))) geopm_imbalancer_frac(double frac);
     /// @brief Sets the entry time for the imbalanced region.
-    int geopm_imbalancer_enter(void);
+    int __attribute__((visibility("default"))) geopm_imbalancer_enter(void);
     /// @brief Spins until the region has been extended by the previously specified delay.
-    int geopm_imbalancer_exit(void);
+    int __attribute__((visibility("default"))) geopm_imbalancer_exit(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_policystore.h
+++ b/libgeopm/include/geopm_policystore.h
@@ -19,13 +19,13 @@ extern "C"
      * @param [in] data_path Path to the data store.
      * @return Zero on success, error code on failure.
      */
-    int geopm_policystore_connect(const char *data_path);
+    int __attribute__((visibility("default"))) geopm_policystore_connect(const char *data_path);
 
     /*!
      * @brief Destroy a geopm policy store interface and release its resources
      * @return Zero on success, error code on failure.
      */
-    int geopm_policystore_disconnect();
+    int __attribute__((visibility("default"))) geopm_policystore_disconnect();
 
     /*!
      * @brief Get the best known policy for a given agent and profile.
@@ -37,8 +37,9 @@ extern "C"
      * @param [out] policy_vals Best known or default policy.
      * @return Zero on success, error code on failure.
      */
-    int geopm_policystore_get_best(const char *agent_name, const char *profile_name,
-                                   size_t max_policy_vals, double *policy_vals);
+    int __attribute__((visibility("default"))) geopm_policystore_get_best(
+        const char *agent_name, const char *profile_name,
+        size_t max_policy_vals, double *policy_vals);
 
     /*!
      * @brief Set the best known policy for a given agent and profile.
@@ -48,8 +49,9 @@ extern "C"
      * @param [in] policy_vals New policy to apply.
      * @return Zero on success, error code on failure.
      */
-    int geopm_policystore_set_best(const char *agent_name, const char *profile_name,
-                                   size_t num_policy_vals, const double *policy_vals);
+    int __attribute__((visibility("default"))) geopm_policystore_set_best(
+        const char *agent_name, const char *profile_name,
+        size_t num_policy_vals, const double *policy_vals);
 
     /*!
      * @brief Set the default policy for a given agent.
@@ -58,8 +60,8 @@ extern "C"
      * @param [in] policy_vals Default policy to apply.
      * @return Zero on success, error code on failure.
      */
-    int geopm_policystore_set_default(const char *agent_name, size_t num_policy_vals,
-                                      const double *policy_vals);
+    int __attribute__((visibility("default"))) geopm_policystore_set_default(
+        const char *agent_name, size_t num_policy_vals, const double *policy_vals);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_policystore.h
+++ b/libgeopm/include/geopm_policystore.h
@@ -21,13 +21,15 @@ extern "C"
      * @param [in] data_path Path to the data store.
      * @return Zero on success, error code on failure.
      */
-    int GEOPM_PUBLIC geopm_policystore_connect(const char *data_path);
+    int GEOPM_PUBLIC
+        geopm_policystore_connect(const char *data_path);
 
     /*!
      * @brief Destroy a geopm policy store interface and release its resources
      * @return Zero on success, error code on failure.
      */
-    int GEOPM_PUBLIC geopm_policystore_disconnect();
+    int GEOPM_PUBLIC
+        geopm_policystore_disconnect();
 
     /*!
      * @brief Get the best known policy for a given agent and profile.
@@ -39,9 +41,9 @@ extern "C"
      * @param [out] policy_vals Best known or default policy.
      * @return Zero on success, error code on failure.
      */
-    int GEOPM_PUBLIC geopm_policystore_get_best(
-        const char *agent_name, const char *profile_name,
-        size_t max_policy_vals, double *policy_vals);
+    int GEOPM_PUBLIC
+        geopm_policystore_get_best(const char *agent_name, const char *profile_name,
+                                   size_t max_policy_vals, double *policy_vals);
 
     /*!
      * @brief Set the best known policy for a given agent and profile.
@@ -51,9 +53,9 @@ extern "C"
      * @param [in] policy_vals New policy to apply.
      * @return Zero on success, error code on failure.
      */
-    int GEOPM_PUBLIC geopm_policystore_set_best(
-        const char *agent_name, const char *profile_name,
-        size_t num_policy_vals, const double *policy_vals);
+    int GEOPM_PUBLIC
+        geopm_policystore_set_best(const char *agent_name, const char *profile_name,
+                                   size_t num_policy_vals, const double *policy_vals);
 
     /*!
      * @brief Set the default policy for a given agent.
@@ -62,8 +64,9 @@ extern "C"
      * @param [in] policy_vals Default policy to apply.
      * @return Zero on success, error code on failure.
      */
-    int GEOPM_PUBLIC geopm_policystore_set_default(
-        const char *agent_name, size_t num_policy_vals, const double *policy_vals);
+    int GEOPM_PUBLIC
+        geopm_policystore_set_default(const char *agent_name, size_t num_policy_vals,
+                                      const double *policy_vals);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_policystore.h
+++ b/libgeopm/include/geopm_policystore.h
@@ -8,6 +8,8 @@
 
 #include <stddef.h>
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -19,13 +21,13 @@ extern "C"
      * @param [in] data_path Path to the data store.
      * @return Zero on success, error code on failure.
      */
-    int __attribute__((visibility("default"))) geopm_policystore_connect(const char *data_path);
+    int GEOPM_PUBLIC geopm_policystore_connect(const char *data_path);
 
     /*!
      * @brief Destroy a geopm policy store interface and release its resources
      * @return Zero on success, error code on failure.
      */
-    int __attribute__((visibility("default"))) geopm_policystore_disconnect();
+    int GEOPM_PUBLIC geopm_policystore_disconnect();
 
     /*!
      * @brief Get the best known policy for a given agent and profile.
@@ -37,7 +39,7 @@ extern "C"
      * @param [out] policy_vals Best known or default policy.
      * @return Zero on success, error code on failure.
      */
-    int __attribute__((visibility("default"))) geopm_policystore_get_best(
+    int GEOPM_PUBLIC geopm_policystore_get_best(
         const char *agent_name, const char *profile_name,
         size_t max_policy_vals, double *policy_vals);
 
@@ -49,7 +51,7 @@ extern "C"
      * @param [in] policy_vals New policy to apply.
      * @return Zero on success, error code on failure.
      */
-    int __attribute__((visibility("default"))) geopm_policystore_set_best(
+    int GEOPM_PUBLIC geopm_policystore_set_best(
         const char *agent_name, const char *profile_name,
         size_t num_policy_vals, const double *policy_vals);
 
@@ -60,7 +62,7 @@ extern "C"
      * @param [in] policy_vals Default policy to apply.
      * @return Zero on success, error code on failure.
      */
-    int __attribute__((visibility("default"))) geopm_policystore_set_default(
+    int GEOPM_PUBLIC geopm_policystore_set_default(
         const char *agent_name, size_t num_policy_vals, const double *policy_vals);
 
 #ifdef __cplusplus

--- a/libgeopm/include/geopm_prof.h
+++ b/libgeopm/include/geopm_prof.h
@@ -18,23 +18,29 @@ extern "C" {
 /*************************/
 /* APPLICATION PROFILING */
 /*************************/
-int GEOPM_PUBLIC geopm_prof_region(const char *region_name,
-                                                             uint64_t hint,
-                                                             uint64_t *region_id);
+int GEOPM_PUBLIC
+    geopm_prof_region(const char *region_name, uint64_t hint, uint64_t *region_id);
 
-int GEOPM_PUBLIC geopm_prof_enter(uint64_t region_id);
+int GEOPM_PUBLIC
+    geopm_prof_enter(uint64_t region_id);
 
-int GEOPM_PUBLIC geopm_prof_exit(uint64_t region_id);
+int GEOPM_PUBLIC
+    geopm_prof_exit(uint64_t region_id);
 
-int GEOPM_PUBLIC geopm_prof_epoch(void);
+int GEOPM_PUBLIC
+    geopm_prof_epoch(void);
 
-int GEOPM_PUBLIC geopm_prof_shutdown(void);
+int GEOPM_PUBLIC
+    geopm_prof_shutdown(void);
 
-int GEOPM_PUBLIC geopm_tprof_init(uint32_t num_work_unit);
+int GEOPM_PUBLIC
+    geopm_tprof_init(uint32_t num_work_unit);
 
-int GEOPM_PUBLIC geopm_tprof_post(void);
+int GEOPM_PUBLIC
+    geopm_tprof_post(void);
 
-int GEOPM_PUBLIC geopm_prof_overhead(double overhead_sec);
+int GEOPM_PUBLIC
+    geopm_prof_overhead(double overhead_sec);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_prof.h
+++ b/libgeopm/include/geopm_prof.h
@@ -16,23 +16,23 @@ extern "C" {
 /*************************/
 /* APPLICATION PROFILING */
 /*************************/
-int geopm_prof_region(const char *region_name,
-                      uint64_t hint,
-                      uint64_t *region_id);
+int __attribute__((visibility("default"))) geopm_prof_region(const char *region_name,
+                                                             uint64_t hint,
+                                                             uint64_t *region_id);
 
-int geopm_prof_enter(uint64_t region_id);
+int __attribute__((visibility("default"))) geopm_prof_enter(uint64_t region_id);
 
-int geopm_prof_exit(uint64_t region_id);
+int __attribute__((visibility("default"))) geopm_prof_exit(uint64_t region_id);
 
-int geopm_prof_epoch(void);
+int __attribute__((visibility("default"))) geopm_prof_epoch(void);
 
-int geopm_prof_shutdown(void);
+int __attribute__((visibility("default"))) geopm_prof_shutdown(void);
 
-int geopm_tprof_init(uint32_t num_work_unit);
+int __attribute__((visibility("default"))) geopm_tprof_init(uint32_t num_work_unit);
 
-int geopm_tprof_post(void);
+int __attribute__((visibility("default"))) geopm_tprof_post(void);
 
-int geopm_prof_overhead(double overhead_sec);
+int __attribute__((visibility("default"))) geopm_prof_overhead(double overhead_sec);
 
 #ifdef __cplusplus
 }

--- a/libgeopm/include/geopm_prof.h
+++ b/libgeopm/include/geopm_prof.h
@@ -9,6 +9,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -16,23 +18,23 @@ extern "C" {
 /*************************/
 /* APPLICATION PROFILING */
 /*************************/
-int __attribute__((visibility("default"))) geopm_prof_region(const char *region_name,
+int GEOPM_PUBLIC geopm_prof_region(const char *region_name,
                                                              uint64_t hint,
                                                              uint64_t *region_id);
 
-int __attribute__((visibility("default"))) geopm_prof_enter(uint64_t region_id);
+int GEOPM_PUBLIC geopm_prof_enter(uint64_t region_id);
 
-int __attribute__((visibility("default"))) geopm_prof_exit(uint64_t region_id);
+int GEOPM_PUBLIC geopm_prof_exit(uint64_t region_id);
 
-int __attribute__((visibility("default"))) geopm_prof_epoch(void);
+int GEOPM_PUBLIC geopm_prof_epoch(void);
 
-int __attribute__((visibility("default"))) geopm_prof_shutdown(void);
+int GEOPM_PUBLIC geopm_prof_shutdown(void);
 
-int __attribute__((visibility("default"))) geopm_tprof_init(uint32_t num_work_unit);
+int GEOPM_PUBLIC geopm_tprof_init(uint32_t num_work_unit);
 
-int __attribute__((visibility("default"))) geopm_tprof_post(void);
+int GEOPM_PUBLIC geopm_tprof_post(void);
 
-int __attribute__((visibility("default"))) geopm_prof_overhead(double overhead_sec);
+int GEOPM_PUBLIC geopm_prof_overhead(double overhead_sec);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/Makefile.am
+++ b/libgeopmd/Makefile.am
@@ -22,6 +22,7 @@ include_HEADERS = include/geopm_debug.hpp \
                   include/geopm_hint.h \
                   include/geopm_pio.h \
                   include/geopm_plugin.hpp \
+                  include/geopm_public.h \
                   include/geopm_sched.h \
                   include/geopm_shmem.h \
                   include/geopm_time.h \

--- a/libgeopmd/contrib/json11/json11.hpp
+++ b/libgeopmd/contrib/json11/json11.hpp
@@ -78,7 +78,7 @@ enum JsonParse {
 
 class JsonValue;
 
-class Json final {
+class __attribute__((visibility("default"))) Json final {
 public:
     // Types
     enum Type {

--- a/libgeopmd/debian/copyright
+++ b/libgeopmd/debian/copyright
@@ -33,6 +33,7 @@ Files:     autogen.sh
            include/geopm_hint.h
            include/geopm_pio.h
            include/geopm_plugin.hpp
+           include/geopm_public.h
            include/geopm_sched.h
            include/geopm_shmem.h
            include/geopm_time.h

--- a/libgeopmd/geopm-service.spec.in
+++ b/libgeopmd/geopm-service.spec.in
@@ -230,6 +230,7 @@ ln -s -r %{buildroot}%{_sbindir}/service %{buildroot}%{_sbindir}/rcgeopm
 %{_includedir}/geopm_hint.h
 %{_includedir}/geopm_pio.h
 %{_includedir}/geopm_plugin.hpp
+%{_includedir}/geopm_public.h
 %{_includedir}/geopm_sched.h
 %{_includedir}/geopm_shmem.h
 %{_includedir}/geopm_time.h

--- a/libgeopmd/include/geopm/Agg.hpp
+++ b/libgeopmd/include/geopm/Agg.hpp
@@ -6,15 +6,17 @@
 #ifndef AGG_HPP_INCLUDE
 #define AGG_HPP_INCLUDE
 
-#include <vector>
-#include <string>
 #include <functional>
+#include <string>
+#include <vector>
+
+#include "geopm_public.h"
 
 namespace geopm
 {
     /// Aggregation functions available to be used by Agents and IOGroups to
     /// condense a vector of signal values into a single value.
-    class __attribute__((visibility("default"))) Agg
+    class GEOPM_PUBLIC Agg
     {
         public:
             enum m_type_e {

--- a/libgeopmd/include/geopm/Agg.hpp
+++ b/libgeopmd/include/geopm/Agg.hpp
@@ -14,7 +14,7 @@ namespace geopm
 {
     /// Aggregation functions available to be used by Agents and IOGroups to
     /// condense a vector of signal values into a single value.
-    class Agg
+    class __attribute__((visibility("default"))) Agg
     {
         public:
             enum m_type_e {

--- a/libgeopmd/include/geopm/CircularBuffer.hpp
+++ b/libgeopmd/include/geopm/CircularBuffer.hpp
@@ -10,6 +10,8 @@
 
 #include <vector>
 
+#include "geopm_public.h"
+
 #include "Exception.hpp"
 
 namespace geopm

--- a/libgeopmd/include/geopm/Cpuid.hpp
+++ b/libgeopmd/include/geopm/Cpuid.hpp
@@ -7,9 +7,11 @@
 
 #include <memory>
 
+#include "geopm_public.h"
+
 namespace geopm
 {
-    class __attribute__((visibility("default"))) Cpuid
+    class GEOPM_PUBLIC Cpuid
     {
         public:
             struct rdt_info_s

--- a/libgeopmd/include/geopm/Cpuid.hpp
+++ b/libgeopmd/include/geopm/Cpuid.hpp
@@ -9,7 +9,7 @@
 
 namespace geopm
 {
-    class Cpuid
+    class __attribute__((visibility("default"))) Cpuid
     {
         public:
             struct rdt_info_s

--- a/libgeopmd/include/geopm/Exception.hpp
+++ b/libgeopmd/include/geopm/Exception.hpp
@@ -32,7 +32,8 @@ namespace geopm
     ///
     /// @return Error number, positive numbers are system errors,
     ///         negative numbers are GEOPM errors.
-    int exception_handler(std::exception_ptr eptr, bool do_print=false);
+    int __attribute__((visibility("default")))
+        exception_handler(std::exception_ptr eptr, bool do_print=false);
 
     /// @brief Class for all GEOPM-specific exceptions.
     ///
@@ -41,7 +42,8 @@ namespace geopm
     /// method called err_value() that returns the error code
     /// associated with the exception.  There are a number of
     /// different constructors.
-    class Exception : public std::runtime_error
+    class __attribute__((visibility("default")))
+        Exception : public std::runtime_error
     {
         public:
             /// @brief Empty constructor.
@@ -99,7 +101,8 @@ namespace geopm
     /// @param error_value The error code associated with the exception.
     ///
     /// @return string The error message associated with the error code.
-    std::string error_message(int error_value);
+    std::string __attribute__ ((visibility("default")))
+        error_message(int error_value);
 }
 
 #endif

--- a/libgeopmd/include/geopm/Exception.hpp
+++ b/libgeopmd/include/geopm/Exception.hpp
@@ -32,8 +32,8 @@ namespace geopm
     ///
     /// @return Error number, positive numbers are system errors,
     ///         negative numbers are GEOPM errors.
-    int __attribute__((visibility("default")))
-        exception_handler(std::exception_ptr eptr, bool do_print=false);
+    int __attribute__((visibility("default"))) exception_handler(
+        std::exception_ptr eptr, bool do_print = false);
 
     /// @brief Class for all GEOPM-specific exceptions.
     ///
@@ -42,8 +42,7 @@ namespace geopm
     /// method called err_value() that returns the error code
     /// associated with the exception.  There are a number of
     /// different constructors.
-    class __attribute__((visibility("default")))
-        Exception : public std::runtime_error
+    class __attribute__((visibility("default"))) Exception : public std::runtime_error
     {
         public:
             /// @brief Empty constructor.
@@ -101,8 +100,7 @@ namespace geopm
     /// @param error_value The error code associated with the exception.
     ///
     /// @return string The error message associated with the error code.
-    std::string __attribute__ ((visibility("default")))
-        error_message(int error_value);
+    std::string __attribute__((visibility("default"))) error_message(int error_value);
 }
 
 #endif

--- a/libgeopmd/include/geopm/Exception.hpp
+++ b/libgeopmd/include/geopm/Exception.hpp
@@ -5,9 +5,11 @@
 #ifndef EXCEPTION_HPP_INCLUDE
 #define EXCEPTION_HPP_INCLUDE
 
-#include <string>
 #include <stdexcept>
+#include <string>
+
 #include "geopm_error.h"
+#include "geopm_public.h"
 
 namespace geopm
 {
@@ -32,7 +34,7 @@ namespace geopm
     ///
     /// @return Error number, positive numbers are system errors,
     ///         negative numbers are GEOPM errors.
-    int __attribute__((visibility("default"))) exception_handler(
+    int GEOPM_PUBLIC exception_handler(
         std::exception_ptr eptr, bool do_print = false);
 
     /// @brief Class for all GEOPM-specific exceptions.
@@ -42,7 +44,7 @@ namespace geopm
     /// method called err_value() that returns the error code
     /// associated with the exception.  There are a number of
     /// different constructors.
-    class __attribute__((visibility("default"))) Exception : public std::runtime_error
+    class GEOPM_PUBLIC Exception : public std::runtime_error
     {
         public:
             /// @brief Empty constructor.
@@ -100,7 +102,7 @@ namespace geopm
     /// @param error_value The error code associated with the exception.
     ///
     /// @return string The error message associated with the error code.
-    std::string __attribute__((visibility("default"))) error_message(int error_value);
+    std::string GEOPM_PUBLIC error_message(int error_value);
 }
 
 #endif

--- a/libgeopmd/include/geopm/Exception.hpp
+++ b/libgeopmd/include/geopm/Exception.hpp
@@ -34,8 +34,8 @@ namespace geopm
     ///
     /// @return Error number, positive numbers are system errors,
     ///         negative numbers are GEOPM errors.
-    int GEOPM_PUBLIC exception_handler(
-        std::exception_ptr eptr, bool do_print = false);
+    int GEOPM_PUBLIC
+        exception_handler(std::exception_ptr eptr, bool do_print = false);
 
     /// @brief Class for all GEOPM-specific exceptions.
     ///
@@ -102,7 +102,8 @@ namespace geopm
     /// @param error_value The error code associated with the exception.
     ///
     /// @return string The error message associated with the error code.
-    std::string GEOPM_PUBLIC error_message(int error_value);
+    std::string GEOPM_PUBLIC
+        error_message(int error_value);
 }
 
 #endif

--- a/libgeopmd/include/geopm/Helper.hpp
+++ b/libgeopmd/include/geopm/Helper.hpp
@@ -6,15 +6,17 @@
 #ifndef HELPER_HPP_INCLUDE
 #define HELPER_HPP_INCLUDE
 
-#include <stdint.h>
 #include <sched.h>
+#include <stdint.h>
 
-#include <string>
+#include <functional>
 #include <memory>
+#include <set>
+#include <string>
 #include <utility>
 #include <vector>
-#include <functional>
-#include <set>
+
+#include "geopm_public.h"
 
 namespace geopm
 {
@@ -30,7 +32,7 @@ namespace geopm
     /// @brief Reads the specified file and returns the contents in a string.
     /// @param [in] path The path of the file to read.
     /// @return The contents of the file at path.
-    std::string __attribute__((visibility("default"))) read_file(
+    std::string GEOPM_PUBLIC read_file(
         const std::string &path);
 
     /// @brief Read a file and return a double read from the file.
@@ -41,14 +43,14 @@ namespace geopm
     /// @param [in] expected_units Expected units to follow the double. Provide
     ///             an empty string if no units are expected.
     /// @return The value read from the file.
-    double __attribute__((visibility("default"))) read_double_from_file(
+    double GEOPM_PUBLIC read_double_from_file(
         const std::string &path, const std::string &expected_units);
 
     /// @brief Writes a string to a file.  This will replace the file
     ///        if it exists or create it if it does not exist.
     /// @param [in] path The path to the file to write to.
     /// @param [in] contents The string to write to the file.
-    void __attribute__((visibility("default"))) write_file(
+    void GEOPM_PUBLIC write_file(
         const std::string &path, const std::string &contents);
 
     /// @brief Splits a string according to a delimiter.
@@ -56,30 +58,30 @@ namespace geopm
     /// @param [in] delim The delimiter to use to divide the string.
     ///        Cannot be empty.
     /// @return A vector of string pieces.
-    std::vector<std::string> __attribute__((visibility("default"))) string_split(
+    std::vector<std::string> GEOPM_PUBLIC string_split(
         const std::string &str, const std::string &delim);
 
     /// @brief Joins a vector of strings together with a delimiter.
     /// @param [in] string_list The list of strings to be joined.
     /// @param [in] delim The delimiter to use to join the strings.
     /// @return The joined string.
-    std::string __attribute__((visibility("default"))) string_join(
+    std::string GEOPM_PUBLIC string_join(
         const std::vector<std::string> &string_list, const std::string &delim);
 
     /// @brief Returns the current hostname as a string.
-    std::string __attribute__((visibility("default"))) hostname(void);
+    std::string GEOPM_PUBLIC hostname(void);
 
     /// @brief List all files in the given directory.
     /// @param [in] path Path to the directory.
-    std::vector<std::string> __attribute__((visibility("default"))) list_directory_files(
+    std::vector<std::string> GEOPM_PUBLIC list_directory_files(
         const std::string &path);
 
     /// @brief Returns whether one string begins with another.
-    bool __attribute__((visibility("default"))) string_begins_with(
+    bool GEOPM_PUBLIC string_begins_with(
         const std::string &str, const std::string &key);
 
     /// @brief Returns whether one string ends with another.
-    bool __attribute__((visibility("default"))) string_ends_with(
+    bool GEOPM_PUBLIC string_ends_with(
         std::string str, std::string key);
 
     enum string_format_e {
@@ -89,34 +91,34 @@ namespace geopm
         STRING_FORMAT_RAW64,
     };
     /// @brief Convert a format type enum string_format_e to a format function
-    std::function<std::string(double)> __attribute__((visibility("default"))) string_format_type_to_function(
+    std::function<std::string(double)> GEOPM_PUBLIC string_format_type_to_function(
         int format_type);
     /// @brief Convert a format function to a format name to a format function
-    std::function<std::string(double)> __attribute__((visibility("default"))) string_format_name_to_function(
+    std::function<std::string(double)> GEOPM_PUBLIC string_format_name_to_function(
         const std::string &format_name);
     /// @brief Convert a format function to a format type enum string_format_e
-    int __attribute__((visibility("default"))) string_format_function_to_type(
+    int GEOPM_PUBLIC string_format_function_to_type(
         std::function<std::string(double)> format_function);
     /// @brief Format a string to best represent a signal encoding a
     ///        double precision floating point number.
     /// @param [in] signal A real number that requires many
     ///        significant digits to accurately represent.
     /// @return A well-formatted string representation of the signal.
-    std::string __attribute__((visibility("default"))) string_format_double(double signal);
+    std::string GEOPM_PUBLIC string_format_double(double signal);
 
     /// @brief Format a string to best represent a signal encoding a
     ///        single precision floating point number.
     /// @param [in] signal A real number that requires a few
     ///        significant digits to accurately represent.
     /// @return A well formatted string representation of the signal.
-    std::string __attribute__((visibility("default"))) string_format_float(double signal);
+    std::string GEOPM_PUBLIC string_format_float(double signal);
 
     /// @brief Format a string to best represent a signal encoding a
     ///        decimal integer.
     /// @param [in] signal An integer that is best represented as a
     ///        decimal number.
     /// @return A well formatted string representation of the signal.
-    std::string __attribute__((visibility("default"))) string_format_integer(double signal);
+    std::string GEOPM_PUBLIC string_format_integer(double signal);
 
     /// @brief Format a string to best represent a signal encoding an
     ///        unsigned hexadecimal integer.
@@ -124,14 +126,14 @@ namespace geopm
     ///        represented as a hexadecimal number and has been
     ///        assigned to a double precision number
     /// @return A well formatted string representation of the signal.
-    std::string __attribute__((visibility("default"))) string_format_hex(double signal);
+    std::string GEOPM_PUBLIC string_format_hex(double signal);
 
     /// @brief Format a string to represent the raw memory supporting
     ///        a signal as an unsigned hexadecimal integer.
     /// @param [in] signal A 64-bit unsigned integer that has been
     ///        byte-wise copied into the memory of signal.
     /// @return A well formatted string representation of the signal.
-    std::string __attribute__((visibility("default"))) string_format_raw64(double signal);
+    std::string GEOPM_PUBLIC string_format_raw64(double signal);
 
     /// @brief Cache line size used to properly align structs to avoid
     ///        false sharing between threads.
@@ -141,37 +143,37 @@ namespace geopm
     /// @brief Read an environment variable.
     /// @param [in] The name of the environment variable to read.
     /// @return The contents of the variable if present, otherwise an empty string.
-    std::string __attribute__((visibility("default"))) get_env(
+    std::string GEOPM_PUBLIC get_env(
         const std::string &name);
 
     /// @brief Query for the user id associated with the process id.
     /// @param [in] pid The process id to query.
     /// @return The user id.
-    unsigned int __attribute__((visibility("default"))) pid_to_uid(const int pid);
+    unsigned int GEOPM_PUBLIC pid_to_uid(const int pid);
 
     /// @brief Query for the group id associated with the process id.
     /// @param [in] pid The process id to query.
     /// @return The group id.
-    unsigned int __attribute__((visibility("default"))) pid_to_gid(const int pid);
+    unsigned int GEOPM_PUBLIC pid_to_gid(const int pid);
 
     /// @brief Wrapper around CPU_ALLOC and CPU_FREE
     /// @param [in] num_cpu The number of CPUs to allocate the CPU set
     /// @param [in] cpu_enabled The CPUs to be included in the CPU set
     /// @return A std::unique_ptr to a cpu_set_t configured to use CPU_FREE as
     ///         the deleter.
-    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> > __attribute__((visibility("default")))
+    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> > GEOPM_PUBLIC
         make_cpu_set(int num_cpu, const std::set<int> &cpu_enabled);
 
     /// @brief Check if the caller has effective capability CAP_SYS_ADMIN
     /// @return True if the PID has CAP_SYS_ADMIN
-    bool __attribute__((visibility("default"))) has_cap_sys_admin(void);
+    bool GEOPM_PUBLIC has_cap_sys_admin(void);
 
     /// @brief Check if the pid has effective capability CAP_SYS_ADMIN
     /// @param [in] pid Linux PID to check
     /// @return True if the PID has CAP_SYS_ADMIN
-    bool __attribute__((visibility("default"))) has_cap_sys_admin(int pid);
+    bool GEOPM_PUBLIC has_cap_sys_admin(int pid);
 
-    class __attribute__((visibility("default"))) DeprecationWarning
+    class GEOPM_PUBLIC DeprecationWarning
     {
         public:
             DeprecationWarning() = delete;

--- a/libgeopmd/include/geopm/Helper.hpp
+++ b/libgeopmd/include/geopm/Helper.hpp
@@ -30,7 +30,8 @@ namespace geopm
     /// @brief Reads the specified file and returns the contents in a string.
     /// @param [in] path The path of the file to read.
     /// @return The contents of the file at path.
-    std::string read_file(const std::string &path);
+    std::string __attribute__((visibility("default"))) read_file(
+        const std::string &path);
 
     /// @brief Read a file and return a double read from the file.
     /// @details If a double cannot be read from the file or the units reported
@@ -40,42 +41,46 @@ namespace geopm
     /// @param [in] expected_units Expected units to follow the double. Provide
     ///             an empty string if no units are expected.
     /// @return The value read from the file.
-    double read_double_from_file(const std::string &path,
-                                 const std::string &expected_units);
+    double __attribute__((visibility("default"))) read_double_from_file(
+        const std::string &path, const std::string &expected_units);
 
     /// @brief Writes a string to a file.  This will replace the file
     ///        if it exists or create it if it does not exist.
     /// @param [in] path The path to the file to write to.
     /// @param [in] contents The string to write to the file.
-    void write_file(const std::string &path, const std::string &contents);
+    void __attribute__((visibility("default"))) write_file(
+        const std::string &path, const std::string &contents);
 
     /// @brief Splits a string according to a delimiter.
     /// @param [in] str The string to be split.
     /// @param [in] delim The delimiter to use to divide the string.
     ///        Cannot be empty.
     /// @return A vector of string pieces.
-    std::vector<std::string> string_split(const std::string &str,
-                                          const std::string &delim);
+    std::vector<std::string> __attribute__((visibility("default"))) string_split(
+        const std::string &str, const std::string &delim);
 
     /// @brief Joins a vector of strings together with a delimiter.
     /// @param [in] string_list The list of strings to be joined.
     /// @param [in] delim The delimiter to use to join the strings.
     /// @return The joined string.
-    std::string string_join(const std::vector<std::string> &string_list,
-                            const std::string &delim);
+    std::string __attribute__((visibility("default"))) string_join(
+        const std::vector<std::string> &string_list, const std::string &delim);
 
     /// @brief Returns the current hostname as a string.
-    std::string hostname(void);
+    std::string __attribute__((visibility("default"))) hostname(void);
 
     /// @brief List all files in the given directory.
     /// @param [in] path Path to the directory.
-    std::vector<std::string> list_directory_files(const std::string &path);
+    std::vector<std::string> __attribute__((visibility("default"))) list_directory_files(
+        const std::string &path);
 
     /// @brief Returns whether one string begins with another.
-    bool string_begins_with(const std::string &str, const std::string &key);
+    bool __attribute__((visibility("default"))) string_begins_with(
+        const std::string &str, const std::string &key);
 
     /// @brief Returns whether one string ends with another.
-    bool string_ends_with(std::string str, std::string key);
+    bool __attribute__((visibility("default"))) string_ends_with(
+        std::string str, std::string key);
 
     enum string_format_e {
         STRING_FORMAT_DOUBLE,
@@ -84,31 +89,34 @@ namespace geopm
         STRING_FORMAT_RAW64,
     };
     /// @brief Convert a format type enum string_format_e to a format function
-    std::function<std::string(double)> string_format_type_to_function(int format_type);
+    std::function<std::string(double)> __attribute__((visibility("default"))) string_format_type_to_function(
+        int format_type);
     /// @brief Convert a format function to a format name to a format function
-    std::function<std::string(double)> string_format_name_to_function(const std::string &format_name);
+    std::function<std::string(double)> __attribute__((visibility("default"))) string_format_name_to_function(
+        const std::string &format_name);
     /// @brief Convert a format function to a format type enum string_format_e
-    int string_format_function_to_type(std::function<std::string(double)> format_function);
+    int __attribute__((visibility("default"))) string_format_function_to_type(
+        std::function<std::string(double)> format_function);
     /// @brief Format a string to best represent a signal encoding a
     ///        double precision floating point number.
     /// @param [in] signal A real number that requires many
     ///        significant digits to accurately represent.
     /// @return A well-formatted string representation of the signal.
-    std::string string_format_double(double signal);
+    std::string __attribute__((visibility("default"))) string_format_double(double signal);
 
     /// @brief Format a string to best represent a signal encoding a
     ///        single precision floating point number.
     /// @param [in] signal A real number that requires a few
     ///        significant digits to accurately represent.
     /// @return A well formatted string representation of the signal.
-    std::string string_format_float(double signal);
+    std::string __attribute__((visibility("default"))) string_format_float(double signal);
 
     /// @brief Format a string to best represent a signal encoding a
     ///        decimal integer.
     /// @param [in] signal An integer that is best represented as a
     ///        decimal number.
     /// @return A well formatted string representation of the signal.
-    std::string string_format_integer(double signal);
+    std::string __attribute__((visibility("default"))) string_format_integer(double signal);
 
     /// @brief Format a string to best represent a signal encoding an
     ///        unsigned hexadecimal integer.
@@ -116,14 +124,14 @@ namespace geopm
     ///        represented as a hexadecimal number and has been
     ///        assigned to a double precision number
     /// @return A well formatted string representation of the signal.
-    std::string string_format_hex(double signal);
+    std::string __attribute__((visibility("default"))) string_format_hex(double signal);
 
     /// @brief Format a string to represent the raw memory supporting
     ///        a signal as an unsigned hexadecimal integer.
     /// @param [in] signal A 64-bit unsigned integer that has been
     ///        byte-wise copied into the memory of signal.
     /// @return A well formatted string representation of the signal.
-    std::string string_format_raw64(double signal);
+    std::string __attribute__((visibility("default"))) string_format_raw64(double signal);
 
     /// @brief Cache line size used to properly align structs to avoid
     ///        false sharing between threads.
@@ -133,36 +141,37 @@ namespace geopm
     /// @brief Read an environment variable.
     /// @param [in] The name of the environment variable to read.
     /// @return The contents of the variable if present, otherwise an empty string.
-    std::string get_env(const std::string &name);
+    std::string __attribute__((visibility("default"))) get_env(
+        const std::string &name);
 
     /// @brief Query for the user id associated with the process id.
     /// @param [in] pid The process id to query.
     /// @return The user id.
-    unsigned int pid_to_uid(const int pid);
+    unsigned int __attribute__((visibility("default"))) pid_to_uid(const int pid);
 
     /// @brief Query for the group id associated with the process id.
     /// @param [in] pid The process id to query.
     /// @return The group id.
-    unsigned int pid_to_gid(const int pid);
+    unsigned int __attribute__((visibility("default"))) pid_to_gid(const int pid);
 
     /// @brief Wrapper around CPU_ALLOC and CPU_FREE
     /// @param [in] num_cpu The number of CPUs to allocate the CPU set
     /// @param [in] cpu_enabled The CPUs to be included in the CPU set
     /// @return A std::unique_ptr to a cpu_set_t configured to use CPU_FREE as
     ///         the deleter.
-    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> >
+    std::unique_ptr<cpu_set_t, std::function<void(cpu_set_t *)> > __attribute__((visibility("default")))
         make_cpu_set(int num_cpu, const std::set<int> &cpu_enabled);
 
     /// @brief Check if the caller has effective capability CAP_SYS_ADMIN
     /// @return True if the PID has CAP_SYS_ADMIN
-    bool has_cap_sys_admin(void);
+    bool __attribute__((visibility("default"))) has_cap_sys_admin(void);
 
     /// @brief Check if the pid has effective capability CAP_SYS_ADMIN
     /// @param [in] pid Linux PID to check
     /// @return True if the PID has CAP_SYS_ADMIN
-    bool has_cap_sys_admin(int pid);
+    bool __attribute__((visibility("default"))) has_cap_sys_admin(int pid);
 
-    class DeprecationWarning
+    class __attribute__((visibility("default"))) DeprecationWarning
     {
         public:
             DeprecationWarning() = delete;

--- a/libgeopmd/include/geopm/Helper.hpp
+++ b/libgeopmd/include/geopm/Helper.hpp
@@ -32,8 +32,8 @@ namespace geopm
     /// @brief Reads the specified file and returns the contents in a string.
     /// @param [in] path The path of the file to read.
     /// @return The contents of the file at path.
-    std::string GEOPM_PUBLIC read_file(
-        const std::string &path);
+    std::string GEOPM_PUBLIC
+        read_file(const std::string &path);
 
     /// @brief Read a file and return a double read from the file.
     /// @details If a double cannot be read from the file or the units reported
@@ -43,46 +43,47 @@ namespace geopm
     /// @param [in] expected_units Expected units to follow the double. Provide
     ///             an empty string if no units are expected.
     /// @return The value read from the file.
-    double GEOPM_PUBLIC read_double_from_file(
-        const std::string &path, const std::string &expected_units);
+    double GEOPM_PUBLIC
+        read_double_from_file(const std::string &path, const std::string &expected_units);
 
     /// @brief Writes a string to a file.  This will replace the file
     ///        if it exists or create it if it does not exist.
     /// @param [in] path The path to the file to write to.
     /// @param [in] contents The string to write to the file.
-    void GEOPM_PUBLIC write_file(
-        const std::string &path, const std::string &contents);
+    void GEOPM_PUBLIC
+        write_file(const std::string &path, const std::string &contents);
 
     /// @brief Splits a string according to a delimiter.
     /// @param [in] str The string to be split.
     /// @param [in] delim The delimiter to use to divide the string.
     ///        Cannot be empty.
     /// @return A vector of string pieces.
-    std::vector<std::string> GEOPM_PUBLIC string_split(
-        const std::string &str, const std::string &delim);
+    std::vector<std::string> GEOPM_PUBLIC
+        string_split(const std::string &str, const std::string &delim);
 
     /// @brief Joins a vector of strings together with a delimiter.
     /// @param [in] string_list The list of strings to be joined.
     /// @param [in] delim The delimiter to use to join the strings.
     /// @return The joined string.
-    std::string GEOPM_PUBLIC string_join(
-        const std::vector<std::string> &string_list, const std::string &delim);
+    std::string GEOPM_PUBLIC
+        string_join(const std::vector<std::string> &string_list, const std::string &delim);
 
     /// @brief Returns the current hostname as a string.
-    std::string GEOPM_PUBLIC hostname(void);
+    std::string GEOPM_PUBLIC
+        hostname(void);
 
     /// @brief List all files in the given directory.
     /// @param [in] path Path to the directory.
-    std::vector<std::string> GEOPM_PUBLIC list_directory_files(
-        const std::string &path);
+    std::vector<std::string> GEOPM_PUBLIC
+        list_directory_files(const std::string &path);
 
     /// @brief Returns whether one string begins with another.
-    bool GEOPM_PUBLIC string_begins_with(
-        const std::string &str, const std::string &key);
+    bool GEOPM_PUBLIC
+        string_begins_with(const std::string &str, const std::string &key);
 
     /// @brief Returns whether one string ends with another.
-    bool GEOPM_PUBLIC string_ends_with(
-        std::string str, std::string key);
+    bool GEOPM_PUBLIC
+        string_ends_with(std::string str, std::string key);
 
     enum string_format_e {
         STRING_FORMAT_DOUBLE,
@@ -91,34 +92,37 @@ namespace geopm
         STRING_FORMAT_RAW64,
     };
     /// @brief Convert a format type enum string_format_e to a format function
-    std::function<std::string(double)> GEOPM_PUBLIC string_format_type_to_function(
-        int format_type);
+    std::function<std::string(double)> GEOPM_PUBLIC
+        string_format_type_to_function(int format_type);
     /// @brief Convert a format function to a format name to a format function
-    std::function<std::string(double)> GEOPM_PUBLIC string_format_name_to_function(
-        const std::string &format_name);
+    std::function<std::string(double)> GEOPM_PUBLIC
+        string_format_name_to_function(const std::string &format_name);
     /// @brief Convert a format function to a format type enum string_format_e
-    int GEOPM_PUBLIC string_format_function_to_type(
-        std::function<std::string(double)> format_function);
+    int GEOPM_PUBLIC
+        string_format_function_to_type(std::function<std::string(double)> format_function);
     /// @brief Format a string to best represent a signal encoding a
     ///        double precision floating point number.
     /// @param [in] signal A real number that requires many
     ///        significant digits to accurately represent.
     /// @return A well-formatted string representation of the signal.
-    std::string GEOPM_PUBLIC string_format_double(double signal);
+    std::string GEOPM_PUBLIC
+        string_format_double(double signal);
 
     /// @brief Format a string to best represent a signal encoding a
     ///        single precision floating point number.
     /// @param [in] signal A real number that requires a few
     ///        significant digits to accurately represent.
     /// @return A well formatted string representation of the signal.
-    std::string GEOPM_PUBLIC string_format_float(double signal);
+    std::string GEOPM_PUBLIC
+        string_format_float(double signal);
 
     /// @brief Format a string to best represent a signal encoding a
     ///        decimal integer.
     /// @param [in] signal An integer that is best represented as a
     ///        decimal number.
     /// @return A well formatted string representation of the signal.
-    std::string GEOPM_PUBLIC string_format_integer(double signal);
+    std::string GEOPM_PUBLIC
+        string_format_integer(double signal);
 
     /// @brief Format a string to best represent a signal encoding an
     ///        unsigned hexadecimal integer.
@@ -126,14 +130,16 @@ namespace geopm
     ///        represented as a hexadecimal number and has been
     ///        assigned to a double precision number
     /// @return A well formatted string representation of the signal.
-    std::string GEOPM_PUBLIC string_format_hex(double signal);
+    std::string GEOPM_PUBLIC
+        string_format_hex(double signal);
 
     /// @brief Format a string to represent the raw memory supporting
     ///        a signal as an unsigned hexadecimal integer.
     /// @param [in] signal A 64-bit unsigned integer that has been
     ///        byte-wise copied into the memory of signal.
     /// @return A well formatted string representation of the signal.
-    std::string GEOPM_PUBLIC string_format_raw64(double signal);
+    std::string GEOPM_PUBLIC
+        string_format_raw64(double signal);
 
     /// @brief Cache line size used to properly align structs to avoid
     ///        false sharing between threads.
@@ -143,18 +149,20 @@ namespace geopm
     /// @brief Read an environment variable.
     /// @param [in] The name of the environment variable to read.
     /// @return The contents of the variable if present, otherwise an empty string.
-    std::string GEOPM_PUBLIC get_env(
-        const std::string &name);
+    std::string GEOPM_PUBLIC
+        get_env(const std::string &name);
 
     /// @brief Query for the user id associated with the process id.
     /// @param [in] pid The process id to query.
     /// @return The user id.
-    unsigned int GEOPM_PUBLIC pid_to_uid(const int pid);
+    unsigned int GEOPM_PUBLIC
+        pid_to_uid(const int pid);
 
     /// @brief Query for the group id associated with the process id.
     /// @param [in] pid The process id to query.
     /// @return The group id.
-    unsigned int GEOPM_PUBLIC pid_to_gid(const int pid);
+    unsigned int GEOPM_PUBLIC
+        pid_to_gid(const int pid);
 
     /// @brief Wrapper around CPU_ALLOC and CPU_FREE
     /// @param [in] num_cpu The number of CPUs to allocate the CPU set
@@ -166,12 +174,14 @@ namespace geopm
 
     /// @brief Check if the caller has effective capability CAP_SYS_ADMIN
     /// @return True if the PID has CAP_SYS_ADMIN
-    bool GEOPM_PUBLIC has_cap_sys_admin(void);
+    bool GEOPM_PUBLIC
+        has_cap_sys_admin(void);
 
     /// @brief Check if the pid has effective capability CAP_SYS_ADMIN
     /// @param [in] pid Linux PID to check
     /// @return True if the PID has CAP_SYS_ADMIN
-    bool GEOPM_PUBLIC has_cap_sys_admin(int pid);
+    bool GEOPM_PUBLIC
+        has_cap_sys_admin(int pid);
 
     class GEOPM_PUBLIC DeprecationWarning
     {

--- a/libgeopmd/include/geopm/IOGroup.hpp
+++ b/libgeopmd/include/geopm/IOGroup.hpp
@@ -232,7 +232,8 @@ namespace geopm
             virtual ~IOGroupFactory() = default;
     };
 
-    IOGroupFactory GEOPM_PUBLIC & iogroup_factory(void);
+    IOGroupFactory GEOPM_PUBLIC &
+        iogroup_factory(void);
 }
 
 #endif

--- a/libgeopmd/include/geopm/IOGroup.hpp
+++ b/libgeopmd/include/geopm/IOGroup.hpp
@@ -15,7 +15,7 @@
 
 namespace geopm
 {
-    class IOGroup
+    class __attribute__((visibility("default"))) IOGroup
     {
         public:
             enum m_units_e {
@@ -223,14 +223,14 @@ namespace geopm
             static const std::map<std::string, m_signal_behavior_e> M_BEHAVIOR_STRING;
     };
 
-    class IOGroupFactory : public PluginFactory<IOGroup>
+    class __attribute__((visibility("default"))) IOGroupFactory : public PluginFactory<IOGroup>
     {
         public:
             IOGroupFactory();
             virtual ~IOGroupFactory() = default;
     };
 
-    IOGroupFactory &iogroup_factory(void);
+    IOGroupFactory __attribute__((visibility("default"))) & iogroup_factory(void);
 }
 
 #endif

--- a/libgeopmd/include/geopm/IOGroup.hpp
+++ b/libgeopmd/include/geopm/IOGroup.hpp
@@ -6,16 +6,18 @@
 #ifndef IOGROUP_HPP_INCLUDE
 #define IOGROUP_HPP_INCLUDE
 
+#include <functional>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
-#include <functional>
+
+#include "geopm_public.h"
 
 #include "PluginFactory.hpp"
 
 namespace geopm
 {
-    class __attribute__((visibility("default"))) IOGroup
+    class GEOPM_PUBLIC IOGroup
     {
         public:
             enum m_units_e {
@@ -223,14 +225,14 @@ namespace geopm
             static const std::map<std::string, m_signal_behavior_e> M_BEHAVIOR_STRING;
     };
 
-    class __attribute__((visibility("default"))) IOGroupFactory : public PluginFactory<IOGroup>
+    class GEOPM_PUBLIC IOGroupFactory : public PluginFactory<IOGroup>
     {
         public:
             IOGroupFactory();
             virtual ~IOGroupFactory() = default;
     };
 
-    IOGroupFactory __attribute__((visibility("default"))) & iogroup_factory(void);
+    IOGroupFactory GEOPM_PUBLIC & iogroup_factory(void);
 }
 
 #endif

--- a/libgeopmd/include/geopm/MSRIOGroup.hpp
+++ b/libgeopmd/include/geopm/MSRIOGroup.hpp
@@ -23,8 +23,8 @@
 
 extern "C"
 {
-    int GEOPM_PUBLIC geopm_allowlist(
-        size_t result_max, char *result);
+    int GEOPM_PUBLIC
+        geopm_allowlist(size_t result_max, char *result);
 }
 
 namespace geopm
@@ -143,48 +143,53 @@ namespace geopm
                     MsrConfigWarningPreference_e warning_preference = SILENCE_CONFIG_DEPRECATION_WARNING);
             /// @brief Override the default description for a signal.
             ///        If signal is not available, does nothing.
-            void GEOPM_PRIVATE set_signal_description(
-                const std::string &name,
-                const std::string &description);
+            void GEOPM_PRIVATE
+                set_signal_description(const std::string &name, const std::string &description);
             /// @brief Override the default description for a signal.
             ///        If signal is not available, does nothing.
-            void GEOPM_PRIVATE set_control_description(
-                const std::string &name,
-                const std::string &description);
+            void GEOPM_PRIVATE
+                set_control_description(const std::string &name, const std::string &description);
             /// @brief Add support for an alias of a signal by name.
-            void GEOPM_PRIVATE register_signal_alias(
-                const std::string &signal_name, const std::string &msr_field_name);
+            void GEOPM_PRIVATE
+                register_signal_alias(const std::string &signal_name, const std::string &msr_field_name);
             /// @brief Add support for an alias of a control by name.
-            void GEOPM_PRIVATE register_control_alias(
-                const std::string &control_name, const std::string &msr_field_name);
+            void GEOPM_PRIVATE
+                register_control_alias(const std::string &control_name, const std::string &msr_field_name);
             /// @brief Add support for temperature combined signals if underlying
             ///        signals are available.
-            void GEOPM_PRIVATE register_temperature_signals(void);
+            void GEOPM_PRIVATE
+                register_temperature_signals(void);
             /// @brief Add support for power combined signals if underlying
             ///        signals are available.
-            void GEOPM_PRIVATE register_power_signals(void);
+            void GEOPM_PRIVATE
+                register_power_signals(void);
             /// @brief Add support for pcnt scalability signals if underlying
             ///        signals are available.
-            void GEOPM_PRIVATE register_pcnt_scalability_signals(void);
+            void GEOPM_PRIVATE
+                register_pcnt_scalability_signals(void);
             /// @brief Add support for Intel Resource Director signals if
             ///        underlying signals are available.
-            void GEOPM_PRIVATE register_rdt_signals(void);
+            void GEOPM_PRIVATE
+                register_rdt_signals(void);
             /// @brief Add support for frequency signal aliases if underlying
             ///        signals are available.
-            void GEOPM_PRIVATE register_frequency_signals(void);
+            void GEOPM_PRIVATE
+                register_frequency_signals(void);
             /// @brief Add support for frequency control aliases if underlying
             ///        controls are available.
-            void GEOPM_PRIVATE register_frequency_controls(void);
+            void GEOPM_PRIVATE
+                register_frequency_controls(void);
             /// @brief Write to enable bits for all fixed counters.
-            void GEOPM_PRIVATE enable_fixed_counters(void);
+            void GEOPM_PRIVATE
+                enable_fixed_counters(void);
             /// @brief Check system configuration and warn if it ma
             ///        interfere with the given control.
-            void GEOPM_PRIVATE check_control(const std::string &control_name);
+            void GEOPM_PRIVATE
+                check_control(const std::string &control_name);
 
             /// @brief Check control lock and error if locked
-            void GEOPM_PRIVATE check_control_lock(
-                const std::string &lock_name,
-                const std::string &error);
+            void GEOPM_PRIVATE
+                check_control_lock(const std::string &lock_name, const std::string &error);
 
             /// Helpers for JSON parsing
             static void check_top_level(const json11::Json &root);
@@ -201,28 +206,21 @@ namespace geopm
             static bool json_check_is_integer(const json11::Json &num);
             static bool json_check_is_valid_aggregation(const json11::Json &obj);
             // Add raw MSR as an available signal
-            void GEOPM_PRIVATE add_raw_msr_signal(
-                const std::string &msr_name, int domain_type,
-                uint64_t msr_offset);
+            void GEOPM_PRIVATE
+                add_raw_msr_signal(const std::string &msr_name, int domain_type, uint64_t msr_offset);
             // Add a bitfield of an MSR as an available signal
-            void GEOPM_PRIVATE add_msr_field_signal(
-                const std::string &msr_name,
-                const std::string &msr_field_name,
-                int domain_type,
-                int begin_bit, int end_bit,
-                int function, double scalar, int units,
-                const std::string &aggregation,
-                const std::string &description,
-                int behavior,
-                const std::function<std::string(double)> &format_function);
+            void GEOPM_PRIVATE
+                add_msr_field_signal(const std::string &msr_name, const std::string &msr_field_name,
+                                     int domain_type, int begin_bit, int end_bit, int function,
+                                     double scalar, int units, const std::string &aggregation,
+                                     const std::string &description, int behavior,
+                                     const std::function<std::string(double)> &format_function);
             // Add a bitfield of an MSR as an available control
-            void GEOPM_PRIVATE add_msr_field_control(
-                const std::string &msr_field_name,
-                int domain_type,
-                uint64_t msr_offset,
-                int begin_bit, int end_bit,
-                int function, double scalar, int units,
-                const std::string &description);
+            void GEOPM_PRIVATE
+                add_msr_field_control(const std::string &msr_field_name, int domain_type,
+                                      uint64_t msr_offset, int begin_bit, int end_bit,
+                                      int function, double scalar, int units,
+                                      const std::string &description);
 
             static const std::string M_DEFAULT_DESCRIPTION;
             static const std::string M_PLUGIN_NAME;

--- a/libgeopmd/include/geopm/MSRIOGroup.hpp
+++ b/libgeopmd/include/geopm/MSRIOGroup.hpp
@@ -21,8 +21,8 @@
 
 extern "C"
 {
-    int geopm_allowlist(size_t result_max,
-                        char *result);
+    int __attribute__((visibility("default"))) geopm_allowlist(
+        size_t result_max, char *result);
 }
 
 namespace geopm
@@ -34,7 +34,7 @@ namespace geopm
     class SaveControl;
 
     /// @brief IOGroup that provides signals and controls based on MSRs.
-    class MSRIOGroup : public IOGroup
+    class __attribute__((visibility("default"))) MSRIOGroup : public IOGroup
     {
         public:
             enum m_cpuid_e {
@@ -141,43 +141,48 @@ namespace geopm
                     MsrConfigWarningPreference_e warning_preference = SILENCE_CONFIG_DEPRECATION_WARNING);
             /// @brief Override the default description for a signal.
             ///        If signal is not available, does nothing.
-            void set_signal_description(const std::string &name,
-                                        const std::string &description);
+            void __attribute__((visibility("hidden"))) set_signal_description(
+                const std::string &name,
+                const std::string &description);
             /// @brief Override the default description for a signal.
             ///        If signal is not available, does nothing.
-            void set_control_description(const std::string &name,
-                                        const std::string &description);
+            void __attribute__((visibility("hidden"))) set_control_description(
+                const std::string &name,
+                const std::string &description);
             /// @brief Add support for an alias of a signal by name.
-            void register_signal_alias(const std::string &signal_name, const std::string &msr_field_name);
+            void __attribute__((visibility("hidden"))) register_signal_alias(
+                const std::string &signal_name, const std::string &msr_field_name);
             /// @brief Add support for an alias of a control by name.
-            void register_control_alias(const std::string &control_name, const std::string &msr_field_name);
+            void __attribute__((visibility("hidden"))) register_control_alias(
+                const std::string &control_name, const std::string &msr_field_name);
             /// @brief Add support for temperature combined signals if underlying
             ///        signals are available.
-            void register_temperature_signals(void);
+            void __attribute__((visibility("hidden"))) register_temperature_signals(void);
             /// @brief Add support for power combined signals if underlying
             ///        signals are available.
-            void register_power_signals(void);
+            void __attribute__((visibility("hidden"))) register_power_signals(void);
             /// @brief Add support for pcnt scalability signals if underlying
             ///        signals are available.
-            void register_pcnt_scalability_signals(void);
+            void __attribute__((visibility("hidden"))) register_pcnt_scalability_signals(void);
             /// @brief Add support for Intel Resource Director signals if
             ///        underlying signals are available.
-            void register_rdt_signals(void);
+            void __attribute__((visibility("hidden"))) register_rdt_signals(void);
             /// @brief Add support for frequency signal aliases if underlying
             ///        signals are available.
-            void register_frequency_signals(void);
+            void __attribute__((visibility("hidden"))) register_frequency_signals(void);
             /// @brief Add support for frequency control aliases if underlying
             ///        controls are available.
-            void register_frequency_controls(void);
+            void __attribute__((visibility("hidden"))) register_frequency_controls(void);
             /// @brief Write to enable bits for all fixed counters.
-            void enable_fixed_counters(void);
+            void __attribute__((visibility("hidden"))) enable_fixed_counters(void);
             /// @brief Check system configuration and warn if it ma
             ///        interfere with the given control.
-            void check_control(const std::string &control_name);
+            void __attribute__((visibility("hidden"))) check_control(const std::string &control_name);
 
             /// @brief Check control lock and error if locked
-            void check_control_lock(const std::string &lock_name,
-                                    const std::string &error);
+            void __attribute__((visibility("hidden"))) check_control_lock(
+                const std::string &lock_name,
+                const std::string &error);
 
             /// Helpers for JSON parsing
             static void check_top_level(const json11::Json &root);
@@ -194,25 +199,28 @@ namespace geopm
             static bool json_check_is_integer(const json11::Json &num);
             static bool json_check_is_valid_aggregation(const json11::Json &obj);
             // Add raw MSR as an available signal
-            void add_raw_msr_signal(const std::string &msr_name, int domain_type,
-                                    uint64_t msr_offset);
+            void __attribute__((visibility("hidden"))) add_raw_msr_signal(
+                const std::string &msr_name, int domain_type,
+                uint64_t msr_offset);
             // Add a bitfield of an MSR as an available signal
-            void add_msr_field_signal(const std::string &msr_name,
-                                      const std::string &msr_field_name,
-                                      int domain_type,
-                                      int begin_bit, int end_bit,
-                                      int function, double scalar, int units,
-                                      const std::string &aggregation,
-                                      const std::string &description,
-                                      int behavior,
-                                      const std::function<std::string(double)> &format_function);
+            void __attribute__((visibility("hidden"))) add_msr_field_signal(
+                const std::string &msr_name,
+                const std::string &msr_field_name,
+                int domain_type,
+                int begin_bit, int end_bit,
+                int function, double scalar, int units,
+                const std::string &aggregation,
+                const std::string &description,
+                int behavior,
+                const std::function<std::string(double)> &format_function);
             // Add a bitfield of an MSR as an available control
-            void add_msr_field_control(const std::string &msr_field_name,
-                                       int domain_type,
-                                       uint64_t msr_offset,
-                                       int begin_bit, int end_bit,
-                                       int function, double scalar, int units,
-                                       const std::string &description);
+            void __attribute__((visibility("hidden"))) add_msr_field_control(
+                const std::string &msr_field_name,
+                int domain_type,
+                uint64_t msr_offset,
+                int begin_bit, int end_bit,
+                int function, double scalar, int units,
+                const std::string &description);
 
             static const std::string M_DEFAULT_DESCRIPTION;
             static const std::string M_PLUGIN_NAME;
@@ -244,7 +252,7 @@ namespace geopm
             // The signals vector is over the indices for the domain.
             // The signals pointers should be copied when signal is
             // pushed and used directly for read_signal.
-            struct signal_info
+            struct __attribute__((visibility("hidden"))) signal_info
             {
                 std::vector<std::shared_ptr<Signal> > signals;
                 int domain;
@@ -256,7 +264,7 @@ namespace geopm
             };
             std::map<std::string, signal_info> m_signal_available;
 
-            struct control_info
+            struct __attribute__((visibility("hidden"))) control_info
             {
                 std::vector<std::shared_ptr<Control> > controls;
                 int domain;

--- a/libgeopmd/include/geopm/MSRIOGroup.hpp
+++ b/libgeopmd/include/geopm/MSRIOGroup.hpp
@@ -6,22 +6,24 @@
 #ifndef MSRIOGROUP_HPP_INCLUDE
 #define MSRIOGROUP_HPP_INCLUDE
 
-#include <vector>
+#include <functional>
 #include <map>
 #include <memory>
-#include <functional>
-#include <string>
 #include <set>
+#include <string>
+#include <vector>
 
 #include "geopm/json11.hpp"
 
-#include "IOGroup.hpp"
-#include "geopm_time.h"
 #include "geopm/Cpuid.hpp"
+#include "geopm_public.h"
+#include "geopm_time.h"
+
+#include "IOGroup.hpp"
 
 extern "C"
 {
-    int __attribute__((visibility("default"))) geopm_allowlist(
+    int GEOPM_PUBLIC geopm_allowlist(
         size_t result_max, char *result);
 }
 
@@ -34,7 +36,7 @@ namespace geopm
     class SaveControl;
 
     /// @brief IOGroup that provides signals and controls based on MSRs.
-    class __attribute__((visibility("default"))) MSRIOGroup : public IOGroup
+    class GEOPM_PUBLIC MSRIOGroup : public IOGroup
     {
         public:
             enum m_cpuid_e {
@@ -141,46 +143,46 @@ namespace geopm
                     MsrConfigWarningPreference_e warning_preference = SILENCE_CONFIG_DEPRECATION_WARNING);
             /// @brief Override the default description for a signal.
             ///        If signal is not available, does nothing.
-            void __attribute__((visibility("hidden"))) set_signal_description(
+            void GEOPM_PRIVATE set_signal_description(
                 const std::string &name,
                 const std::string &description);
             /// @brief Override the default description for a signal.
             ///        If signal is not available, does nothing.
-            void __attribute__((visibility("hidden"))) set_control_description(
+            void GEOPM_PRIVATE set_control_description(
                 const std::string &name,
                 const std::string &description);
             /// @brief Add support for an alias of a signal by name.
-            void __attribute__((visibility("hidden"))) register_signal_alias(
+            void GEOPM_PRIVATE register_signal_alias(
                 const std::string &signal_name, const std::string &msr_field_name);
             /// @brief Add support for an alias of a control by name.
-            void __attribute__((visibility("hidden"))) register_control_alias(
+            void GEOPM_PRIVATE register_control_alias(
                 const std::string &control_name, const std::string &msr_field_name);
             /// @brief Add support for temperature combined signals if underlying
             ///        signals are available.
-            void __attribute__((visibility("hidden"))) register_temperature_signals(void);
+            void GEOPM_PRIVATE register_temperature_signals(void);
             /// @brief Add support for power combined signals if underlying
             ///        signals are available.
-            void __attribute__((visibility("hidden"))) register_power_signals(void);
+            void GEOPM_PRIVATE register_power_signals(void);
             /// @brief Add support for pcnt scalability signals if underlying
             ///        signals are available.
-            void __attribute__((visibility("hidden"))) register_pcnt_scalability_signals(void);
+            void GEOPM_PRIVATE register_pcnt_scalability_signals(void);
             /// @brief Add support for Intel Resource Director signals if
             ///        underlying signals are available.
-            void __attribute__((visibility("hidden"))) register_rdt_signals(void);
+            void GEOPM_PRIVATE register_rdt_signals(void);
             /// @brief Add support for frequency signal aliases if underlying
             ///        signals are available.
-            void __attribute__((visibility("hidden"))) register_frequency_signals(void);
+            void GEOPM_PRIVATE register_frequency_signals(void);
             /// @brief Add support for frequency control aliases if underlying
             ///        controls are available.
-            void __attribute__((visibility("hidden"))) register_frequency_controls(void);
+            void GEOPM_PRIVATE register_frequency_controls(void);
             /// @brief Write to enable bits for all fixed counters.
-            void __attribute__((visibility("hidden"))) enable_fixed_counters(void);
+            void GEOPM_PRIVATE enable_fixed_counters(void);
             /// @brief Check system configuration and warn if it ma
             ///        interfere with the given control.
-            void __attribute__((visibility("hidden"))) check_control(const std::string &control_name);
+            void GEOPM_PRIVATE check_control(const std::string &control_name);
 
             /// @brief Check control lock and error if locked
-            void __attribute__((visibility("hidden"))) check_control_lock(
+            void GEOPM_PRIVATE check_control_lock(
                 const std::string &lock_name,
                 const std::string &error);
 
@@ -199,11 +201,11 @@ namespace geopm
             static bool json_check_is_integer(const json11::Json &num);
             static bool json_check_is_valid_aggregation(const json11::Json &obj);
             // Add raw MSR as an available signal
-            void __attribute__((visibility("hidden"))) add_raw_msr_signal(
+            void GEOPM_PRIVATE add_raw_msr_signal(
                 const std::string &msr_name, int domain_type,
                 uint64_t msr_offset);
             // Add a bitfield of an MSR as an available signal
-            void __attribute__((visibility("hidden"))) add_msr_field_signal(
+            void GEOPM_PRIVATE add_msr_field_signal(
                 const std::string &msr_name,
                 const std::string &msr_field_name,
                 int domain_type,
@@ -214,7 +216,7 @@ namespace geopm
                 int behavior,
                 const std::function<std::string(double)> &format_function);
             // Add a bitfield of an MSR as an available control
-            void __attribute__((visibility("hidden"))) add_msr_field_control(
+            void GEOPM_PRIVATE add_msr_field_control(
                 const std::string &msr_field_name,
                 int domain_type,
                 uint64_t msr_offset,
@@ -252,7 +254,7 @@ namespace geopm
             // The signals vector is over the indices for the domain.
             // The signals pointers should be copied when signal is
             // pushed and used directly for read_signal.
-            struct __attribute__((visibility("hidden"))) signal_info
+            struct GEOPM_PRIVATE signal_info
             {
                 std::vector<std::shared_ptr<Signal> > signals;
                 int domain;
@@ -264,7 +266,7 @@ namespace geopm
             };
             std::map<std::string, signal_info> m_signal_available;
 
-            struct __attribute__((visibility("hidden"))) control_info
+            struct GEOPM_PRIVATE control_info
             {
                 std::vector<std::shared_ptr<Control> > controls;
                 int domain;

--- a/libgeopmd/include/geopm/PlatformIO.hpp
+++ b/libgeopmd/include/geopm/PlatformIO.hpp
@@ -6,16 +6,17 @@
 #ifndef PLATFORMIO_HPP_INCLUDE
 #define PLATFORMIO_HPP_INCLUDE
 
+#include <climits>
+#include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
-#include <functional>
-#include <set>
-#include <climits>
 
 #include "geopm_pio.h"
+#include "geopm_public.h"
 
-struct __attribute__((visibility("default"))) geopm_request_s {
+struct GEOPM_PUBLIC geopm_request_s {
     int domain_type;
     int domain_idx;
     char name[NAME_MAX];
@@ -28,7 +29,7 @@ namespace geopm
 
     /// @brief Class which is a collection of all valid control and
     /// signal objects for a platform
-    class __attribute__((visibility("default"))) PlatformIO
+    class GEOPM_PUBLIC PlatformIO
     {
         public:
             PlatformIO() = default;
@@ -255,7 +256,7 @@ namespace geopm
             static bool is_valid_value(double value);
     };
 
-    PlatformIO __attribute__((visibility("default"))) & platform_io(void);
+    PlatformIO GEOPM_PUBLIC & platform_io(void);
 }
 
 #endif

--- a/libgeopmd/include/geopm/PlatformIO.hpp
+++ b/libgeopmd/include/geopm/PlatformIO.hpp
@@ -15,7 +15,7 @@
 
 #include "geopm_pio.h"
 
-struct geopm_request_s {
+struct __attribute__((visibility("default"))) geopm_request_s {
     int domain_type;
     int domain_idx;
     char name[NAME_MAX];
@@ -28,7 +28,7 @@ namespace geopm
 
     /// @brief Class which is a collection of all valid control and
     /// signal objects for a platform
-    class PlatformIO
+    class __attribute__((visibility("default"))) PlatformIO
     {
         public:
             PlatformIO() = default;
@@ -255,7 +255,7 @@ namespace geopm
             static bool is_valid_value(double value);
     };
 
-    PlatformIO &platform_io(void);
+    PlatformIO __attribute__((visibility("default"))) & platform_io(void);
 }
 
 #endif

--- a/libgeopmd/include/geopm/PlatformIO.hpp
+++ b/libgeopmd/include/geopm/PlatformIO.hpp
@@ -256,7 +256,8 @@ namespace geopm
             static bool is_valid_value(double value);
     };
 
-    PlatformIO GEOPM_PUBLIC & platform_io(void);
+    PlatformIO GEOPM_PUBLIC &
+        platform_io(void);
 }
 
 #endif

--- a/libgeopmd/include/geopm/PlatformTopo.hpp
+++ b/libgeopmd/include/geopm/PlatformTopo.hpp
@@ -18,7 +18,8 @@
 extern "C"
 {
     /// @brief Identify host CPU.
-    int GEOPM_PUBLIC geopm_read_cpuid(void);
+    int GEOPM_PUBLIC
+        geopm_read_cpuid(void);
 }
 
 namespace geopm
@@ -84,6 +85,7 @@ namespace geopm
             static std::map<std::string, int> domain_types(void);
     };
 
-    const PlatformTopo GEOPM_PUBLIC & platform_topo(void);
+    const PlatformTopo GEOPM_PUBLIC &
+        platform_topo(void);
 }
 #endif

--- a/libgeopmd/include/geopm/PlatformTopo.hpp
+++ b/libgeopmd/include/geopm/PlatformTopo.hpp
@@ -7,22 +7,23 @@
 #ifndef PLATFORMTOPO_HPP_INCLUDE
 #define PLATFORMTOPO_HPP_INCLUDE
 
-#include <vector>
-#include <set>
 #include <map>
+#include <set>
 #include <string>
+#include <vector>
 
+#include "geopm_public.h"
 #include "geopm_topo.h"
 
 extern "C"
 {
     /// @brief Identify host CPU.
-    int __attribute__((visibility("default"))) geopm_read_cpuid(void);
+    int GEOPM_PUBLIC geopm_read_cpuid(void);
 }
 
 namespace geopm
 {
-    class __attribute__((visibility("default"))) PlatformTopo
+    class GEOPM_PUBLIC PlatformTopo
     {
         public:
             PlatformTopo() = default;
@@ -83,6 +84,6 @@ namespace geopm
             static std::map<std::string, int> domain_types(void);
     };
 
-    const PlatformTopo __attribute__((visibility("default"))) & platform_topo(void);
+    const PlatformTopo GEOPM_PUBLIC & platform_topo(void);
 }
 #endif

--- a/libgeopmd/include/geopm/PlatformTopo.hpp
+++ b/libgeopmd/include/geopm/PlatformTopo.hpp
@@ -17,12 +17,12 @@
 extern "C"
 {
     /// @brief Identify host CPU.
-    int geopm_read_cpuid(void);
+    int __attribute__((visibility("default"))) geopm_read_cpuid(void);
 }
 
 namespace geopm
 {
-    class PlatformTopo
+    class __attribute__((visibility("default"))) PlatformTopo
     {
         public:
             PlatformTopo() = default;
@@ -83,6 +83,6 @@ namespace geopm
             static std::map<std::string, int> domain_types(void);
     };
 
-    const PlatformTopo &platform_topo(void);
+    const PlatformTopo __attribute__((visibility("default"))) & platform_topo(void);
 }
 #endif

--- a/libgeopmd/include/geopm/PluginFactory.hpp
+++ b/libgeopmd/include/geopm/PluginFactory.hpp
@@ -6,11 +6,13 @@
 #ifndef PLUGINFACTORY_HPP_INCLUDE
 #define PLUGINFACTORY_HPP_INCLUDE
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
-#include <functional>
 #include <vector>
+
+#include "geopm_public.h"
 
 #include "Exception.hpp"
 

--- a/libgeopmd/include/geopm/ServiceProxy.hpp
+++ b/libgeopmd/include/geopm/ServiceProxy.hpp
@@ -19,7 +19,7 @@ namespace geopm
 
     /// @brief Information pertaining to a particular signal supported
     ///        by PlatformIO
-    struct signal_info_s {
+    struct __attribute__((visibility("default"))) signal_info_s {
         /// @brief Name of the signal
         std::string name;
         /// @brief Description of the signal
@@ -42,7 +42,7 @@ namespace geopm
 
     /// @brief Information pertaining to a particular control
     ///        supported by PlatformIO
-    struct control_info_s {
+    struct __attribute__((visibility("default"))) control_info_s {
         /// @brief Name of the control
         std::string name;
         /// @brief Description of the control
@@ -54,7 +54,7 @@ namespace geopm
 
     /// @brief Proxy object for the io.github.geopm D-Bus interface
     ///        used to implement the ServiceIOGroup
-    class ServiceProxy
+    class __attribute__((visibility("default"))) ServiceProxy
     {
         public:
             /// @brief ServiceProxy constructor
@@ -157,7 +157,7 @@ namespace geopm
             virtual std::vector<std::string> platform_pop_profile_region_names(const std::string &profile_name) = 0;
     };
 
-    class ServiceProxyImp : public ServiceProxy
+    class __attribute__((visibility("default"))) ServiceProxyImp : public ServiceProxy
     {
         public:
             ServiceProxyImp();
@@ -188,7 +188,7 @@ namespace geopm
             std::vector<int> platform_get_profile_pids(const std::string &profile_name) override;
             std::vector<std::string> platform_pop_profile_region_names(const std::string &profile_name) override;
         private:
-            std::vector<std::string> read_string_array(std::shared_ptr<SDBusMessage> bus_message);
+            std::vector<std::string> __attribute__((visibility("hidden"))) read_string_array(std::shared_ptr<SDBusMessage> bus_message);
             std::shared_ptr<SDBus> m_bus;
     };
 }

--- a/libgeopmd/include/geopm/ServiceProxy.hpp
+++ b/libgeopmd/include/geopm/ServiceProxy.hpp
@@ -6,9 +6,11 @@
 #ifndef SERVICEPROXY_HPP_INCLUDE
 #define SERVICEPROXY_HPP_INCLUDE
 
-#include <string>
 #include <memory>
+#include <string>
 #include <vector>
+
+#include "geopm_public.h"
 
 struct geopm_request_s;
 
@@ -19,7 +21,7 @@ namespace geopm
 
     /// @brief Information pertaining to a particular signal supported
     ///        by PlatformIO
-    struct __attribute__((visibility("default"))) signal_info_s {
+    struct GEOPM_PUBLIC signal_info_s {
         /// @brief Name of the signal
         std::string name;
         /// @brief Description of the signal
@@ -42,7 +44,7 @@ namespace geopm
 
     /// @brief Information pertaining to a particular control
     ///        supported by PlatformIO
-    struct __attribute__((visibility("default"))) control_info_s {
+    struct GEOPM_PUBLIC control_info_s {
         /// @brief Name of the control
         std::string name;
         /// @brief Description of the control
@@ -54,7 +56,7 @@ namespace geopm
 
     /// @brief Proxy object for the io.github.geopm D-Bus interface
     ///        used to implement the ServiceIOGroup
-    class __attribute__((visibility("default"))) ServiceProxy
+    class GEOPM_PUBLIC ServiceProxy
     {
         public:
             /// @brief ServiceProxy constructor
@@ -157,7 +159,7 @@ namespace geopm
             virtual std::vector<std::string> platform_pop_profile_region_names(const std::string &profile_name) = 0;
     };
 
-    class __attribute__((visibility("default"))) ServiceProxyImp : public ServiceProxy
+    class GEOPM_PUBLIC ServiceProxyImp : public ServiceProxy
     {
         public:
             ServiceProxyImp();
@@ -188,7 +190,7 @@ namespace geopm
             std::vector<int> platform_get_profile_pids(const std::string &profile_name) override;
             std::vector<std::string> platform_pop_profile_region_names(const std::string &profile_name) override;
         private:
-            std::vector<std::string> __attribute__((visibility("hidden"))) read_string_array(std::shared_ptr<SDBusMessage> bus_message);
+            std::vector<std::string> GEOPM_PRIVATE read_string_array(std::shared_ptr<SDBusMessage> bus_message);
             std::shared_ptr<SDBus> m_bus;
     };
 }

--- a/libgeopmd/include/geopm/ServiceProxy.hpp
+++ b/libgeopmd/include/geopm/ServiceProxy.hpp
@@ -190,7 +190,8 @@ namespace geopm
             std::vector<int> platform_get_profile_pids(const std::string &profile_name) override;
             std::vector<std::string> platform_pop_profile_region_names(const std::string &profile_name) override;
         private:
-            std::vector<std::string> GEOPM_PRIVATE read_string_array(std::shared_ptr<SDBusMessage> bus_message);
+            std::vector<std::string> GEOPM_PRIVATE
+                read_string_array(std::shared_ptr<SDBusMessage> bus_message);
             std::shared_ptr<SDBus> m_bus;
     };
 }

--- a/libgeopmd/include/geopm/SharedMemory.hpp
+++ b/libgeopmd/include/geopm/SharedMemory.hpp
@@ -8,15 +8,17 @@
 
 #include <stdlib.h>
 
-#include <string>
 #include <memory>
+#include <string>
+
+#include "geopm_public.h"
 
 #include "SharedMemoryScopedLock.hpp"
 
 namespace geopm
 {
     /// @brief This class encapsulates an inter-process shared memory region.
-    class __attribute__((visibility("default"))) SharedMemory
+    class GEOPM_PUBLIC SharedMemory
     {
         public:
             SharedMemory() = default;

--- a/libgeopmd/include/geopm/SharedMemory.hpp
+++ b/libgeopmd/include/geopm/SharedMemory.hpp
@@ -16,7 +16,7 @@
 namespace geopm
 {
     /// @brief This class encapsulates an inter-process shared memory region.
-    class SharedMemory
+    class __attribute__((visibility("default"))) SharedMemory
     {
         public:
             SharedMemory() = default;

--- a/libgeopmd/include/geopm/SharedMemoryScopedLock.hpp
+++ b/libgeopmd/include/geopm/SharedMemoryScopedLock.hpp
@@ -8,11 +8,13 @@
 
 #include <pthread.h>
 
+#include "geopm_public.h"
+
 namespace geopm
 {
     /// @brief An object used to automatically hold a SharedMemory mutex while
     ///        in scope, and release it when out of scope.
-    class __attribute__((visibility("default"))) SharedMemoryScopedLock
+    class GEOPM_PUBLIC SharedMemoryScopedLock
     {
         public:
             SharedMemoryScopedLock() = delete;

--- a/libgeopmd/include/geopm/SharedMemoryScopedLock.hpp
+++ b/libgeopmd/include/geopm/SharedMemoryScopedLock.hpp
@@ -12,7 +12,7 @@ namespace geopm
 {
     /// @brief An object used to automatically hold a SharedMemory mutex while
     ///        in scope, and release it when out of scope.
-    class SharedMemoryScopedLock
+    class __attribute__((visibility("default"))) SharedMemoryScopedLock
     {
         public:
             SharedMemoryScopedLock() = delete;

--- a/libgeopmd/include/geopm_debug.hpp
+++ b/libgeopmd/include/geopm_debug.hpp
@@ -6,9 +6,10 @@
 #ifndef GEOPM_DEBUG_HPP_INCLUDE
 #define GEOPM_DEBUG_HPP_INCLUDE
 
-#include "config.h"  // for GEOPM_DEBUG
+#include "config.h" // for GEOPM_DEBUG
 
 #include "geopm/Exception.hpp"
+#include "geopm_public.h"
 
 #ifdef GEOPM_DEBUG
 /// Used to check for errors that should never occur unless there is a

--- a/libgeopmd/include/geopm_error.h
+++ b/libgeopmd/include/geopm_error.h
@@ -32,7 +32,8 @@ enum geopm_error_e {
 };
 
 /* Convert error number into an error message */
-void GEOPM_PUBLIC geopm_error_message(int err, char *msg, size_t size);
+void GEOPM_PUBLIC
+    geopm_error_message(int err, char *msg, size_t size);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_error.h
+++ b/libgeopmd/include/geopm_error.h
@@ -30,7 +30,7 @@ enum geopm_error_e {
 };
 
 /* Convert error number into an error message */
-void geopm_error_message(int err, char *msg, size_t size);
+void __attribute__((visibility("default"))) geopm_error_message(int err, char *msg, size_t size);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_error.h
+++ b/libgeopmd/include/geopm_error.h
@@ -8,6 +8,8 @@
 
 #include <stdlib.h>
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -30,7 +32,7 @@ enum geopm_error_e {
 };
 
 /* Convert error number into an error message */
-void __attribute__((visibility("default"))) geopm_error_message(int err, char *msg, size_t size);
+void GEOPM_PUBLIC geopm_error_message(int err, char *msg, size_t size);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_field.h
+++ b/libgeopmd/include/geopm_field.h
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libgeopmd/include/geopm_hash.h
+++ b/libgeopmd/include/geopm_hash.h
@@ -49,7 +49,8 @@ enum geopm_region_hash_epoch_e {
 /// @param [in] key This value is hashed to produce a 32-bit result.
 ///
 /// @return uint64_t The result is returned as a 64-bit integer.
-uint64_t GEOPM_PUBLIC geopm_crc32_u64(uint64_t begin, uint64_t key);
+uint64_t GEOPM_PUBLIC
+    geopm_crc32_u64(uint64_t begin, uint64_t key);
 
 /// @brief This function is used to produce unique region IDs for
 ///        named regions.
@@ -63,14 +64,16 @@ uint64_t GEOPM_PUBLIC geopm_crc32_u64(uint64_t begin, uint64_t key);
 /// @param [in] key This string is hashed to produce a 64-bit value.
 ///
 /// @return uint64_t The result is returned as a 64-bit integer.
-uint64_t GEOPM_PUBLIC geopm_crc32_str(const char *key);
+uint64_t GEOPM_PUBLIC
+    geopm_crc32_str(const char *key);
 
 #ifdef __cplusplus
 }
 
 namespace geopm
 {
-    uint64_t GEOPM_PUBLIC hash(const std::string &key);
+    uint64_t GEOPM_PUBLIC
+        hash(const std::string &key);
 }
 
 #endif

--- a/libgeopmd/include/geopm_hash.h
+++ b/libgeopmd/include/geopm_hash.h
@@ -47,7 +47,7 @@ enum geopm_region_hash_epoch_e {
 /// @param [in] key This value is hashed to produce a 32-bit result.
 ///
 /// @return uint64_t The result is returned as a 64-bit integer.
-uint64_t geopm_crc32_u64(uint64_t begin, uint64_t key);
+uint64_t __attribute__((visibility("default"))) geopm_crc32_u64(uint64_t begin, uint64_t key);
 
 /// @brief This function is used to produce unique region IDs for
 ///        named regions.
@@ -61,14 +61,14 @@ uint64_t geopm_crc32_u64(uint64_t begin, uint64_t key);
 /// @param [in] key This string is hashed to produce a 64-bit value.
 ///
 /// @return uint64_t The result is returned as a 64-bit integer.
-uint64_t geopm_crc32_str(const char *key);
+uint64_t __attribute__((visibility("default"))) geopm_crc32_str(const char *key);
 
 #ifdef __cplusplus
 }
 
 namespace geopm
 {
-    uint64_t hash(const std::string &key);
+    uint64_t __attribute__((visibility("default"))) hash(const std::string &key);
 }
 
 #endif

--- a/libgeopmd/include/geopm_hash.h
+++ b/libgeopmd/include/geopm_hash.h
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 #include <string>
 
@@ -47,7 +49,7 @@ enum geopm_region_hash_epoch_e {
 /// @param [in] key This value is hashed to produce a 32-bit result.
 ///
 /// @return uint64_t The result is returned as a 64-bit integer.
-uint64_t __attribute__((visibility("default"))) geopm_crc32_u64(uint64_t begin, uint64_t key);
+uint64_t GEOPM_PUBLIC geopm_crc32_u64(uint64_t begin, uint64_t key);
 
 /// @brief This function is used to produce unique region IDs for
 ///        named regions.
@@ -61,14 +63,14 @@ uint64_t __attribute__((visibility("default"))) geopm_crc32_u64(uint64_t begin, 
 /// @param [in] key This string is hashed to produce a 64-bit value.
 ///
 /// @return uint64_t The result is returned as a 64-bit integer.
-uint64_t __attribute__((visibility("default"))) geopm_crc32_str(const char *key);
+uint64_t GEOPM_PUBLIC geopm_crc32_str(const char *key);
 
 #ifdef __cplusplus
 }
 
 namespace geopm
 {
-    uint64_t __attribute__((visibility("default"))) hash(const std::string &key);
+    uint64_t GEOPM_PUBLIC hash(const std::string &key);
 }
 
 #endif

--- a/libgeopmd/include/geopm_hint.h
+++ b/libgeopmd/include/geopm_hint.h
@@ -7,6 +7,8 @@
 #define GEOPM_HINT_H_INCLUDE
 #include <stdint.h>
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -34,7 +36,7 @@ enum geopm_region_hint_e {
 
 namespace geopm {
     /// @brief Verify a region's hint value is legal for use.
-    void __attribute__((visibility("default"))) check_hint(uint64_t hint);
+    void GEOPM_PUBLIC check_hint(uint64_t hint);
 }
 #endif
 

--- a/libgeopmd/include/geopm_hint.h
+++ b/libgeopmd/include/geopm_hint.h
@@ -34,7 +34,7 @@ enum geopm_region_hint_e {
 
 namespace geopm {
     /// @brief Verify a region's hint value is legal for use.
-    void check_hint(uint64_t hint);
+    void __attribute__((visibility("default"))) check_hint(uint64_t hint);
 }
 #endif
 

--- a/libgeopmd/include/geopm_hint.h
+++ b/libgeopmd/include/geopm_hint.h
@@ -36,7 +36,8 @@ enum geopm_region_hint_e {
 
 namespace geopm {
     /// @brief Verify a region's hint value is legal for use.
-    void GEOPM_PUBLIC check_hint(uint64_t hint);
+    void GEOPM_PUBLIC
+        check_hint(uint64_t hint);
 }
 #endif
 

--- a/libgeopmd/include/geopm_pio.h
+++ b/libgeopmd/include/geopm_pio.h
@@ -18,7 +18,8 @@ extern "C" {
 ///         name_idx parameter to the geopm_pio_signal_name()
 ///         function.  Any error in loading the platform will result
 ///         in a negative error code describing the failure.
-int GEOPM_PUBLIC geopm_pio_num_signal_name(void);
+int GEOPM_PUBLIC
+    geopm_pio_num_signal_name(void);
 
 /// @param [in] name_idx The value of name_idx must be greater than
 ///        zero and less than the return value from
@@ -34,16 +35,15 @@ int GEOPM_PUBLIC geopm_pio_num_signal_name(void);
 ///
 /// @result Zero is returned on success and
 ///         a negative error code is returned if any error occurs.
-int GEOPM_PUBLIC geopm_pio_signal_name(
-    int name_idx,
-    size_t result_max,
-    char *result);
+int GEOPM_PUBLIC
+    geopm_pio_signal_name(int name_idx, size_t result_max, char *result);
 
 /// @return the number of control names that can be indexed with the
 ///         name_idx parameter to the geopm_pio_control_name()
 ///         function.  Any error in loading the platform will result
 ///         in a negative error code describing the failure.
-int GEOPM_PUBLIC geopm_pio_num_control_name(void);
+int GEOPM_PUBLIC
+    geopm_pio_num_control_name(void);
 
 /// @param [in] name_idx The value of name_idx must be greater than
 ///        zero and less than the return value from
@@ -59,10 +59,8 @@ int GEOPM_PUBLIC geopm_pio_num_control_name(void);
 ///
 /// @result Zero is returned on success and
 ///         a negative error code is returned if any error occurs.
-int GEOPM_PUBLIC geopm_pio_control_name(
-    int name_index,
-    size_t result_max,
-    char *result);
+int GEOPM_PUBLIC
+    geopm_pio_control_name(int name_index, size_t result_max, char *result);
 
 /// @brief Query the domain for the signal with name signal_name.
 ///
@@ -72,8 +70,8 @@ int GEOPM_PUBLIC geopm_pio_control_name(
 ///         granularity at which the signal is measured.  Will return
 ///         a negative error code if any error occurs, e.g. a request
 ///         for a signal_name that is not supported by the platform.
-int GEOPM_PUBLIC geopm_pio_signal_domain_type(
-    const char *signal_name);
+int GEOPM_PUBLIC
+    geopm_pio_signal_domain_type(const char *signal_name);
 
 /// @brief Query the domain for the control with name control_name.
 ///
@@ -83,8 +81,8 @@ int GEOPM_PUBLIC geopm_pio_signal_domain_type(
 ///         granularity at which the control is measured.  Will return
 ///         a negative error code if any error occurs, e.g. a request
 ///         for a control_name that is not supported by the platform.
-int GEOPM_PUBLIC geopm_pio_control_domain_type(
-    const char *control_name);
+int GEOPM_PUBLIC
+    geopm_pio_control_domain_type(const char *control_name);
 
 /// @brief Read from the platform and interpret into SI units a signal
 ///        associated with signal_name and store the value in result.
@@ -107,11 +105,9 @@ int GEOPM_PUBLIC geopm_pio_control_domain_type(
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int GEOPM_PUBLIC geopm_pio_read_signal(
-    const char *signal_name,
-    int domain_type,
-    int domain_idx,
-    double *result);
+int GEOPM_PUBLIC
+    geopm_pio_read_signal(const char *signal_name, int domain_type,
+                          int domain_idx, double *result);
 
 /// @brief Interpret the setting in SI units associated with
 ///        control_name and write it to the platform.  This value is
@@ -135,11 +131,9 @@ int GEOPM_PUBLIC geopm_pio_read_signal(
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int GEOPM_PUBLIC geopm_pio_write_control(
-    const char *control_name,
-    int domain_type,
-    int domain_idx,
-    double setting);
+int GEOPM_PUBLIC
+    geopm_pio_write_control(const char *control_name, int domain_type,
+                            int domain_idx, double setting);
 
 /// @brief Push a signal onto the stack of batch access signals.  The
 ///        signal is defined by selecting a signal_name from one of
@@ -180,10 +174,8 @@ int GEOPM_PUBLIC geopm_pio_write_control(
 ///         the internal state from the last update.  A distinct
 ///         signal index will be returned for each unique combination
 ///         of input parameters.
-int GEOPM_PUBLIC geopm_pio_push_signal(
-    const char *signal_name,
-    int domain_type,
-    int domain_idx);
+int GEOPM_PUBLIC
+    geopm_pio_push_signal(const char *signal_name, int domain_type, int domain_idx);
 
 /// @brief Push a control onto the stack of batch access controls.
 ///        The control is defined by selecting a control_name from one
@@ -223,10 +215,8 @@ int GEOPM_PUBLIC geopm_pio_push_signal(
 ///         internal state used to store batch controls.  A distinct
 ///         control index will be returned for each unique combination
 ///         of input parameters.
-int GEOPM_PUBLIC geopm_pio_push_control(
-    const char *control_name,
-    int domain_type,
-    int domain_idx);
+int GEOPM_PUBLIC
+    geopm_pio_push_control(const char *control_name, int domain_type, int domain_idx);
 
 /// @brief Samples cached value of a single signal that has been
 ///        pushed via geopm_pio_push_signal() and writes the value
@@ -243,9 +233,8 @@ int GEOPM_PUBLIC geopm_pio_push_control(
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int GEOPM_PUBLIC geopm_pio_sample(
-    int signal_idx,
-    double *result);
+int GEOPM_PUBLIC
+    geopm_pio_sample(int signal_idx, double *result);
 
 /// @brief Updates cached value for single control that has been
 ///        pushed via geopm_pio_push_control() to the value setting.
@@ -261,23 +250,24 @@ int GEOPM_PUBLIC geopm_pio_sample(
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int GEOPM_PUBLIC geopm_pio_adjust(
-    int control_idx,
-    double setting);
+int GEOPM_PUBLIC
+    geopm_pio_adjust(int control_idx, double setting);
 
 /// @brief Read all push signals from the platform so that the next
 ///        call to geopm_pio_sample() will reflect the updated data.
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int GEOPM_PUBLIC geopm_pio_read_batch(void);
+int GEOPM_PUBLIC
+    geopm_pio_read_batch(void);
 
 /// @brief Write all pushed controls so that values provided to
 ///        geopm_pio_adjust() are written to the platform.
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int GEOPM_PUBLIC geopm_pio_write_batch(void);
+int GEOPM_PUBLIC
+    geopm_pio_write_batch(void);
 
 /// @brief Save the state of all controls so that any subsequent
 ///        changes made through geopm_pio_write_control() or
@@ -289,7 +279,8 @@ int GEOPM_PUBLIC geopm_pio_write_batch(void);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int GEOPM_PUBLIC geopm_pio_save_control(void);
+int GEOPM_PUBLIC
+    geopm_pio_save_control(void);
 
 /// @brief Save the state of all controls in the directory so that any
 ///        subsequent changes made through geopm_pio_write_control()
@@ -303,7 +294,8 @@ int GEOPM_PUBLIC geopm_pio_save_control(void);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int GEOPM_PUBLIC geopm_pio_save_control_dir(const char *save_dir);
+int GEOPM_PUBLIC
+    geopm_pio_save_control_dir(const char *save_dir);
 
 /// @brief Restore the state recorded by the last call to
 ///        geopm_pio_save_control() so that all subsequent changes
@@ -313,7 +305,8 @@ int GEOPM_PUBLIC geopm_pio_save_control_dir(const char *save_dir);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int GEOPM_PUBLIC geopm_pio_restore_control(void);
+int GEOPM_PUBLIC
+    geopm_pio_restore_control(void);
 
 /// @brief Restore the state recorded by the last call to
 ///        geopm_pio_save_control() in the directory so that all
@@ -325,7 +318,8 @@ int GEOPM_PUBLIC geopm_pio_restore_control(void);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int GEOPM_PUBLIC geopm_pio_restore_control_dir(const char *save_dir);
+int GEOPM_PUBLIC
+    geopm_pio_restore_control_dir(const char *save_dir);
 
 /// @param [in] signal_name A string holding the name of the signal.
 ///
@@ -340,10 +334,9 @@ int GEOPM_PUBLIC geopm_pio_restore_control_dir(const char *save_dir);
 ///
 /// @result Zero is returned on success and a negative error code is
 ///         returned if any error occurs.
-int GEOPM_PUBLIC geopm_pio_signal_description(
-    const char *signal_name,
-    size_t description_max,
-    char *description);
+int GEOPM_PUBLIC
+    geopm_pio_signal_description(const char *signal_name, size_t description_max,
+                                 char *description);
 
 /// @param [in] control_name A string holding the name of the control.
 ///
@@ -357,10 +350,9 @@ int GEOPM_PUBLIC geopm_pio_signal_description(
 ///
 /// @result Zero is returned on success and a negative error code is
 ///         returned if any error occurs.
-int GEOPM_PUBLIC geopm_pio_control_description(
-    const char *control_name,
-    size_t description_max,
-    char *description);
+int GEOPM_PUBLIC
+    geopm_pio_control_description(const char *control_name, size_t description_max,
+                                  char *description);
 
 /// @brief C interface to get enums associated with a signal name.
 ///
@@ -381,11 +373,9 @@ int GEOPM_PUBLIC geopm_pio_control_description(
 ///        enum values that describes the signals behavior over time.
 ///
 /// @return Zero on success, error value on failure.
-int GEOPM_PUBLIC geopm_pio_signal_info(
-    const char *signal_name,
-    int *aggregation_type,
-    int *format_type,
-    int *behavior_type);
+int GEOPM_PUBLIC
+    geopm_pio_signal_info(const char *signal_name, int *aggregation_type,
+                          int *format_type, int *behavior_type);
 
 struct geopm_request_s;
 
@@ -423,15 +413,12 @@ struct geopm_request_s;
 ///
 /// @result Zero is returned on success and
 ///         a negative error code is returned if any error occurs.
-int GEOPM_PUBLIC geopm_pio_start_batch_server(
-    int client_pid,
-    int num_signal,
-    const struct geopm_request_s *signal_config,
-    int num_control,
-    const struct geopm_request_s *control_config,
-    int *server_pid,
-    int key_size,
-    char *server_key);
+int GEOPM_PUBLIC
+    geopm_pio_start_batch_server(int client_pid, int num_signal,
+                                 const struct geopm_request_s *signal_config,
+                                 int num_control,
+                                 const struct geopm_request_s *control_config,
+                                 int *server_pid, int key_size, char *server_key);
 
 /// @brief Supports the D-Bus interface for stopping a batch server.
 ///        Call through to BatchServer::stop_batch()
@@ -445,7 +432,8 @@ int GEOPM_PUBLIC geopm_pio_start_batch_server(
 ///
 /// @result Zero is returned on success and a negative error code is
 ///         returned if any error occurs.
-int GEOPM_PUBLIC geopm_pio_stop_batch_server(int server_pid);
+int GEOPM_PUBLIC
+    geopm_pio_stop_batch_server(int server_pid);
 
 /// @brief Format the signal according to the format type specified,
 ///        and write the output into the result string.
@@ -465,11 +453,9 @@ int GEOPM_PUBLIC geopm_pio_stop_batch_server(int server_pid);
 ///        any result.
 ///
 /// @return Zero on success, error value on failure.
-int GEOPM_PUBLIC geopm_pio_format_signal(
-    double signal,
-    int format_type,
-    size_t result_max,
-    char *result);
+int GEOPM_PUBLIC
+    geopm_pio_format_signal(double signal, int format_type, size_t result_max,
+                            char *result);
 
 /// @brief Reset the GEOPM platform interface causing resources to be
 ///        freed.  This will cause the internal PlatormIO instance to
@@ -481,12 +467,14 @@ int GEOPM_PUBLIC geopm_pio_format_signal(
 ///        NOTE: the reset only applies to the Service PlatformIO
 ///        instance and does not affect the PlatformIO instance
 ///        managed by the GEOPM HPC runtime.
-void GEOPM_PUBLIC geopm_pio_reset(void);
+void GEOPM_PUBLIC
+    geopm_pio_reset(void);
 
 /// @param [in] value Check if the given parameter is a valid value.
 ///
 /// @return 0 if the value is valid, GEOPM_ERROR_INVALID if the value is invalid.
-int GEOPM_PUBLIC geopm_pio_check_valid_value(double value);
+int GEOPM_PUBLIC
+    geopm_pio_check_valid_value(double value);
 
 /// @brief Discover the thread PIDS associated with an application
 ///
@@ -504,8 +492,8 @@ int GEOPM_PUBLIC geopm_pio_check_valid_value(double value);
 ///
 /// @param [out] pid An array of Linux PIDs that are associated with
 ///        the application.
-int GEOPM_PUBLIC geopm_pio_profile_pids(
-    const char *profile_name, int max_num_pid, int *num_pid, int *pid);
+int GEOPM_PUBLIC
+    geopm_pio_profile_pids(const char *profile_name, int max_num_pid, int *num_pid, int *pid);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_pio.h
+++ b/libgeopmd/include/geopm_pio.h
@@ -8,6 +8,7 @@
 
 #include <stddef.h>
 #include <limits.h>
+#include "geopm_public.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,7 +18,7 @@ extern "C" {
 ///         name_idx parameter to the geopm_pio_signal_name()
 ///         function.  Any error in loading the platform will result
 ///         in a negative error code describing the failure.
-int __attribute__((visibility("default"))) geopm_pio_num_signal_name(void);
+int GEOPM_PUBLIC geopm_pio_num_signal_name(void);
 
 /// @param [in] name_idx The value of name_idx must be greater than
 ///        zero and less than the return value from
@@ -33,7 +34,7 @@ int __attribute__((visibility("default"))) geopm_pio_num_signal_name(void);
 ///
 /// @result Zero is returned on success and
 ///         a negative error code is returned if any error occurs.
-int __attribute__((visibility("default"))) geopm_pio_signal_name(
+int GEOPM_PUBLIC geopm_pio_signal_name(
     int name_idx,
     size_t result_max,
     char *result);
@@ -42,7 +43,7 @@ int __attribute__((visibility("default"))) geopm_pio_signal_name(
 ///         name_idx parameter to the geopm_pio_control_name()
 ///         function.  Any error in loading the platform will result
 ///         in a negative error code describing the failure.
-int __attribute__((visibility("default"))) geopm_pio_num_control_name(void);
+int GEOPM_PUBLIC geopm_pio_num_control_name(void);
 
 /// @param [in] name_idx The value of name_idx must be greater than
 ///        zero and less than the return value from
@@ -58,7 +59,7 @@ int __attribute__((visibility("default"))) geopm_pio_num_control_name(void);
 ///
 /// @result Zero is returned on success and
 ///         a negative error code is returned if any error occurs.
-int __attribute__((visibility("default"))) geopm_pio_control_name(
+int GEOPM_PUBLIC geopm_pio_control_name(
     int name_index,
     size_t result_max,
     char *result);
@@ -71,7 +72,7 @@ int __attribute__((visibility("default"))) geopm_pio_control_name(
 ///         granularity at which the signal is measured.  Will return
 ///         a negative error code if any error occurs, e.g. a request
 ///         for a signal_name that is not supported by the platform.
-int __attribute__((visibility("default"))) geopm_pio_signal_domain_type(
+int GEOPM_PUBLIC geopm_pio_signal_domain_type(
     const char *signal_name);
 
 /// @brief Query the domain for the control with name control_name.
@@ -82,7 +83,7 @@ int __attribute__((visibility("default"))) geopm_pio_signal_domain_type(
 ///         granularity at which the control is measured.  Will return
 ///         a negative error code if any error occurs, e.g. a request
 ///         for a control_name that is not supported by the platform.
-int __attribute__((visibility("default"))) geopm_pio_control_domain_type(
+int GEOPM_PUBLIC geopm_pio_control_domain_type(
     const char *control_name);
 
 /// @brief Read from the platform and interpret into SI units a signal
@@ -106,7 +107,7 @@ int __attribute__((visibility("default"))) geopm_pio_control_domain_type(
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int __attribute__((visibility("default"))) geopm_pio_read_signal(
+int GEOPM_PUBLIC geopm_pio_read_signal(
     const char *signal_name,
     int domain_type,
     int domain_idx,
@@ -134,7 +135,7 @@ int __attribute__((visibility("default"))) geopm_pio_read_signal(
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int __attribute__((visibility("default"))) geopm_pio_write_control(
+int GEOPM_PUBLIC geopm_pio_write_control(
     const char *control_name,
     int domain_type,
     int domain_idx,
@@ -179,7 +180,7 @@ int __attribute__((visibility("default"))) geopm_pio_write_control(
 ///         the internal state from the last update.  A distinct
 ///         signal index will be returned for each unique combination
 ///         of input parameters.
-int __attribute__((visibility("default"))) geopm_pio_push_signal(
+int GEOPM_PUBLIC geopm_pio_push_signal(
     const char *signal_name,
     int domain_type,
     int domain_idx);
@@ -222,7 +223,7 @@ int __attribute__((visibility("default"))) geopm_pio_push_signal(
 ///         internal state used to store batch controls.  A distinct
 ///         control index will be returned for each unique combination
 ///         of input parameters.
-int __attribute__((visibility("default"))) geopm_pio_push_control(
+int GEOPM_PUBLIC geopm_pio_push_control(
     const char *control_name,
     int domain_type,
     int domain_idx);
@@ -242,7 +243,7 @@ int __attribute__((visibility("default"))) geopm_pio_push_control(
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int __attribute__((visibility("default"))) geopm_pio_sample(
+int GEOPM_PUBLIC geopm_pio_sample(
     int signal_idx,
     double *result);
 
@@ -260,7 +261,7 @@ int __attribute__((visibility("default"))) geopm_pio_sample(
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int __attribute__((visibility("default"))) geopm_pio_adjust(
+int GEOPM_PUBLIC geopm_pio_adjust(
     int control_idx,
     double setting);
 
@@ -269,14 +270,14 @@ int __attribute__((visibility("default"))) geopm_pio_adjust(
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int __attribute__((visibility("default"))) geopm_pio_read_batch(void);
+int GEOPM_PUBLIC geopm_pio_read_batch(void);
 
 /// @brief Write all pushed controls so that values provided to
 ///        geopm_pio_adjust() are written to the platform.
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int __attribute__((visibility("default"))) geopm_pio_write_batch(void);
+int GEOPM_PUBLIC geopm_pio_write_batch(void);
 
 /// @brief Save the state of all controls so that any subsequent
 ///        changes made through geopm_pio_write_control() or
@@ -288,7 +289,7 @@ int __attribute__((visibility("default"))) geopm_pio_write_batch(void);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int __attribute__((visibility("default"))) geopm_pio_save_control(void);
+int GEOPM_PUBLIC geopm_pio_save_control(void);
 
 /// @brief Save the state of all controls in the directory so that any
 ///        subsequent changes made through geopm_pio_write_control()
@@ -302,7 +303,7 @@ int __attribute__((visibility("default"))) geopm_pio_save_control(void);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int __attribute__((visibility("default"))) geopm_pio_save_control_dir(const char *save_dir);
+int GEOPM_PUBLIC geopm_pio_save_control_dir(const char *save_dir);
 
 /// @brief Restore the state recorded by the last call to
 ///        geopm_pio_save_control() so that all subsequent changes
@@ -312,7 +313,7 @@ int __attribute__((visibility("default"))) geopm_pio_save_control_dir(const char
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int __attribute__((visibility("default"))) geopm_pio_restore_control(void);
+int GEOPM_PUBLIC geopm_pio_restore_control(void);
 
 /// @brief Restore the state recorded by the last call to
 ///        geopm_pio_save_control() in the directory so that all
@@ -324,7 +325,7 @@ int __attribute__((visibility("default"))) geopm_pio_restore_control(void);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int __attribute__((visibility("default"))) geopm_pio_restore_control_dir(const char *save_dir);
+int GEOPM_PUBLIC geopm_pio_restore_control_dir(const char *save_dir);
 
 /// @param [in] signal_name A string holding the name of the signal.
 ///
@@ -339,7 +340,7 @@ int __attribute__((visibility("default"))) geopm_pio_restore_control_dir(const c
 ///
 /// @result Zero is returned on success and a negative error code is
 ///         returned if any error occurs.
-int __attribute__((visibility("default"))) geopm_pio_signal_description(
+int GEOPM_PUBLIC geopm_pio_signal_description(
     const char *signal_name,
     size_t description_max,
     char *description);
@@ -356,7 +357,7 @@ int __attribute__((visibility("default"))) geopm_pio_signal_description(
 ///
 /// @result Zero is returned on success and a negative error code is
 ///         returned if any error occurs.
-int __attribute__((visibility("default"))) geopm_pio_control_description(
+int GEOPM_PUBLIC geopm_pio_control_description(
     const char *control_name,
     size_t description_max,
     char *description);
@@ -380,7 +381,7 @@ int __attribute__((visibility("default"))) geopm_pio_control_description(
 ///        enum values that describes the signals behavior over time.
 ///
 /// @return Zero on success, error value on failure.
-int __attribute__((visibility("default"))) geopm_pio_signal_info(
+int GEOPM_PUBLIC geopm_pio_signal_info(
     const char *signal_name,
     int *aggregation_type,
     int *format_type,
@@ -422,7 +423,7 @@ struct geopm_request_s;
 ///
 /// @result Zero is returned on success and
 ///         a negative error code is returned if any error occurs.
-int __attribute__((visibility("default"))) geopm_pio_start_batch_server(
+int GEOPM_PUBLIC geopm_pio_start_batch_server(
     int client_pid,
     int num_signal,
     const struct geopm_request_s *signal_config,
@@ -444,7 +445,7 @@ int __attribute__((visibility("default"))) geopm_pio_start_batch_server(
 ///
 /// @result Zero is returned on success and a negative error code is
 ///         returned if any error occurs.
-int __attribute__((visibility("default"))) geopm_pio_stop_batch_server(int server_pid);
+int GEOPM_PUBLIC geopm_pio_stop_batch_server(int server_pid);
 
 /// @brief Format the signal according to the format type specified,
 ///        and write the output into the result string.
@@ -464,7 +465,7 @@ int __attribute__((visibility("default"))) geopm_pio_stop_batch_server(int serve
 ///        any result.
 ///
 /// @return Zero on success, error value on failure.
-int __attribute__((visibility("default"))) geopm_pio_format_signal(
+int GEOPM_PUBLIC geopm_pio_format_signal(
     double signal,
     int format_type,
     size_t result_max,
@@ -480,12 +481,12 @@ int __attribute__((visibility("default"))) geopm_pio_format_signal(
 ///        NOTE: the reset only applies to the Service PlatformIO
 ///        instance and does not affect the PlatformIO instance
 ///        managed by the GEOPM HPC runtime.
-void __attribute__((visibility("default"))) geopm_pio_reset(void);
+void GEOPM_PUBLIC geopm_pio_reset(void);
 
 /// @param [in] value Check if the given parameter is a valid value.
 ///
 /// @return 0 if the value is valid, GEOPM_ERROR_INVALID if the value is invalid.
-int __attribute__((visibility("default"))) geopm_pio_check_valid_value(double value);
+int GEOPM_PUBLIC geopm_pio_check_valid_value(double value);
 
 /// @brief Discover the thread PIDS associated with an application
 ///
@@ -503,7 +504,7 @@ int __attribute__((visibility("default"))) geopm_pio_check_valid_value(double va
 ///
 /// @param [out] pid An array of Linux PIDs that are associated with
 ///        the application.
-int __attribute__((visibility("default"))) geopm_pio_profile_pids(
+int GEOPM_PUBLIC geopm_pio_profile_pids(
     const char *profile_name, int max_num_pid, int *num_pid, int *pid);
 
 #ifdef __cplusplus

--- a/libgeopmd/include/geopm_pio.h
+++ b/libgeopmd/include/geopm_pio.h
@@ -17,7 +17,7 @@ extern "C" {
 ///         name_idx parameter to the geopm_pio_signal_name()
 ///         function.  Any error in loading the platform will result
 ///         in a negative error code describing the failure.
-int geopm_pio_num_signal_name(void);
+int __attribute__((visibility("default"))) geopm_pio_num_signal_name(void);
 
 /// @param [in] name_idx The value of name_idx must be greater than
 ///        zero and less than the return value from
@@ -33,15 +33,16 @@ int geopm_pio_num_signal_name(void);
 ///
 /// @result Zero is returned on success and
 ///         a negative error code is returned if any error occurs.
-int geopm_pio_signal_name(int name_idx,
-                          size_t result_max,
-                          char *result);
+int __attribute__((visibility("default"))) geopm_pio_signal_name(
+    int name_idx,
+    size_t result_max,
+    char *result);
 
 /// @return the number of control names that can be indexed with the
 ///         name_idx parameter to the geopm_pio_control_name()
 ///         function.  Any error in loading the platform will result
 ///         in a negative error code describing the failure.
-int geopm_pio_num_control_name(void);
+int __attribute__((visibility("default"))) geopm_pio_num_control_name(void);
 
 /// @param [in] name_idx The value of name_idx must be greater than
 ///        zero and less than the return value from
@@ -57,9 +58,10 @@ int geopm_pio_num_control_name(void);
 ///
 /// @result Zero is returned on success and
 ///         a negative error code is returned if any error occurs.
-int geopm_pio_control_name(int name_index,
-                           size_t result_max,
-                           char *result);
+int __attribute__((visibility("default"))) geopm_pio_control_name(
+    int name_index,
+    size_t result_max,
+    char *result);
 
 /// @brief Query the domain for the signal with name signal_name.
 ///
@@ -69,7 +71,8 @@ int geopm_pio_control_name(int name_index,
 ///         granularity at which the signal is measured.  Will return
 ///         a negative error code if any error occurs, e.g. a request
 ///         for a signal_name that is not supported by the platform.
-int geopm_pio_signal_domain_type(const char *signal_name);
+int __attribute__((visibility("default"))) geopm_pio_signal_domain_type(
+    const char *signal_name);
 
 /// @brief Query the domain for the control with name control_name.
 ///
@@ -79,7 +82,8 @@ int geopm_pio_signal_domain_type(const char *signal_name);
 ///         granularity at which the control is measured.  Will return
 ///         a negative error code if any error occurs, e.g. a request
 ///         for a control_name that is not supported by the platform.
-int geopm_pio_control_domain_type(const char *control_name);
+int __attribute__((visibility("default"))) geopm_pio_control_domain_type(
+    const char *control_name);
 
 /// @brief Read from the platform and interpret into SI units a signal
 ///        associated with signal_name and store the value in result.
@@ -102,10 +106,11 @@ int geopm_pio_control_domain_type(const char *control_name);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int geopm_pio_read_signal(const char *signal_name,
-                          int domain_type,
-                          int domain_idx,
-                          double *result);
+int __attribute__((visibility("default"))) geopm_pio_read_signal(
+    const char *signal_name,
+    int domain_type,
+    int domain_idx,
+    double *result);
 
 /// @brief Interpret the setting in SI units associated with
 ///        control_name and write it to the platform.  This value is
@@ -129,10 +134,11 @@ int geopm_pio_read_signal(const char *signal_name,
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int geopm_pio_write_control(const char *control_name,
-                            int domain_type,
-                            int domain_idx,
-                            double setting);
+int __attribute__((visibility("default"))) geopm_pio_write_control(
+    const char *control_name,
+    int domain_type,
+    int domain_idx,
+    double setting);
 
 /// @brief Push a signal onto the stack of batch access signals.  The
 ///        signal is defined by selecting a signal_name from one of
@@ -173,9 +179,10 @@ int geopm_pio_write_control(const char *control_name,
 ///         the internal state from the last update.  A distinct
 ///         signal index will be returned for each unique combination
 ///         of input parameters.
-int geopm_pio_push_signal(const char *signal_name,
-                          int domain_type,
-                          int domain_idx);
+int __attribute__((visibility("default"))) geopm_pio_push_signal(
+    const char *signal_name,
+    int domain_type,
+    int domain_idx);
 
 /// @brief Push a control onto the stack of batch access controls.
 ///        The control is defined by selecting a control_name from one
@@ -215,9 +222,10 @@ int geopm_pio_push_signal(const char *signal_name,
 ///         internal state used to store batch controls.  A distinct
 ///         control index will be returned for each unique combination
 ///         of input parameters.
-int geopm_pio_push_control(const char *control_name,
-                           int domain_type,
-                           int domain_idx);
+int __attribute__((visibility("default"))) geopm_pio_push_control(
+    const char *control_name,
+    int domain_type,
+    int domain_idx);
 
 /// @brief Samples cached value of a single signal that has been
 ///        pushed via geopm_pio_push_signal() and writes the value
@@ -234,8 +242,9 @@ int geopm_pio_push_control(const char *control_name,
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int geopm_pio_sample(int signal_idx,
-                     double *result);
+int __attribute__((visibility("default"))) geopm_pio_sample(
+    int signal_idx,
+    double *result);
 
 /// @brief Updates cached value for single control that has been
 ///        pushed via geopm_pio_push_control() to the value setting.
@@ -251,22 +260,23 @@ int geopm_pio_sample(int signal_idx,
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int geopm_pio_adjust(int control_idx,
-                     double setting);
+int __attribute__((visibility("default"))) geopm_pio_adjust(
+    int control_idx,
+    double setting);
 
 /// @brief Read all push signals from the platform so that the next
 ///        call to geopm_pio_sample() will reflect the updated data.
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int geopm_pio_read_batch(void);
+int __attribute__((visibility("default"))) geopm_pio_read_batch(void);
 
 /// @brief Write all pushed controls so that values provided to
 ///        geopm_pio_adjust() are written to the platform.
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int geopm_pio_write_batch(void);
+int __attribute__((visibility("default"))) geopm_pio_write_batch(void);
 
 /// @brief Save the state of all controls so that any subsequent
 ///        changes made through geopm_pio_write_control() or
@@ -278,7 +288,7 @@ int geopm_pio_write_batch(void);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int geopm_pio_save_control(void);
+int __attribute__((visibility("default"))) geopm_pio_save_control(void);
 
 /// @brief Save the state of all controls in the directory so that any
 ///        subsequent changes made through geopm_pio_write_control()
@@ -292,7 +302,7 @@ int geopm_pio_save_control(void);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int geopm_pio_save_control_dir(const char *save_dir);
+int __attribute__((visibility("default"))) geopm_pio_save_control_dir(const char *save_dir);
 
 /// @brief Restore the state recorded by the last call to
 ///        geopm_pio_save_control() so that all subsequent changes
@@ -302,7 +312,7 @@ int geopm_pio_save_control_dir(const char *save_dir);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int geopm_pio_restore_control(void);
+int __attribute__((visibility("default"))) geopm_pio_restore_control(void);
 
 /// @brief Restore the state recorded by the last call to
 ///        geopm_pio_save_control() in the directory so that all
@@ -314,7 +324,7 @@ int geopm_pio_restore_control(void);
 ///
 /// @return If an error occurs then negative error code is returned.
 ///         Zero is returned upon success.
-int geopm_pio_restore_control_dir(const char *save_dir);
+int __attribute__((visibility("default"))) geopm_pio_restore_control_dir(const char *save_dir);
 
 /// @param [in] signal_name A string holding the name of the signal.
 ///
@@ -329,9 +339,10 @@ int geopm_pio_restore_control_dir(const char *save_dir);
 ///
 /// @result Zero is returned on success and a negative error code is
 ///         returned if any error occurs.
-int geopm_pio_signal_description(const char *signal_name,
-                                 size_t description_max,
-                                 char *description);
+int __attribute__((visibility("default"))) geopm_pio_signal_description(
+    const char *signal_name,
+    size_t description_max,
+    char *description);
 
 /// @param [in] control_name A string holding the name of the control.
 ///
@@ -345,9 +356,10 @@ int geopm_pio_signal_description(const char *signal_name,
 ///
 /// @result Zero is returned on success and a negative error code is
 ///         returned if any error occurs.
-int geopm_pio_control_description(const char *control_name,
-                                  size_t description_max,
-                                  char *description);
+int __attribute__((visibility("default"))) geopm_pio_control_description(
+    const char *control_name,
+    size_t description_max,
+    char *description);
 
 /// @brief C interface to get enums associated with a signal name.
 ///
@@ -368,10 +380,11 @@ int geopm_pio_control_description(const char *control_name,
 ///        enum values that describes the signals behavior over time.
 ///
 /// @return Zero on success, error value on failure.
-int geopm_pio_signal_info(const char *signal_name,
-                          int *aggregation_type,
-                          int *format_type,
-                          int *behavior_type);
+int __attribute__((visibility("default"))) geopm_pio_signal_info(
+    const char *signal_name,
+    int *aggregation_type,
+    int *format_type,
+    int *behavior_type);
 
 struct geopm_request_s;
 
@@ -409,14 +422,15 @@ struct geopm_request_s;
 ///
 /// @result Zero is returned on success and
 ///         a negative error code is returned if any error occurs.
-int geopm_pio_start_batch_server(int client_pid,
-                                 int num_signal,
-                                 const struct geopm_request_s *signal_config,
-                                 int num_control,
-                                 const struct geopm_request_s *control_config,
-                                 int *server_pid,
-                                 int key_size,
-                                 char *server_key);
+int __attribute__((visibility("default"))) geopm_pio_start_batch_server(
+    int client_pid,
+    int num_signal,
+    const struct geopm_request_s *signal_config,
+    int num_control,
+    const struct geopm_request_s *control_config,
+    int *server_pid,
+    int key_size,
+    char *server_key);
 
 /// @brief Supports the D-Bus interface for stopping a batch server.
 ///        Call through to BatchServer::stop_batch()
@@ -430,7 +444,7 @@ int geopm_pio_start_batch_server(int client_pid,
 ///
 /// @result Zero is returned on success and a negative error code is
 ///         returned if any error occurs.
-int geopm_pio_stop_batch_server(int server_pid);
+int __attribute__((visibility("default"))) geopm_pio_stop_batch_server(int server_pid);
 
 /// @brief Format the signal according to the format type specified,
 ///        and write the output into the result string.
@@ -450,10 +464,11 @@ int geopm_pio_stop_batch_server(int server_pid);
 ///        any result.
 ///
 /// @return Zero on success, error value on failure.
-int geopm_pio_format_signal(double signal,
-                            int format_type,
-                            size_t result_max,
-                            char *result);
+int __attribute__((visibility("default"))) geopm_pio_format_signal(
+    double signal,
+    int format_type,
+    size_t result_max,
+    char *result);
 
 /// @brief Reset the GEOPM platform interface causing resources to be
 ///        freed.  This will cause the internal PlatormIO instance to
@@ -465,12 +480,12 @@ int geopm_pio_format_signal(double signal,
 ///        NOTE: the reset only applies to the Service PlatformIO
 ///        instance and does not affect the PlatformIO instance
 ///        managed by the GEOPM HPC runtime.
-void geopm_pio_reset(void);
+void __attribute__((visibility("default"))) geopm_pio_reset(void);
 
 /// @param [in] value Check if the given parameter is a valid value.
 ///
 /// @return 0 if the value is valid, GEOPM_ERROR_INVALID if the value is invalid.
-int geopm_pio_check_valid_value(double value);
+int __attribute__((visibility("default"))) geopm_pio_check_valid_value(double value);
 
 /// @brief Discover the thread PIDS associated with an application
 ///
@@ -488,8 +503,8 @@ int geopm_pio_check_valid_value(double value);
 ///
 /// @param [out] pid An array of Linux PIDs that are associated with
 ///        the application.
-int geopm_pio_profile_pids(const char *profile_name, int max_num_pid, int *num_pid, int *pid);
-
+int __attribute__((visibility("default"))) geopm_pio_profile_pids(
+    const char *profile_name, int max_num_pid, int *num_pid, int *pid);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_plugin.hpp
+++ b/libgeopmd/include/geopm_plugin.hpp
@@ -8,8 +8,8 @@
 
 namespace geopm
 {
-    void __attribute__((visibility("default"))) plugin_load(const std::string &plugin_prefix);
-    void __attribute__((visibility("default"))) plugin_reset(void);
+    void GEOPM_PUBLIC plugin_load(const std::string &plugin_prefix);
+    void GEOPM_PUBLIC plugin_reset(void);
 }
 
 #endif

--- a/libgeopmd/include/geopm_plugin.hpp
+++ b/libgeopmd/include/geopm_plugin.hpp
@@ -8,8 +8,8 @@
 
 namespace geopm
 {
-    void plugin_load(const std::string &plugin_prefix);
-    void plugin_reset(void);
+    void __attribute__((visibility("default"))) plugin_load(const std::string &plugin_prefix);
+    void __attribute__((visibility("default"))) plugin_reset(void);
 }
 
 #endif

--- a/libgeopmd/include/geopm_plugin.hpp
+++ b/libgeopmd/include/geopm_plugin.hpp
@@ -6,10 +6,16 @@
 #ifndef GEOPM_PLUGIN_HPP_INCLUDE
 #define GEOPM_PLUGIN_HPP_INCLUDE
 
+#include <string>
+
+#include "geopm_public.h"
+
 namespace geopm
 {
-    void GEOPM_PUBLIC plugin_load(const std::string &plugin_prefix);
-    void GEOPM_PUBLIC plugin_reset(void);
+    void GEOPM_PUBLIC
+        plugin_load(const std::string &plugin_prefix);
+    void GEOPM_PUBLIC
+        plugin_reset(void);
 }
 
 #endif

--- a/libgeopmd/include/geopm_public.h
+++ b/libgeopmd/include/geopm_public.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2015 - 2024, Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef GEOPM_PUBLIC_H_INCLUDE
+#define GEOPM_PUBLIC_H_INCLUDE
+/*
+ * Indicates that a symbol **is** part of a GEOPM library's public interface
+ */
+#define GEOPM_PUBLIC __attribute__((visibility("default")))
+
+/*
+ * Indicates that a symbol **is not** part of a GEOPM library's public interface
+ */
+#define GEOPM_PRIVATE __attribute__((visibility("hidden")))
+#endif

--- a/libgeopmd/include/geopm_sched.h
+++ b/libgeopmd/include/geopm_sched.h
@@ -17,7 +17,7 @@ extern "C"
 /*!
  * @brief cpuset definition for non-linux platforms.
  */
-typedef struct cpu_set_t {
+typedef struct __attribute__((visibility("default"))) cpu_set_t {
     long int x[512];
 } cpu_set_t;
 
@@ -49,15 +49,15 @@ static inline int  CPU_ISSET(int cpu, cpu_set_t *set)
 #include <sched.h>
 #endif
 
-int geopm_sched_num_cpu(void);
+int __attribute__((visibility("default"))) geopm_sched_num_cpu(void);
 
-int geopm_sched_get_cpu(void);
+int __attribute__((visibility("default"))) geopm_sched_get_cpu(void);
 
-int geopm_sched_proc_cpuset(int num_cpu, cpu_set_t *proc_cpuset);
+int __attribute__((visibility("default"))) geopm_sched_proc_cpuset(int num_cpu, cpu_set_t *proc_cpuset);
 
-int geopm_sched_proc_cpuset_pid(int pid, int num_cpu, cpu_set_t *cpuset);
+int __attribute__((visibility("default"))) geopm_sched_proc_cpuset_pid(int pid, int num_cpu, cpu_set_t *cpuset);
 
-int geopm_sched_woomp(int num_cpu, cpu_set_t *woomp);
+int __attribute__((visibility("default"))) geopm_sched_woomp(int num_cpu, cpu_set_t *woomp);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_sched.h
+++ b/libgeopmd/include/geopm_sched.h
@@ -7,6 +7,7 @@
 #define GEOPM_SCHED_H_INCLUDE
 
 #include <stdio.h>
+#include "geopm_public.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -17,7 +18,7 @@ extern "C"
 /*!
  * @brief cpuset definition for non-linux platforms.
  */
-typedef struct __attribute__((visibility("default"))) cpu_set_t {
+typedef struct GEOPM_PUBLIC cpu_set_t {
     long int x[512];
 } cpu_set_t;
 
@@ -49,15 +50,15 @@ static inline int  CPU_ISSET(int cpu, cpu_set_t *set)
 #include <sched.h>
 #endif
 
-int __attribute__((visibility("default"))) geopm_sched_num_cpu(void);
+int GEOPM_PUBLIC geopm_sched_num_cpu(void);
 
-int __attribute__((visibility("default"))) geopm_sched_get_cpu(void);
+int GEOPM_PUBLIC geopm_sched_get_cpu(void);
 
-int __attribute__((visibility("default"))) geopm_sched_proc_cpuset(int num_cpu, cpu_set_t *proc_cpuset);
+int GEOPM_PUBLIC geopm_sched_proc_cpuset(int num_cpu, cpu_set_t *proc_cpuset);
 
-int __attribute__((visibility("default"))) geopm_sched_proc_cpuset_pid(int pid, int num_cpu, cpu_set_t *cpuset);
+int GEOPM_PUBLIC geopm_sched_proc_cpuset_pid(int pid, int num_cpu, cpu_set_t *cpuset);
 
-int __attribute__((visibility("default"))) geopm_sched_woomp(int num_cpu, cpu_set_t *woomp);
+int GEOPM_PUBLIC geopm_sched_woomp(int num_cpu, cpu_set_t *woomp);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_sched.h
+++ b/libgeopmd/include/geopm_sched.h
@@ -50,15 +50,20 @@ static inline int  CPU_ISSET(int cpu, cpu_set_t *set)
 #include <sched.h>
 #endif
 
-int GEOPM_PUBLIC geopm_sched_num_cpu(void);
+int GEOPM_PUBLIC
+    geopm_sched_num_cpu(void);
 
-int GEOPM_PUBLIC geopm_sched_get_cpu(void);
+int GEOPM_PUBLIC
+    geopm_sched_get_cpu(void);
 
-int GEOPM_PUBLIC geopm_sched_proc_cpuset(int num_cpu, cpu_set_t *proc_cpuset);
+int GEOPM_PUBLIC
+    geopm_sched_proc_cpuset(int num_cpu, cpu_set_t *proc_cpuset);
 
-int GEOPM_PUBLIC geopm_sched_proc_cpuset_pid(int pid, int num_cpu, cpu_set_t *cpuset);
+int GEOPM_PUBLIC
+    geopm_sched_proc_cpuset_pid(int pid, int num_cpu, cpu_set_t *cpuset);
 
-int GEOPM_PUBLIC geopm_sched_woomp(int num_cpu, cpu_set_t *woomp);
+int GEOPM_PUBLIC
+    geopm_sched_woomp(int num_cpu, cpu_set_t *woomp);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_shmem.h
+++ b/libgeopmd/include/geopm_shmem.h
@@ -11,15 +11,19 @@
 
 namespace geopm
 {
-    std::string shmem_path_prof(const std::string &shm_key, int pid, int uid);
-    void shmem_create_prof(const std::string &shm_key, size_t size, int pid, int uid, int gid);
+    std::string __attribute__((visibility("default"))) shmem_path_prof(
+        const std::string &shm_key, int pid, int uid);
+    void __attribute__((visibility("default"))) shmem_create_prof(
+        const std::string &shm_key, size_t size, int pid, int uid, int gid);
 }
 
 extern "C" {
 #endif
 
-    int geopm_shmem_path_prof(const char *shm_key, int pid, int uid, size_t shm_path_max, char *shm_path);
-    int geopm_shmem_create_prof(const char *shm_key, size_t size, int pid, int uid, int gid);
+    int __attribute__((visibility("default"))) geopm_shmem_path_prof(
+        const char *shm_key, int pid, int uid, size_t shm_path_max, char *shm_path);
+    int __attribute__((visibility("default"))) geopm_shmem_create_prof(
+        const char *shm_key, size_t size, int pid, int uid, int gid);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_shmem.h
+++ b/libgeopmd/include/geopm_shmem.h
@@ -13,19 +13,20 @@
 
 namespace geopm
 {
-    std::string GEOPM_PUBLIC shmem_path_prof(
-        const std::string &shm_key, int pid, int uid);
-    void GEOPM_PUBLIC shmem_create_prof(
-        const std::string &shm_key, size_t size, int pid, int uid, int gid);
+    std::string GEOPM_PUBLIC
+        shmem_path_prof(const std::string &shm_key, int pid, int uid);
+    void GEOPM_PUBLIC
+        shmem_create_prof(const std::string &shm_key, size_t size, int pid, int uid, int gid);
 }
 
 extern "C" {
 #endif
 
-    int GEOPM_PUBLIC geopm_shmem_path_prof(
-        const char *shm_key, int pid, int uid, size_t shm_path_max, char *shm_path);
-    int GEOPM_PUBLIC geopm_shmem_create_prof(
-        const char *shm_key, size_t size, int pid, int uid, int gid);
+int GEOPM_PUBLIC
+    geopm_shmem_path_prof(const char *shm_key, int pid, int uid,
+                          size_t shm_path_max, char *shm_path);
+int GEOPM_PUBLIC
+    geopm_shmem_create_prof(const char *shm_key, size_t size, int pid, int uid, int gid);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_shmem.h
+++ b/libgeopmd/include/geopm_shmem.h
@@ -6,23 +6,25 @@
 #ifndef GEOPM_SHMEM_H_INCLUDE
 #define GEOPM_SHMEM_H_INCLUDE
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 #include <string>
 
 namespace geopm
 {
-    std::string __attribute__((visibility("default"))) shmem_path_prof(
+    std::string GEOPM_PUBLIC shmem_path_prof(
         const std::string &shm_key, int pid, int uid);
-    void __attribute__((visibility("default"))) shmem_create_prof(
+    void GEOPM_PUBLIC shmem_create_prof(
         const std::string &shm_key, size_t size, int pid, int uid, int gid);
 }
 
 extern "C" {
 #endif
 
-    int __attribute__((visibility("default"))) geopm_shmem_path_prof(
+    int GEOPM_PUBLIC geopm_shmem_path_prof(
         const char *shm_key, int pid, int uid, size_t shm_path_max, char *shm_path);
-    int __attribute__((visibility("default"))) geopm_shmem_create_prof(
+    int GEOPM_PUBLIC geopm_shmem_create_prof(
         const char *shm_key, size_t size, int pid, int uid, int gid);
 
 #ifdef __cplusplus

--- a/libgeopmd/include/geopm_time.h
+++ b/libgeopmd/include/geopm_time.h
@@ -24,7 +24,9 @@ static inline double geopm_time_diff(const struct geopm_time_s *begin, const str
 static inline bool geopm_time_comp(const struct geopm_time_s *aa, const struct geopm_time_s *bb);
 static inline void geopm_time_add(const struct geopm_time_s *begin, double elapsed, struct geopm_time_s *end);
 static inline double geopm_time_since(const struct geopm_time_s *begin);
-int geopm_time_zero(struct geopm_time_s *zero_time);
+
+int __attribute__((visibility("default")))
+    geopm_time_zero(struct geopm_time_s *zero_time);
 
 #include <time.h>
 
@@ -32,7 +34,8 @@ int geopm_time_zero(struct geopm_time_s *zero_time);
  * @brief structure to abstract the timespec on linux from other
  *        representations of time.
  */
-struct geopm_time_s {
+struct __attribute__((visibility("default")))
+    geopm_time_s {
     struct timespec t;
 };
 
@@ -111,9 +114,12 @@ static inline double geopm_time_since(const struct geopm_time_s *begin)
 }
 namespace geopm
 {
-    struct geopm_time_s time_zero(void);
-    struct geopm_time_s time_curr(void);
-    void time_zero_reset(const geopm_time_s &zero);
+    struct geopm_time_s __attribute__((visibility("default")))
+        time_zero(void);
+    struct geopm_time_s __attribute__((visibility("default")))
+        time_curr(void);
+    void __attribute__((visibility("default")))
+        time_zero_reset(const geopm_time_s &zero);
 }
 #endif
 #endif

--- a/libgeopmd/include/geopm_time.h
+++ b/libgeopmd/include/geopm_time.h
@@ -34,8 +34,7 @@ int __attribute__((visibility("default")))
  * @brief structure to abstract the timespec on linux from other
  *        representations of time.
  */
-struct __attribute__((visibility("default")))
-    geopm_time_s {
+struct __attribute__((visibility("default"))) geopm_time_s {
     struct timespec t;
 };
 
@@ -114,12 +113,9 @@ static inline double geopm_time_since(const struct geopm_time_s *begin)
 }
 namespace geopm
 {
-    struct geopm_time_s __attribute__((visibility("default")))
-        time_zero(void);
-    struct geopm_time_s __attribute__((visibility("default")))
-        time_curr(void);
-    void __attribute__((visibility("default")))
-        time_zero_reset(const geopm_time_s &zero);
+    struct geopm_time_s __attribute__((visibility("default"))) time_zero(void);
+    struct geopm_time_s __attribute__((visibility("default"))) time_curr(void);
+    void __attribute__((visibility("default"))) time_zero_reset(const geopm_time_s &zero);
 }
 #endif
 #endif

--- a/libgeopmd/include/geopm_time.h
+++ b/libgeopmd/include/geopm_time.h
@@ -5,9 +5,11 @@
 #ifndef GEOPM_TIME_H_INCLUDE
 #define GEOPM_TIME_H_INCLUDE
 
-#include <math.h>
 #include <errno.h>
+#include <math.h>
 #include <string.h>
+
+#include "geopm_public.h"
 
 #ifndef __cplusplus
 #include <stdbool.h>
@@ -25,7 +27,7 @@ static inline bool geopm_time_comp(const struct geopm_time_s *aa, const struct g
 static inline void geopm_time_add(const struct geopm_time_s *begin, double elapsed, struct geopm_time_s *end);
 static inline double geopm_time_since(const struct geopm_time_s *begin);
 
-int __attribute__((visibility("default")))
+int GEOPM_PUBLIC
     geopm_time_zero(struct geopm_time_s *zero_time);
 
 #include <time.h>
@@ -34,7 +36,7 @@ int __attribute__((visibility("default")))
  * @brief structure to abstract the timespec on linux from other
  *        representations of time.
  */
-struct __attribute__((visibility("default"))) geopm_time_s {
+struct GEOPM_PUBLIC geopm_time_s {
     struct timespec t;
 };
 
@@ -113,9 +115,9 @@ static inline double geopm_time_since(const struct geopm_time_s *begin)
 }
 namespace geopm
 {
-    struct geopm_time_s __attribute__((visibility("default"))) time_zero(void);
-    struct geopm_time_s __attribute__((visibility("default"))) time_curr(void);
-    void __attribute__((visibility("default"))) time_zero_reset(const geopm_time_s &zero);
+    struct geopm_time_s GEOPM_PUBLIC time_zero(void);
+    struct geopm_time_s GEOPM_PUBLIC time_curr(void);
+    void GEOPM_PUBLIC time_zero_reset(const geopm_time_s &zero);
 }
 #endif
 #endif

--- a/libgeopmd/include/geopm_time.h
+++ b/libgeopmd/include/geopm_time.h
@@ -115,9 +115,12 @@ static inline double geopm_time_since(const struct geopm_time_s *begin)
 }
 namespace geopm
 {
-    struct geopm_time_s GEOPM_PUBLIC time_zero(void);
-    struct geopm_time_s GEOPM_PUBLIC time_curr(void);
-    void GEOPM_PUBLIC time_zero_reset(const geopm_time_s &zero);
+    struct geopm_time_s GEOPM_PUBLIC
+        time_zero(void);
+    struct geopm_time_s GEOPM_PUBLIC
+        time_curr(void);
+    void GEOPM_PUBLIC
+        time_zero_reset(const geopm_time_s &zero);
 }
 #endif
 #endif

--- a/libgeopmd/include/geopm_topo.h
+++ b/libgeopmd/include/geopm_topo.h
@@ -8,6 +8,8 @@
 
 #include <stddef.h>
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -71,33 +73,33 @@ enum geopm_domain_e {
     GEOPM_NUM_DOMAIN = 11,
 };
 
-int __attribute__((visibility("default"))) geopm_topo_num_domain(
+int GEOPM_PUBLIC geopm_topo_num_domain(
     int domain_type);
 
-int __attribute__((visibility("default"))) geopm_topo_domain_idx(
+int GEOPM_PUBLIC geopm_topo_domain_idx(
     int domain_type,
     int cpu_idx);
 
-int __attribute__((visibility("default"))) geopm_topo_num_domain_nested(
+int GEOPM_PUBLIC geopm_topo_num_domain_nested(
     int inner_domain,
     int outer_domain);
 
-int __attribute__((visibility("default"))) geopm_topo_domain_nested(
+int GEOPM_PUBLIC geopm_topo_domain_nested(
     int inner_domain,
     int outer_domain,
     int outer_idx,
     size_t num_domain_nested,
     int *domain_nested);
 
-int __attribute__((visibility("default"))) geopm_topo_domain_name(
+int GEOPM_PUBLIC geopm_topo_domain_name(
     int domain_type,
     size_t domain_name_max,
     char *domain_name);
 
-int __attribute__((visibility("default"))) geopm_topo_domain_type(
+int GEOPM_PUBLIC geopm_topo_domain_type(
     const char *domain_name);
 
-int __attribute__((visibility("default"))) geopm_topo_create_cache(void);
+int GEOPM_PUBLIC geopm_topo_create_cache(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_topo.h
+++ b/libgeopmd/include/geopm_topo.h
@@ -71,27 +71,33 @@ enum geopm_domain_e {
     GEOPM_NUM_DOMAIN = 11,
 };
 
-int geopm_topo_num_domain(int domain_type);
+int __attribute__((visibility("default"))) geopm_topo_num_domain(
+    int domain_type);
 
-int geopm_topo_domain_idx(int domain_type,
-                          int cpu_idx);
+int __attribute__((visibility("default"))) geopm_topo_domain_idx(
+    int domain_type,
+    int cpu_idx);
 
-int geopm_topo_num_domain_nested(int inner_domain,
-                                 int outer_domain);
+int __attribute__((visibility("default"))) geopm_topo_num_domain_nested(
+    int inner_domain,
+    int outer_domain);
 
-int geopm_topo_domain_nested(int inner_domain,
-                             int outer_domain,
-                             int outer_idx,
-                             size_t num_domain_nested,
-                             int *domain_nested);
+int __attribute__((visibility("default"))) geopm_topo_domain_nested(
+    int inner_domain,
+    int outer_domain,
+    int outer_idx,
+    size_t num_domain_nested,
+    int *domain_nested);
 
-int geopm_topo_domain_name(int domain_type,
-                           size_t domain_name_max,
-                           char *domain_name);
+int __attribute__((visibility("default"))) geopm_topo_domain_name(
+    int domain_type,
+    size_t domain_name_max,
+    char *domain_name);
 
-int geopm_topo_domain_type(const char *domain_name);
+int __attribute__((visibility("default"))) geopm_topo_domain_type(
+    const char *domain_name);
 
-int geopm_topo_create_cache(void);
+int __attribute__((visibility("default"))) geopm_topo_create_cache(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_topo.h
+++ b/libgeopmd/include/geopm_topo.h
@@ -73,33 +73,27 @@ enum geopm_domain_e {
     GEOPM_NUM_DOMAIN = 11,
 };
 
-int GEOPM_PUBLIC geopm_topo_num_domain(
-    int domain_type);
+int GEOPM_PUBLIC
+    geopm_topo_num_domain(int domain_type);
 
-int GEOPM_PUBLIC geopm_topo_domain_idx(
-    int domain_type,
-    int cpu_idx);
+int GEOPM_PUBLIC
+    geopm_topo_domain_idx(int domain_type, int cpu_idx);
 
-int GEOPM_PUBLIC geopm_topo_num_domain_nested(
-    int inner_domain,
-    int outer_domain);
+int GEOPM_PUBLIC
+    geopm_topo_num_domain_nested(int inner_domain, int outer_domain);
 
-int GEOPM_PUBLIC geopm_topo_domain_nested(
-    int inner_domain,
-    int outer_domain,
-    int outer_idx,
-    size_t num_domain_nested,
-    int *domain_nested);
+int GEOPM_PUBLIC
+    geopm_topo_domain_nested(int inner_domain, int outer_domain, int outer_idx,
+                             size_t num_domain_nested, int *domain_nested);
 
-int GEOPM_PUBLIC geopm_topo_domain_name(
-    int domain_type,
-    size_t domain_name_max,
-    char *domain_name);
+int GEOPM_PUBLIC
+    geopm_topo_domain_name(int domain_type, size_t domain_name_max, char *domain_name);
 
-int GEOPM_PUBLIC geopm_topo_domain_type(
-    const char *domain_name);
+int GEOPM_PUBLIC
+    geopm_topo_domain_type(const char *domain_name);
 
-int GEOPM_PUBLIC geopm_topo_create_cache(void);
+int GEOPM_PUBLIC
+    geopm_topo_create_cache(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_version.h
+++ b/libgeopmd/include/geopm_version.h
@@ -12,7 +12,8 @@
 extern "C" {
 #endif
 
-const char GEOPM_PUBLIC * geopm_version(void);
+const char GEOPM_PUBLIC *
+    geopm_version(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_version.h
+++ b/libgeopmd/include/geopm_version.h
@@ -6,11 +6,13 @@
 #ifndef GEOPM_VERSION_H_INCLUDE
 #define GEOPM_VERSION_H_INCLUDE
 
+#include "geopm_public.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-const char __attribute__((visibility("default"))) * geopm_version(void);
+const char GEOPM_PUBLIC * geopm_version(void);
 
 #ifdef __cplusplus
 }

--- a/libgeopmd/include/geopm_version.h
+++ b/libgeopmd/include/geopm_version.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-const char *geopm_version(void);
+const char __attribute__((visibility("default"))) * geopm_version(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Adds annotations to export free functions, classes, and structs that are part of our public header interface.
- Adds annotations to hide private member functions that are members of classes in our public header interface.
- Does not hide symbols that are not in public headers. More changes are needed first. If you wish to try that out, run `./configure CXXFLAGS='-fvisibility=hidden <other flags you want>' CFLAGS='-fvisibility=hidden <other flags you want>'` before `make`.
- Relates to #3427