### PR TITLE
Fix names of compiler wrappers in integration build scripts

### DIFF
--- a/integration/Makefile.am
+++ b/integration/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST = README.md \
              config/dudley_env.sh \
              config/endeavor_env.sh \
              config/gnu_env.sh \
+             config/mcfly_env.sh \
              config/README.md \
              config/run_env.sh \
              config/smng_env.sh \

--- a/integration/config/README.md
+++ b/integration/config/README.md
@@ -20,20 +20,20 @@ A `bash` script that may be sourced within a shell in order to set up
 the user's build/run environment on the australis system.
 
 
-`build.sh`
-----------
-
-An executable script that will automate use of the GEOPM and GEOPM Service
-build systems.  This script provides documentation if run with the `--help`
-command line option.
-
-
 `build_env.sh`
 --------------
 
 A `bash` script that may be sourced within a shell in order to set up
 the user's build environment.  By default this will use the Intel
 compiler toolchain.
+
+
+`build.sh`
+----------
+
+An executable script that will automate use of the GEOPM and GEOPM Service
+build systems.  This script provides documentation if run with the `--help`
+command line option.
 
 
 `dudley_env.sh`
@@ -51,14 +51,21 @@ the user's build environment on the endeavor system.
 
 
 `gnu_env.sh`
-----------
+------------
 
 A `bash` script that may be sourced within a shell in order to set up
 the user's build environment to use the GNU compiler toolchain.
 
 
+`mcfly_env.sh`
+--------------
+
+A `bash` script that may be sourced within a shell in order to set up
+the user's build environment on the mcfly system.
+
+
 `run_env.sh`
-----------
+------------
 
 A `bash` script that may be source within a shell in order to set up the
 user's run environment to use a locally installed version of the GEOPM
@@ -66,14 +73,14 @@ packages.
 
 
 `smng_env.sh`
------------
+-------------
 
 A `bash` script that may be sourced within a shell in order to set up
 the user's build environment on the SuperMUC-NG system.
 
 
 `theta_env.sh`
-------------
+--------------
 
 A `bash` script that may be sourced within a shell in order to set up
 the user's build environment on the Theta system.

--- a/integration/config/build_env.sh
+++ b/integration/config/build_env.sh
@@ -29,12 +29,12 @@ export CXX=${CXX:-icpx}
 export FC=${FC:-ifx}
 export F77=${F77:-ifx}
 export F90=${F90:-ifx}
-export MPICC=${MPICC:-mpiicc}
-export MPICXX=${MPICXX:-mpiicpc}
-export MPIFORT=${MPIFORT:-mpiifort}
-export MPIFC=${MPIFC:-mpiifort}
-export MPIF77=${MPIF77:-mpiifort}
-export MPIF90=${MPIF90:-mpiifort}
+export MPICC=${MPICC:-mpicc}
+export MPICXX=${MPICXX:-mpic++}
+export MPIFORT=${MPIFORT:-mpifort}
+export MPIFC=${MPIFC:-mpifort}
+export MPIF77=${MPIF77:-mpifort}
+export MPIF90=${MPIF90:-mpifort}
 
 if [ -z ${GEOPM_SKIP_COMPILER_CHECK+x} ]; then
     COMPILER_LIST="CC CXX MPICC MPICXX FC F77 F90 MPIFC MPIFORT MPIF77 MPIF90"

--- a/integration/config/mcfly_env.sh
+++ b/integration/config/mcfly_env.sh
@@ -20,5 +20,4 @@ export MPIFORT=mpiifort
 export MPIFC=mpiifort
 export MPIF77=mpiifort
 export MPIF90=mpiifort
-export PALS_PMI=pmix
 export GEOPM_LAUNCHER=srun

--- a/integration/config/mcfly_env.sh
+++ b/integration/config/mcfly_env.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+#  Copyright (c) 2015 - 2025 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+# MCFLY BUILD/RUN ENVIRONMENT
+#
+# This script is intended to be sourced within an existing script or shell ONLY.
+# It is NOT intended to be ./ executed.
+
+export CC=icx
+export CXX=icpx
+export MPICC=mpiicc
+export MPICXX=mpiicpc
+export FC=ifx
+export F77=ifx
+export F90=ifx
+export MPIFORT=mpiifort
+export MPIFC=mpiifort
+export MPIF77=mpiifort
+export MPIF90=mpiifort
+export PALS_PMI=pmix
+export GEOPM_LAUNCHER=srun


### PR DESCRIPTION
- Fixes name of the intel compiler wrappers in accordance with the latest agama release
- Minor spelling typo fix

Relates to #3775 