### PR TITLE
Use the gen-src directory as a order-only prerequisite

### DIFF
--- a/libgeopmd/Makefile.am
+++ b/libgeopmd/Makefile.am
@@ -325,14 +325,14 @@ endif
 $(gen_src_dir):
 	$(MKDIR_P) $@
 
-$(msr_cpp_files): $(gen_src_dir)/%.cpp: $(top_srcdir)/json_data/%.json $(gen_src_dir) $(top_srcdir)/src/json_data.cpp.in
+$(msr_cpp_files): $(gen_src_dir)/%.cpp: $(top_srcdir)/json_data/%.json $(top_srcdir)/src/json_data.cpp.in | $(gen_src_dir)
 	sed -e '/@JSON_CONTENTS@/ {' \
 	    -e "r $<" \
 	    -e 'd' -e '}' \
 	    -e "s/@JSON_IDENTIFIER@/$(lastword $(subst _, ,$*))_msr_json/g" \
 	$(top_srcdir)/src/json_data.cpp.in > $@
 
-$(sysfs_cpp_files): $(gen_src_dir)/%.cpp: $(top_srcdir)/json_data/%.json $(gen_src_dir) $(top_srcdir)/src/json_data.cpp.in
+$(sysfs_cpp_files): $(gen_src_dir)/%.cpp: $(top_srcdir)/json_data/%.json $(top_srcdir)/src/json_data.cpp.in | $(gen_src_dir)
 	sed -e '/@JSON_CONTENTS@/ {' \
 	    -e "r $<" \
 	    -e 'd' -e '}' \


### PR DESCRIPTION
- Fixes #3455
- Avoids unnecessary rebuilds of files in gen-src