### PR TITLE
Correct imports in test_frequency_balancer.py

### DIFF
--- a/integration/test/test_cpu_characterization.py
+++ b/integration/test/test_cpu_characterization.py
@@ -96,8 +96,7 @@ class TestIntegration_cpu_characterization(unittest.TestCase):
                                    # scenarios if preferred.
             mach,
             run_type='sse', # Only the SSE workload is used for characterization
-            ranks_per_node=None,
-            distribute_slow_ranks=False)
+            ranks_per_node=None)
         cls._minife_app_conf = minife.create_appconf(mach, experiment_args)
 
         # use a two step characterization process to reduce runtime

--- a/integration/test/test_frequency_balancer.py
+++ b/integration/test/test_frequency_balancer.py
@@ -85,7 +85,7 @@ class TestIntegration_frequency_balancer(unittest.TestCase):
             power_cap=None,
         )
 
-        sst_evaluation.launch(app_conf, args=experiment_args, experiment_cli_args=[])
+        sst_evaluation.launch(app_conf, args=experiment_args, experiment_cli_args=['--geopm-ctl=process'])
 
         results = defaultdict(lambda: defaultdict(list))
         for report_path in output_dir.glob('*.report'):

--- a/integration/test/test_frequency_balancer.py
+++ b/integration/test/test_frequency_balancer.py
@@ -16,17 +16,17 @@ import sys
 import unittest
 from pathlib import Path
 import shutil
-from experiment import machine
 from types import SimpleNamespace
+from collections import defaultdict
 
 import geopmpy.agent
 from geopmpy.io import RawReport
-from collections import defaultdict
 
 from integration.test import util
 from integration.test import geopm_test_launcher
-from experiment.sst_evaluation import sst_evaluation
-from apps.arithmetic_intensity import arithmetic_intensity
+from integration.experiment import machine
+from integration.experiment.sst_evaluation import sst_evaluation
+from integration.apps.arithmetic_intensity import arithmetic_intensity
 
 
 @util.skip_unless_do_launch()


### PR DESCRIPTION
- `export PYTHONPATH=${GEOPM_SOURCE}/integration:${PYTHONPATH}` should be the only env tweak needed.
- Relates to #3062.
