### PR TITLE
Add cffi python build dependency

### DIFF
--- a/.github/workflows/launchpad.yml
+++ b/.github/workflows/launchpad.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: install system dependencies
-      run: sudo apt-get update && sudo apt-get install libelf-dev mpich libmpich-dev libomp-15-dev libsystemd-dev liburing-dev python3-gi python3-yaml osc python3-m2crypto libcap-dev zlib1g-dev python3-build python3-setuptools-scm doxygen graphviz debhelper-compat debhelper libnvidia-ml-dev pkgconf dh-python python3-all dput elfutils
+      run: sudo apt-get update && sudo apt-get install libelf-dev mpich libmpich-dev libomp-15-dev libsystemd-dev liburing-dev python3-gi python3-yaml osc python3-m2crypto libcap-dev zlib1g-dev python3-build python3-setuptools-scm doxygen graphviz debhelper-compat debhelper libnvidia-ml-dev pkgconf dh-python python3-all dput elfutils python3-cffi
     - name: install geopmpy and geopmdpy python dependencies
       run: |
            python3 -m pip install --upgrade pip setuptools wheel pep517

--- a/geopmdpy/debian/control
+++ b/geopmdpy/debian/control
@@ -6,7 +6,9 @@ Build-Depends: debhelper-compat (= 12),
  dh-python,
  python3-all,
  python3-setuptools,
- python3-setuptools-scm
+ python3-setuptools-scm,
+ python3-cffi,
+ libgeopmd-dev
 Standards-Version: 4.4.1
 Vcs-Git: https://github.com/geopm/geopm.git
 Homepage: https://geopm.github.io

--- a/geopmdpy/geopmdpy.spec.in
+++ b/geopmdpy/geopmdpy.spec.in
@@ -20,6 +20,8 @@ Source0: @ARCHIVE@
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
+BuildRequires: python3-cffi
+BuildRequires: geopm-service-devel
 BuildRequires: python-rpm-macros
 %if 0%{?fedora}
 BuildRequires: marshalparser

--- a/geopmpy/debian/control
+++ b/geopmpy/debian/control
@@ -6,7 +6,9 @@ Build-Depends: debhelper-compat (= 12),
  dh-python,
  python3-all,
  python3-setuptools,
- python3-setuptools-scm
+ python3-setuptools-scm,
+ python3-cffi,
+ libgeopm-dev
 Standards-Version: 4.4.1
 Vcs-Git: https://github.com/geopm/geopm.git
 Homepage: https://geopm.github.io
@@ -30,4 +32,3 @@ Recommends: libgeopmd2 (= ${binary:Version}),
  python3-geopmpy-doc (= ${binary:Version})
 Description: GEOPM - Global Extensible Open Power Manager Runtime Tools
  Python support for GEOPM Runtime
- 

--- a/geopmpy/geopmpy.spec.in
+++ b/geopmpy/geopmpy.spec.in
@@ -20,6 +20,8 @@ Source0: @ARCHIVE@
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
+BuildRequires: python3-cffi
+BuildRequires: geopm-service-devel
 BuildRequires: python-rpm-macros
 Requires: python3-cffi >= 1.14.5
 Requires: python3-cycler >= 0.11.0


### PR DESCRIPTION
- Current launchpad packages are missing _libgeopm*.so cffi modules
- Python packages are not building in OBS since switch to using cffi in API mode