### PR TITLE
Adding user guide for frequency steering/selection.

### DIFF
--- a/docs/source/frequency_guide.rst
+++ b/docs/source/frequency_guide.rst
@@ -21,12 +21,12 @@ GEOPM-driven frequency setting will vary depending upon the interface used.
 Generally speaking, if a ``userspace`` governor is available on a given driver,
 it is more likely to play nicely with GEOPM.
 
-The ideal mechanism of frequency control depends of course on the use-case and
+The ideal mechanism of frequency control depends of course on the use case and
 priorities of the user. If performance repeatability is critical or the user
 knows of ideal frequency settings, direct frequency requests are likely ideal.
 If the user wishes to leverage as much of the power headroom as possible, SST
 or HWP interfaces are useful. If the user also wishes the system to steer power
-intelligently between cores/uncore based on internal telemetry, HWP will work
+intelligently between cores and uncore based on internal telemetry, HWP will work
 best. If computation on a given node is heterogeneous (i.e. some CPUs are given
 more work or more critical work than others), SST features are likely to work
 best.
@@ -35,7 +35,7 @@ Linux Frequency Drivers
 -----------------------
 
 Linux CPU driver information can be found using ``cpupower`` as shown in the
-example below. If the driver has a ``userspace`` governor available, that will
+example below. If the driver has a ``userspace`` CPU governor available, that will
 generally not interfere with GEOPM frequency decisions.
 
 .. code-block:: bash
@@ -67,12 +67,10 @@ systems that support that feature. The ``performance`` governor is more likely
 to adhere to GEOPM frequency decisions. The ``powersave`` governor tends to
 lower CPU frequency when cores are running idle.
 
-
 Direct Frequency Requests
 -------------------------
 
 This is the most straightforward mechanism for selecting a specific frequency.
-
 
 .. code-block:: bash
 
@@ -83,7 +81,7 @@ This is the most straightforward mechanism for selecting a specific frequency.
     $ geopmread CPU_FREQUENCY_STATUS core 0
     1200000000
 
-To set CPU uncore frequency, both min/max can be specified. To fix
+To set CPU uncore frequency, both min and max can be specified. To fix
 uncore frequency to a specific value, set ``CPU_UNCORE_FREQUENCY_MAX_CONTROL``
 and ``CPU_UNCORE_FREQUENCY_MIN_CONTROL`` to the same value. Note that there is
 no guarantee that the specified frequencies will be achieved, as the system may
@@ -92,7 +90,7 @@ be limited by hardware constraints.
 GPU Frequency
 ~~~~~~~~~~~~~
 
-Similar to CPU uncore frequency, GPU frequencies are specified via a min/max.
+Similar to CPU uncore frequency, GPU frequencies are specified via a min and max.
 Some hardware has underlying logic that require
 ``GPU_CORE_FREQUENCY_MIN_CONTROL`` to always be less than
 ``GPU_CORE_FREQUENCY_MAX_CONTROL``. If you try to set the min control greater
@@ -106,7 +104,6 @@ Example: Set GPU 0 frequency to 1.0 GHz
     $ echo -e "GPU_CORE_FREQUENCY_MAX_CONTROL gpu 0 1e9\
                \nGPU_CORE_FREQUENCY_MIN_CONTROL gpu 0 1e9"\
                | geopmwrite -f -"
-
 
 Example: Let GPU 1 frequency float between 800 MHz and 1.2 GHz
 
@@ -143,7 +140,7 @@ specify a frequency range per-core. Typically, a core with an EPP of 0 will
 try to reach the higher end of the frequency range while a core with an EPP of
 15 will try to remain at the lower end of its frequency range. If no frequency
 range is specified, the core will have access to the full frequency range. Note
-that setting min/max does not guarantee performance. Cores are still bound by
+that setting min and max frequencies does not guarantee performance. Cores are still bound by
 power/thermal/current limits and can be restricted beyond the minimum frequency
 if required to do so by hardware limitations.
 
@@ -196,9 +193,9 @@ Intel Speed Select Technology (SST)
 Intel Speed Select Technology (SST) includes a multitude of features for
 heterogeneous power steering on CPUs. GEOPM supports SST-CP (Core Priority) and
 SST-TF (Turbo Frequency). SST-CP is used to assign cores to different priority
-buckets 0-3, where 0 is highest priority and 3 is lowest priority for power
+buckets numbered 0-3, where 0 is highest priority and 3 is lowest priority for power
 distribution. This feature uses similar controls as HWP. If the power budget is
-exceeded, frequency of lower priority cores is decreased more than the frequency
+exceeded, the frequency of lower priority cores is decreased more than the frequency
 of higher priority cores.
 
 SST-TF allows cores in high priority buckets 0/1 to achieve higher turbo

--- a/docs/source/frequency_guide.rst
+++ b/docs/source/frequency_guide.rst
@@ -23,7 +23,7 @@ it is more likely to play nicely with GEOPM.
 
 The ideal mechanism of frequency control depends of course on the use-case and
 priorities of the user. If performance repeatability is critical or the user
-knows of ideal frequency settings, direct frequency requests is likely ideal.
+knows of ideal frequency settings, direct frequency requests are likely ideal.
 If the user wishes to leverage as much of the power headroom as possible, SST
 or HWP interfaces are useful. If the user also wishes the system to steer power
 intelligently between cores/uncore based on internal telemetry, HWP will work

--- a/docs/source/frequency_guide.rst
+++ b/docs/source/frequency_guide.rst
@@ -1,5 +1,5 @@
-User Frequency Guide
-=====================
+User Guide for Frequency Control
+================================
 
 Description
 -----------

--- a/docs/source/frequency_guide.rst
+++ b/docs/source/frequency_guide.rst
@@ -1,0 +1,212 @@
+User Frequency Guide
+=====================
+
+Description
+-----------
+GEOPM supports many interfaces to manipulate frequency. This guide provides
+specifics on each of these interfaces including suggested use, implementation
+nuances, and common pitfalls. Supported interfaces include:
+
+* Direct frequency requests on CPU core/uncore and GPU
+* Hardware P-States (HWP) on CPU
+* Speed Select Technology - Core Priority (SST-CP) and Turbo Frequency (SST-TF)
+  on Intel CPUs ICX+
+
+GEOPM frequency decisions interact with the OS frequency drivers. This
+interaction is detailed below. At a high level, frequency drivers may include
+settings to drive frequency with the objective of achieving greater performance
+or to lower power consumption, while other frequency driver settings may adhere
+more strictly to user frequency requests. The interaction between driver and
+GEOPM-driven frequency setting will vary depending upon the interface used.
+Generally speaking, if a ``userspace`` governor is available on a given driver,
+it is more likely to play nicely with GEOPM.
+
+The ideal mechanism of frequency control depends of course on the use-case and
+priorities of the user. If performance repeatability is critical or the user
+knows of ideal frequency settings, direct frequency requests is likely ideal.
+If the user wishes to leverage as much of the power headroom as possible, SST
+or HWP interfaces are useful. If the user also wishes the system to steer power
+intelligently between cores/uncore based on internal telemetry, HWP will work
+best. If computation on a given node is heterogeneous (i.e. some CPUs are given
+more work or more critical work than others), SST features are likely to work
+best.
+
+Linux Frequency Drivers
+-----------------------
+
+Linux CPU driver information can be found using ``cpupower`` as shown in the
+example below. If the driver has a ``userspace`` governor available, that will
+generally not interfere with GEOPM frequency decisions.
+
+.. code-block:: bash
+
+    $ cpupower frequency-info
+    analyzing CPU 0:
+      driver: acpi-cpufreq
+      CPUs which run at the same hardware frequency: 0
+      CPUs which need to have their frequency coordinated by software: 0
+      maximum transition latency: 10.0 us
+      hardware limits: 1000 MHz - 2.10 GHz
+      available frequency steps:  2.10 GHz, 2.10 GHz, 2.00 GHz, 1.90 GHz, 1.80 GHz, 1.70 GHz, 1.60 GHz, 1.50 GHz, 1.40 GHz, 1.30 GHz, 1.20 GHz, 1.10 GHz, 1000 MHz
+      available cpufreq governors: ondemand performance schedutil
+      current policy: frequency should be within 1000 MHz and 2.10 GHz.
+                      The governor "performance" may decide which speed to use
+                      within this range.
+      current CPU frequency: Unable to call hardware
+      current CPU frequency: 1.02 GHz (asserted by call to kernel)
+      boost state support:
+        Supported: yes
+        Active: yes
+
+When using the ``userspace`` or ``performance`` governor, the ``acpi-cpufreq``
+driver will not interfere with frequency decisions made by GEOPM. Other
+governors may interfere with GEOPM frequency settings.
+
+The ``intel_pstate`` driver allows users access to ``Hardware P-States`` on
+systems that support that feature. The ``performance`` governor is more likely
+to adhere to GEOPM frequency decisions. The ``powersave`` governor tends to
+lower CPU frequency when cores are running idle.
+
+
+Direct Frequency Requests
+-------------------------
+
+This is the most straightforward mechanism for selecting a specific frequency.
+
+
+.. code-block:: bash
+
+    $ geopmread CPU_FREQUENCY_STATUS core 0
+    3400000000
+
+    $ geopmwrite MSR::PERF_CTL:FREQ core 0 1.2e9
+    $ geopmread CPU_FREQUENCY_STATUS core 0
+    1200000000
+
+To set CPU uncore frequency, both min/max can be specified. To fix
+uncore frequency to a specific value, set ``CPU_UNCORE_FREQUENCY_MAX_CONTROL``
+and ``CPU_UNCORE_FREQUENCY_MIN_CONTROL`` to the same value. Note that there is
+no guarantee that the specified frequencies will be achieved, as the system may
+be limited by hardware constraints.
+
+GPU Frequency
+~~~~~~~~~~~~~
+
+Similar to CPU uncore frequency, GPU frequencies are specified via a min/max.
+Some hardware has underlying logic that require
+``GPU_CORE_FREQUENCY_MIN_CONTROL`` to always be less than
+``GPU_CORE_FREQUENCY_MAX_CONTROL``. If you try to set the min control greater
+than the max or the max control less than the min, it will result in a failure.
+To avoid this issue, use the batch interface on geopmwrite.
+
+Example: Set GPU 0 frequency to 1.0 GHz
+
+.. code-block:: bash
+
+    $ echo -e "GPU_CORE_FREQUENCY_MAX_CONTROL gpu 0 1e9\
+               \nGPU_CORE_FREQUENCY_MIN_CONTROL gpu 0 1e9"\
+               | geopmwrite -f -"
+
+
+Example: Let GPU 1 frequency float between 800 MHz and 1.2 GHz
+
+.. code-block:: bash
+
+    $ echo -e "GPU_CORE_FREQUENCY_MAX_CONTROL gpu 1 8e8\
+               \nGPU_CORE_FREQUENCY_MIN_CONTROL gpu 1 1.2e9"\
+               | geopmwrite -f -"
+
+Example: Set all GPU frequencies to use the full frequency range.
+
+.. code-block:: bash
+
+     $ echo -e "GPU_CORE_FREQUENCY_MIN_CONTROL board 0\
+                `geopmread GPU_CORE_FREQUENCY_MIN_AVAIL board 0`\
+                \nGPU_CORE_FREQUENCY_MAX_CONTROL board 0\
+                `geopmread GPU_CORE_FREQUENCY_MAX_AVAIL board 0`"\
+                | geopmwrite -f -
+
+Intel Hardware P-States (HWP)
+-----------------------------
+
+Users of Intel Hardware P-States (HWP) can set per-CPU or per-socket hints,
+like desired energy-perf bias and suggested min/max frequency range. These
+hints are ingested along with hardware telemetry and used to allow the CPU
+to steer its own frequency setting dynamically. This allows the system to 
+respond more rapidly than the OS could to changes in workload behavior while
+maintaining power requirements and desired user priority.
+
+The main control mechanism with HWP is the per-core
+``ENERGY_PERFORMANCE_PREFERENCE`` or EPP. This is a value 0-15, where 0 is
+higher performance and 15 is higher energy efficiency. The user can also
+specify a frequency range per-core. Typically, a core with an EPP of 0 will
+try to reach the higher end of the frequency range while a core with an EPP of
+15 will try to remain at the lower end of its frequency range. If no frequency
+range is specified, the core will have access to the full frequency range. Note
+that setting min/max does not guarantee performance. Cores are still bound by
+power/thermal/current limits and can be restricted beyond the minimum frequency
+if required to do so by hardware limitations.
+
+``HWP_CAPABILITIES`` includes frequencies of interest. The full frequency range
+is [``LOWEST_PERFORMANCE``, ``HIGHEST_PERFORMANCE``], and
+``GUARANTEED_PERFORMANCE`` is the frequency that all cores should be able to
+reach simultaneously when running a typical power-hungry workload.
+
+Using GEOPM with HWP
+~~~~~~~~~~~~~~~~~~~~
+
+Enabling HWP on a system cannot be done using GEOPM. This is because a system
+reset is required to disable it once it has been enabled. Thus, it interferes
+with GEOPM's save/restore capabilities.
+
+The instructions below assume that the ``intel_pstate`` driver is active.
+
+To check the status of HWP, use ``HWP_ENABLE``. A return value of 0 indicates
+HWP is disabled.
+
+.. code-block:: bash
+
+    $ geopmread MSR::PM_ENABLE:HWP_ENABLE package 0
+    1
+
+Set a core's HWP parameters (and check frequency to see the change reflected).
+Here we will try to make core 0 be more power hungry and core 4 be more energy
+efficient.
+
+.. code-block:: bash
+
+    $ # Check core 0 and 4 frequency (running idle)
+    $ geopmread CPU_FREQUENCY_STATUS cpu 0
+    1000000000
+    $ geopmread CPU_FREQUENCY_STATUS cpu 4
+    1000000000
+    $ geopmwrite MSR::HWP_REQUEST:ENERGY_PERFORMANCE_PREFERENCE cpu 4 15
+    $ geopmwrite MSR::HWP_REQUEST:MAXIMUM_PERFORMANCE cpu 4 1.4e9
+    $ geopmwrite MSR::HWP_REQUEST:ENERGY_PERFORMANCE_PREFERENCE cpu 0 0
+    $ geopmwrite MSR::HWP_REQUEST:MINIMUM_PERFORMANCE cpu 0 2.2e9
+    $ geopmread CPU_FREQUENCY_STATUS cpu 0
+    2200000000
+    $ geopmread CPU_FREQUENCY_STATUS cpu 4
+    1000000000
+
+
+Intel Speed Select Technology (SST)
+-----------------------------------
+
+Intel Speed Select Technology (SST) includes a multitude of features for
+heterogeneous power steering on CPUs. GEOPM supports SST-CP (Core Priority) and
+SST-TF (Turbo Frequency). SST-CP is used to assign cores to different priority
+buckets 0-3, where 0 is highest priority and 3 is lowest priority for power
+distribution. This feature uses similar controls as HWP. If the power budget is
+exceeded, frequency of lower priority cores is decreased more than the frequency
+of higher priority cores.
+
+SST-TF allows cores in high priority buckets 0/1 to achieve higher turbo
+frequencies than is typically allowed by reducing the maximum turbo frequencies
+of the lower priority cores. That way, even in power constrained scenarios
+where all cores are active, cores with high priority work can be granted a
+higher proportion of the power budget. This is achieved without violating any
+hardware constraints, unlike overclocking.
+
+These features are described in detail in the
+:doc:`geopm_pio_sst(7)<geopm_pio_sst.7>` man page.

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -1221,8 +1221,8 @@ or HWP interfaces are useful. If the user also wishes the system to steer power
 intelligently between cores/uncore based on internal telemetry, HWP will work
 best. If computation on a given node is heterogeneous (i.e. some CPUs are given
 more work or more critical work than others), SST features are likely to work
-best. See the :doc:`User Frequency Guide <frequency_guide>` for full
-details on how and when to use these interfaces.
+best. See the :doc:`User Guide for Frequency Control <frequency_guide>` for
+full details on how and when to use these interfaces.
 
 OS frequency drivers may interfere with and take precedent over GEOPM settings.
 Frequency drivers may include settings to drive frequency with the objective of

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -1082,10 +1082,37 @@ decipher what each alias represents. For instance:
 For more information about the currently supported aliases and IOGroups, see:
 :ref:`geopm_pio.7:Aliasing Signals And Controls`.
 
-.. Nuances in Setting CPU Frequency
-.. """"""""""""""""""""""""""""""""
+Nuances in Setting CPU Frequency
+""""""""""""""""""""""""""""""""
 
-.. Discussion of how HWP and the CPU Governor impact observed frequency.
+GEOPM supports many interfaces to manipulate frequency. Supported interfaces
+include:
+
+* Direct frequency requests on CPU core/uncore and GPU
+* Hardware P-States (HWP) on CPU
+* Speed Select Technology - Core Priority (SST-CP) and Turbo Frequency (SST-TF)
+  on Intel CPUs ICX+
+
+The ideal mechanism of frequency control depends of course on the use-case and
+priorities of the user. If performance repeatability is critical or the user
+knows of ideal frequency settings, direct frequency requests is likely ideal.
+If the user wishes to leverage as much of the power headroom as possible, SST
+or HWP interfaces are useful. If the user also wishes the system to steer power
+intelligently between cores/uncore based on internal telemetry, HWP will work
+best. If computation on a given node is heterogeneous (i.e. some CPUs are given
+more work or more critical work than others), SST features are likely to work
+best. See the :doc:`User Frequency Guide <frequency_guide>` for full
+details on how and when to use these interfaces.
+
+OS frequency drivers may interfere with and take precedent over GEOPM settings.
+Frequency drivers may include settings to drive frequency with the objective of
+achieving greater performance or to lower power consumption, while other
+frequency driver settings may adhere more strictly to user frequency requests.
+The interaction between driver and GEOPM-driven frequency setting will vary
+depending upon the interface used. Generally speaking, if a ``userspace``
+governor is available on a given driver, it is more likely to play nicely with
+GEOPM. Also, the availability of HWP may depend upon OS driver settings. It is
+fully supported by the ``intel_pstate`` driver.
 
 .. Reading Power
 .. """""""""""""

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -1242,34 +1242,10 @@ For more information about the currently supported aliases and IOGroups, see:
 Nuances in Setting CPU Frequency
 """"""""""""""""""""""""""""""""
 
-GEOPM supports many interfaces to manipulate frequency. Supported interfaces
-include:
-
-* Direct frequency requests on CPU core/uncore and GPU
-* Hardware P-States (HWP) on CPU
-* Speed Select Technology - Core Priority (SST-CP) and Turbo Frequency (SST-TF)
-  on Intel CPUs ICX+
-
-The ideal mechanism of frequency control depends of course on the use-case and
-priorities of the user. If performance repeatability is critical or the user
-knows of ideal frequency settings, direct frequency requests is likely ideal.
-If the user wishes to leverage as much of the power headroom as possible, SST
-or HWP interfaces are useful. If the user also wishes the system to steer power
-intelligently between cores/uncore based on internal telemetry, HWP will work
-best. If computation on a given node is heterogeneous (i.e. some CPUs are given
-more work or more critical work than others), SST features are likely to work
-best. See the :doc:`User Guide for Frequency Control <frequency_guide>` for
-full details on how and when to use these interfaces.
-
-OS frequency drivers may interfere with and take precedent over GEOPM settings.
-Frequency drivers may include settings to drive frequency with the objective of
-achieving greater performance or to lower power consumption, while other
-frequency driver settings may adhere more strictly to user frequency requests.
-The interaction between driver and GEOPM-driven frequency setting will vary
-depending upon the interface used. Generally speaking, if a ``userspace``
-governor is available on a given driver, it is more likely to play nicely with
-GEOPM. Also, the availability of HWP may depend upon OS driver settings. It is
-fully supported by the ``intel_pstate`` driver.
+GEOPM supports multiple interfaces to manipulate frequency and there are
+nuanced interactions with OS drivers. See the
+:doc:`User Guide for Frequency Control <frequency_guide>` for full details on
+how and when to use these interfaces.
 
 .. Reading Power
 .. """""""""""""

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -841,28 +841,27 @@ Writing Multiple Controls
             int ctl1_idx;
             int err;
 
-            ctl0_idx = geopm_pio_push_control("CPU_FREQUENCY_MAX_CONTROL",
-                                              GEOPM_DOMAIN_CORE,
-                                              0);
-            ctl1_idx = geopm_pio_push_control("CPU_FREQUENCY_MAX_CONTROL",
-                                              GEOPM_DOMAIN_CORE,
-                                              1);
+            // Push controls for each core
+            ctl0_idx = geopm_pio_push_control("CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_CORE, 0);
+            ctl1_idx = geopm_pio_push_control("CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_CORE, 1);
 
+            // Adjust the controls to the target frequencies
             err = geopm_pio_adjust(ctl0_idx, 1.0e9);
             if (err != 0) {
                 geopm_error_message(err, err_msg, GEOPM_MESSAGE_MAX);
-                printf("Err msg = %s\n", err_msg);
+                printf("Error adjusting core 0: %s\n", err_msg);
             }
             err = geopm_pio_adjust(ctl1_idx, 1.8e9);
             if (err != 0) {
                 geopm_error_message(err, err_msg, GEOPM_MESSAGE_MAX);
-                printf("Err msg = %s\n", err_msg);
+                printf("Error adjusting core 1: %s\n", err_msg);
             }
 
+            // Write the batch of controls
             err = geopm_pio_write_batch();
             if (err != 0) {
                 geopm_error_message(err, err_msg, GEOPM_MESSAGE_MAX);
-                printf("Err msg = %s\n", err_msg);
+                printf("Error writing batch: %s\n", err_msg);
             }
 
             return 0;
@@ -878,15 +877,18 @@ Writing Multiple Controls
 
         int main (int argc, char** argv)
         {
-            int ctl0_idx = geopm::platform_io().push_control("CPU_FREQUENCY_MAX_CONTROL",
-                                                             GEOPM_DOMAIN_CORE, 0);
-            int ctl1_idx = geopm::platform_io().push_control("CPU_FREQUENCY_MAX_CONTROL",
-                                                             GEOPM_DOMAIN_CORE, 1);
+            geopm::PlatformIO &pio = geopm::platform_io();
 
-            geopm::platform_io().adjust(ctl0_idx, 1.0e9);
-            geopm::platform_io().adjust(ctl1_idx, 1.8e9);
+            // Push controls for each core
+            int ctl0_idx = pio.push_control("CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_CORE, 0);
+            int ctl1_idx = pio.push_control("CPU_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_CORE, 1);
 
-            geopm::platform_io().write_batch();
+            // Adjust the controls to the target frequencies
+            pio.adjust(ctl0_idx, 1.0e9);
+            pio.adjust(ctl1_idx, 1.8e9);
+
+            // Write the batch of controls
+            pio.write_batch();
 
             return 0;
         }
@@ -898,28 +900,63 @@ Writing Multiple Controls
         import geopmdpy.topo as topo
         import geopmdpy.pio as pio
 
+        # Define target frequencies for each core
         freqs = [1.0e9, 1.8e9]
         ctl_idxs = []
 
+        # Push controls for each core
         ctl_idxs.append(pio.push_control('CPU_FREQUENCY_MAX_CONTROL', topo.DOMAIN_CORE, 0))
         ctl_idxs.append(pio.push_control('CPU_FREQUENCY_MAX_CONTROL', topo.DOMAIN_CORE, 1))
 
+        # Adjust the controls to the target frequencies
         for idx, ctl in enumerate(ctl_idxs):
             pio.adjust(ctl, freqs[idx])
 
+        # Write the batch of controls
         pio.write_batch()
 
     .. code-tab:: go
 
-        // Write the current CPU frequency for core 0 to 3.0 GHz
+        // Write the core 0 frequency to 1 GHz and core 1 frequency to 1.8 GHz
 
         package main
 
         import (
+            "fmt"
             "github.com/geopm/geopmdgo/geopmdgo"
         )
 
         func main() {
+            // Push controls for each core
+            ctl0Idx, err := geopmdgo.PushControl("CPU_FREQUENCY_MAX_CONTROL", geopmdgo.DOMAIN_CORE, 0)
+            if err != nil {
+                fmt.Println("Error pushing control for core 0:", err)
+                return
+            }
+            ctl1Idx, err := geopmdgo.PushControl("CPU_FREQUENCY_MAX_CONTROL", geopmdgo.DOMAIN_CORE, 1)
+            if err != nil {
+                fmt.Println("Error pushing control for core 1:", err)
+                return
+            }
+
+            // Adjust the controls to the target frequencies
+            err = geopmdgo.Adjust(ctl0Idx, 1.0e9)
+            if err != nil {
+                fmt.Println("Error adjusting core 0:", err)
+                return
+            }
+            err = geopmdgo.Adjust(ctl1Idx, 1.8e9)
+            if err != nil {
+                fmt.Println("Error adjusting core 1:", err)
+                return
+            }
+
+            // Write the batch of controls
+            err = geopmdgo.WriteBatch()
+            if err != nil {
+                fmt.Println("Error writing batch:", err)
+                return
+            }
         }
 
 .. note::

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -811,6 +811,126 @@ Writing Controls
 
         $ geopmread CPU_FREQUENCY_MAX_CONTROL core 0
 
+Writing Multiple Controls
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. tabs::
+
+    .. code-tab:: bash
+
+        # Write the core 0 frequency to 1 GHz and core 1 frequency to 1.8 GHz
+
+        $ echo -e "CPU_FREQUENCY_MAX_CONTROL core 0 1e9\
+                   \nCPU_CORE_FREQUENCY_MAX_CONTROL core 0 1.8e9"\
+                   | geopmwrite -f -"
+
+    .. code-tab:: c
+
+        // Write the core 0 frequency to 1 GHz and core 1 frequency to 1.8 GHz
+
+        #include <limits.h>
+        #include <stdio.h>
+        #include <geopm_topo.h>
+        #include <geopm_pio.h>
+        #include <geopm_error.h>
+
+        int main (int argc, char** argv)
+        {
+            char err_msg[GEOPM_MESSAGE_MAX];
+            int ctl0_idx;
+            int ctl1_idx;
+            int err;
+
+            ctl0_idx = geopm_pio_push_control("CPU_FREQUENCY_MAX_CONTROL",
+                                              GEOPM_DOMAIN_CORE,
+                                              0);
+            ctl1_idx = geopm_pio_push_control("CPU_FREQUENCY_MAX_CONTROL",
+                                              GEOPM_DOMAIN_CORE,
+                                              1);
+
+            err = geopm_pio_adjust(ctl0_idx, 1.0e9);
+            if (err != 0) {
+                geopm_error_message(err, err_msg, GEOPM_MESSAGE_MAX);
+                printf("Err msg = %s\n", err_msg);
+            }
+            err = geopm_pio_adjust(ctl1_idx, 1.8e9);
+            if (err != 0) {
+                geopm_error_message(err, err_msg, GEOPM_MESSAGE_MAX);
+                printf("Err msg = %s\n", err_msg);
+            }
+
+            err = geopm_pio_write_batch();
+            if (err != 0) {
+                geopm_error_message(err, err_msg, GEOPM_MESSAGE_MAX);
+                printf("Err msg = %s\n", err_msg);
+            }
+
+            return 0;
+        }
+
+    .. code-tab:: c++
+
+        // Write the core 0 frequency to 1 GHz and core 1 frequency to 1.8 GHz
+
+        #include <iostream>
+        #include <geopm/PlatformIO.hpp>
+        #include <geopm/PlatformTopo.hpp>
+
+        int main (int argc, char** argv)
+        {
+            int ctl0_idx = geopm::platform_io().push_control("CPU_FREQUENCY_MAX_CONTROL",
+                                                             GEOPM_DOMAIN_CORE, 0);
+            int ctl1_idx = geopm::platform_io().push_control("CPU_FREQUENCY_MAX_CONTROL",
+                                                             GEOPM_DOMAIN_CORE, 1);
+
+            geopm::platform_io().adjust(ctl0_idx, 1.0e9);
+            geopm::platform_io().adjust(ctl1_idx, 1.8e9);
+
+            geopm::platform_io().write_batch();
+
+            return 0;
+        }
+
+    .. code-tab:: python
+
+        # Write the core 0 frequency to 1 GHz and core 1 frequency to 1.8 GHz
+
+        import geopmdpy.topo as topo
+        import geopmdpy.pio as pio
+
+        freqs = [1.0e9, 1.8e9]
+        ctl_idxs = []
+
+        ctl_idxs.append(pio.push_control('CPU_FREQUENCY_MAX_CONTROL', topo.DOMAIN_CORE, 0))
+        ctl_idxs.append(pio.push_control('CPU_FREQUENCY_MAX_CONTROL', topo.DOMAIN_CORE, 1))
+
+        for idx, ctl in enumerate(ctl_idxs):
+            pio.adjust(ctl, freqs[idx])
+
+        pio.write_batch()
+
+    .. code-tab:: go
+
+        // Write the current CPU frequency for core 0 to 3.0 GHz
+
+        package main
+
+        import (
+            "github.com/geopm/geopmdgo/geopmdgo"
+        )
+
+        func main() {
+        }
+
+.. note::
+
+    To determine the initial value of any control, use ``geopmread`` or the
+    corresponding ``PlatformIO`` APIs at the desired domain.  E.g.:
+
+    .. code-block:: bash
+
+        $ geopmread CPU_FREQUENCY_MAX_CONTROL core 0
+
 Understanding Disaggregation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/user_guides.rst
+++ b/docs/source/user_guides.rst
@@ -4,7 +4,7 @@ User Guides
 In depth documentation about the GEOPM Service and the GEOPM Runtime are
 provided in two separate guides.
 
-A frequency steering guide is also provided.
+A guide for controlling frequency is also provided.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/user_guides.rst
+++ b/docs/source/user_guides.rst
@@ -4,9 +4,11 @@ User Guides
 In depth documentation about the GEOPM Service and the GEOPM Runtime are
 provided in two separate guides.
 
+A frequency steering guide is also provided.
+
 .. toctree::
    :maxdepth: 1
 
    service
    runtime
-
+   frequency_guide


### PR DESCRIPTION
- Relates to #3760
- Relates to #3770 

Adding a doc page to guide user on how to steer frequency and understand expected behavior. This will also detail interaction with Linux acpi/intel frequency drivers.