### PR TITLE
Include i915 hwmon entries in SysfsIOGroup

### DIFF
--- a/docs/json_data/sysfs_attributes_drm.json
+++ b/docs/json_data/sysfs_attributes_drm.json
@@ -1,5 +1,101 @@
 {
     "attributes": {
+        "HWMON::IN0_INPUT": {
+            "attribute": "in0_input",
+            "scalar": 1e-3,
+            "description": "The current voltage",
+            "doc_domain": "gpu",
+            "aggregation": "average",
+            "behavior": "variable",
+            "format": "double",
+            "units": "volts",
+            "writeable": false,
+            "alias": ""
+        },
+        "HWMON::POWER1_MAX": {
+            "attribute": "power1_max",
+            "scalar": 1e-6,
+            "description": "Requested power limit, sustained on average over DRM::HWMON::POWER1_MAX_INTERVAL",
+            "doc_domain": "gpu",
+            "aggregation": "sum",
+            "behavior": "variable",
+            "format": "double",
+            "units": "watts",
+            "writeable": true,
+            "alias": "GPU_POWER_LIMIT_CONTROL"
+        },
+        "HWMON::POWER1_RATED_MAX": {
+            "attribute": "power1_max",
+            "scalar": 1e-6,
+            "description": "Default thermal design power limit",
+            "doc_domain": "gpu",
+            "aggregation": "sum",
+            "behavior": "variable",
+            "format": "double",
+            "units": "watts",
+            "writeable": false,
+            "alias": "GPU_POWER_LIMIT_DEFAULT"
+        },
+        "HWMON::POWER1_MAX_INTERVAL": {
+            "attribute": "power1_max_interval",
+            "scalar": 1e-3,
+            "description": "Requested time window over which DRM::HWMON::POWER1_MAX is sustained on average",
+            "doc_domain": "gpu",
+            "aggregation": "expect_same",
+            "behavior": "variable",
+            "format": "double",
+            "units": "seconds",
+            "writeable": true,
+            "alias": "GPU_POWER_TIME_WINDOW_CONTROL"
+        },
+        "HWMON::POWER1_CRIT": {
+            "attribute": "power1_crit",
+            "scalar": 1e-6,
+            "description": "Critical power limit, influencing the power manager's throttling decisions",
+            "doc_domain": "gpu",
+            "aggregation": "sum",
+            "behavior": "variable",
+            "format": "double",
+            "units": "watts",
+            "writeable": true,
+            "alias": ""
+        },
+        "HWMON::CURR1_CRIT": {
+            "attribute": "curr1_crit",
+            "scalar": 1e-3,
+            "description": "Critical current limit, influencing the power manager's throttling decisions",
+            "doc_domain": "gpu",
+            "aggregation": "sum",
+            "behavior": "variable",
+            "format": "double",
+            "units": "amperes",
+            "writeable": true,
+            "alias": ""
+        },
+        "HWMON::ENERGY1_INPUT::GPU": {
+            "attribute": "energy1_input",
+            "scalar": 1e-6,
+            "description": "GPU card-level energy counter",
+            "doc_domain": "gpu",
+            "aggregation": "sum",
+            "behavior": "monotone",
+            "format": "double",
+            "units": "joules",
+            "writeable": false,
+            "alias": "GPU_ENERGY"
+        },
+        "HWMON::ENERGY1_INPUT::GPU_CHIP": {
+            "attribute": "energy1_input",
+            "scalar": 1e-6,
+            "description": "GPU tile-level energy counter",
+            "doc_domain": "gpu_chip",
+            "aggregation": "sum",
+            "behavior": "monotone",
+            "format": "double",
+            "units": "joules",
+            "writeable": false,
+            "alias": "GPU_CHIP_ENERGY"
+        },
         "RPS_MIN_FREQ": {
             "attribute": "rps_min_freq_mhz",
             "scalar": 1e6,

--- a/docs/json_schemas/const_config_io.schema.json
+++ b/docs/json_schemas/const_config_io.schema.json
@@ -11,7 +11,7 @@
                         "type": "string"
                     },
                     "units": {
-                        "enum": ["none", "seconds", "hertz", "watts", "joules", "celsius"]
+                        "enum": ["none", "seconds", "hertz", "watts", "joules", "celsius", "amperes", "volts"]
                     },
                     "domain": {
                         "enum": ["board", "package", "core", "cpu", "memory", "package_integrated_memory", "nic", "package_integrated_nic", "gpu", "package_integrated_gpu", "gpu_chip"]

--- a/docs/json_schemas/msrs.schema.json
+++ b/docs/json_schemas/msrs.schema.json
@@ -16,7 +16,7 @@
             "enum": ["scale", "log_half", "7_bit_float", "overflow", "logic"]
           },
           "units": {
-            "enum": ["none", "seconds", "hertz", "watts", "joules", "celsius"]
+            "enum": ["none", "seconds", "hertz", "watts", "joules", "celsius", "amperes", "volts"]
           },
           "scalar": {
             "type": "number"

--- a/docs/json_schemas/sysfs_attributes.schema.json
+++ b/docs/json_schemas/sysfs_attributes.schema.json
@@ -28,7 +28,7 @@
           "format": { "description": "How to present read values",
                       "enum": ["double", "integer", "hex", "raw64"] },
           "units": { "description": "Which units are represented by the attribute's read values",
-                      "enum": ["none", "seconds", "hertz", "watts", "joules", "celsius"] },
+                      "enum": ["none", "seconds", "hertz", "watts", "joules", "celsius", "amperes", "volts"] },
           "writeable": { "description": "True if the attribute is also writeable as a control",
                          "type": "boolean" },
           "alias": { "description": "An alias signal/control to create for this attribute. An empty string if no alias is desired.",

--- a/docs/source/_ext/geopm_rst_extensions.py
+++ b/docs/source/_ext/geopm_rst_extensions.py
@@ -217,7 +217,7 @@ class GeopmSysfsJson(SphinxDirective):
             logger.error('Unable to parse %s. Error: %s', json_path, e, location=self.get_location())
             return []
 
-        attribute_regex = re.compile('(' + driver_name + r'::\w+)', flags=re.ASCII)
+        attribute_regex = re.compile('(' + driver_name + r'::[\w:]+)', flags=re.ASCII)
         doc_nodes = nodes.definition_list()
         alias_map = collections.defaultdict(list)
         attribute_definitions = []

--- a/docs/source/geopm_pio_sysfs.7.rst
+++ b/docs/source/geopm_pio_sysfs.7.rst
@@ -39,6 +39,10 @@ Some signals and controls are made available to GEOPM through the sysfs interfac
 to the ``i915 DRM`` (Direct Rendering Manager) driver. For more information, see the
 `i915 documentation <https://www.kernel.org/doc/html/next/gpu/i915.html>`_ and the
 `oneAPI GPU Optimization Guide <https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2024-0/configuring-gpu-device.html>`_.
+Furthermore, the i915 DRM devices may link to i915 hwmon devices. If the hwmon
+links are present, this IOGroup also exposes signals and controls from the
+`i915 hwmon interface <https://www.kernel.org/doc/html/latest/admin-guide/abi-testing.html#file-testing-sysfs-driver-intel-i915-hwmon>`_.
+
 The i915 driver is available in `upstream Linux <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/gpu/drm/i915>`_.
 Additional features are available in the `out-of-tree version of the driver <https://github.com/intel-gpu/intel-gpu-i915-backports>`_.
 This IOGroup is intended for use with either version of the driver.

--- a/geopmdpy/geopmdpy/schemas.py
+++ b/geopmdpy/geopmdpy/schemas.py
@@ -84,7 +84,7 @@ GEOPM_CONST_CONFIG_IO_SCHEMA = """
                         "type": "string"
                     },
                     "units": {
-                        "enum": ["none", "seconds", "hertz", "watts", "joules", "celsius"]
+                        "enum": ["none", "seconds", "hertz", "watts", "joules", "celsius", "amperes", "volts"]
                     },
                     "domain": {
                         "enum": ["board", "package", "core", "cpu", "memory", "package_integrated_memory", "nic", "package_integrated_nic", "gpu", "package_integrated_gpu", "gpu_chip"]

--- a/libgeopmd/include/geopm/IOGroup.hpp
+++ b/libgeopmd/include/geopm/IOGroup.hpp
@@ -27,6 +27,8 @@ namespace geopm
                 M_UNITS_WATTS,
                 M_UNITS_JOULES,
                 M_UNITS_CELSIUS,
+                M_UNITS_AMPERES,
+                M_UNITS_VOLTS,
                 M_NUM_UNITS
             };
 

--- a/libgeopmd/src/DrmSysfsDriver.cpp
+++ b/libgeopmd/src/DrmSysfsDriver.cpp
@@ -136,7 +136,7 @@ namespace geopm
     {
         // So far, all of the supported i915 DRM signals are tile-scoped and
         // most of the i915 hwmon signals are card-scoped.
-        if (signal_name_is_from_hwmon(name) && !string_ends_with(name, TILE_SIGNAL_NAME_SUFFIX)) {
+        if (signal_name_is_from_hwmon(name) && !geopm::string_ends_with(name, TILE_SIGNAL_NAME_SUFFIX)) {
             return GEOPM_DOMAIN_GPU;
         }
         else {

--- a/libgeopmd/src/DrmSysfsDriver.cpp
+++ b/libgeopmd/src/DrmSysfsDriver.cpp
@@ -110,7 +110,7 @@ namespace geopm
         return [scaling_factor](const std::string &content) {
             double result = static_cast<double>(NAN);
             try {
-                result = static_cast<double>(std::stoi(content) * scaling_factor);
+                result = static_cast<double>(std::stol(content) * scaling_factor);
             }
             catch (const std::invalid_argument &ex) {}
             catch (const std::out_of_range &ex) {}

--- a/libgeopmd/src/DrmSysfsDriver.hpp
+++ b/libgeopmd/src/DrmSysfsDriver.hpp
@@ -37,8 +37,8 @@ namespace geopm
             static std::unique_ptr<IOGroup> make_plugin(void);
         private:
             const std::map<std::string, SysfsDriver::properties_s> M_PROPERTIES;
+            const std::map<std::pair<geopm_domain_e, int>, std::string> M_DRM_HWMON_DIR_BY_GEOPM_DOMAIN;
             const std::map<int, std::string> M_DRM_RESOURCE_BY_GPU_TILE;
-            geopm_domain_e m_domain;
     };
 }
 

--- a/libgeopmd/src/DrmSysfsDriver.hpp
+++ b/libgeopmd/src/DrmSysfsDriver.hpp
@@ -36,8 +36,11 @@ namespace geopm
             static std::string plugin_name(void);
             static std::unique_ptr<IOGroup> make_plugin(void);
         private:
+            // Map of signal names to sysfs signal properties
             const std::map<std::string, SysfsDriver::properties_s> M_PROPERTIES;
+            // Map of (GEOPM signal domain, GEOPM signal index) pairs to hwmon sysfs directory paths symlinked via drm paths
             const std::map<std::pair<geopm_domain_e, int>, std::string> M_DRM_HWMON_DIR_BY_GEOPM_DOMAIN;
+            // Map of GEOPM gpu_chip index to drm sysfs directory paths
             const std::map<int, std::string> M_DRM_RESOURCE_BY_GPU_TILE;
     };
 }

--- a/libgeopmd/src/IOGroup.cpp
+++ b/libgeopmd/src/IOGroup.cpp
@@ -50,7 +50,9 @@ namespace geopm
         "hertz",
         "watts",
         "joules",
-        "celsius"
+        "celsius",
+        "amperes",
+        "volts"
     };
 
     const std::string IOGroup::M_BEHAVIORS[IOGroup::M_NUM_SIGNAL_BEHAVIOR] = {
@@ -66,7 +68,9 @@ namespace geopm
         {IOGroup::M_UNITS[M_UNITS_HERTZ], M_UNITS_HERTZ},
         {IOGroup::M_UNITS[M_UNITS_WATTS], M_UNITS_WATTS},
         {IOGroup::M_UNITS[M_UNITS_JOULES], M_UNITS_JOULES},
-        {IOGroup::M_UNITS[M_UNITS_CELSIUS], M_UNITS_CELSIUS}
+        {IOGroup::M_UNITS[M_UNITS_CELSIUS], M_UNITS_CELSIUS},
+        {IOGroup::M_UNITS[M_UNITS_AMPERES], M_UNITS_AMPERES},
+        {IOGroup::M_UNITS[M_UNITS_VOLTS], M_UNITS_VOLTS}
     };
 
     const std::map<std::string, IOGroup::m_signal_behavior_e> IOGroup::M_BEHAVIOR_STRING = {

--- a/libgeopmd/test/LevelZeroGPUTopoTest.cpp
+++ b/libgeopmd/test/LevelZeroGPUTopoTest.cpp
@@ -93,20 +93,21 @@ TEST_F(LevelZeroGPUTopoTest, four_forty_config)
     EXPECT_EQ(num_gpu, topo_sub.num_gpu());
     EXPECT_EQ(num_gpu_subdevice, topo_sub.num_gpu(GEOPM_DOMAIN_GPU_CHIP));
 
-    std::set<int> cpus_allowed_set_subdevice[num_gpu_subdevice];
-    cpus_allowed_set_subdevice[0] = {0,2,4,6,8};
-    cpus_allowed_set_subdevice[1] = {1,3,5,7,9};
-    cpus_allowed_set_subdevice[2] = {10,12,14,16,18};
-    cpus_allowed_set_subdevice[3] = {11,13,15,17,19};
-    cpus_allowed_set_subdevice[4] = {20,22,24,26,28};
-    cpus_allowed_set_subdevice[5] = {21,23,25,27,29};
-    cpus_allowed_set_subdevice[6] = {30,32,34,36,38};
-    cpus_allowed_set_subdevice[7] = {31,33,35,37,39};
+    std::vector<std::set<int>> cpus_allowed_set_subdevice = {
+        {0,2,4,6,8},
+        {1,3,5,7,9},
+        {10,12,14,16,18},
+        {11,13,15,17,19},
+        {20,22,24,26,28},
+        {21,23,25,27,29},
+        {30,32,34,36,38},
+        {31,33,35,37,39}
+    };
 
     for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
         ASSERT_THAT(topo_sub.cpu_affinity_ideal(gpu_idx), cpus_allowed_set[gpu_idx]);
     }
-    for (int gpu_idx = 0; gpu_idx < num_gpu_subdevice; ++gpu_idx) {
+    for (int gpu_idx = 0; gpu_idx < static_cast<int>(cpus_allowed_set_subdevice.size()); ++gpu_idx) {
         ASSERT_THAT(topo_sub.cpu_affinity_ideal(GEOPM_DOMAIN_GPU_CHIP, gpu_idx), cpus_allowed_set_subdevice[gpu_idx]);
     }
 }

--- a/libgeopmd/test/Makefile.mk
+++ b/libgeopmd/test/Makefile.mk
@@ -36,6 +36,7 @@ test_geopm_test_SOURCES = test/GPUTopoNullTest.cpp \
                           test/DCGMIOGroupTest.cpp \
                           test/DerivativeSignalTest.cpp \
                           test/DifferenceSignalTest.cpp \
+                          test/DrmSysfsDriverTest.cpp \
                           test/RatioSignalTest.cpp \
                           test/DomainControlTest.cpp \
                           test/ExceptionTest.cpp \

--- a/libgeopmd/test/NVMLGPUTopoTest.cpp
+++ b/libgeopmd/test/NVMLGPUTopoTest.cpp
@@ -309,17 +309,18 @@ TEST_F(NVMLGPUTopoTest, high_cpu_count_gaps_config)
     NVMLGPUTopo topo(*m_device_pool, num_cpu);
 
     EXPECT_EQ(num_gpu, topo.num_gpu());
-    std::set<int> cpus_allowed_set[num_gpu];
-    cpus_allowed_set[0] = {0 ,1 ,2 ,3 ,4 ,5 ,6 ,7};
-    cpus_allowed_set[1] = {8 ,9 ,10,11,12,13,14,15};
-    cpus_allowed_set[2] = {16,17,18,19,20,21,22,23};
-    cpus_allowed_set[3] = {24,25,26,27,64,65,66,67};
-    cpus_allowed_set[4] = {28,29,30,31,32,33,34,35,127};
-    cpus_allowed_set[5] = {36,37,38,39,40,41,42,43};
-    cpus_allowed_set[6] = {44,45,46,47,48,49,50,51};
-    cpus_allowed_set[7] = {52,53,54,55,123,124,125,126};
+    std::vector<std::set<int>> cpus_allowed_set = {
+        {0 ,1 ,2 ,3 ,4 ,5 ,6 ,7},
+        {8 ,9 ,10,11,12,13,14,15},
+        {16,17,18,19,20,21,22,23},
+        {24,25,26,27,64,65,66,67},
+        {28,29,30,31,32,33,34,35,127},
+        {36,37,38,39,40,41,42,43},
+        {44,45,46,47,48,49,50,51},
+        {52,53,54,55,123,124,125,126}
+    };
 
-    for (int gpu_idx = 0; gpu_idx < num_gpu; ++gpu_idx) {
+    for (int gpu_idx = 0; gpu_idx < static_cast<int>(cpus_allowed_set.size()); ++gpu_idx) {
         ASSERT_THAT(topo.cpu_affinity_ideal(gpu_idx), cpus_allowed_set[gpu_idx]);
     }
 }


### PR DESCRIPTION
- Relates to #3545 (I think the same / a similar pattern can be used for `/dev/class/accel` drivers that are used in that case)
- Relates to #3546
- Fixes #2449. This doesn't use the solution requested in that issue, but it does make the request obsolete since this change includes `GPU_POWER_LIMIT_CONTROL`, `GPU_POWER_TIME_WINDOW_CONTROL`, and `GPU_POWER_LIMIT_DEFAULT` controls/signals.