### PR TITLE
Add explicit dependency of the geopm-service rpm on python3-geopmdpy and support for fedora packaging

### DIFF
--- a/docs/geopm-doc.spec.in
+++ b/docs/geopm-doc.spec.in
@@ -131,8 +131,8 @@ Man pages for python3-geopmpy package
 %doc %{_mandir}/man7/geopm_pio_sysfs.7.gz
 %doc %{_mandir}/man7/geopm_pio_time.7.gz
 %doc %{_mandir}/man7/geopm_report.7.gz
-%{completionsdir}/geopmread
-%{completionsdir}/geopmwrite
+%doc %{completionsdir}/geopmread
+%doc %{completionsdir}/geopmwrite
 
 %files -n libgeopmd-doc
 %doc %{_mandir}/man3/geopm::Agg.3.gz
@@ -177,4 +177,4 @@ Man pages for python3-geopmpy package
 %files -n python3-geopmpy-doc
 %doc %{_mandir}/man1/geopmlaunch.1.gz
 %doc %{_mandir}/man7/geopmpy.7.gz
-%{completionsdir}/geopmlaunch
+%doc %{completionsdir}/geopmlaunch

--- a/docs/geopm-doc.spec.in
+++ b/docs/geopm-doc.spec.in
@@ -94,7 +94,9 @@ Man pages for python3-geopmpy package
 
 %install
 %{__make} DESTDIR=%{buildroot} prefix=%{_prefix} datarootdir=%{_datarootdir} mandir=%{_mandir} install_man
+%if 0%{?fedora} <= 40
 %{__make} DESTDIR=%{buildroot} prefix=%{_prefix} datarootdir=%{_datarootdir} mandir=%{_mandir} completionsdir=%{completionsdir} install_completion
+%endif
 
 %clean
 
@@ -131,8 +133,10 @@ Man pages for python3-geopmpy package
 %doc %{_mandir}/man7/geopm_pio_sysfs.7.gz
 %doc %{_mandir}/man7/geopm_pio_time.7.gz
 %doc %{_mandir}/man7/geopm_report.7.gz
+%if 0%{?fedora} <= 40
 %doc %{completionsdir}/geopmread
 %doc %{completionsdir}/geopmwrite
+%endif
 
 %files -n libgeopmd-doc
 %doc %{_mandir}/man3/geopm::Agg.3.gz
@@ -177,4 +181,6 @@ Man pages for python3-geopmpy package
 %files -n python3-geopmpy-doc
 %doc %{_mandir}/man1/geopmlaunch.1.gz
 %doc %{_mandir}/man7/geopmpy.7.gz
+%if 0%{?fedora} <= 40
 %doc %{completionsdir}/geopmlaunch
+%endif

--- a/docs/geopm-doc.spec.in
+++ b/docs/geopm-doc.spec.in
@@ -42,6 +42,10 @@ BuildRequires: bash-completion-devel
 %else
 BuildRequires: bash-completion
 %endif
+%if 0%{?fedora}
+BuildRequires: marshalparser
+%global debug_package %{nil}
+%endif
 
 %define completionsdir %(pkg-config --variable=completionsdir bash-completion)
 %if "x%{?completionsdir}" == "x"

--- a/geopmdpy/geopmdpy.spec.in
+++ b/geopmdpy/geopmdpy.spec.in
@@ -20,8 +20,12 @@ Source0: @ARCHIVE@
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
-
 BuildRequires: python-rpm-macros
+%if 0%{?fedora}
+BuildRequires: marshalparser
+%global debug_package %{nil}
+%endif
+
 
 %define python_bin %{__python3}
 

--- a/geopmpy/geopmpy.spec.in
+++ b/geopmpy/geopmpy.spec.in
@@ -34,6 +34,10 @@ Requires: python3-tables>=3.7.0
 Requires: python3-geopmdpy
 Requires: libgeopm2 = %{version}
 Recommends: python3-geopmpy-doc
+%if 0%{?fedora}
+BuildRequires: marshalparser
+%global debug_package %{nil}
+%endif
 
 %{?python_provide:%python_provide python3-geopmpy}
 

--- a/libgeopm/geopm-runtime.spec.in
+++ b/libgeopm/geopm-runtime.spec.in
@@ -59,7 +59,7 @@ Development package for GEOPM.
 
 %package -n libgeopm2
 Summary: Provides libgeopm shared object library
-%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rocky_ver} || 0%{?fedora}
 # Deprecated for RHEL and CentOS
 Group: System Environment/Libraries
 %else

--- a/libgeopmd/geopm-service.spec.in
+++ b/libgeopmd/geopm-service.spec.in
@@ -46,6 +46,7 @@ Requires: level-zero >= 1.8.1
 BuildRequires: fdupes
 %endif
 BuildRequires: systemd-rpm-macros
+Requires: python3-geopmdpy
 Recommends: geopm-service-doc
 
 %if %{defined suse_version}

--- a/libgeopmd/geopm-service.spec.in
+++ b/libgeopmd/geopm-service.spec.in
@@ -130,10 +130,14 @@ library which provides C and C++ interfaces.
 %define level_zero_option --enable-levelzero
 %endif
 %endif
+%if 0%{?fedora} != 0 && ! 0%{?fedora} <= 40
+# Our use of relro flag causes a configure test to fail on fedora rawhide
+%define relro_flags LDFLAGS=-Wl,-z,norelro
+%endif
 
 ./autogen.sh
 unset CFLAGS CXXFLAGS
-CC=gcc CXX=g++ \
+CC=gcc CXX=g++ %{?relro_flags} \
 ./configure --prefix=%{_prefix} --libdir=%{_libdir} --libexecdir=%{_libexecdir} \
             --includedir=%{_includedir} --sbindir=%{_sbindir} \
             --mandir=%{_mandir} --docdir=%{docdir} \

--- a/libgeopmd/geopm-service.spec.in
+++ b/libgeopmd/geopm-service.spec.in
@@ -21,7 +21,7 @@ Name: geopm-service
 Version: @VERSION@
 Release: 1
 License: BSD-3-Clause
-%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver} || 0%{?fedora}
 # Deprecated for RHEL and CentOS
 Group: System Environment/Daemons
 %else
@@ -71,7 +71,7 @@ is installed with this package.
 %package devel
 
 Summary: Global Extensible Open Power Manager Service - development
-%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver} || 0%{?fedora}
 # Deprecated for RHEL and CentOS
 Group: Development/Libraries
 %else
@@ -89,7 +89,7 @@ libgeopmd.so shared object symbolic link.
 %package -n libgeopmd2
 
 Summary: Provides libgeopmd shared object library
-%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}  || 0%{?fedora}
 # Deprecated for RHEL and CentOS
 Group: System Environment/Libraries
 %else
@@ -165,21 +165,21 @@ ln -s -r %{buildroot}%{_sbindir}/service %{buildroot}%{_sbindir}/rcgeopm
 %endif
 
 %post -n geopm-service
-%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver} || 0%{?fedora}
 %systemd_post geopm.service
 %else
 %service_add_post geopm.service
 %endif
 
 %preun -n geopm-service
-%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver} || 0%{?fedora}
 %systemd_preun geopm.service
 %else
 %service_del_preun geopm.service
 %endif
 
 %postun -n geopm-service
-%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver}
+%if 0%{?rhel_version} || 0%{?centos_ver} || 0%{?rocky_ver} || 0%{?fedora}
 %systemd_postun_with_restart geopm.service
 %else
 %service_del_postun geopm.service

--- a/libgeopmd/geopm-service.spec.in
+++ b/libgeopmd/geopm-service.spec.in
@@ -46,7 +46,6 @@ Requires: level-zero >= 1.8.1
 BuildRequires: fdupes
 %endif
 BuildRequires: systemd-rpm-macros
-Requires: python3-geopmdpy
 Recommends: geopm-service-doc
 
 %if %{defined suse_version}
@@ -56,6 +55,7 @@ Recommends: geopm-service-doc
 %endif
 
 Requires: libgeopmd2 = %{version}
+Requires: python3-geopmdpy = %{version}
 
 %description
 


### PR DESCRIPTION
- Without this change an install of the geopm-service will result in the service unit to be restarted until the limit for restarts is reached.
- Fixes #3500
- Adds support for Fedora 40 to spec file
- Fixes for spelling errors