### PR TITLE
Add a GEOPM_VERBOSITY environment variable

### DIFF
--- a/docs/source/admin.rst
+++ b/docs/source/admin.rst
@@ -65,3 +65,24 @@ configures the service using the ``geopmaccess`` command line tool.
 This command line interface allows the administrator to set access
 permissions for all users, and may extend these default privileges for
 specific Unix groups.
+
+Configuring Systemd Unit File
+-----------------------------
+
+The GEOPM Systemd unit is configured with the ``geopm.service`` file that is
+installed as part of the ``geopm-service`` package.  This configuration file may
+be amended using the command ``systemctl edit geopm.service``. See
+`systemctl(1) <https://man7.org/linux/man-pages/man1/systemctl.1.html>`_ for
+more details.
+
+An administrator may wish to modify the ``GEOPM_VERBOSITY`` environment variable
+set in the configuration file.  Increasing this will cause more messages to be
+printed in the system journal which may assist in debugging problems where
+expected signals or controls are not available.
+
+- ``GEOPM_VERBOSITY=0``: Print errors and critical warning messages
+- ``GEOPM_VERBOSITY=1``: Print warning messages
+- ``GEOPM_VERBOSITY=2``: Print diagnostic info messages
+
+The scope of messages printed when ``GEOPM_VERBOSITY`` is non-zero may increase
+in the future.

--- a/libgeopmd/geopm.service
+++ b/libgeopmd/geopm.service
@@ -13,6 +13,7 @@ After=msr-safe.service
 Environment=PYTHONUNBUFFERED=true
 Environment=ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
 Environment=ZES_ENABLE_SYSMAN=1
+Environment=GEOPM_VERBOSITY=1
 
 Type=dbus
 BusName=io.github.geopm

--- a/libgeopmd/geopm.service
+++ b/libgeopmd/geopm.service
@@ -13,7 +13,7 @@ After=msr-safe.service
 Environment=PYTHONUNBUFFERED=true
 Environment=ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
 Environment=ZES_ENABLE_SYSMAN=1
-Environment=GEOPM_VERBOSITY=1
+Environment=GEOPM_VERBOSITY=0
 
 Type=dbus
 BusName=io.github.geopm

--- a/libgeopmd/include/geopm/Helper.hpp
+++ b/libgeopmd/include/geopm/Helper.hpp
@@ -152,6 +152,22 @@ namespace geopm
     std::string GEOPM_PUBLIC
         get_env(const std::string &name);
 
+    /// @brief Query environment for verbosity level
+    ///
+    /// Read GEOPM_VERBOSITY environment variable.  If set, convert to
+    /// integer.  If unset, or conversion fails, returns default
+    /// value.  The default value is 0 unless the GEOPM software is
+    /// compiled with --enable-debug configuration.  When debug is
+    /// enabled at compile time, the default value is 2.
+    ///
+    /// Level 0: Print errors and critical warning messages
+    /// Level 1: Print warning messages
+    /// Level 2: Print diagnostic info messages
+    ///
+    /// @return Verbosity level for GEOPM messaging
+    int GEOPM_PUBLIC
+        verbosity_level(void);
+
     /// @brief Query for the user id associated with the process id.
     /// @param [in] pid The process id to query.
     /// @return The user id.

--- a/libgeopmd/src/Helper.cpp
+++ b/libgeopmd/src/Helper.cpp
@@ -272,6 +272,25 @@ namespace geopm
         return env_string;
     }
 
+    int verbosity_level(void)
+    {
+        int result = 0;
+#ifdef GEOPM_DEBUG
+        // Default verbosity is 2 when configured with --enable-debug
+        result = 2;
+#endif
+        std::string verb_str = geopm::get_env("GEOPM_VERBOSITY");
+        try {
+            result = std::stoi(verb_str);
+        }
+        catch (const std::invalid_argument &ex) {
+        }
+        catch (const std::out_of_range &ex) {
+        }
+        return result;
+    }
+
+
     unsigned int pid_to_uid(const int pid) {
         int err = 0;
         std::string proc_path = "/proc/" + std::to_string(pid);

--- a/libgeopmd/src/PlatformIO.cpp
+++ b/libgeopmd/src/PlatformIO.cpp
@@ -242,14 +242,14 @@ namespace geopm
                     register_iogroup(IOGroup::make_unique(it));
                 }
                 catch (const geopm::Exception &ex) {
-#ifdef GEOPM_DEBUG
-                    std::cerr << "Warning: <geopm> Failed to load " << it << " IOGroup.  "
-                              << "GEOPM may not work properly unless an alternate "
-                              << "IOGroup plugin is loaded to provide signals/controls "
-                              << "required by the Controller and Agent."
-                              << std::endl;
-                    std::cerr << "The error was: " << ex.what() << std::endl;
-#endif
+                    if (geopm::verbosity_level() > 0) {
+                        std::cerr << "Warning: <geopm> Failed to load " << it << " IOGroup.  "
+                                  << "GEOPM may not work properly unless an alternate "
+                                  << "IOGroup plugin is loaded to provide signals/controls "
+                                  << "required by the Controller and Agent."
+                                  << std::endl;
+                        std::cerr << "The error was: " << ex.what() << std::endl;
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Currently only applies to Warnings from loading IOGroup plugins.
- Relates to #1529
