### PR TITLE
Install latest osc packages with pip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,8 @@ jobs:
       run: |
            python3 -m pip install --upgrade pip setuptools wheel pep517
            python3 -m pip install -r docs/requirements.txt -r geopmdpy/requirements.txt -r geopmpy/requirements.txt
+    - name: install latest osc
+      run: python3 -m pip install --upgrade osc
     - name: configure libgeopmd dir
       working-directory: libgeopmd
       run: ./autogen.sh && ./configure || (cat config.log && false)


### PR DESCRIPTION
- Fix CI issue:

```
Run osc co ${SERVICE_PACKAGE}
Traceback (most recent call last):
  File "/usr/bin/osc", line 10, in <module>
    from osc import commandline, babysitter
  File "/usr/lib/python3/dist-packages/osc/commandline.py", line 14, in <module>
    import imp
ModuleNotFoundError: No module named 'imp'
Error: Process completed with exit code 1.
```