### PR TITLE
Make OMPT region detection opt-in

### DIFF
--- a/docs/source/geopm.7.rst
+++ b/docs/source/geopm.7.rst
@@ -163,9 +163,9 @@ runtime configured to support OMPT if the default OpenMP runtime does
 not support the OMPT callbacks.  Note that your compiler must be
 compatible with the LLVM OpenMP ABI for extending it in this way.
 
-This feature can be disabled on a per-run basis by setting the
-``GEOPM_OMPT_DISABLE`` environment variable, or by using the
-``--geopm-ompt-disable`` option in :doc:`geopmlaunch(1) <geopmlaunch.1>`
+This feature can be enabled on a per-run basis by setting the
+``GEOPM_OMPT_ENABLE`` environment variable, or by using the
+``--geopm-ompt-enable`` option in :doc:`geopmlaunch(1) <geopmlaunch.1>`
 
 Choosing An Agent And Policy
 ----------------------------
@@ -347,10 +347,10 @@ GEOPM Environment Variables
   hyperthreads per CPU core. See the ``--geopm-hyperthreads-disable``
   :ref:`option description <geopm-hyperthreads-disable option>` in
   :doc:`geopmlaunch(1) <geopmlaunch.1>` for more details.
-``GEOPM_OMPT_DISABLE``
-  Set to any value to disable OpenMP region detection as described in
-  :ref:`geopm.7:integration with ompt`.  See the ``--geopm-ompt-disable``
-  :ref:`option description <geopm-ompt-disable option>` in :doc:`geopmlaunch(1)
+``GEOPM_OMPT_ENABLE``
+  Set to any value to enable OpenMP region detection as described in
+  :ref:`geopm.7:integration with ompt`.  See the ``--geopm-ompt-enable``
+  :ref:`option description <geopm-ompt-enable option>` in :doc:`geopmlaunch(1)
   <geopmlaunch.1>` for more details.
 ``GEOPM_INIT_CONTROL``
   The path to the control initialization file.  See the ``--geopm-init-control``

--- a/docs/source/geopm_report.7.rst
+++ b/docs/source/geopm_report.7.rst
@@ -19,8 +19,8 @@ The application regions and epoch are defined by use of the
 :doc:`geopm_prof(3) <geopm_prof.3>` interface to mark up the user application, or
 through automatic inference of regions based on interposing on the MPI
 or OpenMP interfaces (interposing on OpenMP requires that OMPT is
-enabled at GEOPM compile time, and the ``--geopm-ompt-disable`` option
-is not provided to ``geopmlaunch``). Alternatively, epochs may be
+enabled at GEOPM compile time, and the ``--geopm-ompt-enable`` option
+is provided to ``geopmlaunch``). Alternatively, epochs may be
 inserted automatically when ``--geopm-record-filter`` is used, as
 described in :doc:`geopmlaunch(1) <geopmlaunch.1>`.
 

--- a/docs/source/geopmlaunch.1.rst
+++ b/docs/source/geopmlaunch.1.rst
@@ -563,9 +563,9 @@ GEOPM Options
                    effect if ``--geopm-ctl`` or ``--geopm-ctl-disable``
                    are provided. This is especially useful when launching
                    non-MPI applications.
---geopm-ompt-disable  .. _geopm-ompt-disable option:
+--geopm-ompt-enable  .. _geopm-ompt-enable option:
 
-                      Disable OMPT detection of OpenMP regions.
+                      Enable OMPT detection of OpenMP regions.
                       See the :ref:`INTEGRATION WITH OMPT section of geopm(7)<geopm.7:Integration With OMPT>`
                       for more information about OpenMP region detection.
 --geopm-period  .. _geopm-period option:

--- a/geopmpy/geopmpy/launcher.py
+++ b/geopmpy/geopmpy/launcher.py
@@ -141,7 +141,9 @@ class Config(object):
         parser.add_argument('--geopm-debug-attach', dest='debug_attach', type=str)
         parser.add_argument('--geopm-preload', dest='preload', action='store_true', default=False)
         parser.add_argument('--geopm-hyperthreads-disable', dest='allow_ht_pinning', action='store_false', default=True)
-        parser.add_argument('--geopm-ompt-disable', dest='ompt_disable', action='store_true', default=False)
+        ompt_group = parser.add_mutually_exclusive_group()
+        ompt_group.add_argument('--geopm-ompt-enable', dest='ompt_enable', action='store_true', default=False)
+        ompt_group.add_argument('--geopm-ompt-disable', dest='ompt_disable', action='store_true', default=False)
         parser.add_argument('--geopm-record-filter', dest='record_filter', type=str)
         parser.add_argument('--geopm-affinity-enable', dest='do_affinity', action='store_true', default=False)
         parser.add_argument('--geopm-launch-verbose', dest='quiet', action='store_false', default=True)
@@ -154,6 +156,8 @@ class Config(object):
         # Error check inputs
         if opts.ctl not in ('process', 'pthread', 'application'):
             raise SyntaxError('<geopm> geopmpy.launcher: --geopm-ctl must be one of: "process", "pthread", or "application"')
+        if opts.ompt_disable:
+            print('Warning: --geopm-ompt-disable is deprecated since OMPT regions are now disabled by default. The option may be removed in future releases.', file=sys.stderr)
         # copy opts object into self
         self.ctl = opts.ctl
         self.policy = opts.policy
@@ -172,7 +176,7 @@ class Config(object):
         self.preload = opts.preload
         self.omp_num_threads = None
         self.allow_ht_pinning = opts.allow_ht_pinning and 'GEOPM_DISABLE_HYPERTHREADS' not in os.environ
-        self.ompt_disable = opts.ompt_disable
+        self.ompt_enable = opts.ompt_enable
         self.record_filter = opts.record_filter
         self.do_affinity = opts.do_affinity
         self.quiet = opts.quiet
@@ -239,8 +243,8 @@ class Config(object):
             result['GEOPM_DEBUG_ATTACH'] = self.debug_attach
         if self.omp_num_threads:
             result['OMP_NUM_THREADS'] = self.omp_num_threads
-        if self.ompt_disable:
-            result['GEOPM_OMPT_DISABLE'] = 'true'
+        if self.ompt_enable:
+            result['GEOPM_OMPT_ENABLE'] = 'true'
         if self.record_filter:
             result['GEOPM_RECORD_FILTER'] = self.record_filter
         if self.init_control:
@@ -1786,7 +1790,9 @@ GEOPM_OPTIONS:
                                do not allow pinning to HTs
       --geopm-ctl-disable      do not launch geopm; pass through commands to
                                underlying launcher
-      --geopm-ompt-disable     disable automatic OpenMP region detection
+      --geopm-ompt-enable      enable automatic OpenMP region detection
+      --geopm-ompt-disable     *DEPRECATED* automatic OpenMP region detection disabled
+                               by default, using option prints warning.
       --geopm-affinity-enable  Emit CPU affinity settings
       --geopm-launch-verbose   emit launch script and affinity configuration to stderr
       --geopm-launch-script=output_file

--- a/integration/apps/apps.py
+++ b/integration/apps/apps.py
@@ -231,7 +231,7 @@ class AppConf(object):
 
     def get_custom_geopm_args(self):
         ''' Additional geopmlaunch arguments required for the app, such as
-            --geopm-ompt-disable.
+            --geopm-ompt-enable.
 
             Returns:
                 list of str: list of geopmlaunch command line arguments.

--- a/integration/apps/nekbone/nekbone.py
+++ b/integration/apps/nekbone/nekbone.py
@@ -76,8 +76,7 @@ class NekboneAppConf(apps.AppConf):
         return ['ex1']
 
     def get_custom_geopm_args(self):
-        return ['--geopm-ompt-disable',
-                '--geopm-hyperthreads-disable']
+        return ['--geopm-hyperthreads-disable']
 
     def parse_fom(self, log_path):
         result = None

--- a/integration/apps/pennant/pennant.py
+++ b/integration/apps/pennant/pennant.py
@@ -117,7 +117,7 @@ class PennantAppConf(apps.AppConf):
         return self._cores_per_rank
 
     def get_custom_geopm_args(self):
-        return ['--geopm-hyperthreads-disable', '--geopm-ompt-disable']
+        return ['--geopm-hyperthreads-disable']
 
     def parse_fom(self, log_path):
         with open(log_path) as fid:

--- a/integration/test/geopm_test_launcher.py
+++ b/integration/test/geopm_test_launcher.py
@@ -74,7 +74,7 @@ class TestLauncher(object):
             self._pmpi_ctl = 'process'
         self._job_name = 'geopm_int_test'
         self._timeout = 120
-        self._disable_ompt = False
+        self._enable_ompt = False
         self.set_num_cpu()
         self.set_num_rank(4 * test_util.get_num_node())
         self.set_num_node(test_util.get_num_node())
@@ -136,8 +136,8 @@ class TestLauncher(object):
                 argv.extend(['--geopm-report', self._report_path])
             if self._trace_path is not None:
                 argv.extend(['--geopm-trace', self._trace_path])
-            if self._disable_ompt:
-                argv.append('--geopm-ompt-disable')
+            if self._enable_ompt:
+                argv.append('--geopm-ompt-enable')
             if self._trace_profile_path:
                 argv.extend(['--geopm-trace-profile', self._trace_profile_path])
             if self._report_signals:
@@ -262,5 +262,5 @@ class TestLauncher(object):
                                                          self._time_limit, 'msr_save', self._node_list, self._exclude_list, self._host_file)
             launcher.run()
 
-    def disable_ompt(self):
-        self._disable_ompt = True
+    def enable_ompt(self):
+        self._enable_ompt = True

--- a/integration/test/test_omp_outer_loop.py
+++ b/integration/test/test_omp_outer_loop.py
@@ -72,8 +72,8 @@ class TestIntegrationOMPOuterLoop(unittest.TestCase):
                                                             time_limit=6000)
                 launcher.set_num_node(num_node)
                 launcher.set_num_rank(num_rank)
-                if config == '_without_ompt':
-                    launcher.disable_ompt()
+                if config == '_with_ompt':
+                    launcher.enable_ompt()
                 launcher.run(curr_run)
 
 

--- a/integration/test/test_ompt.py
+++ b/integration/test/test_ompt.py
@@ -40,6 +40,7 @@ class TestIntegration_ompt(unittest.TestCase):
                                                     cls._report_path)
         launcher.set_num_node(cls._num_node)
         launcher.set_num_rank(num_rank)
+        launcher.enable_ompt()
         # Run the test application
         launcher.run(test_name)
 

--- a/libgeopm/src/Environment.cpp
+++ b/libgeopm/src/Environment.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <errno.h>
 
+#include <iostream>
 #include <algorithm>
 #include <string>
 #include <vector>
@@ -100,6 +101,11 @@ namespace geopm
             m_name_value_map["GEOPM_ENDPOINT"] = std::move(default_endpoint);
         }
         parse_environment_file(m_override_config_path, m_all_names, m_user_defined_names, m_name_value_map);
+#ifdef GEOPM_DEBUG
+        if (is_set("GEOPM_OMPT_DISABLE")) {
+            std::cerr << "Warning: GEOPM_OMPT_DISABLE environment variable is set, but use is deprecated. OMPT detection is disabled by default, use GEOPM_OMPT_ENABLE to enable OMPT detection.\n";
+        }
+#endif
     }
 
     std::set<std::string> EnvironmentImp::get_all_vars()
@@ -120,6 +126,7 @@ namespace geopm
                 "GEOPM_PROFILE",
                 "GEOPM_FREQUENCY_MAP",
                 "GEOPM_MAX_FAN_OUT",
+                "GEOPM_OMPT_ENABLE",
                 "GEOPM_OMPT_DISABLE",
                 "GEOPM_RECORD_FILTER",
                 "GEOPM_INIT_CONTROL",
@@ -462,7 +469,7 @@ namespace geopm
 
     bool EnvironmentImp::do_ompt(void) const
     {
-        return !is_set("GEOPM_OMPT_DISABLE");
+        return is_set("GEOPM_OMPT_ENABLE");
     }
 
     std::string EnvironmentImp::default_config_path(void) const

--- a/libgeopm/test/EnvironmentTest.cpp
+++ b/libgeopm/test/EnvironmentTest.cpp
@@ -583,10 +583,10 @@ TEST_F(EnvironmentTest, user_policy_and_endpoint)
     EXPECT_EQ("policy-user_value", m_env->policy());
 }
 
-TEST_F(EnvironmentTest, user_disable_ompt)
+TEST_F(EnvironmentTest, user_enable_ompt)
 {
     std::map<std::string, std::string> default_vars;
-    setenv("GEOPM_OMPT_DISABLE", "is_set", 1);
+    setenv("GEOPM_OMPT_ENABLE", "is_set", 1);
     std::map<std::string, std::string> override_vars;
 
     vars_to_json(default_vars, M_DEFAULT_PATH);
@@ -594,7 +594,7 @@ TEST_F(EnvironmentTest, user_disable_ompt)
 
     m_env = geopm::make_unique<EnvironmentImp>(M_DEFAULT_PATH, M_OVERRIDE_PATH);
 
-    EXPECT_FALSE(m_env->do_ompt());
+    EXPECT_TRUE(m_env->do_ompt());
 }
 
 TEST_F(EnvironmentTest, record_filter_on)


### PR DESCRIPTION
- Overhead from OMPT calls can be significant
- Since only benefits some use cases, change it to opt-in rather than opt-out