### PR TITLE
Enbable https for geopmexporter

### DIFF
--- a/docs/source/geopmexporter.1.rst
+++ b/docs/source/geopmexporter.1.rst
@@ -1,4 +1,3 @@
-
 geopmexporter(1) -- Prometheus exporter for GEOPM metrics
 =========================================================
 
@@ -7,7 +6,7 @@ Synopsis
 
 .. code-block:: none
 
-    geopmexporter [-h] [-v] [-t PERIOD] [-p PORT] [-i CONFIG_PATH] [--summary SUMMARY]
+    geopmexporter [-h] [-v] [-t PERIOD] [-p PORT] [-i CONFIG_PATH] [--summary SUMMARY] [-c CERTFILE] [-k KEYFILE] [--insecure-http]
 
 
 Description
@@ -53,6 +52,18 @@ Options
 --summary  .. _summary SUMMARY option:
 
     Summary method, one of "geopm", or "prometheus". Default: geopm
+
+-c, --certfile  .. _certfile CERTFILE option:
+
+    Server certificate used during the TLS handshake.
+
+-k, --keyfile  .. _keyfile KEYFILE option:
+
+    Server certificate private key.
+
+--insecure-http  .. _insecure-http option:
+
+    Use HTTP instead of HTTPS to export metrics over TCP/IP.
 
 
 Configuration File

--- a/geopmdpy/geopmdpy/exporter.py
+++ b/geopmdpy/geopmdpy/exporter.py
@@ -178,11 +178,11 @@ def run(period, port, config_path=None, summary='geopm', certfile=None, keyfile=
 
     """
     if use_insecure_http:
-        certfile = None
-        keyfile = None
+        if certfile is not None or keyfile is not None:
+            raise ValueError('Do not specify certfile or keyfile when running with insecure http')
     else:
         if certfile is None or keyfile is None:
-            raise ValueError('The certfile and keyfile arguments are required unless insecure HTTP is selected')
+            raise ValueError('The certfile and keyfile arguments are required unless insecure http is selected')
         if not system_files.is_secure_path(certfile):
             raise ValueError(f'File "{certfile}" is not secure')
         if not system_files.is_secure_path(keyfile):

--- a/geopmdpy/geopmdpy/exporter.py
+++ b/geopmdpy/geopmdpy/exporter.py
@@ -8,7 +8,7 @@ import os
 import re
 from time import sleep
 from argparse import ArgumentParser
-from . import pio, topo, stats, loop, session, __version_str__
+from . import pio, topo, stats, loop, session, system_files, __version_str__
 
 _STARTUP_SLEEP = 0.005
 
@@ -33,11 +33,11 @@ class PrometheusExporter:
                  self._num_metric += 1
         self._num_fresh = self._num_metric
 
-    def run(self, period, port):
+    def run(self, period, port, certfile, keyfile):
         """Run the GEOPM Prometheus exporter with geopm.stats.Collector
 
         """
-        _start_http_server(port)
+        _start_http_server(port, certfile, keyfile)
         for _ in loop.TimedLoop(period):
             pio.read_batch()
             self._stats_collector.update()
@@ -87,12 +87,12 @@ class PrometheusMetricExporter:
                 raise RuntimeError(f'Invalid behavior for signal {metric_name}, '
                                    'only support for monotone or variable signals')
 
-    def run(self, period, port):
+    def run(self, period, port, certfile, keyfile):
         """Run the GEOPM Prometheus exporter with prometheus Summary and
         Counter metrics
 
         """
-        _start_http_server(port)
+        _start_http_server(port, certfile, keyfile)
         sample_last = [None] * len(self._metrics)
         sleep(_STARTUP_SLEEP) # Take two samples to enable derivative signals
         for sample_idx in loop.TimedLoop(period):
@@ -129,7 +129,7 @@ def _sanitize_metric_name(name):
     return name
 
 _install_prometheus_msg = 'Please install python3-prometheus-client: https://pypi.org/project/prometheus-client/'
-def _start_http_server(port):
+def _start_http_server(port, certfile, keyfile):
     """Wrapper to enable easier mocking in unit tests
 
     """
@@ -137,7 +137,7 @@ def _start_http_server(port):
         from prometheus_client import start_http_server
     except Exception as ex:
         raise RuntimeError(_install_prometheus_msg) from ex
-    start_http_server(port)
+    start_http_server(port, certfile=certfile, keyfile=keyfile)
 
 def _create_prom_metric(name, descr, prom_name):
     """Wrapper to enable easier mocking in unit tests
@@ -173,10 +173,20 @@ def default_requests():
         raise RuntimeError('Failed to find any signals to report')
     return requests
 
-def run(period, port, config_path=None, summary='geopm'):
+def run(period, port, config_path=None, summary='geopm', certfile=None, keyfile=None, use_insecure_http=False):
     """Run the GEOPM Prometheus exporter
 
     """
+    if use_insecure_http:
+        certfile = None
+        keyfile = None
+    else:
+        if certfile is None or keyfile is None:
+            raise ValueError('The certfile and keyfile arguments are required unless insecure HTTP is selected')
+        if not system_files.is_secure_path(certfile):
+            raise ValueError(f'File "{certfile}" is not secure')
+        if not system_files.is_secure_path(keyfile):
+            raise ValueError(f'File "{keyfile}" is not secure')
     if config_path is None:
         requests = default_requests()
     elif config_path == '-':
@@ -187,10 +197,10 @@ def run(period, port, config_path=None, summary='geopm'):
     if summary == 'geopm':
         with stats.Collector(requests) as stats_collector:
             exporter = PrometheusExporter(stats_collector)
-            exporter.run(period, port)
+            exporter.run(period, port, certfile, keyfile)
     elif summary == 'prometheus':
         exporter = PrometheusMetricExporter(requests)
-        exporter.run(period, port)
+        exporter.run(period, port, certfile, keyfile)
     else:
         raise ValueError(f'Unknown summary type: "{summary}".  Must be "geopm" or "prometheus"')
 
@@ -213,12 +223,18 @@ def main():
                                  'temperature signals at the board domain')
         parser.add_argument('--summary', dest='summary', default='geopm',
                             help='Summary method, one of "geopm", or "prometheus". Default: %(default)s')
+        parser.add_argument('-c', '--certfile',
+                            help='Server certificate used during the TLS handshake')
+        parser.add_argument('-k', '--keyfile',
+                            help='Server certificate private key')
+        parser.add_argument('--insecure-http', action='store_true',
+                            help='Use http not https to export metrics over TCP/IP')
 
         args = parser.parse_args()
         if args.version:
             print(__version_str__)
         else:
-            run(args.period, args.port, args.config_path, args.summary)
+            run(args.period, args.port, args.config_path, args.summary, args.certfile, args.keyfile, args.insecure_http)
     except Exception as ee:
         if 'GEOPM_DEBUG' in os.environ:
             # Do not handle exception if GEOPM_DEBUG is set

--- a/geopmdpy/test/TestPrometheusExporter.py
+++ b/geopmdpy/test/TestPrometheusExporter.py
@@ -80,17 +80,16 @@ class TestPrometheusExporter(TestCase):
     def test_run_https(self):
         period = 0.1
         port = 8000
-        certfile = 'path/to/certfile'
-        keyfile = 'path/to/keyfile'
         num_calls = 10
-        with mock.patch('geopmdpy.exporter._create_prom_metric', return_value=mock.create_autospec(Gauge)), \
+        with tempfile.NamedTemporaryFile() as certfile, tempfile.NamedTemporaryFile() as keyfile, \
+             mock.patch('geopmdpy.exporter._create_prom_metric', return_value=mock.create_autospec(Gauge)), \
              mock.patch('geopmdpy.loop.TimedLoop', return_value=range(num_calls)) as mtl, \
              mock.patch('geopmdpy.exporter._start_http_server') as mshs, \
              mock.patch('geopmdpy.pio.read_batch') as mrb:
             prom_exp = PrometheusExporter(self._mock_collector)
-            prom_exp.run(period, port, certfile, keyfile)
+            prom_exp.run(period, port, certfile.name, keyfile.name)
             mtl.assert_called_with(period)
-            mshs.assert_called_with(port, certfile, keyfile)
+            mshs.assert_called_with(port, certfile.name, keyfile.name)
         calls = [mock.call()] * num_calls
         self._mock_collector.update.assert_has_calls(calls)
         mrb.assert_has_calls(calls)
@@ -175,17 +174,16 @@ class TestPrometheusMetricExporter(TestCase):
     def test_run_prometheus_metric_exporter_https(self):
         period = 0.1
         port = 8000
-        certfile = 'path/to/certfile'
-        keyfile = 'path/to/keyfile'
         num_calls = 10
         mock_counter = mock.create_autospec(Counter)
-        with mock.patch('geopmdpy.exporter._create_prom_metric', return_value=mock_counter), \
+        with tempfile.NamedTemporaryFile() as certfile, tempfile.NamedTemporaryFile() as keyfile, \
+             mock.patch('geopmdpy.exporter._create_prom_metric', return_value=mock_counter), \
              mock.patch('geopmdpy.loop.TimedLoop', return_value=range(num_calls)) as mtl, \
              mock.patch('geopmdpy.exporter._start_http_server') as mshs:
             prom_exp = PrometheusMetricExporter(self._requests)
-            prom_exp.run(period, port, certfile, keyfile)
+            prom_exp.run(period, port, certfile.name, keyfile.name)
             mtl.assert_called_with(period)
-            mshs.assert_called_with(port, certfile, keyfile)
+            mshs.assert_called_with(port, certfile.name, keyfile.name)
             mock_counter.inc.assert_called()
 
 @skipUnless(_prometheus_enabled, "prometheus_client not installed")
@@ -250,23 +248,25 @@ class TestExporterCli(TestCase):
         mock_exporter.run.assert_called_with(0.1, 8000, None, None)
 
     def test_https(self):
-        sys.argv = ['', '--certfile', 'path/to/certfile', '--keyfile', 'path/to/keyfile']
-        mock_exporter = mock.create_autospec(PrometheusExporter)
-        mock_collector = mock.create_autospec(Collector)
-        port = 8000
-        with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
-             mock.patch('geopmdpy.exporter.PrometheusExporter', return_value=mock_exporter), \
-             mock.patch('geopmdpy.stats.Collector', return_value=mock_collector):
-            exporter.main()
-            mock_exporter.run.assert_called_with(0.1, port, 'path/to/certfile', 'path/to/keyfile')
+        with tempfile.NamedTemporaryFile() as certfile, tempfile.NamedTemporaryFile() as keyfile:
+            sys.argv = ['', '--certfile', certfile.name, '--keyfile', keyfile.name]
+            mock_exporter = mock.create_autospec(PrometheusExporter)
+            mock_collector = mock.create_autospec(Collector)
+            port = 8000
+            with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
+                 mock.patch('geopmdpy.exporter.PrometheusExporter', return_value=mock_exporter), \
+                 mock.patch('geopmdpy.stats.Collector', return_value=mock_collector):
+                exporter.main()
+                mock_exporter.run.assert_called_with(0.1, port, certfile.name, keyfile.name)
 
     def test_https_prometheus_metric_exporter(self):
-        sys.argv = ['', '--certfile', 'path/to/certfile', '--keyfile', 'path/to/keyfile', '--summary', 'prometheus']
-        mock_exporter = mock.create_autospec(PrometheusMetricExporter)
-        with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
-             mock.patch('geopmdpy.exporter.PrometheusMetricExporter', return_value=mock_exporter):
-            exporter.main()
-            mock_exporter.run.assert_called_with(0.1, 8000, 'path/to/certfile', 'path/to/keyfile')
+        with tempfile.NamedTemporaryFile() as certfile, tempfile.NamedTemporaryFile() as keyfile:
+            sys.argv = ['', '--certfile', certfile.name, '--keyfile', keyfile.name, '--summary', 'prometheus']
+            mock_exporter = mock.create_autospec(PrometheusMetricExporter)
+            with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
+                 mock.patch('geopmdpy.exporter.PrometheusMetricExporter', return_value=mock_exporter):
+                exporter.main()
+                mock_exporter.run.assert_called_with(0.1, 8000, certfile.name, keyfile.name)
 
 if __name__ == '__main__':
     main()

--- a/geopmdpy/test/TestPrometheusExporter.py
+++ b/geopmdpy/test/TestPrometheusExporter.py
@@ -77,6 +77,24 @@ class TestPrometheusExporter(TestCase):
         self._mock_collector.update.assert_has_calls(calls)
         mrb.assert_has_calls(calls)
 
+    def test_run_https(self):
+        period = 0.1
+        port = 8000
+        certfile = 'path/to/certfile'
+        keyfile = 'path/to/keyfile'
+        num_calls = 10
+        with mock.patch('geopmdpy.exporter._create_prom_metric', return_value=mock.create_autospec(Gauge)), \
+             mock.patch('geopmdpy.loop.TimedLoop', return_value=range(num_calls)) as mtl, \
+             mock.patch('geopmdpy.exporter._start_http_server') as mshs, \
+             mock.patch('geopmdpy.pio.read_batch') as mrb:
+            prom_exp = PrometheusExporter(self._mock_collector)
+            prom_exp.run(period, port, certfile, keyfile)
+            mtl.assert_called_with(period)
+            mshs.assert_called_with(port, certfile, keyfile)
+        calls = [mock.call()] * num_calls
+        self._mock_collector.update.assert_has_calls(calls)
+        mrb.assert_has_calls(calls)
+
     def test_refresh(self):
         with mock.patch('geopmdpy.exporter._create_prom_metric', return_value=mock.create_autospec(Gauge)):
             prom_exp = PrometheusExporter(self._mock_collector)
@@ -154,6 +172,22 @@ class TestPrometheusMetricExporter(TestCase):
             mshs.assert_called_with(port, None, None)
             mock_counter.inc.assert_called()
 
+    def test_run_prometheus_metric_exporter_https(self):
+        period = 0.1
+        port = 8000
+        certfile = 'path/to/certfile'
+        keyfile = 'path/to/keyfile'
+        num_calls = 10
+        mock_counter = mock.create_autospec(Counter)
+        with mock.patch('geopmdpy.exporter._create_prom_metric', return_value=mock_counter), \
+             mock.patch('geopmdpy.loop.TimedLoop', return_value=range(num_calls)) as mtl, \
+             mock.patch('geopmdpy.exporter._start_http_server') as mshs:
+            prom_exp = PrometheusMetricExporter(self._requests)
+            prom_exp.run(period, port, certfile, keyfile)
+            mtl.assert_called_with(period)
+            mshs.assert_called_with(port, certfile, keyfile)
+            mock_counter.inc.assert_called()
+
 @skipUnless(_prometheus_enabled, "prometheus_client not installed")
 class TestExporterCli(TestCase):
     def test_insecure_http(self):
@@ -214,6 +248,25 @@ class TestExporterCli(TestCase):
                     exporter.main()
         mock_exporter_init.assert_called_once_with([('TIME', 0, 0)])
         mock_exporter.run.assert_called_with(0.1, 8000, None, None)
+
+    def test_https(self):
+        sys.argv = ['', '--certfile', 'path/to/certfile', '--keyfile', 'path/to/keyfile']
+        mock_exporter = mock.create_autospec(PrometheusExporter)
+        mock_collector = mock.create_autospec(Collector)
+        port = 8000
+        with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
+             mock.patch('geopmdpy.exporter.PrometheusExporter', return_value=mock_exporter), \
+             mock.patch('geopmdpy.stats.Collector', return_value=mock_collector):
+            exporter.main()
+            mock_exporter.run.assert_called_with(0.1, port, 'path/to/certfile', 'path/to/keyfile')
+
+    def test_https_prometheus_metric_exporter(self):
+        sys.argv = ['', '--certfile', 'path/to/certfile', '--keyfile', 'path/to/keyfile', '--summary', 'prometheus']
+        mock_exporter = mock.create_autospec(PrometheusMetricExporter)
+        with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
+             mock.patch('geopmdpy.exporter.PrometheusMetricExporter', return_value=mock_exporter):
+            exporter.main()
+            mock_exporter.run.assert_called_with(0.1, 8000, 'path/to/certfile', 'path/to/keyfile')
 
 if __name__ == '__main__':
     main()

--- a/geopmdpy/test/TestPrometheusExporter.py
+++ b/geopmdpy/test/TestPrometheusExporter.py
@@ -70,9 +70,9 @@ class TestPrometheusExporter(TestCase):
              mock.patch('geopmdpy.exporter._start_http_server') as mshs, \
              mock.patch('geopmdpy.pio.read_batch') as mrb:
             prom_exp = PrometheusExporter(self._mock_collector)
-            prom_exp.run(period, port)
+            prom_exp.run(period, port, None, None)
             mtl.assert_called_with(period)
-            mshs.assert_called_with(port)
+            mshs.assert_called_with(port, None, None)
         calls = [mock.call()] * num_calls
         self._mock_collector.update.assert_has_calls(calls)
         mrb.assert_has_calls(calls)
@@ -149,49 +149,50 @@ class TestPrometheusMetricExporter(TestCase):
              mock.patch('geopmdpy.loop.TimedLoop', return_value=range(num_calls)) as mtl, \
              mock.patch('geopmdpy.exporter._start_http_server') as mshs:
             prom_exp = PrometheusMetricExporter(self._requests)
-            prom_exp.run(period, port)
+            prom_exp.run(period, port, None, None)
             mtl.assert_called_with(period)
-            mshs.assert_called_with(port)
+            mshs.assert_called_with(port, None, None)
             mock_counter.inc.assert_called()
 
 @skipUnless(_prometheus_enabled, "prometheus_client not installed")
 class TestExporterCli(TestCase):
-    def test_default(self):
-        sys.argv = ['']
+    def test_insecure_http(self):
+        sys.argv = ['', '--insecure-http']
         mock_exporter = mock.create_autospec(PrometheusExporter)
         mock_collector = mock.create_autospec(Collector)
+        port = 8000
         with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
              mock.patch('geopmdpy.exporter.PrometheusExporter', return_value=mock_exporter), \
              mock.patch('geopmdpy.stats.Collector', return_value=mock_collector):
             exporter.main()
-            mock_exporter.run.assert_called_with(0.1, 8000)
+            mock_exporter.run.assert_called_with(0.1, port, None, None)
 
     def test_period(self):
-        sys.argv = ['', '--period', '1']
+        sys.argv = ['', '--period', '1', '--insecure-http']
         mock_exporter = mock.create_autospec(PrometheusExporter)
         mock_collector = mock.create_autospec(Collector)
         with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
              mock.patch('geopmdpy.exporter.PrometheusExporter', return_value=mock_exporter), \
              mock.patch('geopmdpy.stats.Collector', return_value=mock_collector):
             exporter.main()
-            mock_exporter.run.assert_called_with(1, 8000)
+            mock_exporter.run.assert_called_with(1, 8000, None, None)
 
     def test_port(self):
-        sys.argv = ['', '--port', '8005']
+        sys.argv = ['', '--port', '8005', '--insecure-http']
         mock_exporter = mock.create_autospec(PrometheusExporter)
         mock_collector = mock.create_autospec(Collector)
         with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
              mock.patch('geopmdpy.exporter.PrometheusExporter', return_value=mock_exporter), \
              mock.patch('geopmdpy.stats.Collector', return_value=mock_collector):
             exporter.main()
-            mock_exporter.run.assert_called_with(0.1, 8005)
+            mock_exporter.run.assert_called_with(0.1, 8005, None, None)
 
     def test_signal_config(self):
         with tempfile.NamedTemporaryFile() as tmp:
             tmp.write(b'TIME board 0\n')
             tmp.flush()
             tmp.seek(0)
-            sys.argv = ['', '--signal-config', tmp.name]
+            sys.argv = ['', '--signal-config', tmp.name, '--insecure-http']
             mock_exporter = mock.create_autospec(PrometheusExporter)
             mock_collector = mock.create_autospec(Collector)
             with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
@@ -199,20 +200,20 @@ class TestExporterCli(TestCase):
                  mock.patch('geopmdpy.stats.Collector', return_value=mock_collector) as mock_collector_init:
                 exporter.main()
         mock_collector_init.assert_called_once_with([('TIME', 0, 0)])
-        mock_exporter.run.assert_called_with(0.1, 8000)
+        mock_exporter.run.assert_called_with(0.1, 8000, None, None)
 
     def test_summary(self):
         with tempfile.NamedTemporaryFile() as tmp:
             tmp.write(b'TIME board 0\n')
             tmp.flush()
             tmp.seek(0)
-            sys.argv = ['', '--signal-config', tmp.name, '--summary', 'prometheus']
+            sys.argv = ['', '--signal-config', tmp.name, '--summary', 'prometheus', '--insecure-http']
             mock_exporter = mock.create_autospec(PrometheusMetricExporter)
             with mock.patch('geopmdpy.pio.signal_names', return_value=_MOCK_SIGNAL_NAMES), \
                  mock.patch('geopmdpy.exporter.PrometheusMetricExporter', return_value=mock_exporter) as mock_exporter_init:
                     exporter.main()
         mock_exporter_init.assert_called_once_with([('TIME', 0, 0)])
-        mock_exporter.run.assert_called_with(0.1, 8000)
+        mock_exporter.run.assert_called_with(0.1, 8000, None, None)
 
 if __name__ == '__main__':
     main()

--- a/integration/grafana/README.md
+++ b/integration/grafana/README.md
@@ -110,6 +110,13 @@ To avoid conflicts, or firewall limitations, the user may override the defaults
 using command line arguments to `clush_prometheus.py`.
 
 
+### Selecting https or http
+
+Provide the `--certfile` and `--keyfile` options to `clush_promethus.py` to run
+the prometheus client over https.  Provide the `--insecure-http` option to
+`clush_prometheus.py` to use an insecure protocol.
+
+
 ### Configuring Grafana Server
 
 Before deploying the GEOPM Prometheus exporter across the system for the first
@@ -131,7 +138,7 @@ and Prometheus servers must be running.  This is done by executing the
 option.
 
 ```bash
-    clush_prometheus.py --pbs-jobid=JOBID PROMETHEUS_DIR GRAFANA_DIR
+    clush_prometheus.py --insecure-http --pbs-jobid=JOBID PROMETHEUS_DIR GRAFANA_DIR
 ```
 This will bring up the Prometheus server and Grafana server on the head
 node.
@@ -176,7 +183,7 @@ the PBS queue using `qsub(1)` to obtain a PBS Job ID.  Use the PBS Job ID
 
 ```bash
     JOBID=$(qsub ...)
-    ./clush_prometheus.py --pbs-jobid JOBID PROMETHEUS_DIR GRAFANA_DIR
+    ./clush_prometheus.py --insecure-http --pbs-jobid JOBID PROMETHEUS_DIR GRAFANA_DIR
 
 ```
 

--- a/integration/grafana/clush_prometheus.py
+++ b/integration/grafana/clush_prometheus.py
@@ -107,7 +107,7 @@ def _signal_handler(signum, frame):
         os.unlink(_temp_hostfile_path)
     exit(0)
 
-def run(prom_dir, graf_dir, prom_port, graf_port, client_port, geopm_dir, pbs_jobid, hostfile_path):
+def run(prom_dir, graf_dir, prom_port, graf_port, client_port, geopm_dir, pbs_jobid, hostfile_path, certfile, keyfile, insecure_http):
     """Entry function with inputs derived from CLI
 
     """
@@ -153,6 +153,12 @@ def run(prom_dir, graf_dir, prom_port, graf_port, client_port, geopm_dir, pbs_jo
         clush_cmd = ['clush', f'--hostfile={hostfile_path}', '--',
                      'env', f'LD_LIBRARY_PATH={geopm_dir}/lib:{geopm_dir}/lib64:${{LD_LIBRARY_PATH}}',
                      'geopmexporter', '-p', f'{client_port}']
+        if certfile:
+            clush_cmd.extend(['--certfile', certfile])
+        if keyfile:
+            clush_cmd.extend(['--keyfile', keyfile])
+        if insecure_http:
+            clush_cmd.append('--insecure-http')
         _clush_pid = popen_wrapper(clush_cmd, 'clush', clush_log_path)
 
     configure_prom(prom_dir, hosts, client_port)
@@ -218,7 +224,13 @@ def main():
     parser.add_argument('--client-port', type=int, default=8000,
                         help='Port for geopmexporter Prometheus client')
     parser.add_argument('--geopm-prefix', default='/usr',
-                        help='Path pprefix for user install of GEOPM')
+                        help='Path prefix for user install of GEOPM')
+    parser.add_argument('--certfile', type=str, default=None,
+                        help='Path to the certificate file for geopmexporter')
+    parser.add_argument('--keyfile', type=str, default=None,
+                        help='Path to the key file for geopmexporter')
+    parser.add_argument('--insecure-http', action='store_true',
+                        help='Use insecure HTTP for geopmexporter')
     host_group = parser.add_mutually_exclusive_group()
     host_group.add_argument('--pbs-jobid', type=str, default=None,
                             help='PBS job ID to monitor')
@@ -227,7 +239,8 @@ def main():
     args = parser.parse_args()
 
     run(args.PROMETHEUS_DIR, args.GRAFANA_DIR, args.prom_port, args.graf_port,
-        args.client_port, args.geopm_prefix, args.pbs_jobid, args.hostfile)
+        args.client_port, args.geopm_prefix, args.pbs_jobid, args.hostfile,
+        args.certfile, args.keyfile, args.insecure_http)
     return 0
 
 if __name__ == '__main__':

--- a/integration/k8/geopm-prometheus-k8.yml
+++ b/integration/k8/geopm-prometheus-k8.yml
@@ -44,7 +44,7 @@ spec:
         ports:
         - containerPort: 8000
           hostPort: 8000
-        command: ['/usr/bin/sh', '-c', 'while [ ! -e /run/geopm/grpc.sock ]; do sleep 1; done; /usr/bin/geopmexporter']
+        command: ['/usr/bin/sh', '-c', 'while [ ! -e /run/geopm/grpc.sock ]; do sleep 1; done; /usr/bin/geopmexporter --insecure-http']
       - name: geopm-client
         image: cmcantal/geopm-prometheus:latest
         securityContext:


### PR DESCRIPTION
- Fixes #3730 
- [x] Get coverage of the https path in unit tests.
- [x] Add option doc to geopmexporter.1 man page