### PR TITLE
Add release packaging for OpenSUSE and debian for v3.2.0

### DIFF
--- a/release/OpenSUSE/geopmd.spec
+++ b/release/OpenSUSE/geopmd.spec
@@ -1,0 +1,133 @@
+#  Copyright (c) 2015 - 2024 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+# This spec file does not enable grpc by default.  Use the following syntax to
+# enable grpc
+#
+#    rpmbuild --define 'enable_grpc 1' ...
+
+
+%global debug_package %{nil}
+%global prj_name geopmdpy
+%global desc %{expand: \
+The Global Extensible Open Power Manager (GEOPM) provides a framework to
+explore power and energy optimizations on platforms with heterogeneous mixes
+of computing hardware.
+
+Users can monitor their system's energy and power consumption, and safely
+optimize system hardware settings to achieve energy efficiency and/or
+performance objectives.}
+
+%if ! %{defined autorelease}
+%define autorelease 1
+%endif
+
+Name:           geopmd
+Version:	3.2.0
+Release:	%autorelease
+Summary:	GEOPM daemon
+
+License:	BSD-3-Clause
+Group:		System/Daemons
+URL:		https://geopm.github.io
+Source0:	https://github.com/geopm/geopm/archive/v%{version}/geopm-%{version}.tar.gz
+
+BuildRequires:	libgeopmd-devel
+BuildRequires:	python3-devel
+BuildRequires:	python3-setuptools
+BuildRequires:	python3-setuptools_scm
+BuildRequires:	python3-cffi
+BuildRequires:	python3-dasbus
+BuildRequires:	python3-jsonschema
+BuildRequires:	python3-psutil
+Requires:	python3-cffi
+Requires:	python3-dasbus
+Requires:	python3-jsonschema
+Requires:	python3-psutil
+Requires:	python3-%{prj_name} = %{version}-%{release}
+Requires:	geopmd-cli
+%if %{defined enable_grpc}
+Requires: python3-grpcio
+Requires: python3-protobuf
+%endif
+
+%description
+%{desc}
+
+%package -n python3-%{prj_name}
+Summary:        Python bindings for libgeopmd
+Group:		Development/Libraries/Python
+%description -n python3-%{prj_name}
+%{desc}
+
+%prep
+%autosetup -p1 -n geopm-%{version}
+pushd %{prj_name}
+echo %{version} > %{prj_name}/VERSION
+sed -i 's/usr\/bin/usr\/sbin/g' geopm.service
+popd
+
+
+%build
+pushd %{prj_name}
+%py3_build
+popd
+
+%install
+pushd %{prj_name}
+%py3_install
+mkdir -p %{buildroot}%{_sysconfdir}/geopm
+chmod 0700 %{buildroot}%{_sysconfdir}/geopm
+%if "%{_bindir}" != "%{_sbindir}"
+mkdir -p %{buildroot}%{_sbindir}
+mv %{buildroot}{%{_bindir},%{_sbindir}}/geopmd
+%endif
+install -D -p -m 644 io.github.geopm.xml %{buildroot}%{_datadir}/dbus-1/interfaces/io.github.geopm.xml
+install -D -p -m 644 io.github.geopm.conf %{buildroot}%{_datadir}/dbus-1/system.d/io.github.geopm.conf
+install -D -p -m 644 geopm.service %{buildroot}%{_unitdir}/geopm.service
+popd
+
+%check
+pushd %{buildroot}%{python3_sitearch}
+python3 -m unittest discover -p 'Test*.py' -v %{_builddir}/%{prj_name}-%{version}/test
+popd
+
+%pre -n geopmd
+%service_add_pre geopm.service
+
+%post -n geopmd
+%service_add_post geopm.service
+
+%preun -n geopmd
+%service_del_preun geopm.service
+
+%postun -n geopmd
+%service_del_postun geopm.service
+
+%files
+%license LICENSE-BSD-3-Clause
+%doc README.md
+%{_sbindir}/geopmd
+%dir %{_sysconfdir}/geopm
+%dir %{_datadir}/dbus-1
+%dir %{_datadir}/dbus-1/interfaces
+%dir %{_datadir}/dbus-1/system.d
+%{_datadir}/dbus-1/interfaces/io.github.geopm.xml
+%{_datadir}/dbus-1/system.d/io.github.geopm.conf
+%{_unitdir}/geopm.service
+
+%files -n python3-%{prj_name}
+%{_bindir}/geopmaccess
+%{_bindir}/geopmexporter
+%{_bindir}/geopmread
+%{_bindir}/geopmsession
+%{_bindir}/geopmwrite
+%{python3_sitearch}/%{prj_name}
+%{python3_sitearch}/_libgeopmd_py_cffi.abi3.so
+%{python3_sitearch}/%{prj_name}-*.egg-info
+
+%if %{defined autochangelog}
+%changelog
+%autochangelog
+%endif

--- a/release/OpenSUSE/libgeopm2.spec
+++ b/release/OpenSUSE/libgeopm2.spec
@@ -1,0 +1,120 @@
+%define abi_ver 2.1.0
+%global desc %{expand: \
+The Global Extensible Open Power Manager (GEOPM) provides a framework to
+explore power and energy optimizations on platforms with heterogeneous mixes
+of computing hardware.
+
+Users can monitor their system's energy and power consumption, and safely
+optimize system hardware settings to achieve energy efficiency and/or
+performance objectives.}
+
+%if ! %{defined autorelease}
+%define autorelease 1
+%endif
+
+Name:		libgeopm2
+Version:	3.2.0
+Release:	%autorelease
+Summary:	C/C++ implementation of the GEOPM runtime service
+
+License:	BSD-3-Clause
+Group:		System/Libraries
+URL:		https://geopm.github.io
+Source0:	https://github.com/geopm/geopm/archive/v%{version}/geopm-%{version}.tar.gz
+
+BuildRequires:	autoconf
+BuildRequires:	automake
+BuildRequires:	gcc-c++
+BuildRequires:	libtool
+BuildRequires:	systemd-rpm-macros
+BuildRequires:	libelf-devel
+BuildRequires:	libgeopmd-devel
+Recommends:	libgeopm-doc
+
+%define docdir %{_defaultdocdir}/libgeopm
+
+%description
+%{desc}
+
+%package -n libgeopm-devel
+Summary:	Development files for %{name}
+Group:		Development/Libraries/C and C++
+Requires:	%{name} = %{version}-%{release}
+
+%description -n libgeopm-devel
+The libgeopm-devel package contains libraries and header files for
+applications that use libgeopm.
+
+%package -n geopm-cli
+Summary:	libgeopm command-line tools
+Group:		System/Management
+Requires:	%{name} = %{version}-%{release}
+Requires:	geopmd
+Requires:	python3dist(geopmpy)
+
+%description -n geopm-cli
+%{desc}
+
+%prep
+%autosetup -p1 -n geopm-%{version}
+
+pushd libgeopm
+echo %{version} > VERSION
+autoreconf -vif
+popd
+
+%build
+pushd libgeopm
+%configure \
+	--docdir=%{docdir} \
+	--disable-mpi \
+	--disable-openmp \
+	--disable-fortran \
+	--disable-geopmd-local
+%make_build
+popd
+
+%install
+pushd libgeopm
+%make_install
+rm -v %{buildroot}/%{_libdir}/libgeopm.a
+rm -v %{buildroot}/%{_libdir}/libgeopm.la
+%if "%{_bindir}" != "%{_sbindir}"
+mkdir -p %{buildroot}%{_sbindir}
+mv %{buildroot}{%{_bindir},%{_sbindir}}/geopmadmin
+%endif
+popd
+
+%check
+pushd libgeopm
+make check || (cat ./test-suite.log && false)
+popd
+
+%post
+ldconfig
+
+%postun
+ldconfig
+
+%files
+%dir %{docdir}
+%doc %{docdir}/LICENSE-BSD-3-Clause
+%doc %{docdir}/README.md
+%doc %{docdir}/VERSION
+%{_libdir}/libgeopm.so.%{abi_ver}
+%{_libdir}/libgeopm.so.2
+
+%files -n libgeopm-devel
+%{_includedir}/geopm
+%{_includedir}/geopm_*
+%{_libdir}/libgeopm.so
+
+%files -n geopm-cli
+%{_sbindir}/geopmadmin
+%{_bindir}/geopmagent
+%{_bindir}/geopmctl
+
+%if %{defined autochangelog}
+%changelog
+%autochangelog
+%endif

--- a/release/OpenSUSE/libgeopmd2.spec
+++ b/release/OpenSUSE/libgeopmd2.spec
@@ -1,0 +1,173 @@
+%define abi_ver 2.1.0
+%global desc %{expand: \
+The Global Extensible Open Power Manager (GEOPM) provides a framework to
+explore power and energy optimizations on platforms with heterogeneous mixes
+of computing hardware.
+
+Users can monitor their system's energy and power consumption, and safely
+optimize system hardware settings to achieve energy efficiency and/or
+performance objectives.}
+
+%if ! %{defined autorelease}
+%define autorelease 1
+%endif
+
+Name:		libgeopmd2
+Version:	3.2.0
+Release:	%autorelease
+Summary:	C/C++ implementation of the GEOPM access service
+
+License:	BSD-3-Clause
+Group:		System/Libraries
+URL:		https://geopm.github.io
+Source0:	https://github.com/geopm/geopm/archive/v%{version}/geopm-%{version}.tar.gz
+
+BuildRequires:	autoconf
+BuildRequires:	automake
+BuildRequires:	gcc-c++
+BuildRequires:	glibc-devel
+BuildRequires:	libcap-devel
+BuildRequires:	libtool
+BuildRequires:	liburing-devel
+BuildRequires:	systemd-devel
+BuildRequires:	zlib-devel
+
+# Lets GEOPM batch its IO operations to reduce syscall overhead in IOGroups
+# with a lot of reads/writes per GEOPM batch operation.
+%if %{defined disable_io_uring}
+%define io_uring_option --disable-io-uring
+%else
+BuildRequires: liburing-devel
+%endif
+
+%if "%{_arch}" != "x86_64"
+%define cpuid_option --disable-cpuid
+%endif
+
+# This spec file does not enable grpc by default.  Use the following syntax to
+# enable grpc
+#
+#    rpmbuild --define 'enable_grpc 1' ...
+%if %{defined enable_grpc}
+%define grpc_option --enable-grpc
+BuildRequires: grpc-devel
+BuildRequires: protobuf-devel
+%endif
+
+# This spec file supports three options for level-zero support:
+#
+# 1. default:
+#    No level-zero support.
+#
+# 2. rpmbuild --define 'enable_level_zero 1' ...
+#    Enable level-zero with packages installed into standard
+#    locations: libdir and includedir.
+#
+# 3. rpmbuild --define 'with_level_zero <LEVEL_ZERO_PREFIX>' ...
+#    Enable level-zero with packages installed into a
+#    non-standard prefix.
+%if %{defined enable_level_zero}
+BuildRequires: level-zero
+BuildRequires: level-zero-devel
+Requires: level-zero >= 1.8.1
+%endif
+%if %{defined with_level_zero}
+# Disable libze_loader as an explicit dependency for installing the RPM
+%global __requires_exclude ^(libze_loader[.]so.*)$
+%define level_zero_option --enable-levelzero --with-levelzero=%{with_level_zero}
+%else
+%if %{defined enable_level_zero}
+%define level_zero_option --enable-levelzero
+%endif
+%endif
+
+BuildRequires: fdupes
+
+Recommends: libgeopmd-doc
+
+%define docdir %{_defaultdocdir}/libgeopmd
+
+
+%description
+%{desc}
+
+%package -n libgeopmd-devel
+Summary:	Development files for %{name}
+Group:		Development/Libraries/C and C++
+Requires:	%{name}%{?_isa} = %{version}-%{release}
+
+%description -n libgeopmd-devel
+The libgeopmd-devel package contains libraries and header files for
+applications that use %{name}.
+
+%package -n geopmd-cli
+Summary:	The libgeopmd command-line tools
+Group:		System/Management
+Requires:	%{name}%{?_isa} = %{version}-%{release}
+
+%description -n geopmd-cli
+%{desc}
+
+%prep
+%autosetup -p1 -n geopm-%{version}
+
+pushd libgeopmd
+echo %{version} > VERSION
+autoreconf -vif
+popd
+
+%build
+pushd libgeopmd
+%configure \
+	--docdir=%{docdir} \
+	%{?level_zero_option} \
+	%{?io_uring_option} \
+	%{?cpuid_option} \
+	%{?grpc_option} \
+	|| ( cat config.log && false )
+%make_build
+popd
+
+%install
+pushd libgeopmd
+%make_install
+rm -v %{buildroot}/%{_libdir}/libgeopmd.a
+rm -v %{buildroot}/%{_libdir}/libgeopmd.la
+%if "%{_bindir}" != "%{_sbindir}"
+mkdir -p %{buildroot}%{_sbindir}
+mv %{buildroot}{%{_bindir},%{_sbindir}}/geopmbatch
+%endif
+popd
+
+%check
+pushd libgeopmd
+make check || (cat ./test-suite.log && false)
+popd
+
+%post
+ldconfig
+
+%postun
+ldconfig
+
+%files
+%dir %{docdir}
+%doc %{docdir}/LICENSE-BSD-3-Clause
+%doc %{docdir}/README.md
+%doc %{docdir}/VERSION
+%{_libdir}/libgeopmd.so.%{abi_ver}
+%{_libdir}/libgeopmd.so.2
+
+%files -n libgeopmd-devel
+%{_includedir}/geopm
+%{_includedir}/geopm_*
+%{_libdir}/libgeopmd.so
+
+%files -n geopmd-cli
+%{_sbindir}/geopmbatch
+
+
+%if %{defined autochangelog}
+%changelog
+%autochangelog
+%endif

--- a/release/OpenSUSE/python-geopmpy.spec
+++ b/release/OpenSUSE/python-geopmpy.spec
@@ -1,0 +1,70 @@
+%global debug_package %{nil}
+%global prj_name geopmpy
+%global desc %{expand: \
+The Global Extensible Open Power Manager (GEOPM) provides a framework to
+explore power and energy optimizations on platforms with heterogeneous mixes
+of computing hardware.
+
+Users can monitor their system's energy and power consumption, and safely
+optimize system hardware settings to achieve energy efficiency and/or
+performance objectives.}
+
+Name:		python3-%{prj_name}
+Version:	3.2.0
+Release:	%autorelease
+Summary:	Python bindings for libgeopm
+
+License:	BSD-3-Clause
+Group:		Development/Libraries/Python
+URL:		https://geopm.github.io
+Source0:	https://github.com/geopm/geopm/archive/v%{version}/geopm-%{version}.tar.gz
+
+BuildRequires:	python3-devel
+BuildRequires:	python3-setuptools
+BuildRequires:	python3-setuptools_scm
+BuildRequires:	python3-geopmdpy
+BuildRequires:	python3-pandas
+BuildRequires:	python3-natsort
+BuildRequires:	python3-PyYAML
+BuildRequires:	python3-tables
+BuildRequires:	libgeopm-devel
+BuildRequires:	libgeopmd-devel
+Requires:	geopmd
+
+%description
+%{desc}
+
+%prep
+%autosetup -p1 -n geopm-%{version}
+
+pushd %{prj_name}
+echo %{version} > %{prj_name}/VERSION
+popd
+
+%build
+pushd %{prj_name}
+%py3_build
+popd
+
+%install
+pushd %{prj_name}
+%py3_install
+popd
+
+%check
+pushd %{buildroot}%{python3_sitearch}
+python3 -m unittest discover -p 'Test*.py' -v %{_builddir}/%{prj_name}-%{version}/test
+popd
+
+%files
+%license LICENSE-BSD-3-Clause
+%doc README.md
+%{_bindir}/geopmlaunch
+%{python3_sitearch}/%{prj_name}
+%{python3_sitearch}/_libgeopm_py_cffi.abi3.so
+%{python3_sitearch}/%{prj_name}-*.egg-info
+
+%if %{defined autochangelog}
+%changelog
+%autochangelog
+%endif

--- a/release/OpenSUSE/python3-geopmpy.spec
+++ b/release/OpenSUSE/python3-geopmpy.spec
@@ -19,12 +19,14 @@ Group:		Development/Libraries/Python
 URL:		https://geopm.github.io
 Source0:	https://github.com/geopm/geopm/archive/v%{version}/geopm-%{version}.tar.gz
 
+BuildRequires:	python3-cffi
 BuildRequires:	python3-devel
 BuildRequires:	python3-setuptools
 BuildRequires:	python3-setuptools_scm
 BuildRequires:	python3-geopmdpy
 BuildRequires:	python3-pandas
 BuildRequires:	python3-natsort
+BuildRequires:	python3-psutil
 BuildRequires:	python3-PyYAML
 BuildRequires:	python3-tables
 BuildRequires:	libgeopm-devel

--- a/release/debian/geopmdpy/debian/changelog
+++ b/release/debian/geopmdpy/debian/changelog
@@ -1,0 +1,5 @@
+python3-geopmdpy (3.2.0-1) jammy; urgency=low
+
+  * Update to version 3.2.0
+
+ -- Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>  Mon, 24 Feb 2025 09:34:16 -0800

--- a/release/debian/geopmdpy/debian/control
+++ b/release/debian/geopmdpy/debian/control
@@ -1,0 +1,40 @@
+Source: python3-geopmdpy
+Section: python
+Priority: optional
+Maintainer: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
+Build-Depends: debhelper-compat (= 12),
+ dh-python,
+ python3-all,
+ python3-setuptools,
+ python3-setuptools-scm,
+ python3-dev,
+ python3-cffi,
+ libgeopmd-dev
+Standards-Version: 4.4.1
+Vcs-Git: https://github.com/geopm/geopm.git
+Homepage: https://geopm.github.io
+
+Package: geopmd
+Architecture: all
+Depends: python3 (>= 3.6~),
+ python3-geopmdpy,
+ python3:any
+Description: GEOPM - Global Extensible Open Power Manager Daemon and Systemd Service
+ Python support for the GEOPM Service
+
+Package: python3-geopmdpy
+Architecture: all
+Depends: python3 (>= 3.6~),
+ python3-cffi (>= 1.14.5),
+ python3-dasbus (>= 1.6),
+ python3-jsonschema (>= 3.2.0),
+ python3-psutil (>= 5.8.0),
+ python3-setuptools (>= 53.0.0),
+ python3-grpcio (>=1.30.2),
+ python3-protobuf (>=3.12.4),
+ python3-prometheus-client (>= 0.9.0),
+ python3:any
+Recommends: libgeopmd2 (= ${binary:Version}),
+            geopmd-doc (= ${binary:Version}),
+Description: GEOPM - Global Extensible Open Power Manager Daemon Python Package
+ Python support for the GEOPM Service

--- a/release/debian/geopmdpy/debian/geopmd.postinst
+++ b/release/debian/geopmdpy/debian/geopmd.postinst
@@ -1,0 +1,2 @@
+#/bin/bash
+mkdir -p -m 711 /run/geopm

--- a/release/debian/geopmdpy/debian/rules
+++ b/release/debian/geopmdpy/debian/rules
@@ -1,0 +1,18 @@
+#!/usr/bin/make -f
+
+export DH_VERBOSE = 1
+export PYBUILD_NAME=geopmdpy
+
+%:
+	dh $@ --with python3 --buildsystem=pybuild
+
+override_dh_install:
+	dh $@ --with python3 --buildsystem=pybuild
+	mkdir -p debian/geopmd/usr/bin
+	mkdir -p debian/geopmd/lib/systemd/system
+	mkdir -p debian/geopmd/usr/share/dbus-1/system.d
+	mkdir -p debian/geopmd/usr/share/dbus-1/interfaces
+	cp ../geopm.service debian/geopmd/lib/systemd/system
+	cp ../io.github.geopm.conf debian/geopmd/usr/share/dbus-1/system.d
+	cp ../io.github.geopm.xml debian/geopmd/usr/share/dbus-1/interfaces
+	mv debian/python3-geopmdpy/usr/bin/geopmd debian/geopmd/usr/bin

--- a/release/debian/geopmpy/debian/changelog
+++ b/release/debian/geopmpy/debian/changelog
@@ -1,0 +1,6 @@
+python3-geopmpy (3.2.0-1) jammy; urgency=low
+
+  * Update to version 3.2.0
+
+ -- Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>  Mon, 24 Feb 2025 09:34:16 -0800
+

--- a/release/debian/geopmpy/debian/control
+++ b/release/debian/geopmpy/debian/control
@@ -1,0 +1,36 @@
+Source: python3-geopmpy
+Section: python
+Priority: optional
+Maintainer: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
+Build-Depends: debhelper-compat (= 12),
+ dh-python,
+ python3-all,
+ python3-setuptools,
+ python3-setuptools-scm,
+ python3-dev,
+ python3-cffi,
+ libgeopm-dev
+Standards-Version: 4.4.1
+Vcs-Git: https://github.com/geopm/geopm.git
+Homepage: https://geopm.github.io
+
+Package: python3-geopmpy
+Architecture: all
+Depends: python3 (>= 3.6~),
+ python3-cffi (>=1.14.5),
+ python3-cycler (>=0.11.0),
+ python3-natsort (>=8.0.2),
+ python3-numpy (>=1.19.5),
+ python3-pandas (>=1.1.5),
+ python3-psutil (>=5.8.0),
+ python3-yaml (>=5.4.1),
+ python3-setuptools (>=53.0.0),
+ python3-tables (>=3.7.0),
+ python3-geopmdpy (= ${binary:Version}),
+ python3:any
+Recommends: libgeopmd2 (= ${binary:Version}),
+ geopmd (= ${binary:Version}),
+ libgeopm2 (= ${binary:Version}),
+ python3-geopmpy-doc (= ${binary:Version})
+Description: GEOPM - Global Extensible Open Power Manager Runtime Tools
+ Python support for GEOPM Runtime

--- a/release/debian/geopmpy/debian/rules
+++ b/release/debian/geopmpy/debian/rules
@@ -1,0 +1,7 @@
+#!/usr/bin/make -f
+
+export DH_VERBOSE = 1
+export PYBUILD_NAME=geopmpy
+
+%:
+	dh $@ --with python3 --buildsystem=pybuild

--- a/release/debian/libgeopm/debian/changelog
+++ b/release/debian/libgeopm/debian/changelog
@@ -1,0 +1,7 @@
+libgeopm (3.2.0-1) jammy; urgency=low
+
+  * Update to version 3.2.0
+  * ABI set to @geopm_abi_version@
+  * Latest tagged release <https://github.com/geopm/geopm/releases/tag/v3.0.0>
+
+ -- Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>  Mon, 24 Feb 2025 09:34:16 -0800

--- a/release/debian/libgeopm/debian/control
+++ b/release/debian/libgeopm/debian/control
@@ -1,0 +1,58 @@
+Source: libgeopm
+Section: utils
+Priority: optional
+Maintainer: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
+Build-Depends: debhelper-compat (=13),
+               build-essential,
+               debhelper (>= 11~),
+               elfutils,
+               libgeopmd-dev,
+               libelf-dev,
+               openssh-client,
+               unzip
+Standards-Version: 4.1.4
+Homepage: https://geopm.github.io
+Vcs-Git: https://github.com/geopm/geopm.git
+Vcs-Browser: https://github.com/geopm/geopm.git
+
+Package: geopm-cli
+Section: utils
+Architecture: any
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+         libgeopm2 (= ${binary:Version}),
+         libgeopmd2 (= ${binary:Version})
+Recommends: libgeopm-doc (= ${binary:Version})
+Description: The GEOPM Service provides a foundation for manipulating
+ hardware settings to optimize an objective defined by an unprivileged
+ user.  The GEOPM Runtime is a software platform built on top of the
+ GEOPM Service that enables users to select a runtime algorithm and
+ policy to meet energy efficiency or performance objectives.  More
+ documentation on the GEOPM Runtime is posted with our web
+ documentation.
+
+Package: libgeopm-dev
+Section: libdevel
+Architecture: any
+Multi-Arch: same
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+         libgeopm2 (= ${binary:Version})
+Recommends: libgeopm-doc (= ${binary:Version})
+Description: Development package for the GEOPM Runtime.  This provides
+ the programming interface to libgeopm.so.  The package includes the C
+ and C++ header files, maunuals for these interfaces and the
+ unversioned libgeopm.so shared object symbolic link and the static
+ library.
+
+Package: libgeopm2
+Section: libs
+Architecture: any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Recommends: libgeopm-doc (= ${binary:Version})
+Description: Library supporting the GEOPM Runtime.  This provides the
+ libgeopm library which provides C and C++ interfaces.
+ .
+ This package contains the shared library.

--- a/release/debian/libgeopm/debian/geopm-cli.dirs
+++ b/release/debian/libgeopm/debian/geopm-cli.dirs
@@ -1,0 +1,1 @@
+usr/share/doc/geopm

--- a/release/debian/libgeopm/debian/geopm-cli.install
+++ b/release/debian/libgeopm/debian/geopm-cli.install
@@ -1,0 +1,4 @@
+usr/bin/geopmadmin
+usr/bin/geopmagent
+usr/bin/geopmctl
+

--- a/release/debian/libgeopm/debian/libgeopm-dev.dirs
+++ b/release/debian/libgeopm/debian/libgeopm-dev.dirs
@@ -1,0 +1,1 @@
+usr/include/geopm

--- a/release/debian/libgeopm/debian/libgeopm-dev.install
+++ b/release/debian/libgeopm/debian/libgeopm-dev.install
@@ -1,0 +1,4 @@
+usr/include/geopm*.h
+usr/include/geopm/*.hpp
+usr/lib/*/lib*.a
+usr/lib/*/lib*.so

--- a/release/debian/libgeopm/debian/libgeopm2.install
+++ b/release/debian/libgeopm/debian/libgeopm2.install
@@ -1,0 +1,1 @@
+usr/lib/*/lib*.so.*

--- a/release/debian/libgeopm/debian/rules
+++ b/release/debian/libgeopm/debian/rules
@@ -1,0 +1,15 @@
+#!/usr/bin/make -f
+
+export DH_VERBOSE = 1
+
+%:
+	dh $@ --with autoreconf
+
+override_dh_missing:
+	dh_missing --list-missing -X.la
+
+override_dh_auto_configure:
+	dh_auto_configure -- --disable-mpi \
+	                     --disable-openmp \
+	                     --disable-fortran \
+	                     --disable-geopmd-local

--- a/release/debian/libgeopmd/debian/changelog
+++ b/release/debian/libgeopmd/debian/changelog
@@ -1,0 +1,6 @@
+libgeopmd (3.2.0-1) jammy; urgency=low
+
+  * Update to version 3.2.0
+  * ABI set to @geopm_abi_version@
+
+ -- Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>  Mon, 24 Feb 2025 09:34:16 -0800

--- a/release/debian/libgeopmd/debian/control
+++ b/release/debian/libgeopmd/debian/control
@@ -1,0 +1,65 @@
+Source: libgeopmd
+Section: utils
+Priority: optional
+Maintainer: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
+Build-Depends: debhelper-compat (=13),
+               build-essential,
+               debhelper (>= 11~),
+               libcap-dev,
+               libnvidia-ml-dev [amd64 arm64],
+               libgrpc-dev,
+               libgrpc++-dev,
+               libprotobuf-dev,
+               libprotoc-dev,
+               libsystemd-dev (>= 221),
+               liburing-dev,
+               libtool,
+               pkgconf,
+               protobuf-compiler,
+               protobuf-compiler-grpc,
+               unzip,
+               zlib1g-dev
+Standards-Version: 4.1.4
+Homepage: https://geopm.github.io
+Vcs-Git: https://github.com/geopm/geopm.git
+Vcs-Browser: https://github.com/geopm/geopm.git
+
+Package: geopmd-cli
+Section: utils
+Architecture: any
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+         libgeopmd2 (= ${binary:Version}),
+Recommends: libgeopmd-doc (= ${binary:Version})
+Description: The GEOPM Service provides a user-level interface to read
+ telemetry and configure settings of heterogeneous hardware
+ platforms. Linux system administrators may manage permissions for
+ user access to telemetry and configuration at a fine granularity.
+ This package provides the geopmbatch binary used by geopmd.
+
+Package: libgeopmd-dev
+Section: libdevel
+Architecture: any
+Multi-Arch: same
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+         libgeopmd2 (= ${binary:Version})
+Recommends: libgeopmd-doc (= ${binary:Version})
+Description: Development package for the GEOPM Service.  This provides
+ the programming interface to libgeopmd.so.  The package includes the
+ C and C++ header files, maunuals for these interfaces and the
+ unversioned libgeopmd.so shared object symbolic link and the static
+ library.
+
+Package: libgeopmd2
+Section: libs
+Architecture: any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Recommends: libgeopmd-doc (= ${binary:Version})
+Description: Library supporting the GEOPM Service.  This provides the
+ libgeopmd library which provides C and C++ interfaces.
+ .
+ This package contains the shared library.
+

--- a/release/debian/libgeopmd/debian/geopm-service.dirs
+++ b/release/debian/libgeopmd/debian/geopm-service.dirs
@@ -1,0 +1,1 @@
+usr/lib/geopm

--- a/release/debian/libgeopmd/debian/geopmd-cli.install
+++ b/release/debian/libgeopmd/debian/geopmd-cli.install
@@ -1,0 +1,1 @@
+usr/bin/geopmbatch

--- a/release/debian/libgeopmd/debian/libgeopmd-dev.dirs
+++ b/release/debian/libgeopmd/debian/libgeopmd-dev.dirs
@@ -1,0 +1,2 @@
+usr/include/geopm
+usr/share/doc/geopm

--- a/release/debian/libgeopmd/debian/libgeopmd-dev.install
+++ b/release/debian/libgeopmd/debian/libgeopmd-dev.install
@@ -1,0 +1,7 @@
+usr/include/geopm*.h
+usr/include/geopm*.hpp
+usr/include/geopm/*.hpp
+usr/lib/*/lib*.so
+usr/lib/*/lib*.a
+usr/share/doc/libgeopmd/*
+

--- a/release/debian/libgeopmd/debian/libgeopmd2.install
+++ b/release/debian/libgeopmd/debian/libgeopmd2.install
@@ -1,0 +1,1 @@
+usr/lib/*/lib*.so.*

--- a/release/debian/libgeopmd/debian/rules
+++ b/release/debian/libgeopmd/debian/rules
@@ -1,0 +1,21 @@
+#!/usr/bin/make -f
+
+export DH_VERBOSE = 1
+
+%:
+	dh $@ --with autoreconf 
+
+override_dh_missing:
+	dh_missing --list-missing -X.la
+
+override_dh_auto_configure:
+	if [ "$(DEB_BUILD_ARCH)" != "amd64" ]; then \
+	    CONFIG_OPTION="--disable-cpuid "; \
+	fi; \
+	if [ "$(DEB_BUILD_ARCH)" = "amd64" ] || [ "$(DEB_BUILD_ARCH)" = "arm64" ]; then \
+	    CONFIG_OPTION="$$CONFIG_OPTION --enable-nvml"; \
+	fi; \
+	if [ -n "$(ENABLE_LEVELZERO)" ]; then \
+	    CONFIG_OPTION="$$CONFIG_OPTION --enable-levelzero"; \
+	fi; \
+	dh_auto_configure -- --with-bash-completion-dir=/etc/bash_completion.d --enable-grpc $$CONFIG_OPTION


### PR DESCRIPTION
To complement the fedora files for creating the latest stable release, this pull request adds OpenSUSE and Debian packaging for version 3.2.0.

Requires source code changes from CI packaging update PR https://github.com/geopm/geopm/pull/3693 which should be merged first.