### PR TITLE
Make DrmSysfsDriver compatible with /sys/class/accel

### DIFF
--- a/libgeopmd/src/DrmSysfsDriver.hpp
+++ b/libgeopmd/src/DrmSysfsDriver.hpp
@@ -22,9 +22,10 @@ namespace geopm
     class DrmSysfsDriver: public SysfsDriver
     {
         public:
-            DrmSysfsDriver();
+            DrmSysfsDriver() = delete;
             DrmSysfsDriver(const PlatformTopo &topo,
-                           const std::string &drm_directory);
+                           const std::string &drm_directory,
+                           const std::string &driver_signal_prefix);
             virtual ~DrmSysfsDriver() = default;
             int domain_type(const std::string &name) const override;
             std::string attribute_path(const std::string &name,
@@ -33,9 +34,16 @@ namespace geopm
             std::function<std::string(double)> control_gen(const std::string &control_name) const override;
             std::string driver(void) const override;
             std::map<std::string, SysfsDriver::properties_s> properties(void) const override;
-            static std::string plugin_name(void);
-            static std::unique_ptr<IOGroup> make_plugin(void);
+
+            static std::string plugin_name_drm(void);
+            static std::unique_ptr<IOGroup> make_plugin_drm(void);
+
+            static std::string plugin_name_accel(void);
+            static std::unique_ptr<IOGroup> make_plugin_accel(void);
         private:
+            // Prefix to use at the start of signal names exported by this SysfsDriver
+            // E.g., "DRM" or "ACCEL"
+            const std::string M_DRIVER_SIGNAL_PREFIX;
             // Map of signal names to sysfs signal properties
             const std::map<std::string, SysfsDriver::properties_s> M_PROPERTIES;
             // Map of (GEOPM signal domain, GEOPM signal index) pairs to hwmon sysfs directory paths symlinked via drm paths

--- a/libgeopmd/src/IOGroup.cpp
+++ b/libgeopmd/src/IOGroup.cpp
@@ -162,8 +162,10 @@ namespace geopm
 #endif
         register_plugin(ConstConfigIOGroup::plugin_name(),
                         ConstConfigIOGroup::make_plugin);
-        register_plugin(DrmSysfsDriver::plugin_name(),
-                        DrmSysfsDriver::make_plugin);
+        register_plugin(DrmSysfsDriver::plugin_name_drm(),
+                        DrmSysfsDriver::make_plugin_drm);
+        register_plugin(DrmSysfsDriver::plugin_name_accel(),
+                        DrmSysfsDriver::make_plugin_accel);
     }
 
     IOGroupFactory &iogroup_factory(void)

--- a/libgeopmd/test/DrmSysfsDriverTest.cpp
+++ b/libgeopmd/test/DrmSysfsDriverTest.cpp
@@ -180,24 +180,25 @@ void DrmSysfsDriverTest::SetUp()
     m_dir_manager->write_file_in_card_tile(0, 1, "rps_cur_freq_mhz", "2345");
     m_dir_manager->write_file_in_card_tile(0, 0, "rps_act_freq_mhz", "1230");
     m_dir_manager->write_file_in_card_tile(0, 1, "rps_act_freq_mhz", "2340");
-    m_driver = std::make_unique<DrmSysfsDriver>(*m_topo, m_dir_manager->get_driver_dir());
+    m_driver = std::make_unique<DrmSysfsDriver>(*m_topo, m_dir_manager->get_driver_dir(), "TEST_DRIVER_PREFIX");
     m_driver_properties = m_driver->properties();
 }
 
 TEST_F(DrmSysfsDriverTest, iogroup_plugin_name_matches_driver_name)
 {
-    EXPECT_EQ("DRM", m_driver->driver());
-    EXPECT_EQ("DRM", DrmSysfsDriver::plugin_name());
+    EXPECT_EQ("TEST_DRIVER_PREFIX", m_driver->driver());
+    EXPECT_EQ("DRM", DrmSysfsDriver::plugin_name_drm());
+    EXPECT_EQ("ACCEL", DrmSysfsDriver::plugin_name_accel());
 }
 
 TEST_F(DrmSysfsDriverTest, domain_type)
 {
-    m_driver = std::make_unique<DrmSysfsDriver>(*m_topo, m_dir_manager->get_driver_dir());
+    m_driver = std::make_unique<DrmSysfsDriver>(*m_topo, m_dir_manager->get_driver_dir(), "TEST_DRIVER_PREFIX");
     for (const auto &attribute_properties : m_driver->properties()) {
         auto domain_type = [this](const std::string &s) { return m_driver->domain_type(s); };
         EXPECT_THAT(attribute_properties.first,
-                    AnyOf(AllOf(StartsWith("DRM::HWMON::"), Not(EndsWith("::GPU_CHIP")), Not(EndsWith("::GPU")), ResultOf("domain type", domain_type, Eq(GEOPM_DOMAIN_GPU))),
-                          AllOf(Not(StartsWith("DRM::HWMON::")), Not(EndsWith("::GPU_CHIP")), Not(EndsWith("::GPU")), ResultOf("domain type", domain_type, Eq(GEOPM_DOMAIN_GPU_CHIP))),
+                    AnyOf(AllOf(StartsWith("TEST_DRIVER_PREFIX::HWMON::"), Not(EndsWith("::GPU_CHIP")), Not(EndsWith("::GPU")), ResultOf("domain type", domain_type, Eq(GEOPM_DOMAIN_GPU))),
+                          AllOf(Not(StartsWith("TEST_DRIVER_PREFIX::HWMON::")), Not(EndsWith("::GPU_CHIP")), Not(EndsWith("::GPU")), ResultOf("domain type", domain_type, Eq(GEOPM_DOMAIN_GPU_CHIP))),
                           AllOf(EndsWith("::GPU_CHIP"), ResultOf("domain type", domain_type, Eq(GEOPM_DOMAIN_GPU_CHIP))),
                           AllOf(EndsWith("::GPU"), ResultOf("domain type", domain_type, Eq(GEOPM_DOMAIN_GPU)))));
     }
@@ -206,11 +207,11 @@ TEST_F(DrmSysfsDriverTest, domain_type)
 TEST_F(DrmSysfsDriverTest, attribute_path)
 {
     EXPECT_EQ(m_dir_manager->get_driver_dir() + "/card0/gt/gt0/rps_cur_freq_mhz",
-              m_driver->attribute_path("DRM::RPS_CUR_FREQ", 0))
+              m_driver->attribute_path("TEST_DRIVER_PREFIX::RPS_CUR_FREQ", 0))
         << "Should successfully get a path for an attribute that exists";
-    EXPECT_THROW(m_driver->attribute_path("DRM::A_MADE_UP_ATTRIBUTE_NAME", 0), geopm::Exception)
+    EXPECT_THROW(m_driver->attribute_path("TEST_DRIVER_PREFIX::A_MADE_UP_ATTRIBUTE_NAME", 0), geopm::Exception)
         << "Should fail to get a path for an attribute that does not exist";
-    EXPECT_THROW(m_driver->attribute_path("DRM::RPS_CUR_FREQ", 12345), geopm::Exception)
+    EXPECT_THROW(m_driver->attribute_path("TEST_DRIVER_PREFIX::RPS_CUR_FREQ", 12345), geopm::Exception)
         << "Should fail to get a path for an attribute at a domain that does not exist";
 }
 
@@ -232,38 +233,38 @@ TEST_F(DrmSysfsDriverTest, hwmon_attribute_paths)
     m_dir_manager->write_hwmon_name_and_attribute(1, 6, "i915_gt1\n", "energy1_input", "234567");
     m_dir_manager->write_hwmon_name_and_attribute(1, 7, "i915\n", "energy1_input", "345678");
 
-    m_driver = std::make_unique<DrmSysfsDriver>(*m_topo, m_dir_manager->get_driver_dir());
+    m_driver = std::make_unique<DrmSysfsDriver>(*m_topo, m_dir_manager->get_driver_dir(), "TEST_DRIVER_PREFIX");
 
     EXPECT_EQ(m_dir_manager->get_driver_dir() + "/card0/device/hwmon/hwmon123/curr1_crit",
-              m_driver->attribute_path("DRM::HWMON::CURR1_CRIT", 0))
-        << "Should successfully get a DRM->HWMON path for a card-scoped hwmon";
+              m_driver->attribute_path("TEST_DRIVER_PREFIX::HWMON::CURR1_CRIT", 0))
+        << "Should successfully get a TEST_DRIVER_PREFIX->HWMON path for a card-scoped hwmon";
 
     // Card1/GT0: gpu_chip 2
     EXPECT_EQ(m_dir_manager->get_driver_dir() + "/card1/device/hwmon/hwmon45/energy1_input",
-              m_driver->attribute_path("DRM::HWMON::ENERGY1_INPUT::GPU_CHIP", 2))
-        << "Should successfully get a DRM->HWMON path for a tile-scoped hwmon";
+              m_driver->attribute_path("TEST_DRIVER_PREFIX::HWMON::ENERGY1_INPUT::GPU_CHIP", 2))
+        << "Should successfully get a TEST_DRIVER_PREFIX->HWMON path for a tile-scoped hwmon";
     // Card1/GT1: gpu_chip 3
     EXPECT_EQ(m_dir_manager->get_driver_dir() + "/card1/device/hwmon/hwmon6/energy1_input",
-              m_driver->attribute_path("DRM::HWMON::ENERGY1_INPUT::GPU_CHIP", 3))
-        << "Should successfully get a DRM->HWMON path for a tile-scoped hwmon";
+              m_driver->attribute_path("TEST_DRIVER_PREFIX::HWMON::ENERGY1_INPUT::GPU_CHIP", 3))
+        << "Should successfully get a TEST_DRIVER_PREFIX->HWMON path for a tile-scoped hwmon";
     // Card1: gpu 1
     EXPECT_EQ(m_dir_manager->get_driver_dir() + "/card1/device/hwmon/hwmon7/energy1_input",
-              m_driver->attribute_path("DRM::HWMON::ENERGY1_INPUT::GPU", 1))
-        << "Should successfully get a DRM->HWMON path for a card hwmon";
+              m_driver->attribute_path("TEST_DRIVER_PREFIX::HWMON::ENERGY1_INPUT::GPU", 1))
+        << "Should successfully get a TEST_DRIVER_PREFIX->HWMON path for a card hwmon";
 }
 
 TEST_F(DrmSysfsDriverTest, signal_parse)
 {
-    EXPECT_THROW(m_driver->signal_parse("DRM::A_MADE_UP_ATTRIBUTE_NAME"), geopm::Exception)
+    EXPECT_THROW(m_driver->signal_parse("TEST_DRIVER_PREFIX::A_MADE_UP_ATTRIBUTE_NAME"), geopm::Exception)
         << "Should fail to parse a signal that does not exist";
-    EXPECT_DOUBLE_EQ(1.234e9, m_driver->signal_parse("DRM::RPS_CUR_FREQ")("1234" /* in MHz */));
-    EXPECT_DOUBLE_EQ(2.345e9, m_driver->signal_parse("DRM::RPS_ACT_FREQ")("2345" /* in MHz */));
+    EXPECT_DOUBLE_EQ(1.234e9, m_driver->signal_parse("TEST_DRIVER_PREFIX::RPS_CUR_FREQ")("1234" /* in MHz */));
+    EXPECT_DOUBLE_EQ(2.345e9, m_driver->signal_parse("TEST_DRIVER_PREFIX::RPS_ACT_FREQ")("2345" /* in MHz */));
 }
 
 TEST_F(DrmSysfsDriverTest, control_gen)
 {
-    EXPECT_THROW(m_driver->control_gen("DRM::A_MADE_UP_ATTRIBUTE_NAME"), geopm::Exception)
+    EXPECT_THROW(m_driver->control_gen("TEST_DRIVER_PREFIX::A_MADE_UP_ATTRIBUTE_NAME"), geopm::Exception)
         << "Should fail to generate a control that does not exist";
-    EXPECT_EQ("1100", m_driver->control_gen("DRM::RPS_MIN_FREQ")(1.1e9));
-    EXPECT_EQ("1200", m_driver->control_gen("DRM::RPS_MAX_FREQ")(1.2e9));
+    EXPECT_EQ("1100", m_driver->control_gen("TEST_DRIVER_PREFIX::RPS_MIN_FREQ")(1.1e9));
+    EXPECT_EQ("1200", m_driver->control_gen("TEST_DRIVER_PREFIX::RPS_MAX_FREQ")(1.2e9));
 }


### PR DESCRIPTION
- /sys/class/accel exposes a DRM interface, but uses a different name so
  that users don't mistake accelerators for render-focused graphics card
- This change reuses our existing /sys/class/drm code, but makes the
  target directory an IOGroup name configurable, and registers both
  accel and drm instances with PlatformIO.
- Resolves #3560