### PR TITLE
Add -D option to geopmread and geopmwrite

### DIFF
--- a/docs/source/geopmread.1.rst
+++ b/docs/source/geopmread.1.rst
@@ -99,28 +99,30 @@ exists.  See the ``--cache`` option below for more information.
 
 Options
 -------
--d, --domain    Print a list of all domains on the system.
--i, --info      Print description of the provided ``SIGNAL_NAME``.
--I, --info-all  Print a list of all available signals with their descriptions,
-                if any.
--c, --cache     Create a cache file for the ``geopm::PlatformTopo`` object if one
-                does not exist or if the existing cache is from a previous boot
-                cycle.  If a privileged user requests this option (e.g. root or
-                if invoked with sudo) the file path will be
-                ``/run/geopm/geopm-topo-cache``. If a non-privileged user requests
-                this option the file path will be ``/tmp/geopm-topo-cache-<UID>``.
-                In either case, the permissions will be ``-rw-------``, i.e.
-                **600**.  If the file exists from the current boot cycle and
-                has the proper permissions no operation will be performed.  To
-                force the creation of a new cache file, remove the existing
-                cache file prior to executing this command.  Additionally when
-                this command is executed any existing GEOPM HPC Runtime shared
-                memory keys owned by the user running the command will be
-                deleted.
--h, --help      Print brief summary of the command line usage information, then
-                exit.
--v, --version   Print version of :doc:`geopm(7) <geopm.7>` to standard output, then
-                exit.
+-d, --domain         Print a list of all domains on the system.
+-D, --signal-domain  Print the domain of the signal name provided for option.
+-i, --info           Print description of the provided ``SIGNAL_NAME``.
+-I, --info-all       Print a list of all available signals with their descriptions,
+                     if any.
+-c, --cache          Create a cache file for the ``geopm::PlatformTopo`` object
+                     if one does not exist or if the existing cache is from a
+                     previous boot cycle.  If a privileged user requests this
+                     option (e.g. root or if invoked with sudo) the file path
+                     will be ``/run/geopm/geopm-topo-cache``. If a
+                     non-privileged user requests this option the file path will
+                     be ``/tmp/geopm-topo-cache-<UID>``.  In either case, the
+                     permissions will be ``-rw-------``, i.e.  **600**.  If the
+                     file exists from the current boot cycle and has the proper
+                     permissions no operation will be performed.  To force the
+                     creation of a new cache file, remove the existing cache
+                     file prior to executing this command.  Additionally when
+                     this command is executed any existing GEOPM HPC Runtime
+                     shared memory keys owned by the user running the command
+                     will be deleted.
+-h, --help           Print brief summary of the command line usage information,
+                     then exit.
+-v, --version        Print version of :doc:`geopm(7) <geopm.7>` to standard
+                     output, then exit.
 
 Examples
 --------
@@ -170,7 +172,7 @@ Show domain type for DRAM_ENERGY signal:
 
 .. code-block::
 
-   $ geopmread --domain DRAM_ENERGY
+   $ geopmread --signal-domain DRAM_ENERGY
    memory
 
 Read the current energy for package 1:

--- a/docs/source/geopmsession.1.rst
+++ b/docs/source/geopmsession.1.rst
@@ -50,8 +50,9 @@ Command line interface for the GEOPM service batch read features. The input to
 the command line tool has one request per line. A request for reading is made up
 of three strings separated by white space. The first string is the signal name,
 the second string is the domain name, and the third string is the domain index.
-Provide the "``*``" character as the third string to request all domains
-available on the system.
+Provide the "``*``" character as the second string to request the native domain
+for the signal.  Provide the "``*``" character as the third string to request
+all domains available on the system.
 
 A descriptive header is written first, unless the ``-n`` option is specified, in
 which case the header omitted.  The output from reading values is printed

--- a/docs/source/geopmwrite.1.rst
+++ b/docs/source/geopmwrite.1.rst
@@ -113,38 +113,39 @@ exists.  See the ``--cache`` option below for more information.
 
 Options
 -------
--d, --domain    Print a list of all domains on the system.
--i, --info      Print description of the provided ``CONTROL_NAME``.
--I, --info-all  Print a list of all available controls with their descriptions,
-                if any.
--c, --cache     Create a cache file for the ``geopm::PlatformTopo`` object if one
-                does not exist or if the existing cache is from a previous boot
-                cycle.  If a privileged user requests this option (e.g. root or
-                if invoked with sudo) the file path will be
-                ``/run/geopm/geopm-topo-cache``. If a non-privileged user
-                requests this option the file path will be
-                ``/tmp/geopm-topo-cache-<UID>``.  In either case, the
-                permissions will be ``-rw-------``, i.e.  **600**.  If the
-                file exists from the current boot cycle and has the proper
-                permissions no operation will be performed.  To force the
-                creation of a new cache file, remove the existing cache file
-                prior to executing this command.
--f, --config    Read control name, control domain, control index and control value
-                from a configuration file rather than using the positional
-                arguments.  These four parameters are provided on each line of
-                the file separated by white space.  The file may have many lines
-                specifying multiple controls to be written. Providing ``-`` for this
-                option specifies to read the configuration from standard input.
--e, --enable-fixed
-                Write to the registers that enable the fixed counters.  Enabling
-                the fixed counters is required for the signals starting with
-                ``MSR::FIXED_CTR`` to report non-zero values.  The signal
-                ``CPU_INSTRUCTIONS_RETIRED`` also requires the fixed counters to
-                be enabled.
--h, --help      Print brief summary of the command line usage information, then
-                exit.
--v, --version   Print version of :doc:`geopm(7) <geopm.7>` to standard output,
-                then exit.
+-d, --domain          Print a list of all domains on the system.
+-D, --control-domain  Print the domain of the signal name provided for option.
+-i, --info            Print description of the provided ``CONTROL_NAME``.
+-I, --info-all        Print a list of all available controls with their
+                      descriptions, if any.
+-c, --cache           Create a cache file for the ``geopm::PlatformTopo`` object
+                      if one does not exist or if the existing cache is from a
+                      previous boot cycle.  If a privileged user requests this
+                      option (e.g. root or if invoked with sudo) the file path
+                      will be ``/run/geopm/geopm-topo-cache``. If a
+                      non-privileged user requests this option the file path
+                      will be ``/tmp/geopm-topo-cache-<UID>``.  In either case,
+                      the permissions will be ``-rw-------``, i.e.  **600**.  If
+                      the file exists from the current boot cycle and has the
+                      proper permissions no operation will be performed.  To
+                      force the creation of a new cache file, remove the
+                      existing cache file prior to executing this command.
+-f, --config          Read control name, control domain, control index and
+                      control value from a configuration file rather than using
+                      the positional arguments.  These four parameters are
+                      provided on each line of the file separated by white
+                      space.  The file may have many lines specifying multiple
+                      controls to be written. Providing ``-`` for this option
+                      specifies to read the configuration from standard input.
+-e, --enable-fixed    Write to the registers that enable the fixed counters.
+                      Enabling the fixed counters is required for the signals
+                      starting with ``MSR::FIXED_CTR`` to report non-zero
+                      values.  The signal ``CPU_INSTRUCTIONS_RETIRED`` also
+                      requires the fixed counters to be enabled.
+-h, --help            Print brief summary of the command line usage information,
+                      then exit.
+-v, --version         Print version of :doc:`geopm(7) <geopm.7>` to standard
+                      output, then exit.
 
 Examples
 --------
@@ -189,7 +190,7 @@ Show domain type for ``CPU_POWER`` control:
 
 .. code-block::
 
-   $ geopmwrite --domain CPU_POWER
+   $ geopmwrite --control-domain CPU_POWER
    package
 
 Set the frequency of CPU 2 to 1.9 *GHz*:

--- a/geopmdpy/geopmdpy/read.py
+++ b/geopmdpy/geopmdpy/read.py
@@ -29,6 +29,9 @@ gpu                         {topo.num_domain('gpu')}
 package_integrated_gpu      {topo.num_domain('package_integrated_gpu')}
 gpu_chip                    {topo.num_domain('gpu_chip')}""")
 
+def print_signal_domain(signal_name):
+    print(topo.domain_name(pio.signal_domain_type(signal_name)))
+
 def print_info(signal_name):
     print(f'{signal_name}:\n{pio.signal_description(signal_name)}')
 
@@ -45,6 +48,8 @@ def run():
     parser_group = parser.add_mutually_exclusive_group()
     parser_group.add_argument('-d', '--domain', action='store_true',
                               help='print domains detected')
+    parser_group.add_argument('-D', '--signal-domain',
+                              help='print native domain of specified signal')
     parser_group.add_argument('-i', '--info',
                               help='print longer description of a signal')
     parser_group.add_argument('-I', '--info-all', action='store_true',
@@ -56,6 +61,8 @@ def run():
     args = parser.parse_args()
     if args.domain:
         print_domains()
+    elif args.signal_domain:
+        print_signal_domain(args.signal_domain)
     elif args.info:
         print_info(args.info)
     elif args.info_all:

--- a/geopmdpy/geopmdpy/session.py
+++ b/geopmdpy/geopmdpy/session.py
@@ -561,7 +561,10 @@ class ReadRequestQueue(RequestQueue):
                 raise RuntimeError('Read request must be three words: "{}"'.format(line))
             try:
                 signal_name = words[0]
-                domain_type = topo.domain_type(words[1])
+                if words[1] == '*':
+                    domain_type = pio.signal_domain_type(signal_name)
+                else:
+                    domain_type = topo.domain_type(words[1])
                 if words[2] == '*':
                     requests.extend([(signal_name, domain_type, domain_idx) for domain_idx in range(topo.num_domain(domain_type))])
                 else :

--- a/geopmdpy/geopmdpy/write.py
+++ b/geopmdpy/geopmdpy/write.py
@@ -15,6 +15,9 @@ from . import topo
 from . import __version__
 from . import read
 
+def print_control_domain(control_name):
+    print(topo.domain_name(pio.control_domain_type(control_name)))
+
 def print_info(control_name):
     print(f'{control_name}:\n{pio.control_description(control_name)}')
 
@@ -43,6 +46,8 @@ def run():
     parser_group = parser.add_mutually_exclusive_group()
     parser_group.add_argument('-d', '--domain', action='store_true',
                               help='print domains detected')
+    parser_group.add_argument('-D', '--control-domain',
+                              help='print native domain of specified control')
     parser_group.add_argument('-i', '--info',
                               help='print longer description of a control')
     parser_group.add_argument('-I', '--info-all', action='store_true',
@@ -64,6 +69,8 @@ def run():
                 batch(input_stream)
     elif args.domain:
         read.print_domains()
+    elif args.control_domain:
+        print_control_domain(args.control_domain)
     elif args.info:
         print_info(args.info)
     elif args.info_all:


### PR DESCRIPTION
- Fixes #3667
- Prints the native domain of a given signal or control
- Add wildcard option for geopmsession domain type parameter
