### PR TITLE
Fork and use pio, do not popen geopmread/geopmwrite

### DIFF
--- a/geopmdpy/geopmdpy/system_files.py
+++ b/geopmdpy/geopmdpy/system_files.py
@@ -994,7 +994,10 @@ def _get_names():
         os.close(pipe_w)
         with os.fdopen(pipe_r) as pipe_ro:
             buffer = pipe_ro.read()
-        os.waitpid(pid, 0)
+        _, exit_status = os.waitpid(pid, 0)
+        exit_code = os.waitstatus_to_exitcode(exit_status)
+        if exit_code != 0:
+            raise RuntimeError(f'Child process to read signal and control names failed with exit status: {exit_code}')
         signal_buffer, control_buffer = buffer.split(marker)
         signals = []
         controls = []

--- a/geopmdpy/geopmdpy/system_files.py
+++ b/geopmdpy/geopmdpy/system_files.py
@@ -995,9 +995,12 @@ def _get_names():
         with os.fdopen(pipe_r) as pipe_ro:
             buffer = pipe_ro.read()
         _, exit_status = os.waitpid(pid, 0)
-        exit_code = os.waitstatus_to_exitcode(exit_status)
-        if exit_code != 0:
-            raise RuntimeError(f'Child process to read signal and control names failed with exit status: {exit_code}')
+        if os.WIFEXITED(exit_status):
+            exit_code = os.WEXITSTATUS(exit_status)
+            if exit_code != 0:
+                raise ChildProcessError(f'Child process to read signal and control names failed with exit status: {exit_code}')
+        else:
+            raise ChildProcessError('Child process to read signal and control names terminated abnormally')
         signal_buffer, control_buffer = buffer.split(marker)
         signals = []
         controls = []


### PR DESCRIPTION
- Now that geopmread and geopmwrite are python3 implementations avoid creating a new python interpreter by using fork.
