### PR TITLE
Locate new man pages in spec file

### DIFF
--- a/docs/debian/geopm-runtime-docs.manpages
+++ b/docs/debian/geopm-runtime-docs.manpages
@@ -1,6 +1,7 @@
 build/man/geopmadmin.1
 build/man/geopmagent.1
 build/man/geopmctl.1
+build/man/geopm_agent_ffnet.7
 build/man/geopm_agent_frequency_map.7
 build/man/geopm_agent_monitor.7
 build/man/geopm_agent_power_balancer.7

--- a/docs/debian/libgeopm-docs.manpages
+++ b/docs/debian/libgeopm-docs.manpages
@@ -1,4 +1,5 @@
 build/man/geopm::Agent.3
+build/man/geopm::CPUActivityAgent.3
 build/man/geopm::PowerBalancer.3
 build/man/geopm::PowerGovernor.3
 build/man/geopm_agent.3

--- a/docs/geopm-doc.spec.in
+++ b/docs/geopm-doc.spec.in
@@ -98,6 +98,7 @@ Man pages for python3-geopmpy package
 %doc %{_mandir}/man1/geopmadmin.1.gz
 %doc %{_mandir}/man1/geopmagent.1.gz
 %doc %{_mandir}/man1/geopmctl.1.gz
+%doc %{_mandir}/man7/geopm_agent_ffnet.7.gz
 %doc %{_mandir}/man7/geopm_agent_frequency_map.7.gz
 %doc %{_mandir}/man7/geopm_agent_monitor.7.gz
 %doc %{_mandir}/man7/geopm_agent_power_balancer.7.gz
@@ -152,6 +153,7 @@ Man pages for python3-geopmpy package
 
 %files -n libgeopm-doc
 %doc %{_mandir}/man3/geopm::Agent.3.gz
+%doc %{_mandir}/man3/geopm::CPUActivityAgent.3.gz
 %doc %{_mandir}/man3/geopm::PowerBalancer.3.gz
 %doc %{_mandir}/man3/geopm::PowerGovernor.3.gz
 %doc %{_mandir}/man3/geopm_agent.3.gz


### PR DESCRIPTION
Fixes change introduced here:

https://github.com/geopm/geopm/pull/3462/files#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698R214-R215
