### PR TITLE
Do not clobber CONFIG_OPTION

### DIFF
--- a/libgeopmd/debian/rules
+++ b/libgeopmd/debian/rules
@@ -16,6 +16,6 @@ override_dh_auto_configure:
 	    CONFIG_OPTION="--enable-nvml $$CONFIG_OPTION"; \
 	fi; \
 	if [ -n "$(ENABLE_LEVELZERO)" ]; then \
-	    CONFIG_OPTION="--enable-levelzero $$CONFIG_OPTION "; \
+	    CONFIG_OPTION="--enable-levelzero $$CONFIG_OPTION"; \
 	fi; \
 	dh_auto_configure -- --with-bash-completion-dir=/etc/bash_completion.d --enable-grpc $$CONFIG_OPTION

--- a/libgeopmd/debian/rules
+++ b/libgeopmd/debian/rules
@@ -10,12 +10,12 @@ override_dh_missing:
 
 override_dh_auto_configure:
 	if [ "$(DEB_BUILD_ARCH)" != "amd64" ]; then \
-	    CONFIG_OPTION="--disable-cpuid "; \
+	    CONFIG_OPTION="--disable-cpuid $$CONFIG_OPTION"; \
 	fi; \
 	if [ "$(DEB_BUILD_ARCH)" = "amd64" ] || [ "$(DEB_BUILD_ARCH)" = "arm64" ]; then \
-	    CONFIG_OPTION="$$CONFIG_OPTION --enable-nvml"; \
+	    CONFIG_OPTION="--enable-nvml $$CONFIG_OPTION"; \
 	fi; \
 	if [ -n "$(ENABLE_LEVELZERO)" ]; then \
-	    CONFIG_OPTION="$$CONFIG_OPTION --enable-levelzero"; \
+	    CONFIG_OPTION="--enable-levelzero $$CONFIG_OPTION "; \
 	fi; \
 	dh_auto_configure -- --with-bash-completion-dir=/etc/bash_completion.d --enable-grpc $$CONFIG_OPTION


### PR DESCRIPTION
- Allows user override of Debian packaging configure options for libgeopmd
- Relates to #3738