### PR TITLE
Resolve integration test out-of-tree build issues

### DIFF
--- a/integration/test/test_epoch_inference.py
+++ b/integration/test/test_epoch_inference.py
@@ -57,8 +57,7 @@ class AppConf(object):
         """Path to benchmark filled in by template automatically.
 
         """
-        script_dir = os.path.dirname(os.path.realpath(__file__))
-        return os.path.join(script_dir, '.libs', 'test_epoch_inference')
+        return util.get_exec_path('test_epoch_inference')
 
     def get_exec_args(self):
         """Returns a list of strings representing the command line arguments

--- a/integration/test/test_frequency_hint_usage.py
+++ b/integration/test/test_frequency_hint_usage.py
@@ -41,8 +41,7 @@ class AppConf(object):
         """Path to benchmark filled in by template automatically.
 
         """
-        script_dir = os.path.dirname(os.path.realpath(__file__))
-        return os.path.join(script_dir, '.libs', 'test_frequency_hint_usage')
+        return util.get_exec_path('test_frequency_hint_usage')
 
     def get_exec_args(self):
         """Returns a list of strings representing the command line arguments

--- a/integration/test/test_hint_time.py
+++ b/integration/test/test_hint_time.py
@@ -41,20 +41,7 @@ class AppConf(object):
         """Path to benchmark filled in by template automatically.
 
         """
-        bin_name = 'test_hint_time'
-        # Look for in place build
-        script_dir = os.path.dirname(os.path.realpath(__file__))
-        bin_path = os.path.join(script_dir, '.libs', bin_name)
-        if not os.path.exists(bin_path):
-            # Look for out of place build from using apps/build_func.sh
-            int_dir = os.path.dirname(script_dir)
-            bin_path_op = os.path.join(int_dir, 'build/integration/test/.libs', bin_name)
-            if not os.path.exists(bin_path_op):
-                msg = 'Could not find application binary, tried \n    "{}"\n    "{}"'.format(
-                      bin_path, bin_path_op)
-                raise RuntimeError(msg)
-            bin_path = bin_path_op
-        return bin_path
+        return util.get_exec_path('test_hint_time')
 
     def get_exec_args(self):
         """Returns a list of strings representing the command line arguments

--- a/integration/test/test_omp_outer_loop.py
+++ b/integration/test/test_omp_outer_loop.py
@@ -38,8 +38,7 @@ class AppConf(object):
         """Path to bencmark
 
         """
-        script_dir = os.path.dirname(os.path.realpath(__file__))
-        return os.path.join(script_dir, '.libs', 'test_omp_outer_loop')
+        return util.get_exec_path('test_omp_outer_loop')
 
     def get_exec_args(self):
         return []

--- a/integration/test/test_profile_overflow.py
+++ b/integration/test/test_profile_overflow.py
@@ -39,8 +39,7 @@ class AppConf(object):
         """Path to benchmark filled in by template automatically.
 
         """
-        script_dir = os.path.dirname(os.path.realpath(__file__))
-        return os.path.join(script_dir, '.libs', 'test_profile_overflow')
+        return util.get_exec_path('test_profile_overflow')
 
     def get_exec_args(self):
         """Returns a list of strings representing the command line arguments

--- a/integration/test/test_scaling_region.py
+++ b/integration/test/test_scaling_region.py
@@ -38,8 +38,7 @@ class AppConf(object):
         """Path to benchmark
 
         """
-        script_dir = os.path.dirname(os.path.realpath(__file__))
-        return os.path.join(script_dir, '.libs', 'test_scaling_region')
+        return util.get_exec_path('test_scaling_region')
 
     def get_exec_args(self):
         return []

--- a/integration/test/test_timed_scaling_region.py
+++ b/integration/test/test_timed_scaling_region.py
@@ -38,8 +38,7 @@ class AppConf(object):
         """Path to benchmark
 
         """
-        script_dir = os.path.dirname(os.path.realpath(__file__))
-        return os.path.join(script_dir, '.libs', 'test_timed_scaling_region')
+        return util.get_exec_path('test_timed_scaling_region')
 
     def get_exec_args(self):
         return []

--- a/integration/test/util.py
+++ b/integration/test/util.py
@@ -184,6 +184,7 @@ def get_exec_path(bin_name):
     int_dir = os.path.dirname(int_test_dir)
     # Look for out of place build from using apps/build_func.sh
     path_list.append(os.path.join(int_dir, 'build/integration/test/.libs'))
+    path_list.append(int_test_dir) # Required for out-of-tree builds
     bin_list = [os.path.join(pp, bin_name) for pp in path_list]
     for bb in bin_list:
         if os.path.isfile(bb):

--- a/libgeopm/test/MPIInterfaceTest.cpp
+++ b/libgeopm/test/MPIInterfaceTest.cpp
@@ -248,7 +248,8 @@ TEST_F(MPIInterfaceTest, geopm_api)
 TEST_F(MPIInterfaceTest, mpi_api)
 {
     int junk = 0;
-    int size = 100;
+    const int csize = 100;
+    int size = csize;
     EXPECT_EQ(0, MPI_Comm_size(MPI_COMM_WORLD, &size));
     std::vector<int> zeros(size);
     std::fill(zeros.begin(), zeros.end(), 0);
@@ -268,7 +269,7 @@ TEST_F(MPIInterfaceTest, mpi_api)
     MPI_File fh = 0;
     MPI_Win win = 0;
 #ifdef GEOPM_ENABLE_MPI3
-    MPI_Aint aints[size];
+    MPI_Aint aints[csize];
     MPI_Message message = 0;
 #endif
 


### PR DESCRIPTION
- Relates to #3513.
- config.log checks are now best effort.
- The search order for tests requiring binaries is now .libs then CWD.
- Resolve unit test compilation issue on newer compilers.
