### PR TITLE
Fix dependency issues resulting from the move to CFFI API mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
     - name: install geopmpy and geopmdpy python dependencies
       run: |
            python3 -m pip install --upgrade pip setuptools wheel pep517
-           python3 -m pip install -r docs/requirements.txt
+           python3 -m pip install -r docs/requirements.txt -r geopmdpy/requirements.txt -r geopmpy/requirements.txt
     - name: configure libgeopmd dir
       working-directory: libgeopmd
       run: ./autogen.sh && ./configure || (cat config.log && false)
@@ -204,6 +204,7 @@ jobs:
       working-directory: geopmpy
       run: ./make_sdist.sh
     - name: make docs dist
+
       working-directory: docs
       run: make dist
     - name: set OSC credentials

--- a/.github/workflows/launchpad.yml
+++ b/.github/workflows/launchpad.yml
@@ -31,14 +31,6 @@ jobs:
       run: |
            python3 -m pip install --upgrade pip setuptools wheel pep517
            python3 -m pip install -r docs/requirements.txt
-           python3 -m pip install ./geopmdpy
-           python3 -m pip install ./geopmpy
-    - name: make and install geopmdpy deb
-      working-directory: geopmdpy
-      run: |
-           ./make_deb.sh
-           sudo apt-get install ./*deb
-           git clean -ffdx
     - name: configure libgeopmd dir
       working-directory: libgeopmd
       run: ./autogen.sh && ./configure || (cat config.log && false)
@@ -46,6 +38,12 @@ jobs:
       working-directory: libgeopmd
       run: |
            make deb
+           sudo apt-get install ./libgeopmd*deb
+           git clean -ffdx
+    - name: make and install geopmdpy deb
+      working-directory: geopmdpy
+      run: |
+           ./make_deb.sh --no-local
            sudo apt-get install ./*deb
            git clean -ffdx
     - name: configure GPG key

--- a/integration/test/test_profile_policy.py
+++ b/integration/test/test_profile_policy.py
@@ -14,7 +14,6 @@ import subprocess
 
 import geopmpy.launcher
 import geopmpy.io
-import geopmpy.policy_store
 
 from integration.test import util
 from integration.test import geopm_test_launcher
@@ -22,8 +21,11 @@ from integration.test import geopm_test_launcher
 
 @util.skip_unless_do_launch()
 @util.skip_unless_batch()
+@util.skip_unless_config_enable('beta')
 class TestIntegrationProfilePolicy(unittest.TestCase):
     def setUp(self):
+        import geopmpy.policy_store
+
         # clean up stale keys
         try:
             os.unlink("/dev/shm/geopm*")
@@ -82,7 +84,6 @@ class TestIntegrationProfilePolicy(unittest.TestCase):
         except:
             pass
 
-    @util.skip_unless_config_enable('beta')
     def test_policy_default(self):
         profile = 'unknown'
         report_path = profile + '.report'
@@ -105,7 +106,6 @@ class TestIntegrationProfilePolicy(unittest.TestCase):
         csv_data = pandas.read_csv(policy_trace, delimiter='|', comment='#')
         self.assertEqual(csv_data['CPU_POWER_LIMIT'][0], self.default_power_cap)
 
-    @util.skip_unless_config_enable('beta')
     @unittest.expectedFailure # Suite needs to be updated to be run out-of-tree
     def test_policy_custom(self):
         profile = 'power_custom'


### PR DESCRIPTION
- Fixes a launchpad-upload issue introduced by https://github.com/geopm/geopm/pull/3530. The python packages cannot be built until after their libgeopm and libgeopmd dependencies are built.
- Fixes a nightly test failure introduced by https://github.com/geopm/geopm/pull/3530. The policystore module should not be imported by integration tests unless we are testing a beta build (where policystore exists)