### PR TITLE
Only parse SaveControl inputs once

### DIFF
--- a/libgeopmd/src/SaveControl.cpp
+++ b/libgeopmd/src/SaveControl.cpp
@@ -38,38 +38,33 @@ namespace geopm
 
     SaveControlImp::SaveControlImp(const std::vector<m_setting_s> &settings)
         : m_settings(settings)
+        , m_json(json(settings))
     {
 
     }
 
     SaveControlImp::SaveControlImp(const std::string &json_string)
-        : m_json(json_string)
+        : m_settings(settings(json_string))
+        , m_json(json_string)
     {
 
     }
 
     SaveControlImp::SaveControlImp(IOGroup &io_group, const PlatformTopo &topo)
         : m_settings(settings(io_group, topo))
+        , m_json(json(m_settings))
     {
 
     }
 
     std::string SaveControlImp::json(void) const
     {
-        std::string result = m_json;
-        if (result.empty()) {
-            result = json(m_settings);
-        }
-        return result;
+        return m_json;
     }
 
     std::vector<SaveControl::m_setting_s> SaveControlImp::settings(void) const
     {
-        std::vector<m_setting_s> result = m_settings;
-        if (result.empty()) {
-            result = settings(m_json);
-        }
-        return result;
+        return m_settings;
     }
 
 

--- a/libgeopmd/test/SaveControlTest.cpp
+++ b/libgeopmd/test/SaveControlTest.cpp
@@ -186,3 +186,17 @@ TEST_F(SaveControlTest, write_file)
     std::string actual_json_string = geopm::read_file(m_tmp_path);
     ASSERT_EQ(m_settings_json, actual_json_string);
 }
+
+TEST_F(SaveControlTest, from_empty_settings)
+{
+    auto save_ctl = SaveControl::make_unique(std::vector<SaveControl::m_setting_s>{});
+    ASSERT_EQ("[]", save_ctl->json());
+    ASSERT_EQ(0ul, save_ctl->settings().size());
+}
+
+TEST_F(SaveControlTest, from_empty_json)
+{
+    auto save_ctl = SaveControl::make_unique("[]");
+    ASSERT_EQ("[]", save_ctl->json());
+    ASSERT_EQ(0ul, save_ctl->settings().size());
+}


### PR DESCRIPTION
- SaveControl constuctors accept either json or vectors of settings and can output either form regardless of which input was provided.
- Previously, SaveControl would convert between formats on demand if a memoized requested output format was empty. If the output was truly empty (no controls to save) instead of not-cached, then SaveControl would attempt to re-load the json inputs, even if json was not provided as an initial input.
- This change initializes json and vector formats when SaveControl is constructed, so we don't need to check whether they have been initialized.