### PR TITLE
Remove work-arounds required for OBS Rawhide image

### DIFF
--- a/release/fedora/geopm-doc.spec
+++ b/release/fedora/geopm-doc.spec
@@ -42,8 +42,6 @@ Requires: geopm-runtime-doc
 Requires: libgeopm-doc
 Requires: python3-geopmpy-doc
 BuildRequires: bash-completion
-BuildRequires: marshalparser
-%global debug_package %{nil}
 
 %define completionsdir %(pkg-config --variable=completionsdir bash-completion)
 %if "x%{?completionsdir}" == "x"
@@ -102,9 +100,7 @@ echo %{version} > VERSION
 %install
 cd docs
 %{__make} DESTDIR=%{buildroot} prefix=%{_prefix} datarootdir=%{_datarootdir} mandir=%{_mandir} install_man
-%if 0%{?fedora} <= 40
 %{__make} DESTDIR=%{buildroot} prefix=%{_prefix} datarootdir=%{_datarootdir} mandir=%{_mandir} completionsdir=%{completionsdir} install_completion
-%endif
 
 %clean
 
@@ -141,10 +137,8 @@ cd docs
 %doc %{_mandir}/man7/geopm_pio_sysfs.7.gz
 %doc %{_mandir}/man7/geopm_pio_time.7.gz
 %doc %{_mandir}/man7/geopm_report.7.gz
-%if 0%{?fedora} <= 40
 %doc %{completionsdir}/geopmread
 %doc %{completionsdir}/geopmwrite
-%endif
 
 %files -n libgeopmd-doc
 %doc %{_mandir}/man3/geopm::Agg.3.gz
@@ -189,9 +183,7 @@ cd docs
 %files -n python3-geopmpy-doc
 %doc %{_mandir}/man1/geopmlaunch.1.gz
 %doc %{_mandir}/man7/geopmpy.7.gz
-%if 0%{?fedora} <= 40
 %doc %{completionsdir}/geopmlaunch
-%endif
 
 %changelog
 * Fri May 17 2024 Christopher M Cantalupo <christopher.m.cantalupo@intel.com> v3.1.0

--- a/release/fedora/geopm-service.spec
+++ b/release/fedora/geopm-service.spec
@@ -109,14 +109,9 @@ cd libgeopmd
 %define level_zero_option --enable-levelzero
 %endif
 %endif
-%if 0%{?fedora} != 0 && ! 0%{?fedora} <= 40
-# Our use of relro flag causes a configure test to fail on fedora rawhide
-%define relro_flags LDFLAGS=-Wl,-z,norelro
-%endif
 
 echo %{version} > VERSION
 ./autogen.sh
-%{?relro_flags} \
 ./configure --prefix=%{_prefix} --libdir=%{_libdir} --libexecdir=%{_libexecdir} \
             --includedir=%{_includedir} --sbindir=%{_sbindir} \
             --mandir=%{_mandir} --docdir=%{docdir} \

--- a/release/fedora/geopmdpy.spec
+++ b/release/fedora/geopmdpy.spec
@@ -18,7 +18,6 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 BuildRequires: python-rpm-macros
-BuildRequires: marshalparser
 
 # Packages required to run tests
 BuildRequires: python3-dasbus >= 1.6
@@ -26,8 +25,6 @@ BuildRequires: python3-jsonschema
 BuildRequires: python3-psutil
 BuildRequires: python3-cffi
 BuildRequires: libgeopmd2
-
-%global debug_package %{nil}
 
 %define python_bin %{__python3}
 


### PR DESCRIPTION
- There are several commits to the CI spec files that may be working around problems in the non-standard OBS image for Fedora Rawhide
- These changes are reflected in the proposed Fedora spec files for 3.1.0
- This patch modifies the spec files proposed for Fedora to revert the changes to the CI spec files described in the following commits

  ef38ae5d2055ea2a3f17d6dc005b47fa7b167aaa 
 dd4513aafda58d68a6784c1c005490482db01d9a 
 76e8f37e9171e3951f2ed9ebada506c133c278fd
