### PR TITLE
Fix single tile GPU part interactions with Level Zero

### DIFF
--- a/docs/source/geopm_pio_levelzero.7.rst
+++ b/docs/source/geopm_pio_levelzero.7.rst
@@ -143,7 +143,7 @@ Signals
     GPU Compute Hardware chip energy in joules.
 
     *  **Aggregation**: sum
-    *  **Domain**: gpu_chip
+    *  **Domain**: gpu_chip for multi-chip systems or gpu for single chip per gpu systems
     *  **Format**: double
     *  **Unit**: joules
 
@@ -151,7 +151,7 @@ Signals
     GPU compute hardware domain energy timestamp in seconds.  Value cached on LEVELZERO::GPU_CORE_ENERGY read.
 
     *  **Aggregation**: sum
-    *  **Domain**: gpu_chip
+    *  **Domain**: gpu_chip for multi-chip systems or gpu for single chip per gpu systems
     *  **Format**: double
     *  **Unit**: seconds
 
@@ -167,7 +167,7 @@ Signals
     Performance Factor of the GPU Compute Hardware Domain. Expresses a trade-off between energy provided to the GPU compute hardware and the supporting units.  A value of 1 indicates a compute focused energy trade-off, a value of 0 indicates a memory focused energy trade-off.  Default value is 0.5
 
     *  **Aggregation**: averge
-    *  **Domain**: gpu_chip
+    *  **Domain**: gpu_chip for multi-chip systems or gpu for single chip per gpu systems
     *  **Format**: double
     *  **Unit**: none
 

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -564,12 +564,6 @@ namespace geopm
                                                       int l0_domain) const
     {
         double result = NAN;
-        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
-            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
-                            ": domain " + std::to_string(domain) +
-                            " is not supported for the performance factor domain.",
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
 
         std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
         dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);

--- a/libgeopmd/src/LevelZeroIOGroup.hpp
+++ b/libgeopmd/src/LevelZeroIOGroup.hpp
@@ -111,6 +111,7 @@ namespace geopm
             const PlatformTopo &m_platform_topo;
             const LevelZeroDevicePool &m_levelzero_device_pool;
             bool m_is_batch_read;
+            int m_native_domain;
 
             std::map<std::string, signal_info> m_signal_available;
             std::map<std::string, control_info> m_control_available;
@@ -125,6 +126,8 @@ namespace geopm
             std::vector<double> m_perf_factor;
 
             std::shared_ptr<SaveControl> m_mock_save_ctl;
+
+            bool m_is_perf_factor_enabled;
     };
 }
 #endif


### PR DESCRIPTION
- Support for systems that do not have perf factor
- Fixes https://github.com/intel-innersource/applications.analyzers.geopm.geopm/issues/90
- Some assumptions about Level Zero reporting were not valid for single tile GPUs