### PR TITLE
Fix out-of-tree builds of Fortran code

### DIFF
--- a/integration/configure.ac
+++ b/integration/configure.ac
@@ -248,6 +248,14 @@ if test "x$with_geopm_lib" != x; then
   AC_SUBST([GEOPM_LIBDIR])
 fi
 
+AC_ARG_WITH([geopm-fortran-include], [AS_HELP_STRING([--with-geopm-fortran-include=PATH],
+            [specify directory for the installed geopm Fortran include files.])])
+if test "x$with_geopm_fortran_include" != x; then
+  GEOPM_FC_INCLUDE=$with_geopm_fortran_include
+  AM_FCFLAGS="$AM_FCFLAGS -I$GEOPM_FC_INCLUDE"
+  AC_SUBST([GEOPM_FC_INCLUDE])
+fi
+
 AC_ARG_WITH([libelf], [AS_HELP_STRING([--with-libelf=PATH],
             [specify directory for installed libelf package.])])
 if test "x$with_libelf" != x; then


### PR DESCRIPTION
- Fixes #3513.

With this change, you have to specify both the ``--with-geopm`` and ``--with-geopm-include`` options.  The former gets you libgeopmd's C/C++ includes, while the latter gets the arch specific Fortran mod file.  Example:
```
$ CC=icx CXX=icpx FC=ifx F77=ifx F90=ifx ./configure \
    --with-geopmd=${GEOPM_INSTALL} \
    --with-geopm=${GEOPM_INSTALL} \
    --with-geopm-include=${GEOPM_INSTALL}/lib/ifx/modules/geopm-x86_64 \
    --disable-geopmd-local \
    --disable-geopm-local
```
