### PR TITLE
Avoid use of auto that causes object copies

### DIFF
--- a/libgeopm/src/DomainNetMap.cpp
+++ b/libgeopm/src/DomainNetMap.cpp
@@ -108,7 +108,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        const auto nnet_properties = nnet_json.object_items();
+        const auto &nnet_properties = nnet_json.object_items();
         const auto signal_it = nnet_properties.find("signal_inputs");
         bool use_signal_it = (signal_it != nnet_properties.end());
         const auto delta_it = nnet_properties.find("delta_inputs");

--- a/libgeopm/src/Environment.cpp
+++ b/libgeopm/src/Environment.cpp
@@ -178,7 +178,7 @@ namespace geopm
                 }
                 auto override_value = json_obj.second.string_value();
                 if (user_defined_names.find(var_name) != user_defined_names.end()) {
-                    auto user_value = name_value_map[var_name];
+                    const auto &user_value = name_value_map[var_name];
                     std::cerr << "Warning: <geopm> User provided environment variable \"" << var_name
                               << "\" with value <"  << user_value << ">"
                               << " has been overridden with value <"  << override_value << ">" << std::endl;

--- a/libgeopmd/src/MSRIOGroup.cpp
+++ b/libgeopmd/src/MSRIOGroup.cpp
@@ -582,10 +582,9 @@ namespace geopm
         std::string msr_name = "MSR::PCNT_RATE";
         auto read_it = signal_hidden.find(msr_name);
         if (read_it != signal_hidden.end()) {
-            auto readings = read_it->second.signals;
             int cnt_domain = read_it->second.domain;
             int num_domain = m_platform_topo.num_domain(cnt_domain);
-            GEOPM_DEBUG_ASSERT(num_domain == (int)readings.size(),
+            GEOPM_DEBUG_ASSERT(num_domain == (int)read_it->second.signals.size(),
                                "size of domain for " + msr_name +
                                " does not match number of signals available.");
             std::vector<std::shared_ptr<Signal> > result(num_domain);

--- a/libgeopmd/src/SSTIOGroup.cpp
+++ b/libgeopmd/src/SSTIOGroup.cpp
@@ -326,8 +326,8 @@ namespace geopm
 
         // For MMIO-based controls, register both a control and a signal.
         for (const auto &kv : sst_control_mmio_info) {
-            auto raw_name = kv.first;
-            auto raw_desc = kv.second;
+            const auto &raw_name = kv.first;
+            const auto &raw_desc = kv.second;
 
             uint32_t control_read_mask = 0;
 
@@ -682,8 +682,8 @@ namespace geopm
         int num_domain = m_topo.num_domain(domain_type);
 
         for (const auto &ff : fields) {
-            auto field_name = ff.first;
-            auto field_desc = ff.second;
+            const auto &field_name = ff.first;
+            const auto &field_desc = ff.second;
             auto request_data = field_desc.request_data;
             auto begin_bit = field_desc.begin_bit;
             auto end_bit = field_desc.end_bit;
@@ -748,8 +748,8 @@ namespace geopm
         int num_domain = m_topo.num_domain(domain_type);
 
         for (const auto &ff : fields) {
-            auto field_name = ff.first;
-            auto field_description = ff.second;
+            const auto &field_name = ff.first;
+            const auto &field_description = ff.second;
             auto write_data = field_description.write_data;
             auto begin_bit = field_description.begin_bit;
             auto end_bit = field_description.end_bit;
@@ -793,8 +793,8 @@ namespace geopm
         int num_domain = m_topo.num_domain(domain_type);
 
         for (const auto &ff : fields) {
-            auto field_name = ff.first;
-            auto field_desc = ff.second;
+            const auto &field_name = ff.first;
+            const auto &field_desc = ff.second;
             auto write_value = field_desc.write_value;
             auto begin_bit = field_desc.begin_bit;
             auto end_bit = field_desc.end_bit;
@@ -863,8 +863,8 @@ namespace geopm
         int num_domain = m_topo.num_domain(domain_type);
 
         for (const auto &ff : fields) {
-            auto field_name = ff.first;
-            auto field_desc = ff.second;
+            const auto &field_name = ff.first;
+            const auto &field_desc = ff.second;
             auto begin_bit = field_desc.begin_bit;
             auto end_bit = field_desc.end_bit;
             auto description = field_desc.description;

--- a/libgeopmd/src/SaveControl.cpp
+++ b/libgeopmd/src/SaveControl.cpp
@@ -104,7 +104,7 @@ namespace geopm
                 throw Exception("SaveControlImp::settings(): Expected a JSON object, unable to parse",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
-            auto jss_map = jss.object_items();
+            const auto &jss_map = jss.object_items();
             std::vector<std::string> required_keys = {"name",
                                                       "domain_type",
                                                       "domain_idx",


### PR DESCRIPTION
- Resolves several issues found by static analysis where auto was being used in a way that resulted in copies of non-primitive data types.
- Resolution: use const references instead of copies.
- One instance in MSRIOGroup was only needed in debug-only code, so the reference was moved inside the debug-only section.