### PR TITLE
DerivativeSignal update so GPU_ACTIVITY reads 0 instead of NAN.

### DIFF
--- a/libgeopmd/src/DerivativeSignal.cpp
+++ b/libgeopmd/src/DerivativeSignal.cpp
@@ -104,7 +104,7 @@ namespace geopm
         double time = m_time_sig->sample();
         size_t history_size = m_history.size();
         // Check if this is the first call ever to sample() (history_size == 0)
-        // Or check if this is the first call to sample() since the last call to read_batch() (last element of history buffer does not match the sampled time)
+        // Or check if this is the first call to sample() since the last call to read_batch()
         if (history_size == 0ULL || ! is_sampled) {
             double signal = m_y_sig->sample();
             m_last_result = compute_next(m_history, m_derivative_num_fit, time, signal, m_nan_replace);

--- a/libgeopmd/src/DerivativeSignal.cpp
+++ b/libgeopmd/src/DerivativeSignal.cpp
@@ -26,6 +26,7 @@ namespace geopm
         , m_is_batch_ready(false)
         , m_sleep_time(sleep_time)
         , m_last_result(NAN)
+        , m_nan_replace(0)
     {
         GEOPM_DEBUG_ASSERT(m_time_sig && m_y_sig,
                            "Signal pointers for time_sig and y_sig cannot be null.");
@@ -75,6 +76,9 @@ namespace geopm
             if (ssxx != 0) {
                 result = ssxy / ssxx;
             }
+            else {
+                result = m_nan_replace;
+	    }
         }
         return result;
     }

--- a/libgeopmd/src/DerivativeSignal.cpp
+++ b/libgeopmd/src/DerivativeSignal.cpp
@@ -18,19 +18,11 @@ namespace geopm
                                        std::shared_ptr<Signal> y_sig,
                                        int num_sample_history,
                                        double sleep_time)
-        : m_time_sig(std::move(time_sig))
-        , m_y_sig(std::move(y_sig))
-        , M_NUM_SAMPLE_HISTORY(num_sample_history)
-        , m_history(M_NUM_SAMPLE_HISTORY)
-        , m_derivative_num_fit(0)
-        , m_is_batch_ready(false)
-        , m_sleep_time(sleep_time)
-        , m_last_result(NAN)
-        , m_nan_replace(NAN)
+        : DerivativeSignal(time_sig, y_sig, num_sample_history, sleep_time, NAN)
     {
-        GEOPM_DEBUG_ASSERT(m_time_sig && m_y_sig,
-                           "Signal pointers for time_sig and y_sig cannot be null.");
+
     }
+
     DerivativeSignal::DerivativeSignal(std::shared_ptr<Signal> time_sig,
                                        std::shared_ptr<Signal> y_sig,
                                        int num_sample_history,

--- a/libgeopmd/src/DerivativeSignal.cpp
+++ b/libgeopmd/src/DerivativeSignal.cpp
@@ -26,7 +26,25 @@ namespace geopm
         , m_is_batch_ready(false)
         , m_sleep_time(sleep_time)
         , m_last_result(NAN)
-        , m_nan_replace(0)
+        , m_nan_replace(NAN)
+    {
+        GEOPM_DEBUG_ASSERT(m_time_sig && m_y_sig,
+                           "Signal pointers for time_sig and y_sig cannot be null.");
+    }
+    DerivativeSignal::DerivativeSignal(std::shared_ptr<Signal> time_sig,
+                                       std::shared_ptr<Signal> y_sig,
+                                       int num_sample_history,
+                                       double sleep_time,
+                                       double nan_replace)
+        : m_time_sig(std::move(time_sig))
+        , m_y_sig(std::move(y_sig))
+        , M_NUM_SAMPLE_HISTORY(num_sample_history)
+        , m_history(M_NUM_SAMPLE_HISTORY)
+        , m_derivative_num_fit(0)
+        , m_is_batch_ready(false)
+        , m_sleep_time(sleep_time)
+        , m_last_result(NAN)
+        , m_nan_replace(nan_replace)
     {
         GEOPM_DEBUG_ASSERT(m_time_sig && m_y_sig,
                            "Signal pointers for time_sig and y_sig cannot be null.");

--- a/libgeopmd/src/DerivativeSignal.cpp
+++ b/libgeopmd/src/DerivativeSignal.cpp
@@ -43,7 +43,8 @@ namespace geopm
 
     double DerivativeSignal::compute_next(CircularBuffer<m_sample_s> &history,
                                           int &num_fit,
-                                          double time, double signal)
+                                          double time, double signal,
+                                          double nan_replace)
     {
         // insert time and signal
         history.insert({time, signal});
@@ -77,8 +78,8 @@ namespace geopm
                 result = ssxy / ssxx;
             }
             else {
-                result = m_nan_replace;
-	    }
+                result = nan_replace;
+            }
         }
         return result;
     }
@@ -96,7 +97,7 @@ namespace geopm
         if (history_size == 0ULL ||
             time != m_history.value(m_history.size() - 1).time) {
             double signal = m_y_sig->sample();
-            m_last_result = compute_next(m_history, m_derivative_num_fit, time, signal);
+            m_last_result = compute_next(m_history, m_derivative_num_fit, time, signal, m_nan_replace);
         }
         return m_last_result;
     }
@@ -109,7 +110,7 @@ namespace geopm
         for (int ii = 0; ii < M_NUM_SAMPLE_HISTORY; ++ii) {
             double signal = m_y_sig->read();
             double time = m_time_sig->read();
-            result = compute_next(temp_history, num_fit, time, signal);
+            result = compute_next(temp_history, num_fit, time, signal, m_nan_replace);
             if (ii < M_NUM_SAMPLE_HISTORY - 1) {
                 usleep(m_sleep_time * 1e6);
             }

--- a/libgeopmd/src/DerivativeSignal.cpp
+++ b/libgeopmd/src/DerivativeSignal.cpp
@@ -27,7 +27,6 @@ namespace geopm
         , m_sleep_time(sleep_time)
         , m_last_result(NAN)
         , m_nan_replace(0)
-        , m_is_first_sample(false)
     {
         GEOPM_DEBUG_ASSERT(m_time_sig && m_y_sig,
                            "Signal pointers for time_sig and y_sig cannot be null.");
@@ -100,7 +99,6 @@ namespace geopm
             double signal = m_y_sig->sample();
             m_last_result = compute_next(m_history, m_derivative_num_fit, time, signal, m_nan_replace);
         }
-        m_is_first_sample = false;
         return m_last_result;
     }
 
@@ -117,7 +115,6 @@ namespace geopm
                 usleep(m_sleep_time * 1e6);
             }
         }
-        m_is_first_sample = true;
         return result;
     }
 

--- a/libgeopmd/src/DerivativeSignal.hpp
+++ b/libgeopmd/src/DerivativeSignal.hpp
@@ -48,9 +48,6 @@ namespace geopm
             double m_sleep_time;
             double m_last_result;
             double m_nan_replace;
-            //Set to true when batch is read. Set to false when sample is
-            //called.
-            mutable bool m_is_first_sample;
     };
 }
 

--- a/libgeopmd/src/DerivativeSignal.hpp
+++ b/libgeopmd/src/DerivativeSignal.hpp
@@ -45,8 +45,8 @@ namespace geopm
             int m_derivative_num_fit;
             bool m_is_batch_ready;
             double m_sleep_time;
-            double m_nan_replace;
             double m_last_result;
+            double m_nan_replace;
     };
 }
 

--- a/libgeopmd/src/DerivativeSignal.hpp
+++ b/libgeopmd/src/DerivativeSignal.hpp
@@ -48,6 +48,9 @@ namespace geopm
             double m_sleep_time;
             double m_last_result;
             double m_nan_replace;
+            //Set to true when batch is read. Set to false when sample is
+            //called.
+            mutable bool m_is_first_sample;
     };
 }
 

--- a/libgeopmd/src/DerivativeSignal.hpp
+++ b/libgeopmd/src/DerivativeSignal.hpp
@@ -45,6 +45,7 @@ namespace geopm
             int m_derivative_num_fit;
             bool m_is_batch_ready;
             double m_sleep_time;
+            double m_nan_replace;
             double m_last_result;
     };
 }

--- a/libgeopmd/src/DerivativeSignal.hpp
+++ b/libgeopmd/src/DerivativeSignal.hpp
@@ -35,7 +35,8 @@ namespace geopm
             /// The read() and sample() methods have separate history.
             static double compute_next(CircularBuffer<m_sample_s> &history,
                                        int &num_fit,
-                                       double time, double signal);
+                                       double time, double signal,
+                                       double nan_replace);
 
             std::shared_ptr<Signal> m_time_sig;
             std::shared_ptr<Signal> m_y_sig;

--- a/libgeopmd/src/DerivativeSignal.hpp
+++ b/libgeopmd/src/DerivativeSignal.hpp
@@ -19,6 +19,10 @@ namespace geopm
             DerivativeSignal(std::shared_ptr<Signal> time_sig,
                              std::shared_ptr<Signal> y_sig,
                              int read_loops, double sleep_time);
+            DerivativeSignal(std::shared_ptr<Signal> time_sig,
+                             std::shared_ptr<Signal> y_sig,
+                             int read_loops, double sleep_time,
+                             double nan_replace);
             DerivativeSignal(const DerivativeSignal &other) = delete;
             DerivativeSignal &operator=(const DerivativeSignal &other) = delete;
             virtual ~DerivativeSignal() = default;

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -759,13 +759,15 @@ namespace geopm
                      M_NAME_PREFIX + "GPU_ENERGY",
                      M_NAME_PREFIX + "GPU_ENERGY_TIMESTAMP",
                      Agg::sum,
-                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
+                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                     NAN}},
             {M_NAME_PREFIX + "GPU_CORE_POWER",
                     {"Average GPU power over 40 ms or 8 control loop iterations",
                     M_NAME_PREFIX + "GPU_CORE_ENERGY",
                     M_NAME_PREFIX + "GPU_CORE_ENERGY_TIMESTAMP",
                     Agg::sum,
-                    IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
+                    IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                    NAN}},
             {M_NAME_PREFIX + "GPU_UTILIZATION",
                     {"Utilization of all GPU engines. Level Zero logical engines may map to the same hardware,"
                      " resulting in a reduced signal range (i.e. less than 0 to 1) in some cases."
@@ -773,7 +775,8 @@ namespace geopm
                      M_NAME_PREFIX + "GPU_ACTIVE_TIME",
                      M_NAME_PREFIX + "GPU_ACTIVE_TIME_TIMESTAMP",
                      Agg::average,
-                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
+                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                     0}},
             {M_NAME_PREFIX + "GPU_CORE_UTILIZATION",
                     {"Utilization of the GPU Compute engines (EUs). Level Zero logical engines may map to the same hardware,"
                      " resulting in a reduced signal range (i.e. less than 0 to 1) in some cases."
@@ -781,7 +784,8 @@ namespace geopm
                      M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME",
                      M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME_TIMESTAMP",
                      Agg::average,
-                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
+                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                     0}},
             {M_NAME_PREFIX + "GPU_UNCORE_UTILIZATION",
                     {"Utilization of the GPU Copy engines. Level Zero logical engines may map to the same hardware,"
                      " resulting in a reduced signal range (i.e. less than 0 to 1) in some cases."
@@ -789,7 +793,8 @@ namespace geopm
                      M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME",
                      M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME_TIMESTAMP",
                      Agg::average,
-                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE}},
+                     IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                     0}},
         })
         , m_frequency_range(m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP), std::make_pair(0, 0))
         , m_perf_factor(m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP), 0.5)
@@ -961,7 +966,8 @@ namespace geopm
                     result[domain_idx] =
                         std::make_shared<DerivativeSignal>(time, read,
                                                            derivative_window,
-                                                           sleep_time);
+                                                           sleep_time,
+                                                           ds.second.m_nan_replace);
                 }
                 m_signal_available[ds.first] = {ds.second.m_description + "\n    alias_for: " +
                                                 ds.second.m_base_name + " rate of change",

--- a/libgeopmd/src/LevelZeroIOGroup.hpp
+++ b/libgeopmd/src/LevelZeroIOGroup.hpp
@@ -104,6 +104,7 @@ namespace geopm
                 std::string m_time_name;
                 std::function<double(const std::vector<double> &)> m_agg_function;
                 int m_behavior;
+                double m_nan_replace;
             };
 
             static const std::string M_PLUGIN_NAME;

--- a/libgeopmd/src/LevelZeroSignal.cpp
+++ b/libgeopmd/src/LevelZeroSignal.cpp
@@ -18,6 +18,7 @@ namespace geopm
         , m_scalar(scalar)
         , m_is_batch_ready(false)
         , m_value(NAN)
+        , m_is_sampled(false)
     {
     }
 
@@ -31,6 +32,12 @@ namespace geopm
     void LevelZeroSignal::set_sample(double value)
     {
         m_value = value;
+        m_is_sampled = false;
+    }
+
+    bool LevelZeroSignal::is_sampled(void) const
+    {
+        return m_is_sampled;
     }
 
     double LevelZeroSignal::sample(void)
@@ -39,11 +46,13 @@ namespace geopm
             throw Exception("setup_batch() must be called before sample().",
                             GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
         }
+        m_is_sampled = true;
         return m_value;
     }
 
     double LevelZeroSignal::read(void) const
     {
+        m_is_sampled = true;
         return m_devpool_func(m_domain_idx) * m_scalar;
     }
 }

--- a/libgeopmd/src/LevelZeroSignal.hpp
+++ b/libgeopmd/src/LevelZeroSignal.hpp
@@ -28,12 +28,14 @@ namespace geopm
             double sample(void) override;
             double read(void) const override;
             void set_sample(double value) override;
+            bool is_sampled(void) const override;
         private:
             std::function<double (unsigned int)> m_devpool_func;
             unsigned int m_domain_idx;
             double m_scalar;
             bool m_is_batch_ready;
             double m_value;
+            mutable bool m_is_sampled;
     };
 }
 

--- a/libgeopmd/src/Signal.hpp
+++ b/libgeopmd/src/Signal.hpp
@@ -30,6 +30,8 @@ namespace geopm
             virtual double read(void) const = 0;
             /// @brief Set the value to be returned by sample()
             virtual void set_sample(double) {};
+            /// @brief True if the signal has been sampled during this batch
+            virtual bool is_sampled(void) const {return false;};
     };
 }
 

--- a/libgeopmd/test/DerivativeSignalTest.cpp
+++ b/libgeopmd/test/DerivativeSignalTest.cpp
@@ -35,9 +35,11 @@ class DerivativeSignalTest : public ::testing::Test
         double m_exp_slope_1;
         std::vector<double> m_sample_values_2;
         double m_exp_slope_2;
+	std::vector<double> m_sample_values_nan;
 
         int m_num_history_sample = 8;
         double m_sleep_time = 0.001;
+	double m_nan_replace = 1.5;
 };
 
 void DerivativeSignalTest::SetUp(void)
@@ -46,6 +48,8 @@ void DerivativeSignalTest::SetUp(void)
     m_y_sig = std::make_shared<MockSignal>();
     m_sig = geopm::make_unique<DerivativeSignal>(m_time_sig, m_y_sig,
                                                  m_num_history_sample, m_sleep_time);
+    m_sig_nan = geopm::make_unique<DerivativeSignal>(m_time_sig, m_y_sig,
+                                                 m_num_history_sample, m_sleep_time, m_nan_replace);
 
     // should have slope of 0.0
     m_sample_values_0 = {5.5, 5.5, 5.5, 5.5};
@@ -61,6 +65,7 @@ void DerivativeSignalTest::SetUp(void)
     // should have slope of .238 with least squares fit
     m_sample_values_2 = {0, 1, 2, 3, 0, 1, 2, 3};
     m_exp_slope_2 = 0.238;
+
 }
 
 TEST_F(DerivativeSignalTest, read_flat)
@@ -150,6 +155,16 @@ TEST_F(DerivativeSignalTest, read_batch_slope_2)
         result = m_sig->sample();
     }
     EXPECT_NEAR(m_exp_slope_2, result, 0.0001);
+}
+TEST_F(DerivativeSignalTest, read_nan)
+{
+    EXPECT_CALL(*m_time_sig, read()).Times(m_num_history_sample)
+        .WillRepeatedly(Return(2));
+    EXPECT_CALL(*m_y_sig, read()).Times(m_num_history_sample)
+        .WillRepeatedly(Return(5));
+
+    double result = m_sig->read();
+    EXPECT_EQ(0, result);
 }
 
 TEST_F(DerivativeSignalTest, setup_batch)

--- a/libgeopmd/test/DerivativeSignalTest.cpp
+++ b/libgeopmd/test/DerivativeSignalTest.cpp
@@ -106,12 +106,38 @@ TEST_F(DerivativeSignalTest, read_nan)
     EXPECT_EQ(0, result);
 }
 
+TEST_F(DerivativeSignalTest, read_batch_nan)
+{
+    EXPECT_CALL(*m_time_sig, setup_batch());
+    EXPECT_CALL(*m_y_sig, setup_batch());
+    m_sig->setup_batch();
+
+    double result = NAN;
+
+    EXPECT_CALL(*m_time_sig, is_sampled()).WillOnce(Return(false));
+    EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(2.0));
+    EXPECT_CALL(*m_y_sig, sample()).WillOnce(Return(7.7));
+
+    //First call returns NAN
+    result = m_sig->sample();
+    EXPECT_TRUE(std::isnan(result));
+
+    EXPECT_CALL(*m_time_sig, is_sampled()).WillOnce(Return(false));
+    EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(2.0));
+    EXPECT_CALL(*m_y_sig, sample()).WillOnce(Return(7.7));
+
+    //Second call replaces NAN with 0
+    result = m_sig->sample();
+    EXPECT_EQ(0, result);
+}
+
 TEST_F(DerivativeSignalTest, read_batch_first)
 {
     EXPECT_CALL(*m_time_sig, setup_batch());
     EXPECT_CALL(*m_y_sig, setup_batch());
     m_sig->setup_batch();
 
+    EXPECT_CALL(*m_time_sig, is_sampled()).WillOnce(Return(false));
     EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(2.0));
     EXPECT_CALL(*m_y_sig, sample()).WillOnce(Return(7.7));
     double result = m_sig->sample();
@@ -126,6 +152,7 @@ TEST_F(DerivativeSignalTest, read_batch_flat)
 
     double result = NAN;
     for (size_t ii = 0; ii < m_sample_values_0.size(); ++ii) {
+        EXPECT_CALL(*m_time_sig, is_sampled()).WillOnce(Return(false));
         EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(ii));
         EXPECT_CALL(*m_y_sig, sample()).WillOnce(Return(m_sample_values_0[ii]));
         result = m_sig->sample();
@@ -141,6 +168,7 @@ TEST_F(DerivativeSignalTest, read_batch_slope_1)
 
     double result = NAN;
     for (size_t ii = 0; ii < m_sample_values_1.size(); ++ii) {
+        EXPECT_CALL(*m_time_sig, is_sampled()).WillOnce(Return(false));
         EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(ii));
         EXPECT_CALL(*m_y_sig, sample()).WillOnce(Return(m_sample_values_1[ii]));
         result = m_sig->sample();
@@ -156,6 +184,7 @@ TEST_F(DerivativeSignalTest, read_batch_slope_2)
 
     double result = NAN;
     for (size_t ii = 0; ii < m_sample_values_2.size(); ++ii) {
+        EXPECT_CALL(*m_time_sig, is_sampled()).WillOnce(Return(false));
         EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(ii));
         EXPECT_CALL(*m_y_sig, sample()).WillOnce(Return(m_sample_values_2[ii]));
         result = m_sig->sample();

--- a/libgeopmd/test/DerivativeSignalTest.cpp
+++ b/libgeopmd/test/DerivativeSignalTest.cpp
@@ -174,6 +174,13 @@ TEST_F(DerivativeSignalTest, read_batch_slope_1)
         result = m_sig->sample();
     }
     EXPECT_NEAR(m_exp_slope_1, result, 0.0001);
+
+    //Read again without an updated signal, check that data is preserved
+    size_t ii = m_sample_values_1.size()-1;
+    EXPECT_CALL(*m_time_sig, is_sampled()).WillOnce(Return(true));
+    EXPECT_CALL(*m_time_sig, sample()).WillOnce(Return(ii));
+    result = m_sig->sample();
+    EXPECT_NEAR(m_exp_slope_1, result, 0.0001);
 }
 
 TEST_F(DerivativeSignalTest, read_batch_slope_2)

--- a/libgeopmd/test/DerivativeSignalTest.cpp
+++ b/libgeopmd/test/DerivativeSignalTest.cpp
@@ -35,11 +35,9 @@ class DerivativeSignalTest : public ::testing::Test
         double m_exp_slope_1;
         std::vector<double> m_sample_values_2;
         double m_exp_slope_2;
-	std::vector<double> m_sample_values_nan;
 
         int m_num_history_sample = 8;
         double m_sleep_time = 0.001;
-	double m_nan_replace = 1.5;
 };
 
 void DerivativeSignalTest::SetUp(void)
@@ -105,7 +103,7 @@ TEST_F(DerivativeSignalTest, read_nan)
         .WillRepeatedly(Return(5));
 
     double result = m_sig->read();
-    EXPECT_EQ(m_nan_replace, result);
+    EXPECT_EQ(0, result);
 }
 
 TEST_F(DerivativeSignalTest, read_batch_first)

--- a/libgeopmd/test/MockSignal.hpp
+++ b/libgeopmd/test/MockSignal.hpp
@@ -16,6 +16,7 @@ class MockSignal : public geopm::Signal
         MOCK_METHOD(void, setup_batch, (), (override));
         MOCK_METHOD(double, sample, (), (override));
         MOCK_METHOD(double, read, (), (const, override));
+        MOCK_METHOD(bool, is_sampled, (), (const, override));
 };
 
 #endif


### PR DESCRIPTION
- Relates to #3550 

Update DerivativeSignal to add a new constructor including m_nan_replace, which replaces NANs due to the denominator evaluating to 0. The default behavior is to output NAN (e.g. oversampling).  For GPU utilization/activity signals, the timer does not update if there's no activity on the card, so 0/0 should evaluate to 0.

In the future, the aggregator should also be updated to handle "NAN" appropriately (rather than propagating NAN).