### PR TITLE
Fedora packaging changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ changes in each release.
 * [integration](integration) contains integration test automation for GEOPM
 * [libgeopm](libgeopm) provides the C/C++ implementation of the GEOPM Runtime Service
 * [libgeopmd](libgeopmd) provides the C/C++ implementation of the GEOPM Access Service
-
+* [release](release) packaging files for latest release by distro
 ## Guide for Contributors
 We appreciate all feedback on our project. See our [contributing
 guide](https://geopm.github.io/contrib.html) for guidelines on

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -106,4 +106,4 @@ install_html:
 	cp -rp json_schemas/* $(GEOPM_GITHUB_IO)
 	VERSION=`cat VERSION` && cd $(GEOPM_GITHUB_IO) && git add -A && git commit -sm"Update to version $$VERSION"
 
-.PHONY: all man html geopmlint clean_all DATE VERSION MANIFEST dist install_man install_completion install_html json_schemas json_schemas/active_sessions.schema.json json_schemas/const_config_io.schema.json
+.PHONY: all man html geopmlint clean_all DATE MANIFEST dist install_man install_completion install_html json_schemas json_schemas/active_sessions.schema.json json_schemas/const_config_io.schema.json

--- a/docs/source/devel.rst
+++ b/docs/source/devel.rst
@@ -45,6 +45,7 @@ options and environment variables are listed below:
 * ``--prefix``: Path prefix for install artifacts
 * ``--enable-debug``: Enable verbose error and warning messaging while disabling optimization.
 * ``--enable-coverage``: Enable coverage report generation with gcov
+* ``--disable-build-gtest``: Use system install of gtest and gmock, do not download or build (version >=1.12.1 required)
 * ``--enable-beta``: Enable beta features, which remain in beta until their
   interfaces are considered finalized and stable for future releases.
 * ``export CC=``: Set the C compiler with environment variable

--- a/geopmdpy/setup.py
+++ b/geopmdpy/setup.py
@@ -4,6 +4,7 @@
 
 import os
 import setuptools
+import os
 
 package_name = 'geopmdpy'
 
@@ -14,7 +15,9 @@ try:
     with open(f'{script_dir}/{package_name}/VERSION', 'w') as fid:
         fid.write(version)
 except (ImportError, LookupError):
-    pass
+    with open(f'{script_dir}/{package_name}/VERSION', 'r') as fid:
+        version = fid.read().strip()
+    os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = version
 
 setuptools.setup()
 

--- a/geopmdpy/test/TestActiveSessions.py
+++ b/geopmdpy/test/TestActiveSessions.py
@@ -202,7 +202,7 @@ class TestActiveSessions(unittest.TestCase):
             mock_srf.assert_called_once_with(full_file_path)
 
             if is_valid:
-                mock_get_session_path.called_once_with(contents['client_pid'])
+                mock_get_session_path.assert_has_calls([mock.call('*'), mock.call(contents['client_pid'])])
                 mock_os_stat.assert_called_once_with(full_file_path)
                 mock_pid_valid.assert_called_once_with(contents['client_pid'], session_mock.st_ctime)
                 mock_smf.assert_called_once_with(full_file_path, string_contents)

--- a/geopmpy/setup.py
+++ b/geopmpy/setup.py
@@ -4,6 +4,7 @@
 
 import os
 import setuptools
+import os
 
 package_name = 'geopmpy'
 
@@ -14,7 +15,9 @@ try:
     with open(f'{script_dir}/{package_name}/VERSION', 'w') as fid:
         fid.write(version)
 except (ImportError, LookupError):
-    pass
+    with open(f'{script_dir}/{package_name}/VERSION', 'r') as fid:
+        version = fid.read().strip()
+    os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = version
 
 setuptools.setup()
 

--- a/libgeopm/Makefile.am
+++ b/libgeopm/Makefile.am
@@ -32,7 +32,6 @@ nodist_include_HEADERS =
 EXTRA_DIST =
 
 install-exec-hook: install-fortran
-dist: dist-googletest
 
 
 include_HEADERS = include/geopm_agent.h \
@@ -394,7 +393,6 @@ DISTCLEANFILES = VERSION MANIFEST
 
 CLEAN_LOCAL_TARGETS= clean-local-coverage \
                      clean-local-fortran \
-                     clean-local-googletest \
                      # end
 
 clean-local: $(CLEAN_LOCAL_TARGETS)

--- a/libgeopm/configure.ac
+++ b/libgeopm/configure.ac
@@ -76,6 +76,18 @@ fi
 AC_SUBST([enable_beta])
 AM_CONDITIONAL([ENABLE_BETA], [test "x$enable_beta" = "x1"])
 
+AC_ARG_ENABLE([build-gtest],
+  [AS_HELP_STRING([--disable-build-gtest], [Do not download and build google test and google mock, system install required])],
+[if test "x$enable_build_gtest" = "xno" ; then
+  enable_build_gtest="0"
+else
+  enable_build_gtest="1"
+fi
+],
+[enable_build_gtest="1"]
+)
+AC_SUBST([enable_build_gtest])
+AM_CONDITIONAL([BUILD_GTEST], [test "x$enable_build_gtest" = "x1"])
 
 AC_ARG_WITH([sqlite3], [AS_HELP_STRING([--with-sqlite3=PATH],
             [specify directory for installed sqlite3 package.])])
@@ -624,6 +636,7 @@ AC_MSG_RESULT([GEOPM_CONFIG_PATH  : ${GEOPM_CONFIG_PATH}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([debug              : ${enable_debug}])
 AC_MSG_RESULT([coverage           : ${enable_coverage}])
+AC_MSG_RESULT([build_gtest        : ${enable_build_gtest}])
 AC_MSG_RESULT([overhead           : ${enable_overhead}])
 AC_MSG_RESULT([mpi                : ${enable_mpi}])
 AC_MSG_RESULT([openmp             : ${enable_openmp}])

--- a/libgeopm/test/Makefile.mk
+++ b/libgeopm/test/Makefile.mk
@@ -168,10 +168,7 @@ test_geopm_test_SOURCES += src/Profile.cpp \
                            include/geopm/Profile.hpp \
                            # endif
 
-test_geopm_test_LDADD = libgeopm.la \
-                        libgmock.a \
-                        libgtest.a \
-                        # end
+test_geopm_test_LDADD = libgeopm.la
 
 test_geopm_test_CPPFLAGS = $(AM_CPPFLAGS) -Iplugin
 test_geopm_test_CFLAGS = $(AM_CFLAGS)
@@ -209,4 +206,13 @@ coverage: init-coverage check
 	lcov --remove coverage-base-combined.info "$$(realpath $$(pwd))/src/geopm_pmpi_fortran.c" --output-file coverage-base-combined-filtered.info
 	genhtml coverage-base-combined-filtered.info --output-directory coverage-base --legend -t $(VERSION) -f
 
+if BUILD_GTEST
 include test/googletest.mk
+test_geopm_test_LDADD += libgtest.a \
+                         libgmock.a \
+                         # end
+else
+test_geopm_test_LDADD += -lgmock \
+                         -lgtest \
+                         # end
+endif

--- a/libgeopmd/Makefile.am
+++ b/libgeopmd/Makefile.am
@@ -49,7 +49,6 @@ geopminclude_HEADERS = include/geopm/json11.hpp \
                        # end
 
 install-exec-hook: install-plugin-dir
-dist: dist-googletest
 
 install-plugin-dir:
 	$(INSTALL) -d $(DESTDIR)/$(libdir)/geopm
@@ -257,8 +256,7 @@ libgeopmd_la_SOURCES = $(include_HEADERS) \
                        src/geopm_version.cpp \
                        # end
 
-nodist_libgeopmd_la_SOURCES = \
-                              $(msr_cpp_files) \
+nodist_libgeopmd_la_SOURCES = $(msr_cpp_files) \
                               $(sysfs_cpp_files) \
                               # end
 
@@ -394,6 +392,8 @@ CLEANFILES = $(msr_cpp_files) $(sysfs_cpp_files)
 
 include test/Makefile.mk
 
+if ENABLE_FUZZTESTS
 include fuzz_test/Makefile.mk
+endif
 
 .PHONY: $(PHONY_TARGETS)

--- a/libgeopmd/configure.ac
+++ b/libgeopmd/configure.ac
@@ -242,6 +242,19 @@ else
   AM_CFLAGS="$AM_CFLAGS $SANITIZE_CFI"
 fi
 
+AC_ARG_ENABLE([build-gtest],
+  [AS_HELP_STRING([--disable-build-gtest], [Do not download and build google test and google mock, system install required])],
+[if test "x$enable_build_gtest" = "xno" ; then
+  enable_build_gtest="0"
+else
+  enable_build_gtest="1"
+fi
+],
+[enable_build_gtest="1"]
+)
+AC_SUBST([enable_build_gtest])
+AM_CONDITIONAL([BUILD_GTEST], [test "x$enable_build_gtest" = "x1"])
+
 AC_SUBST([enable_asan])
 AM_CONDITIONAL([ENABLE_SANITIZERS], [test "x$enable_asan" = "x1"])
 
@@ -539,6 +552,7 @@ AC_MSG_RESULT([GEOPM_CONFIG_PATH  : ${GEOPM_CONFIG_PATH}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([debug              : ${enable_debug}])
 AC_MSG_RESULT([coverage           : ${enable_coverage}])
+AC_MSG_RESULT([build_gtest        : ${enable_build_gtest}])
 AC_MSG_RESULT([dcgm               : ${enable_dcgm}])
 AC_MSG_RESULT([nvml               : ${enable_nvml}])
 AC_MSG_RESULT([levelzero          : ${enable_levelzero}])

--- a/libgeopmd/test/Makefile.mk
+++ b/libgeopmd/test/Makefile.mk
@@ -98,10 +98,18 @@ test_geopm_test_SOURCES = test/GPUTopoNullTest.cpp \
                           test/UniqueFdTest.cpp \
                           # end
 
-test_geopm_test_LDADD = libgeopmd.la \
-                        libgmock.a \
-                        libgtest.a \
-                        # end
+test_geopm_test_LDADD = libgeopmd.la
+
+if BUILD_GTEST
+include test/googletest.mk
+test_geopm_test_LDADD += libgtest.a \
+                         libgmock.a \
+                         # end
+else
+test_geopm_test_LDADD += -lgmock \
+                         -lgtest \
+                         # end
+endif
 
 test_geopm_test_CPPFLAGS = $(AM_CPPFLAGS) -Iplugin
 test_geopm_test_CFLAGS = $(AM_CFLAGS)
@@ -119,4 +127,3 @@ coverage: init-coverage check
 	lcov -a coverage-service-initial.info -a coverage-service.info --output-file coverage-service-combined.info
 	genhtml coverage-service-combined.info --output-directory coverage-service --legend -t $(VERSION) -f
 
-include test/googletest.mk

--- a/libgeopmd/test/googletest.mk
+++ b/libgeopmd/test/googletest.mk
@@ -2,6 +2,9 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 
+CLEAN_LOCAL_TARGETS += clean-local-googletest
+dist: dist-googletest
+
 AM_CPPFLAGS += -I$(googletest)/include
 AM_CPPFLAGS += -I$(googlemock)/include
 BUILT_SOURCES += $(googletest_suite)/VERSION

--- a/release/fedora/0001-Changes-required-for-building-from-git-archive.patch
+++ b/release/fedora/0001-Changes-required-for-building-from-git-archive.patch
@@ -1,0 +1,270 @@
+From 91d20b03954f41c05076e11b0d8feafafdc9abe1 Mon Sep 17 00:00:00 2001
+From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
+Date: Mon, 24 Jun 2024 09:34:51 -0700
+Subject: [PATCH 1/2] Changes required for building from git archive
+
+- Provide options to avoid other downloads
+
+Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
+---
+ docs/Makefile                |  2 +-
+ geopmdpy/setup.py            |  5 ++++-
+ geopmpy/setup.py             |  5 ++++-
+ libgeopm/Makefile.am         |  2 --
+ libgeopm/configure.ac        | 13 +++++++++++++
+ libgeopm/test/Makefile.mk    | 14 ++++++++++----
+ libgeopmd/Makefile.am        |  6 +++---
+ libgeopmd/configure.ac       | 14 ++++++++++++++
+ libgeopmd/test/Makefile.mk   | 17 ++++++++++++-----
+ libgeopmd/test/googletest.mk |  3 +++
+ 10 files changed, 64 insertions(+), 17 deletions(-)
+
+diff --git a/docs/Makefile b/docs/Makefile
+index 6616a4312..2b1cba8e8 100644
+--- a/docs/Makefile
++++ b/docs/Makefile
+@@ -106,4 +106,4 @@ install_html:
+ 	cp -rp json_schemas/* $(GEOPM_GITHUB_IO)
+ 	VERSION=`cat VERSION` && cd $(GEOPM_GITHUB_IO) && git add -A && git commit -sm"Update to version $$VERSION"
+ 
+-.PHONY: all man html geopmlint clean_all DATE VERSION MANIFEST dist install_man install_completion install_html json_schemas json_schemas/active_sessions.schema.json json_schemas/const_config_io.schema.json
++.PHONY: all man html geopmlint clean_all DATE MANIFEST dist install_man install_completion install_html json_schemas json_schemas/active_sessions.schema.json json_schemas/const_config_io.schema.json
+diff --git a/geopmdpy/setup.py b/geopmdpy/setup.py
+index b3938baec..e2e090e52 100644
+--- a/geopmdpy/setup.py
++++ b/geopmdpy/setup.py
+@@ -4,6 +4,7 @@
+ 
+ import os
+ import setuptools
++import os
+ 
+ package_name = 'geopmdpy'
+ 
+@@ -14,7 +15,9 @@ try:
+     with open(f'{script_dir}/{package_name}/VERSION', 'w') as fid:
+         fid.write(version)
+ except (ImportError, LookupError):
+-    pass
++    with open(f'{script_dir}/{package_name}/VERSION', 'r') as fid:
++        version = fid.read().strip()
++    os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = version
+ 
+ setuptools.setup()
+ 
+diff --git a/geopmpy/setup.py b/geopmpy/setup.py
+index e07303374..719ab1405 100644
+--- a/geopmpy/setup.py
++++ b/geopmpy/setup.py
+@@ -4,6 +4,7 @@
+ 
+ import os
+ import setuptools
++import os
+ 
+ package_name = 'geopmpy'
+ 
+@@ -14,7 +15,9 @@ try:
+     with open(f'{script_dir}/{package_name}/VERSION', 'w') as fid:
+         fid.write(version)
+ except (ImportError, LookupError):
+-    pass
++    with open(f'{script_dir}/{package_name}/VERSION', 'r') as fid:
++        version = fid.read().strip()
++    os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = version
+ 
+ setuptools.setup()
+ 
+diff --git a/libgeopm/Makefile.am b/libgeopm/Makefile.am
+index 0a27cef9d..3d6cdf0f8 100644
+--- a/libgeopm/Makefile.am
++++ b/libgeopm/Makefile.am
+@@ -32,7 +32,6 @@ nodist_include_HEADERS =
+ EXTRA_DIST =
+ 
+ install-exec-hook: install-fortran
+-dist: dist-googletest
+ 
+ 
+ include_HEADERS = include/geopm_agent.h \
+@@ -394,7 +393,6 @@ DISTCLEANFILES = VERSION MANIFEST
+ 
+ CLEAN_LOCAL_TARGETS= clean-local-coverage \
+                      clean-local-fortran \
+-                     clean-local-googletest \
+                      # end
+ 
+ clean-local: $(CLEAN_LOCAL_TARGETS)
+diff --git a/libgeopm/configure.ac b/libgeopm/configure.ac
+index 7d7393e24..a6dd98c29 100644
+--- a/libgeopm/configure.ac
++++ b/libgeopm/configure.ac
+@@ -76,6 +76,18 @@ fi
+ AC_SUBST([enable_beta])
+ AM_CONDITIONAL([ENABLE_BETA], [test "x$enable_beta" = "x1"])
+ 
++AC_ARG_ENABLE([build-gtest],
++  [AS_HELP_STRING([--disable-build-gtest], [Do not download and build google test and google mock, system install required])],
++[if test "x$enable_build_gtest" = "xno" ; then
++  enable_build_gtest="0"
++else
++  enable_build_gtest="1"
++fi
++],
++[enable_build_gtest="1"]
++)
++AC_SUBST([enable_build_gtest])
++AM_CONDITIONAL([BUILD_GTEST], [test "x$enable_build_gtest" = "x1"])
+ 
+ AC_ARG_WITH([sqlite3], [AS_HELP_STRING([--with-sqlite3=PATH],
+             [specify directory for installed sqlite3 package.])])
+@@ -624,6 +636,7 @@ AC_MSG_RESULT([GEOPM_CONFIG_PATH  : ${GEOPM_CONFIG_PATH}])
+ AC_MSG_RESULT([])
+ AC_MSG_RESULT([debug              : ${enable_debug}])
+ AC_MSG_RESULT([coverage           : ${enable_coverage}])
++AC_MSG_RESULT([build_gtest        : ${enable_build_gtest}])
+ AC_MSG_RESULT([overhead           : ${enable_overhead}])
+ AC_MSG_RESULT([mpi                : ${enable_mpi}])
+ AC_MSG_RESULT([openmp             : ${enable_openmp}])
+diff --git a/libgeopm/test/Makefile.mk b/libgeopm/test/Makefile.mk
+index 5058c3e44..d32e3cff4 100644
+--- a/libgeopm/test/Makefile.mk
++++ b/libgeopm/test/Makefile.mk
+@@ -168,10 +168,7 @@ test_geopm_test_SOURCES += src/Profile.cpp \
+                            include/geopm/Profile.hpp \
+                            # endif
+ 
+-test_geopm_test_LDADD = libgeopm.la \
+-                        libgmock.a \
+-                        libgtest.a \
+-                        # end
++test_geopm_test_LDADD = libgeopm.la
+ 
+ test_geopm_test_CPPFLAGS = $(AM_CPPFLAGS) -Iplugin
+ test_geopm_test_CFLAGS = $(AM_CFLAGS)
+@@ -209,4 +206,13 @@ coverage: init-coverage check
+ 	lcov --remove coverage-base-combined.info "$$(realpath $$(pwd))/src/geopm_pmpi_fortran.c" --output-file coverage-base-combined-filtered.info
+ 	genhtml coverage-base-combined-filtered.info --output-directory coverage-base --legend -t $(VERSION) -f
+ 
++if BUILD_GTEST
+ include test/googletest.mk
++test_geopm_test_LDADD += libgtest.a \
++                         libgmock.a \
++                         # end
++else
++test_geopm_test_LDADD += -lgmock \
++                         -lgtest \
++                         # end
++endif
+diff --git a/libgeopmd/Makefile.am b/libgeopmd/Makefile.am
+index 6e40c48b2..979e97723 100644
+--- a/libgeopmd/Makefile.am
++++ b/libgeopmd/Makefile.am
+@@ -49,7 +49,6 @@ geopminclude_HEADERS = include/geopm/json11.hpp \
+                        # end
+ 
+ install-exec-hook: install-plugin-dir
+-dist: dist-googletest
+ 
+ install-plugin-dir:
+ 	$(INSTALL) -d $(DESTDIR)/$(libdir)/geopm
+@@ -257,8 +256,7 @@ libgeopmd_la_SOURCES = $(include_HEADERS) \
+                        src/geopm_version.cpp \
+                        # end
+ 
+-nodist_libgeopmd_la_SOURCES = \
+-                              $(msr_cpp_files) \
++nodist_libgeopmd_la_SOURCES = $(msr_cpp_files) \
+                               $(sysfs_cpp_files) \
+                               # end
+ 
+@@ -394,6 +392,8 @@ CLEANFILES = $(msr_cpp_files) $(sysfs_cpp_files)
+ 
+ include test/Makefile.mk
+ 
++if ENABLE_FUZZTESTS
+ include fuzz_test/Makefile.mk
++endif
+ 
+ .PHONY: $(PHONY_TARGETS)
+diff --git a/libgeopmd/configure.ac b/libgeopmd/configure.ac
+index 80e4d8abf..905ac1d67 100644
+--- a/libgeopmd/configure.ac
++++ b/libgeopmd/configure.ac
+@@ -242,6 +242,19 @@ else
+   AM_CFLAGS="$AM_CFLAGS $SANITIZE_CFI"
+ fi
+ 
++AC_ARG_ENABLE([build-gtest],
++  [AS_HELP_STRING([--disable-build-gtest], [Do not download and build google test and google mock, system install required])],
++[if test "x$enable_build_gtest" = "xno" ; then
++  enable_build_gtest="0"
++else
++  enable_build_gtest="1"
++fi
++],
++[enable_build_gtest="1"]
++)
++AC_SUBST([enable_build_gtest])
++AM_CONDITIONAL([BUILD_GTEST], [test "x$enable_build_gtest" = "x1"])
++
+ AC_SUBST([enable_asan])
+ AM_CONDITIONAL([ENABLE_SANITIZERS], [test "x$enable_asan" = "x1"])
+ 
+@@ -536,6 +549,7 @@ AC_MSG_RESULT([GEOPM_CONFIG_PATH  : ${GEOPM_CONFIG_PATH}])
+ AC_MSG_RESULT([])
+ AC_MSG_RESULT([debug              : ${enable_debug}])
+ AC_MSG_RESULT([coverage           : ${enable_coverage}])
++AC_MSG_RESULT([build_gtest        : ${enable_build_gtest}])
+ AC_MSG_RESULT([dcgm               : ${enable_dcgm}])
+ AC_MSG_RESULT([nvml               : ${enable_nvml}])
+ AC_MSG_RESULT([levelzero          : ${enable_levelzero}])
+diff --git a/libgeopmd/test/Makefile.mk b/libgeopmd/test/Makefile.mk
+index 06597860d..7256e9c8d 100644
+--- a/libgeopmd/test/Makefile.mk
++++ b/libgeopmd/test/Makefile.mk
+@@ -98,10 +98,18 @@ test_geopm_test_SOURCES = test/GPUTopoNullTest.cpp \
+                           test/UniqueFdTest.cpp \
+                           # end
+ 
+-test_geopm_test_LDADD = libgeopmd.la \
+-                        libgmock.a \
+-                        libgtest.a \
+-                        # end
++test_geopm_test_LDADD = libgeopmd.la
++
++if BUILD_GTEST
++include test/googletest.mk
++test_geopm_test_LDADD += libgtest.a \
++                         libgmock.a \
++                         # end
++else
++test_geopm_test_LDADD += -lgmock \
++                         -lgtest \
++                         # end
++endif
+ 
+ test_geopm_test_CPPFLAGS = $(AM_CPPFLAGS) -Iplugin
+ test_geopm_test_CFLAGS = $(AM_CFLAGS)
+@@ -119,4 +127,3 @@ coverage: init-coverage check
+ 	lcov -a coverage-service-initial.info -a coverage-service.info --output-file coverage-service-combined.info
+ 	genhtml coverage-service-combined.info --output-directory coverage-service --legend -t $(VERSION) -f
+ 
+-include test/googletest.mk
+diff --git a/libgeopmd/test/googletest.mk b/libgeopmd/test/googletest.mk
+index 6c03d08a3..611976fca 100644
+--- a/libgeopmd/test/googletest.mk
++++ b/libgeopmd/test/googletest.mk
+@@ -2,6 +2,9 @@
+ #  SPDX-License-Identifier: BSD-3-Clause
+ #
+ 
++CLEAN_LOCAL_TARGETS += clean-local-googletest
++dist: dist-googletest
++
+ AM_CPPFLAGS += -I$(googletest)/include
+ AM_CPPFLAGS += -I$(googlemock)/include
+ BUILT_SOURCES += $(googletest_suite)/VERSION
+-- 
+2.26.2
+

--- a/release/fedora/0002-Fixup-TestActiveSessions-assertion.patch
+++ b/release/fedora/0002-Fixup-TestActiveSessions-assertion.patch
@@ -1,0 +1,26 @@
+From a7f2e72aae1e890a4fc6c29844b198871962fdaf Mon Sep 17 00:00:00 2001
+From: Christopher Cantalupo <christopher.m.cantalupo@intel.com>
+Date: Fri, 21 Jun 2024 15:34:20 -0700
+Subject: [PATCH 2/2] Fixup TestActiveSessions assertion
+
+Signed-off-by: Christopher Cantalupo <christopher.m.cantalupo@intel.com>
+---
+ geopmdpy/test/TestActiveSessions.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/geopmdpy/test/TestActiveSessions.py b/geopmdpy/test/TestActiveSessions.py
+index 79befcc91..02525b308 100755
+--- a/geopmdpy/test/TestActiveSessions.py
++++ b/geopmdpy/test/TestActiveSessions.py
+@@ -202,7 +202,7 @@ class TestActiveSessions(unittest.TestCase):
+             mock_srf.assert_called_once_with(full_file_path)
+ 
+             if is_valid:
+-                mock_get_session_path.called_once_with(contents['client_pid'])
++                mock_get_session_path.assert_has_calls([mock.call('*'), mock.call(contents['client_pid'])])
+                 mock_os_stat.assert_called_once_with(full_file_path)
+                 mock_pid_valid.assert_called_once_with(contents['client_pid'], session_mock.st_ctime)
+                 mock_smf.assert_called_once_with(full_file_path, string_contents)
+-- 
+2.26.2
+

--- a/release/fedora/geopm-doc.spec
+++ b/release/fedora/geopm-doc.spec
@@ -1,0 +1,195 @@
+#  Copyright (c) 2015 - 2024 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+# Packages: geopm-service, geopm-service-devel, libgeopmd2
+# This spec file supports three options for level-zero support:
+#
+# 1. default:
+#    No level-zero support.
+#
+# 2. rpmbuild --define 'enable_level_zero 1' ...
+#    Enable level-zero with packages installed into standard
+#    locations: libdir and includedir.
+#
+# 3. rpmbuild --define 'with_level_zero <LEVEL_ZERO_PREFIX>' ...
+#    Enable level-zero with packages installed into a
+#    non-standard prefix.
+
+Summary: Global Extensible Open Power Manager Documentation
+Name: geopm-doc
+Version: 3.1.0
+Release: 1
+License: BSD-3-Clause
+URL: https://geopm.github.io
+Source0: https://github.com/geopm/geopm/archive/v3.1.0/geopm-3.1.0.tar.gz
+Patch0: 0001-Changes-required-for-building-from-git-archive.patch
+BuildRoot: %{_tmppath}/geopm-doc-%{version}-%{release}-root
+Prefix: %{_prefix}
+BuildRequires: python3-sphinx >= 4.5.0
+BuildRequires: python3-sphinx_rtd_theme >= 1.0.0
+BuildRequires: python3-sphinxemoji >= 0.2.0
+BuildRequires: python3-pygments >= 2.13.0
+BuildRequires: python3-sphinx-tabs >= 3.3.1
+BuildRequires: doxygen
+BuildRequires: graphviz
+Requires: geopm-service-doc
+Requires: libgeopmd-doc
+Requires: python3-geopmdpy-doc
+Requires: geopm-runtime-doc
+Requires: libgeopm-doc
+Requires: python3-geopmpy-doc
+BuildRequires: bash-completion
+BuildRequires: marshalparser
+%global debug_package %{nil}
+
+%define completionsdir %(pkg-config --variable=completionsdir bash-completion)
+%if "x%{?completionsdir}" == "x"
+%define completionsdir "%{_sysconfdir}/bash_completion.d"
+%endif
+
+%description
+Man pages for geopm packages
+
+%package  -n geopm-runtime-doc
+Summary: Global Extensible Open Power Manager Runtime Documentation
+Group: Documentation
+%description -n geopm-runtime-doc
+Man pages for geopm-runtime package
+
+%package  -n geopm-service-doc
+Summary: Global Extensible Open Power Manager Service Documentation
+Group: Documentation
+%description -n geopm-service-doc
+Man pages for geopm-service package
+
+%package  -n libgeopmd-doc
+Summary: Global Extensible Open Power Manager Service Library Documentation
+Group: Documentation
+%description -n libgeopmd-doc
+Man pages for libgeopmd package
+
+%package  -n libgeopm-doc
+Summary: Global Extensible Open Power Manager Runtime Library Documentation
+Group: Documentation
+%description -n libgeopm-doc
+Man pages for libgeopm package
+
+%package  -n python3-geopmdpy-doc
+Summary: Global Extensible Open Power Manager Service Python Documentation
+Group: Documentation
+%description -n python3-geopmdpy-doc
+Man pages for python3-geopmdpy package
+
+%package  -n python3-geopmpy-doc
+Summary: Global Extensible Open Power Manager Runtime Python Documentation
+Group: Documentation
+%description -n python3-geopmpy-doc
+Man pages for python3-geopmpy package
+
+%prep
+%setup -n geopm-%{version}
+%patch -P0 -p1
+
+%build
+cd docs
+echo %{version} > VERSION
+%{__make} man
+
+%install
+cd docs
+%{__make} DESTDIR=%{buildroot} prefix=%{_prefix} datarootdir=%{_datarootdir} mandir=%{_mandir} install_man
+%if 0%{?fedora} <= 40
+%{__make} DESTDIR=%{buildroot} prefix=%{_prefix} datarootdir=%{_datarootdir} mandir=%{_mandir} completionsdir=%{completionsdir} install_completion
+%endif
+
+%clean
+
+# Installed files
+%files
+
+%files -n geopm-runtime-doc
+%defattr(-,root,root,-)
+%doc %{_mandir}/man1/geopmadmin.1.gz
+%doc %{_mandir}/man1/geopmagent.1.gz
+%doc %{_mandir}/man1/geopmctl.1.gz
+%doc %{_mandir}/man7/geopm_agent_ffnet.7.gz
+%doc %{_mandir}/man7/geopm_agent_frequency_map.7.gz
+%doc %{_mandir}/man7/geopm_agent_monitor.7.gz
+%doc %{_mandir}/man7/geopm_agent_power_balancer.7.gz
+%doc %{_mandir}/man7/geopm_agent_power_governor.7.gz
+
+%files -n geopm-service-doc
+%defattr(-,root,root,-)
+%doc %{_mandir}/man1/geopmread.1.gz
+%doc %{_mandir}/man1/geopmwrite.1.gz
+%doc %{_mandir}/man7/geopm.7.gz
+%doc %{_mandir}/man7/geopm_pio.7.gz
+%doc %{_mandir}/man7/geopm_pio_cnl.7.gz
+%doc %{_mandir}/man7/geopm_pio_const_config.7.gz
+%doc %{_mandir}/man7/geopm_pio_cpuinfo.7.gz
+%doc %{_mandir}/man7/geopm_pio_dcgm.7.gz
+%doc %{_mandir}/man7/geopm_pio_levelzero.7.gz
+%doc %{_mandir}/man7/geopm_pio_msr.7.gz
+%doc %{_mandir}/man7/geopm_pio_nvml.7.gz
+%doc %{_mandir}/man7/geopm_pio_profile.7.gz
+%doc %{_mandir}/man7/geopm_pio_service.7.gz
+%doc %{_mandir}/man7/geopm_pio_sst.7.gz
+%doc %{_mandir}/man7/geopm_pio_sysfs.7.gz
+%doc %{_mandir}/man7/geopm_pio_time.7.gz
+%doc %{_mandir}/man7/geopm_report.7.gz
+%if 0%{?fedora} <= 40
+%doc %{completionsdir}/geopmread
+%doc %{completionsdir}/geopmwrite
+%endif
+
+%files -n libgeopmd-doc
+%doc %{_mandir}/man3/geopm::Agg.3.gz
+%doc %{_mandir}/man3/geopm::CNLIOGroup.3.gz
+%doc %{_mandir}/man3/geopm::CircularBuffer.3.gz
+%doc %{_mandir}/man3/geopm::CpuinfoIOGroup.3.gz
+%doc %{_mandir}/man3/geopm::Exception.3.gz
+%doc %{_mandir}/man3/geopm::Helper.3.gz
+%doc %{_mandir}/man3/geopm::IOGroup.3.gz
+%doc %{_mandir}/man3/geopm::MSRIO.3.gz
+%doc %{_mandir}/man3/geopm::MSRIOGroup.3.gz
+%doc %{_mandir}/man3/geopm::PlatformIO.3.gz
+%doc %{_mandir}/man3/geopm::PlatformTopo.3.gz
+%doc %{_mandir}/man3/geopm::PluginFactory.3.gz
+%doc %{_mandir}/man3/geopm::SampleAggregator.3.gz
+%doc %{_mandir}/man3/geopm::SharedMemory.3.gz
+%doc %{_mandir}/man3/geopm::TimeIOGroup.3.gz
+%doc %{_mandir}/man3/geopm_error.3.gz
+%doc %{_mandir}/man3/geopm_field.3.gz
+%doc %{_mandir}/man3/geopm_hash.3.gz
+%doc %{_mandir}/man3/geopm_pio.3.gz
+%doc %{_mandir}/man3/geopm_sched.3.gz
+%doc %{_mandir}/man3/geopm_time.3.gz
+%doc %{_mandir}/man3/geopm_topo.3.gz
+%doc %{_mandir}/man3/geopm_version.3.gz
+
+%files -n libgeopm-doc
+%doc %{_mandir}/man3/geopm::Agent.3.gz
+%doc %{_mandir}/man3/geopm::CPUActivityAgent.3.gz
+%doc %{_mandir}/man3/geopm::PowerBalancer.3.gz
+%doc %{_mandir}/man3/geopm::PowerGovernor.3.gz
+%doc %{_mandir}/man3/geopm_agent.3.gz
+%doc %{_mandir}/man3/geopm_ctl.3.gz
+%doc %{_mandir}/man3/geopm_imbalancer.3.gz
+%doc %{_mandir}/man3/geopm_prof.3.gz
+
+%files -n python3-geopmdpy-doc
+%doc %{_mandir}/man1/geopmaccess.1.gz
+%doc %{_mandir}/man1/geopmsession.1.gz
+%doc %{_mandir}/man7/geopmdpy.7.gz
+
+%files -n python3-geopmpy-doc
+%doc %{_mandir}/man1/geopmlaunch.1.gz
+%doc %{_mandir}/man7/geopmpy.7.gz
+%if 0%{?fedora} <= 40
+%doc %{completionsdir}/geopmlaunch
+%endif
+
+%changelog
+* Fri May 17 2024 Christopher M Cantalupo <christopher.m.cantalupo@intel.com> v3.1.0
+- Official v3.1.0 release tag

--- a/release/fedora/geopm-service.spec
+++ b/release/fedora/geopm-service.spec
@@ -1,0 +1,221 @@
+#  Copyright (c) 2015 - 2024 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+# Packages: geopm-service, geopm-service-devel, libgeopmd2
+# This spec file supports three options for level-zero support:
+#
+# 1. default:
+#    No level-zero support.
+#
+# 2. rpmbuild --define 'enable_level_zero 1' ...
+#    Enable level-zero with packages installed into standard
+#    locations: libdir and includedir.
+#
+# 3. rpmbuild --define 'with_level_zero <LEVEL_ZERO_PREFIX>' ...
+#    Enable level-zero with packages installed into a
+#    non-standard prefix.
+
+Summary: Global Extensible Open Power Manager Service
+Name: geopm-service
+Version: 3.1.0
+Release: 1
+License: BSD-3-Clause
+URL: https://geopm.github.io
+Source0: https://github.com/geopm/geopm/archive/v3.1.0/geopm-3.1.0.tar.gz
+Patch0: 0001-Changes-required-for-building-from-git-archive.patch
+BuildRoot: %{_tmppath}/geopm-service-%{version}-%{release}-root
+Prefix: %{_prefix}
+BuildRequires: gcc-c++
+BuildRequires: unzip
+BuildRequires: libtool
+BuildRequires: libcap-devel
+BuildRequires: systemd-devel >= 221
+BuildRequires: zlib-devel
+BuildRequires: gtest-devel >= 1.12.1
+BuildRequires: gmock-devel >= 1.12.1
+%if %{defined enable_level_zero}
+BuildRequires: level-zero
+BuildRequires: level-zero-devel
+Requires: level-zero >= 1.8.1
+%endif
+BuildRequires: systemd-rpm-macros
+Recommends: geopm-service-doc
+
+%define docdir %{_defaultdocdir}/geopm-service-%{version}
+
+Requires: libgeopmd2 = %{version}
+Requires: python3-geopmdpy = %{version}
+
+%description
+
+The GEOPM Service provides a user-level interface to read telemetry
+and configure settings of heterogeneous hardware platforms. Linux
+system administrators may manage permissions for user access to
+telemetry and configuration at a fine granularity.  This package
+includes the geopm systemd service unit that provides a DBus interface
+io.github.geopm.  Additionally the libgeopmd.so shared object library
+is installed with this package.
+
+
+%package devel
+
+Summary: Global Extensible Open Power Manager Service - development
+Requires: libgeopmd2 = %{version}
+
+%description devel
+
+Development package for the GEOPM Service.  This provides the
+programming interface to libgeopmd.so.  The package includes the C and
+C++ header files, maunuals for these interfaces and the unversioned
+libgeopmd.so shared object symbolic link.
+
+%package -n libgeopmd2
+
+Summary: Provides libgeopmd shared object library
+Recommends: libgeopmd-doc
+
+# Lets GEOPM batch its IO operations to reduce syscall overhead in IOGroups
+# with a lot of reads/writes per GEOPM batch operation.
+%if %{defined disable_io_uring} || 0%{?centos_ver} == 8
+%define io_uring_option --disable-io-uring
+%else
+BuildRequires: liburing-devel
+%endif
+
+%if "%{_arch}" != "x86_64"
+%define cpuid_option --disable-cpuid
+%endif
+
+%description -n libgeopmd2
+
+Library supporting the GEOPM Service.  This provides the libgeopmd
+library which provides C and C++ interfaces.
+
+# Steps for all packages
+%prep
+%setup -n geopm-%{version}
+%patch -P0 -p1
+
+%build
+cd libgeopmd
+
+%if %{defined with_level_zero}
+# Disable libze_loader as an explicit dependency for installing the RPM
+%global __requires_exclude ^(libze_loader[.]so.*)$
+%define level_zero_option --enable-levelzero --with-levelzero=%{with_level_zero}
+%else
+%if %{defined enable_level_zero}
+%define level_zero_option --enable-levelzero
+%endif
+%endif
+%if 0%{?fedora} != 0 && ! 0%{?fedora} <= 40
+# Our use of relro flag causes a configure test to fail on fedora rawhide
+%define relro_flags LDFLAGS=-Wl,-z,norelro
+%endif
+
+echo %{version} > VERSION
+./autogen.sh
+%{?relro_flags} \
+./configure --prefix=%{_prefix} --libdir=%{_libdir} --libexecdir=%{_libexecdir} \
+            --includedir=%{_includedir} --sbindir=%{_sbindir} \
+            --mandir=%{_mandir} --docdir=%{docdir} \
+            --disable-build-gtest \
+            %{?level_zero_option} \
+            %{?io_uring_option} \
+            %{?cpuid_option} \
+            || ( cat config.log && false )
+
+%{__make} %{?_smp_mflags}
+
+%check
+cd libgeopmd
+CFLAGS= CXXFLAGS= CC=gcc CXX=g++ \
+%{__make} %{?_smp_mflags} check
+
+%install
+cd libgeopmd
+%{__make} DESTDIR=%{buildroot} install
+rm -f $(find %{buildroot}/%{_libdir} -name '*.a'; \
+        find %{buildroot}/%{_libdir} -name '*.la')
+
+install -Dp -m644 geopm.service %{buildroot}%{_unitdir}/geopm.service
+install -Dp -m644 io.github.geopm.conf %{buildroot}%{_datadir}/dbus-1/system.d/io.github.geopm.conf
+install -Dp -m644 io.github.geopm.xml %{buildroot}%{_datadir}/dbus-1/interfaces/io.github.geopm.xml
+mkdir -p %{buildroot}%{_sysconfdir}/geopm
+mkdir -p %{buildroot}%{_sbindir}
+ln -s -r %{buildroot}%{_sbindir}/service %{buildroot}%{_sbindir}/rcgeopm
+
+%clean
+
+%post -n geopm-service
+cd libgeopmd
+%systemd_post geopm.service
+
+%preun -n geopm-service
+cd libgeopmd
+%systemd_preun geopm.service
+
+%postun -n geopm-service
+cd libgeopmd
+%systemd_postun_with_restart geopm.service
+
+# Installed files
+
+%files
+%defattr(-,root,root,-)
+%{_sbindir}/rcgeopm
+%{_bindir}/geopmread
+%{_bindir}/geopmwrite
+%dir %{_datadir}/dbus-1
+%dir %{_datadir}/dbus-1/system.d
+%{_datadir}/dbus-1/system.d/io.github.geopm.conf
+%dir %{_datadir}/dbus-1/interfaces
+%{_datadir}/dbus-1/interfaces/io.github.geopm.xml
+%{_unitdir}/geopm.service
+%dir %{docdir}
+%doc %{docdir}/LICENSE-BSD-3-Clause
+%doc %{docdir}/README.md
+%doc %{docdir}/VERSION
+
+%files -n libgeopmd2
+%defattr(-,root,root,-)
+%{_libdir}/libgeopmd.so.2.1.0
+%{_libdir}/libgeopmd.so.2
+%dir %{_libdir}/geopm
+
+%files devel
+%defattr(-,root,root,-)
+%dir %{_includedir}/geopm
+%{_includedir}/geopm/Agg.hpp
+%{_includedir}/geopm/Cpuid.hpp
+%{_includedir}/geopm/CircularBuffer.hpp
+%{_includedir}/geopm/Exception.hpp
+%{_includedir}/geopm/Helper.hpp
+%{_includedir}/geopm/IOGroup.hpp
+%{_includedir}/geopm/json11.hpp
+%{_includedir}/geopm/PlatformIO.hpp
+%{_includedir}/geopm/PlatformTopo.hpp
+%{_includedir}/geopm/PluginFactory.hpp
+%{_includedir}/geopm/SaveControl.hpp
+%{_includedir}/geopm/ServiceProxy.hpp
+%{_includedir}/geopm/SharedMemory.hpp
+%{_includedir}/geopm/SharedMemoryScopedLock.hpp
+%{_includedir}/geopm_debug.hpp
+%{_includedir}/geopm_error.h
+%{_includedir}/geopm_field.h
+%{_includedir}/geopm_hash.h
+%{_includedir}/geopm_hint.h
+%{_includedir}/geopm_pio.h
+%{_includedir}/geopm_plugin.hpp
+%{_includedir}/geopm_public.h
+%{_includedir}/geopm_sched.h
+%{_includedir}/geopm_shmem.h
+%{_includedir}/geopm_time.h
+%{_includedir}/geopm_topo.h
+%{_includedir}/geopm_version.h
+%{_libdir}/libgeopmd.so
+
+%changelog
+* Fri May 17 2024 Christopher M Cantalupo <christopher.m.cantalupo@intel.com> v3.1.0
+- Official v3.1.0 release tag

--- a/release/fedora/geopmdpy.spec
+++ b/release/fedora/geopmdpy.spec
@@ -1,0 +1,77 @@
+#  Copyright (c) 2015 - 2024 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+# Packages: python3-geopmdpy
+
+Summary: The geopmdpy Python package for the GEOPM Service
+Name: python3-geopmdpy
+Version: 3.1.0
+Release: 1
+License: BSD-3-Clause
+URL: https://geopm.github.io
+Source0: https://github.com/geopm/geopm/archive/v3.1.0/geopm-3.1.0.tar.gz
+Patch0: 0001-Changes-required-for-building-from-git-archive.patch
+Patch1: 0002-Fixup-TestActiveSessions-assertion.patch
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+BuildRequires: python3-devel
+BuildRequires: python3-setuptools
+BuildRequires: python-rpm-macros
+BuildRequires: marshalparser
+%global debug_package %{nil}
+
+%define python_bin %{__python3}
+
+%{!?python3_pkgversion:%global python3_pkgversion 3}
+
+%define python_major_version 3
+
+Requires: libgeopmd2 = %{version}
+
+Requires: python3-gobject-base
+Requires: python3-dasbus >= 1.6
+Requires: python3-jsonschema
+Requires: python3-psutil
+Requires: python3-cffi
+Requires: libgeopmd2 = %{version}
+Recommends: python3-geopmdpy-doc
+
+%{?python_provide:%python_provide python%{python3_pkgversion}-geopmdpy}
+
+%description
+
+Python %{python_major_version} package for GEOPM service.  Provides
+the implementation for the geopmd service daemon and interfaces for
+configuring the service.
+
+# Steps for all packages
+%prep
+%setup -n geopm-%{version}
+%patch -P0 -p1
+%patch -P1 -p1
+cd geopmdpy
+echo %{version} > geopmdpy/VERSION
+
+%build
+cd geopmdpy
+%py3_build
+
+%check
+cd geopmdpy
+%{__python3} test
+
+%install
+cd geopmdpy
+%py3_install
+
+# Installed files
+%files
+%defattr(-,root,root,-)
+%{python3_sitelib}/*
+%{_bindir}/geopmd
+%{_bindir}/geopmaccess
+%{_bindir}/geopmsession
+
+%changelog
+* Fri May 17 2024 Christopher M Cantalupo <christopher.m.cantalupo@intel.com> v3.1.0
+- Official v3.1.0 release tag


### PR DESCRIPTION
Several changes are required for fedora packaging

- Build from files committed to git only, do not download binaries
  - Do not build gtest or gmock, use packages
  - Do not download fuzz corpus unless fuzz testing is enabled
  - Create VERSION files in spec file rather than rely on generated versions in archive
- Run unit tests in %check sections
- Relates to #3505

