### PR TITLE
Replace negative results from LevelZero with NaN and avoid issues with high order bits in active time

### DIFF
--- a/docs/source/geopm_pio_levelzero.7.rst
+++ b/docs/source/geopm_pio_levelzero.7.rst
@@ -282,52 +282,52 @@ Signals
     *  **Unit**: none
 
 ``LEVELZERO::GPU_ACTIVE_TIME``
-    Time in seconds that this resource is actively running a workload.  See the Intel oneAPI Level Zero Sysman documentation for more info.
+    Time that this resource is actively running a workload in unspecified units.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
     *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
-    *  **Unit**: seconds
+    *  **Unit**: none
 
 ``LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP``
-    The timestamp for the ``LEVELZERO::GPU_ACTIVE_TIME`` read in seconds.  See the Intel oneAPI Level Zero Sysman documentation for more info.
+    The timestamp for the ``LEVELZERO::GPU_ACTIVE_TIME`` read in unspecified units.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
     *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
-    *  **Unit**: seconds
+    *  **Unit**: none
 
 ``LEVELZERO::GPU_CORE_ACTIVE_TIME``
-    Time in seconds that the GPU compute engines (EUs) are actively running a workload.  See the Intel oneAPI Level Zero Sysman documentation for more info.
+    Time that the GPU compute engines (EUs) are actively running a workload in unspecified units.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
     *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
-    *  **Unit**: seconds
+    *  **Unit**: none
 
 ``LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP``
-    The timestamp for the ``LEVELZERO::GPU_CORE_ACTIVE_TIME`` signal read in seconds.  See the Intel oneAPI Level Zero Sysman documentation for more info.
+    The timestamp for the ``LEVELZERO::GPU_CORE_ACTIVE_TIME`` signal read in unspecified units.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
     *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
-    *  **Unit**: seconds
+    *  **Unit**: none
 
 ``LEVELZERO::GPU_UNCORE_ACTIVE_TIME``
-    Time in seconds that the GPU copy engines are actively running a workload.  See the Intel oneAPI Level Zero Sysman documentation for more info.
+    Time that the GPU copy engines are actively running a workload in unspecified units.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
     *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
-    *  **Unit**: seconds
+    *  **Unit**: none
 
 ``LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP``
-    The timestamp for the ``LEVELZERO::GPU_UNCORE_ACTIVE_TIME`` signal read in seconds.  See the Intel oneAPI Level Zero Sysman documentation for more info.
+    The timestamp for the ``LEVELZERO::GPU_UNCORE_ACTIVE_TIME`` signal read in unspecified units.  See the Intel oneAPI Level Zero Sysman documentation for more info.
 
     *  **Aggregation**: sum
     *  **Domain**: gpu_chip
     *  **Format**: double
-    *  **Unit**: seconds
+    *  **Unit**: none
 
 ``LEVELZERO::GPU_POWER``
     Average GPU power over 40ms (via geopmread) or 8 control loop iterations.  Derivative signal based on ``LEVELZERO::GPU_ENERGY``.

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -18,6 +18,13 @@
 
 namespace geopm
 {
+    static double convert_nan(double result)
+    {
+        if (result < 0) {
+            result = NAN;
+        }
+        return result;
+    }
     const LevelZero &levelzero()
     {
         static LevelZeroImp instance;
@@ -807,13 +814,13 @@ namespace geopm
     double LevelZeroImp::frequency_status(unsigned int l0_device_idx,
                                           int l0_domain, int l0_domain_idx) const
     {
-        return frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).actual;
+        return convert_nan(frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).actual);
     }
 
     double LevelZeroImp::frequency_efficient(unsigned int l0_device_idx,
                                              int l0_domain, int l0_domain_idx) const
     {
-        return frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).efficient;
+        return convert_nan(frequency_status_helper(l0_device_idx, l0_domain, l0_domain_idx).efficient);
     }
 
     uint32_t LevelZeroImp::frequency_throttle_reasons(unsigned int l0_device_idx,

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -266,7 +266,7 @@ namespace geopm
                                             dev_subdev_idx_pair.second);
     }
 
-    static double convert_active_time(uint64_t value, uint64_t &last_value, int &rollover_count)
+    static double convert_active_time(uint64_t value, uint64_t &last_value, uint64_t &rollover_count)
     {
         static const int num_bits = 32;
         static const uint64_t overflow = (1ULL << num_bits);
@@ -320,7 +320,7 @@ namespace geopm
                                                        dev_subdev_idx_pair.second);
 
         auto &active_time_last = m_active_time_last.try_emplace(l0_domain, num_gpu(GEOPM_DOMAIN_GPU_CHIP), 0ULL).first->second;
-        auto &active_time_rollover = m_active_time_rollover.try_emplace(l0_domain, active_time_last.size(), 0).first->second;
+        auto &active_time_rollover = m_active_time_rollover.try_emplace(l0_domain, active_time_last.size(), 0ULL).first->second;
 
         return convert_active_time(active_time, active_time_last[domain_idx], active_time_rollover[domain_idx]);
     }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -25,8 +25,6 @@ namespace geopm
 
     LevelZeroDevicePoolImp::LevelZeroDevicePoolImp(const LevelZero &levelzero)
         : m_levelzero(levelzero)
-        , m_active_time_last(num_gpu(GEOPM_DOMAIN_GPU_CHIP), 0ULL)
-        , m_active_time_rollover(m_active_time_last.size(), 0)
     {
     }
 
@@ -321,7 +319,10 @@ namespace geopm
         uint64_t active_time = m_levelzero.active_time(dev_subdev_idx_pair.first, l0_domain,
                                                        dev_subdev_idx_pair.second);
 
-        return convert_active_time(active_time, m_active_time_last[domain_idx], m_active_time_rollover[domain_idx]);
+        auto &active_time_last = m_active_time_last.try_emplace(l0_domain, num_gpu(GEOPM_DOMAIN_GPU_CHIP), 0ULL).first->second;
+        auto &active_time_rollover = m_active_time_rollover.try_emplace(l0_domain, active_time_last.size(), 0).first->second;
+
+        return convert_active_time(active_time, active_time_last[domain_idx], active_time_rollover[domain_idx]);
     }
 
     int32_t LevelZeroDevicePoolImp::power_limit_min(int domain, unsigned int domain_idx,

--- a/libgeopmd/src/LevelZeroDevicePool.hpp
+++ b/libgeopmd/src/LevelZeroDevicePool.hpp
@@ -96,16 +96,16 @@ namespace geopm
             /// @brief Get the LevelZero device timestamp for the active time value in microseconds
             /// @brief Get the LevelZero device active time in microseconds
             /// @return GPU active time in microseconds.
-            virtual uint64_t active_time(int domain, unsigned int domain_idx,
-                                         int l0_domain) const = 0;
+            virtual double active_time(int domain, unsigned int domain_idx,
+                                       int l0_domain) const = 0;
             /// @brief Get the LevelZero device timestamp for the active time value in microseconds
             /// @param [in] domain The GEOPM domain type being targeted
             /// @param [in] domain_idx The GEOPM domain index
             ///             (i.e. GPU being targeted)
             /// @param [in] l0_domain The LevelZero domain type being targeted
             /// @return GPU device timestamp for the active time value in microseconds.
-            virtual uint64_t active_time_timestamp(int domain, unsigned int domain_idx,
-                                                   int l0_domain) const = 0;
+            virtual double active_time_timestamp(int domain, unsigned int domain_idx,
+                                                 int l0_domain) const = 0;
             // POWER SIGNAL FUNCTIONS
             /// @brief Get the LevelZero device default power limit in milliwatts
             /// @param [in] domain The GEOPM domain type being targeted

--- a/libgeopmd/src/LevelZeroDevicePoolImp.hpp
+++ b/libgeopmd/src/LevelZeroDevicePoolImp.hpp
@@ -103,7 +103,7 @@ namespace geopm
             void check_domain_exists(int size, const char *func, int line) const;
             std::pair<unsigned int, unsigned int> subdevice_device_conversion(unsigned int idx) const;
             mutable std::map<int, std::vector<uint64_t> > m_active_time_last; // Map from l0_domain to vector over gpu chips
-            mutable std::map<int, std::vector<int> > m_active_time_rollover; // Map from l0_domain to vector over gpu chips
+            mutable std::map<int, std::vector<uint64_t> > m_active_time_rollover; // Map from l0_domain to vector over gpu chips
     };
 }
 #endif

--- a/libgeopmd/src/LevelZeroDevicePoolImp.hpp
+++ b/libgeopmd/src/LevelZeroDevicePoolImp.hpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <cstdint>
+#include <map>
 
 #include "LevelZeroDevicePool.hpp"
 #include "LevelZero.hpp"
@@ -101,8 +102,8 @@ namespace geopm
             void check_idx_range(int domain, unsigned int domain_idx) const;
             void check_domain_exists(int size, const char *func, int line) const;
             std::pair<unsigned int, unsigned int> subdevice_device_conversion(unsigned int idx) const;
-            mutable std::vector<uint64_t> m_active_time_last;
-            mutable std::vector<int> m_active_time_rollover;
+            mutable std::map<int, std::vector<uint64_t> > m_active_time_last; // Map from l0_domain to vector over gpu chips
+            mutable std::map<int, std::vector<int> > m_active_time_rollover; // Map from l0_domain to vector over gpu chips
     };
 }
 #endif

--- a/libgeopmd/src/LevelZeroDevicePoolImp.hpp
+++ b/libgeopmd/src/LevelZeroDevicePoolImp.hpp
@@ -43,10 +43,10 @@ namespace geopm
             std::pair<uint64_t, uint64_t> active_time_pair(int domain,
                                                            unsigned int device_idx,
                                                            int l0_domain) const override;
-            uint64_t active_time(int domain, unsigned int device_idx,
-                                 int l0_domain) const override;
-            uint64_t active_time_timestamp(int domain, unsigned int device_idx,
-                                           int l0_domain) const override;
+            double active_time(int domain, unsigned int device_idx,
+                               int l0_domain) const override;
+            double active_time_timestamp(int domain, unsigned int device_idx,
+                                         int l0_domain) const override;
             int32_t power_limit_tdp(int domain, unsigned int domain_idx,
                                     int l0_domain) const override;
             int32_t power_limit_min(int domain, unsigned int domain_idx,
@@ -101,6 +101,8 @@ namespace geopm
             void check_idx_range(int domain, unsigned int domain_idx) const;
             void check_domain_exists(int size, const char *func, int line) const;
             std::pair<unsigned int, unsigned int> subdevice_device_conversion(unsigned int idx) const;
+            mutable std::vector<uint64_t> m_active_time_last;
+            mutable std::vector<int> m_active_time_rollover;
     };
 }
 #endif

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -359,7 +359,7 @@ namespace geopm
                                                    domain_idx,
                                                    geopm::LevelZero::M_DOMAIN_ALL);
                                   },
-                                  1 / 1e6
+                                  1
                                   }},
                               {M_NAME_PREFIX + "GPU_ACTIVE_TIME_TIMESTAMP", {
                                   "The timestamp for the LEVELZERO::GPU_ACTIVE_TIME read in seconds."
@@ -377,7 +377,7 @@ namespace geopm
                                                    domain_idx,
                                                    geopm::LevelZero::M_DOMAIN_ALL);
                                   },
-                                  1 / 1e6
+                                  1
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME", {
                                   "Time in seconds that the GPU compute engines (EUs) are actively running a workload."
@@ -394,7 +394,7 @@ namespace geopm
                                                    domain_idx,
                                                    geopm::LevelZero::M_DOMAIN_COMPUTE);
                                   },
-                                  1 / 1e6
+                                  1
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_ACTIVE_TIME_TIMESTAMP", {
                                   "The timestamp for the LEVELZERO::GPU_CORE_ACTIVE_TIME signal read in seconds."
@@ -412,7 +412,7 @@ namespace geopm
                                                    domain_idx,
                                                    geopm::LevelZero::M_DOMAIN_COMPUTE);
                                   },
-                                  1 / 1e6
+                                  1
                                   }},
                               {M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME", {
                                   "Time in seconds that the GPU copy engines are actively running a workload."
@@ -429,7 +429,7 @@ namespace geopm
                                                    domain_idx,
                                                    geopm::LevelZero::M_DOMAIN_MEMORY);
                                   },
-                                  1 / 1e6
+                                  1
                                   }},
                               {M_NAME_PREFIX + "GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", {
                                   "The timestamp for the LEVELZERO::GPU_UNCORE_ACTIVE_TIME signal read in seconds."
@@ -447,7 +447,7 @@ namespace geopm
                                                    domain_idx,
                                                    geopm::LevelZero::M_DOMAIN_MEMORY);
                                   },
-                                  1 / 1e6
+                                  1
                                   }},
                               {M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR", {
                                   "Performance Factor of the GPU Compute Hardware Domain.\n"
@@ -1282,9 +1282,7 @@ namespace geopm
                             __FILE__, __LINE__);
         }
         if (string_ends_with(signal_name, "_TIMESTAMP")) {
-            throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
-                            ": TIMESTAMP Signals are for batch use only.",
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            return NAN;
         }
         double result = NAN;
         auto it = m_signal_available.find(signal_name);

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -9,6 +9,7 @@
 
 #include <fstream>
 #include <string>
+#include <cmath>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
@@ -516,20 +517,20 @@ TEST_F(LevelZeroIOGroupTest, read_timestamp_batch_reverse)
         double active_time = levelzero_io.sample(active_time_batch_idx.at(sub_idx)-1);
         double active_time_timestamp = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
 
-        EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx)/1e6);
-        EXPECT_DOUBLE_EQ(active_time_timestamp, mock_active_time_timestamp.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx));
+        EXPECT_DOUBLE_EQ(active_time_timestamp, mock_active_time_timestamp.at(sub_idx));
 
         double active_time_gpu = levelzero_io.sample(active_time_batch_idx.at(sub_idx)-1);
         double active_time_timestamp_gpu = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
 
-        EXPECT_DOUBLE_EQ(active_time_gpu, mock_active_time.at(sub_idx)/1e6);
-        EXPECT_DOUBLE_EQ(active_time_timestamp_gpu, mock_active_time_timestamp.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_gpu, mock_active_time.at(sub_idx));
+        EXPECT_DOUBLE_EQ(active_time_timestamp_gpu, mock_active_time_timestamp.at(sub_idx));
 
         double active_time_copy = levelzero_io.sample(active_time_batch_idx.at(sub_idx)-1);
         double active_time_timestamp_copy = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
 
-        EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time.at(sub_idx)/1e6);
-        EXPECT_DOUBLE_EQ(active_time_timestamp_copy, mock_active_time_timestamp.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time.at(sub_idx));
+        EXPECT_DOUBLE_EQ(active_time_timestamp_copy, mock_active_time_timestamp.at(sub_idx));
     }
     for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
         double energy = levelzero_io.sample(energy_batch_idx.at(gpu_idx)-1);
@@ -586,20 +587,20 @@ TEST_F(LevelZeroIOGroupTest, read_timestamp_batch)
         double active_time = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
         double active_time_timestamp = levelzero_io.sample(active_time_batch_idx.at(sub_idx)+1);
 
-        EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx)/1e6);
-        EXPECT_DOUBLE_EQ(active_time_timestamp, mock_active_time_timestamp.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx));
+        EXPECT_DOUBLE_EQ(active_time_timestamp, mock_active_time_timestamp.at(sub_idx));
 
         double active_time_gpu = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
         double active_time_timestamp_gpu = levelzero_io.sample(active_time_batch_idx.at(sub_idx)+1);
 
-        EXPECT_DOUBLE_EQ(active_time_gpu, mock_active_time.at(sub_idx)/1e6);
-        EXPECT_DOUBLE_EQ(active_time_timestamp_gpu, mock_active_time_timestamp.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_gpu, mock_active_time.at(sub_idx));
+        EXPECT_DOUBLE_EQ(active_time_timestamp_gpu, mock_active_time_timestamp.at(sub_idx));
 
         double active_time_copy = levelzero_io.sample(active_time_batch_idx.at(sub_idx));
         double active_time_timestamp_copy = levelzero_io.sample(active_time_batch_idx.at(sub_idx)+1);
 
-        EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time.at(sub_idx)/1e6);
-        EXPECT_DOUBLE_EQ(active_time_timestamp_copy, mock_active_time_timestamp.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time.at(sub_idx));
+        EXPECT_DOUBLE_EQ(active_time_timestamp_copy, mock_active_time_timestamp.at(sub_idx));
     }
     for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
         double energy = levelzero_io.sample(energy_batch_idx.at(gpu_idx));
@@ -701,11 +702,11 @@ TEST_F(LevelZeroIOGroupTest, read_signal)
 
         //Active time
         double active_time = levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
-        EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time, mock_active_time.at(sub_idx));
         double active_time_compute = levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
-        EXPECT_DOUBLE_EQ(active_time_compute, mock_active_time_compute.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_compute, mock_active_time_compute.at(sub_idx));
         double active_time_copy = levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
-        EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time_copy.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(active_time_copy, mock_active_time_copy.at(sub_idx));
 
         //Power & energy
         double energy = levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
@@ -791,11 +792,11 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU_CHIP, -1, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
 }
 
 TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)

--- a/libgeopmd/test/MockLevelZeroDevicePool.hpp
+++ b/libgeopmd/test/MockLevelZeroDevicePool.hpp
@@ -65,9 +65,9 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
 
         MOCK_METHOD((std::pair<uint64_t, uint64_t>), active_time_pair,
                     (int, unsigned int, int), (const, override));
-        MOCK_METHOD(uint64_t, active_time,
+        MOCK_METHOD(double, active_time,
                     (int, unsigned int, int), (const, override));
-        MOCK_METHOD(uint64_t, active_time_timestamp,
+        MOCK_METHOD(double, active_time_timestamp,
                     (int, unsigned int, int), (const, override));
 
         MOCK_METHOD(int32_t, power_limit_tdp,


### PR DESCRIPTION
- For of the interfaces where the geopm::LevelZero class returns a double precision value, check for negative results and replace.
- Some of the geopm::LevelZero interfaces return integer values and these are unmodified.
- Fixes #3589
