### PR TITLE
Increase max open file descriptor limit

### DIFF
--- a/libgeopmd/geopm.service
+++ b/libgeopmd/geopm.service
@@ -14,6 +14,7 @@ Environment=PYTHONUNBUFFERED=true
 Environment=ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
 Environment=ZES_ENABLE_SYSMAN=1
 Environment=GEOPM_VERBOSITY=0
+LimitNOFILE=16384
 
 Type=dbus
 BusName=io.github.geopm


### PR DESCRIPTION


- Relates to #3523 bug report from github issues


[Brief description of the change]
The limit for maximum number of open file descriptors by the geopmd service has been increased to 16384 to support processors with large cpu count (> 256 cpus)
