### PR TITLE
Specify the exact sized integer types in structures for inter-process memory sharing

### DIFF
--- a/libgeopm/src/ApplicationRecordLog.hpp
+++ b/libgeopm/src/ApplicationRecordLog.hpp
@@ -195,8 +195,8 @@ namespace geopm
                 int32_t num_region;
                 short_region_s region_table[M_MAX_REGION];
             };
-            static_assert(sizeof(m_layout_s) == M_LAYOUT_SIZE,
-                          "Defined layout size does not match the actual layout size ");
+            static_assert(sizeof(m_layout_s) <= M_LAYOUT_SIZE,
+                          "Layout size used in geopmdpy/system_files.py to create shared memory footprint is smaller than required by C++ code");
 
             struct m_region_enter_s {
                 int record_idx;

--- a/libgeopm/src/ApplicationRecordLog.hpp
+++ b/libgeopm/src/ApplicationRecordLog.hpp
@@ -190,9 +190,9 @@ namespace geopm
             void overhead(const geopm_time_s &time, double overhead_sec) override;
         private:
             struct m_layout_s {
-                int num_record;
+                int32_t num_record;
                 record_s record_table[M_MAX_RECORD];
-                int num_region;
+                int32_t num_region;
                 short_region_s region_table[M_MAX_REGION];
             };
             static_assert(sizeof(m_layout_s) == M_LAYOUT_SIZE,

--- a/libgeopm/src/record.hpp
+++ b/libgeopm/src/record.hpp
@@ -62,16 +62,16 @@ namespace geopm
         /// @brief System time when event was recorded.
         geopm_time_s time;
         /// @brief The process identifier where event occurred.
-        int process;
+        int32_t process;
         /// @brief One of the m_event_e event types.
-        int event;
+        int32_t event;
         /// @brief The signal associated with the event type.
         uint64_t signal;
     };
 
     struct short_region_s {
         uint64_t hash;
-        int num_complete;
+        int32_t num_complete;
         double total_time;
     };
 }


### PR DESCRIPTION
- Fix for broken build for armv7l arch
- Existing static assert is not required for correct behavior