### PR TITLE
Fix import error handling for setuptools_scm

### DIFF
--- a/geopmdpy/setup.py
+++ b/geopmdpy/setup.py
@@ -8,9 +8,9 @@ import os
 
 package_name = 'geopmdpy'
 
+script_dir = os.path.dirname(os.path.realpath(__file__))
 try:
     from setuptools_scm import get_version
-    script_dir = os.path.dirname(os.path.realpath(__file__))
     version = get_version(f'{script_dir}/..')
     with open(f'{script_dir}/{package_name}/VERSION', 'w') as fid:
         fid.write(version)

--- a/geopmpy/setup.py
+++ b/geopmpy/setup.py
@@ -8,9 +8,9 @@ import os
 
 package_name = 'geopmpy'
 
+script_dir = os.path.dirname(os.path.realpath(__file__))
 try:
     from setuptools_scm import get_version
-    script_dir = os.path.dirname(os.path.realpath(__file__))
     version = get_version(f'{script_dir}/..')
     with open(f'{script_dir}/{package_name}/VERSION', 'w') as fid:
         fid.write(version)

--- a/release/fedora/0001-Changes-required-for-building-from-git-archive.patch
+++ b/release/fedora/0001-Changes-required-for-building-from-git-archive.patch
@@ -1,7 +1,7 @@
-From 91d20b03954f41c05076e11b0d8feafafdc9abe1 Mon Sep 17 00:00:00 2001
+From 2d73b8030ae787fe925b1859a81ac12b4d09192a Mon Sep 17 00:00:00 2001
 From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
 Date: Mon, 24 Jun 2024 09:34:51 -0700
-Subject: [PATCH 1/2] Changes required for building from git archive
+Subject: [PATCH 1/4] Changes required for building from git archive
 
 - Provide options to avoid other downloads
 
@@ -266,5 +266,5 @@ index 6c03d08a3..611976fca 100644
  AM_CPPFLAGS += -I$(googlemock)/include
  BUILT_SOURCES += $(googletest_suite)/VERSION
 -- 
-2.26.2
+2.34.1
 

--- a/release/fedora/0002-Fixup-TestActiveSessions-assertion.patch
+++ b/release/fedora/0002-Fixup-TestActiveSessions-assertion.patch
@@ -1,7 +1,7 @@
-From a7f2e72aae1e890a4fc6c29844b198871962fdaf Mon Sep 17 00:00:00 2001
+From 50e1f6b78e821d072bddad016e80e5e58d7ea245 Mon Sep 17 00:00:00 2001
 From: Christopher Cantalupo <christopher.m.cantalupo@intel.com>
 Date: Fri, 21 Jun 2024 15:34:20 -0700
-Subject: [PATCH 2/2] Fixup TestActiveSessions assertion
+Subject: [PATCH 2/4] Fixup TestActiveSessions assertion
 
 Signed-off-by: Christopher Cantalupo <christopher.m.cantalupo@intel.com>
 ---
@@ -22,5 +22,5 @@ index 79befcc91..02525b308 100755
                  mock_pid_valid.assert_called_once_with(contents['client_pid'], session_mock.st_ctime)
                  mock_smf.assert_called_once_with(full_file_path, string_contents)
 -- 
-2.26.2
+2.34.1
 

--- a/release/fedora/0003-Fix-import-error-handling-for-setuptools_scm.patch
+++ b/release/fedora/0003-Fix-import-error-handling-for-setuptools_scm.patch
@@ -1,0 +1,44 @@
+From e6178b650da9b76686b294939dcee859479487d7 Mon Sep 17 00:00:00 2001
+From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
+Date: Tue, 25 Jun 2024 18:04:56 -0700
+Subject: [PATCH 3/4] Fix import error handling for setuptools_scm
+
+Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
+---
+ geopmdpy/setup.py | 2 +-
+ geopmpy/setup.py  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/geopmdpy/setup.py b/geopmdpy/setup.py
+index e2e090e52..d4cacfd27 100644
+--- a/geopmdpy/setup.py
++++ b/geopmdpy/setup.py
+@@ -8,9 +8,9 @@ import os
+ 
+ package_name = 'geopmdpy'
+ 
++script_dir = os.path.dirname(os.path.realpath(__file__))
+ try:
+     from setuptools_scm import get_version
+-    script_dir = os.path.dirname(os.path.realpath(__file__))
+     version = get_version(f'{script_dir}/..')
+     with open(f'{script_dir}/{package_name}/VERSION', 'w') as fid:
+         fid.write(version)
+diff --git a/geopmpy/setup.py b/geopmpy/setup.py
+index 719ab1405..095276d56 100644
+--- a/geopmpy/setup.py
++++ b/geopmpy/setup.py
+@@ -8,9 +8,9 @@ import os
+ 
+ package_name = 'geopmpy'
+ 
++script_dir = os.path.dirname(os.path.realpath(__file__))
+ try:
+     from setuptools_scm import get_version
+-    script_dir = os.path.dirname(os.path.realpath(__file__))
+     version = get_version(f'{script_dir}/..')
+     with open(f'{script_dir}/{package_name}/VERSION', 'w') as fid:
+         fid.write(version)
+-- 
+2.34.1
+

--- a/release/fedora/0004-Remove-network-requirement-from-docs-build.patch
+++ b/release/fedora/0004-Remove-network-requirement-from-docs-build.patch
@@ -1,0 +1,60 @@
+From 8c3d92433b1c76dde154484bfd3aeb02768e04db Mon Sep 17 00:00:00 2001
+From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
+Date: Wed, 26 Jun 2024 11:24:39 -0700
+Subject: [PATCH 4/4] Remove network requirement from docs build
+
+Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
+---
+ docs/Makefile       |  4 ++--
+ docs/source/conf.py | 10 ----------
+ 2 files changed, 2 insertions(+), 12 deletions(-)
+
+diff --git a/docs/Makefile b/docs/Makefile
+index 2b1cba8e8..769f534c5 100644
+--- a/docs/Makefile
++++ b/docs/Makefile
+@@ -27,11 +27,11 @@ json_schemas/const_config_io.schema.json:
+ 
+ man: html
+ 	PYTHONPATH=../geopmdpy:../geopmpy \
+-	    sphinx-build -M man source build -W
++	    sphinx-build -M man source build
+ 
+ html: VERSION json_schemas
+ 	PYTHONPATH=../geopmdpy:../geopmpy \
+-	    sphinx-build -M html source build -W
++	    sphinx-build -M html source build
+ 	./doxygen_update.sh
+ 
+ # Nobody asked for this build target, so don't make it a build-blocker unless
+diff --git a/docs/source/conf.py b/docs/source/conf.py
+index 28b205e0d..c5776b3e7 100644
+--- a/docs/source/conf.py
++++ b/docs/source/conf.py
+@@ -69,7 +69,6 @@ extensions = [
+     'sphinx_rtd_theme',
+     'sphinx.ext.autosectionlabel',
+     'sphinxemoji.sphinxemoji',
+-    'sphinx.ext.intersphinx',
+     'sphinx.ext.todo',
+     'geopmlint',
+     'geopm_rst_extensions',
+@@ -104,15 +103,6 @@ nitpicky = True
+ # which is a python reference link to the documentation.
+ add_function_parentheses = True
+ 
+-intersphinx_mapping = {
+-    'python': ('https://docs.python.org/3', None),
+-    'dasbus': ('https://dasbus.readthedocs.io/en/stable', None),
+-    'pygobject': ('https://pygobject.readthedocs.io/en/latest', None),
+-    'cffi': ('https://cffi.readthedocs.io/en/latest', None),
+-    'pandas': ('https://pandas.pydata.org/docs/', None),
+-    'psutil': ('https://psutil.readthedocs.io/en/latest', None),
+-}
+-
+ # List of patterns, relative to source directory, that match files and
+ # directories to ignore when looking for source files.
+ # This pattern also affects html_static_path and html_extra_path.
+-- 
+2.34.1
+

--- a/release/fedora/geopm-doc.spec
+++ b/release/fedora/geopm-doc.spec
@@ -24,6 +24,7 @@ License: BSD-3-Clause
 URL: https://geopm.github.io
 Source0: https://github.com/geopm/geopm/archive/v3.1.0/geopm-3.1.0.tar.gz
 Patch0: 0001-Changes-required-for-building-from-git-archive.patch
+Patch1: 0004-Remove-network-requirement-from-docs-build.patch
 BuildRoot: %{_tmppath}/geopm-doc-%{version}-%{release}-root
 Prefix: %{_prefix}
 BuildRequires: python3-sphinx >= 4.5.0
@@ -31,6 +32,7 @@ BuildRequires: python3-sphinx_rtd_theme >= 1.0.0
 BuildRequires: python3-sphinxemoji >= 0.2.0
 BuildRequires: python3-pygments >= 2.13.0
 BuildRequires: python3-sphinx-tabs >= 3.3.1
+BuildRequires: python3-setuptools >= 40.5.0
 BuildRequires: doxygen
 BuildRequires: graphviz
 Requires: geopm-service-doc
@@ -90,6 +92,7 @@ Man pages for python3-geopmpy package
 %prep
 %setup -n geopm-%{version}
 %patch -P0 -p1
+%patch -P1 -p1
 
 %build
 cd docs

--- a/release/fedora/geopmdpy.spec
+++ b/release/fedora/geopmdpy.spec
@@ -13,11 +13,20 @@ URL: https://geopm.github.io
 Source0: https://github.com/geopm/geopm/archive/v3.1.0/geopm-3.1.0.tar.gz
 Patch0: 0001-Changes-required-for-building-from-git-archive.patch
 Patch1: 0002-Fixup-TestActiveSessions-assertion.patch
+Patch2: 0003-Fix-import-error-handling-for-setuptools_scm.patch
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 BuildRequires: python-rpm-macros
 BuildRequires: marshalparser
+
+# Packages required to run tests
+BuildRequires: python3-dasbus >= 1.6
+BuildRequires: python3-jsonschema
+BuildRequires: python3-psutil
+BuildRequires: python3-cffi
+BuildRequires: libgeopmd2
+
 %global debug_package %{nil}
 
 %define python_bin %{__python3}
@@ -49,6 +58,7 @@ configuring the service.
 %setup -n geopm-%{version}
 %patch -P0 -p1
 %patch -P1 -p1
+%patch -P2 -p1
 cd geopmdpy
 echo %{version} > geopmdpy/VERSION
 


### PR DESCRIPTION
- Relates to #3504
- Example build working in OBS:
https://build.opensuse.org/package/show/home:cmcantal:branches:home:cmcantal/geopm-service-fedora
- There were a few issues with building in OBS that have been addressed by this PR