### PR TITLE
Remove 0 traceline from ffnet agent integration test

### DIFF
--- a/integration/test/test_ffnet_agent.py
+++ b/integration/test/test_ffnet_agent.py
@@ -183,6 +183,8 @@ class TestIntegration_ffnet_agent(unittest.TestCase):
     #    For a given REGION_HASH, the probability of the correct IDd region is
     #    >95% at least 95% of the time
     def test_region_accuracy(self):
+        # Removing first trace row as it is all 0s (init)
+        self._trace_data = self._trace_data.iloc[1:]
         # Grab region class columns
         subset = self._trace_data[list(self._trace_data.filter(regex='geopmbench'))]
         # Calculate probabilities

--- a/integration/test/test_ffnet_nn_scripts.py
+++ b/integration/test/test_ffnet_nn_scripts.py
@@ -75,7 +75,7 @@ class TestIntegration_ffnet(unittest.TestCase):
             run_max_turbo = False
         )
 
-        experiment_cli_args=['--geopm-ctl=application']
+        experiment_cli_args=['--geopm-ctl=process']
 
         # Configure the CPU test application - geopmbench
         cls._loop_count = 30


### PR DESCRIPTION
Was causing occasional failures as first traceline was just full of 0s, so region class was not matching.