### PR TITLE
Packaging fixes for release package files

### DIFF
--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -151,10 +151,10 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return (this->m_levelzero_device_pool.frequency_range(
+                                      return this->m_levelzero_device_pool.frequency_range(
                                                    GEOPM_DOMAIN_GPU_CHIP,
                                                    domain_idx,
-                                                   geopm::LevelZero::M_DOMAIN_COMPUTE)).second;
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE).second;
                                   },
                                   1e6
                                   }},
@@ -202,10 +202,10 @@ namespace geopm
                                   {},
                                   [this](unsigned int domain_idx) -> double
                                   {
-                                      return (this->m_levelzero_device_pool.frequency_range(
+                                      return this->m_levelzero_device_pool.frequency_range(
                                                    GEOPM_DOMAIN_GPU_CHIP,
                                                    domain_idx,
-                                                   geopm::LevelZero::M_DOMAIN_COMPUTE)).first;
+                                                   geopm::LevelZero::M_DOMAIN_COMPUTE).first;
                                   },
                                   1e6
                                   }},

--- a/release/fedora/geopmd.spec
+++ b/release/fedora/geopmd.spec
@@ -74,7 +74,7 @@ popd
 
 %check
 pushd %{buildroot}%{python3_sitearch}
-python3 -m unittest discover -p 'Test*.py' -v %{_builddir}/%{prj_name}-%{version}/test
+python3 -m unittest discover -p 'Test*.py' -v %{_builddir}/geopm-%{version}/%{prj_name}/test
 popd
 
 %post -n geopmd

--- a/release/fedora/libgeopm.spec
+++ b/release/fedora/libgeopm.spec
@@ -88,6 +88,8 @@ popd
 %files
 %license LICENSE-BSD-3-Clause
 %doc CONTRIBUTING.rst README.md
+%doc %{_docdir}/%{name}/LICENSE-BSD-3-Clause
+%doc %{_docdir}/%{name}/VERSION
 %{_libdir}/%{name}.so.%{abi_ver}
 %{_libdir}/%{name}.so.2
 %{_libdir}/geopm

--- a/release/fedora/libgeopmd.spec
+++ b/release/fedora/libgeopmd.spec
@@ -90,6 +90,8 @@ popd
 %files
 %license LICENSE-BSD-3-Clause
 %doc CONTRIBUTING.rst README.md
+%doc %{_docdir}/%{name}/LICENSE-BSD-3-Clause
+%doc %{_docdir}/%{name}/VERSION
 %{_libdir}/%{name}.so.%{abi_ver}
 %{_libdir}/%{name}.so.2
 

--- a/release/fedora/python-geopmpy.spec
+++ b/release/fedora/python-geopmpy.spec
@@ -60,7 +60,7 @@ popd
 
 %check
 pushd %{buildroot}%{python3_sitearch}
-python3 -m unittest discover -p 'Test*.py' -v %{_builddir}/%{prj_name}-%{version}/test
+python3 -m unittest discover -p 'Test*.py' -v %{_builddir}/geopm-%{version}/%{prj_name}/test
 popd
 
 %files -n python3-%{prj_name}

--- a/release/openSUSE/geopmd.spec
+++ b/release/openSUSE/geopmd.spec
@@ -95,7 +95,7 @@ popd
 
 %check
 pushd %{buildroot}%{python3_sitearch}
-python3 -m unittest discover -p 'Test*.py' -v %{_builddir}/%{prj_name}-%{version}/test
+python3 -m unittest discover -p 'Test*.py' -v %{_builddir}/geopm-%{version}/%{prj_name}/test
 popd
 
 %pre -n geopmd

--- a/release/openSUSE/libgeopm2.spec
+++ b/release/openSUSE/libgeopm2.spec
@@ -93,9 +93,11 @@ mv %{buildroot}{%{_bindir},%{_sbindir}}/geopmadmin
 popd
 
 %check
+%if ! %{defined _without_check}
 pushd libgeopm
 make check || (cat ./test-suite.log && false)
 popd
+%endif
 
 %post
 ldconfig

--- a/release/openSUSE/libgeopmd2.spec
+++ b/release/openSUSE/libgeopmd2.spec
@@ -143,9 +143,11 @@ mv %{buildroot}{%{_bindir},%{_sbindir}}/geopmbatch
 popd
 
 %check
+%if ! %{defined _without_check}
 pushd libgeopmd
 make check || (cat ./test-suite.log && false)
 popd
+%endif
 
 %post
 ldconfig

--- a/release/openSUSE/python3-geopmpy.spec
+++ b/release/openSUSE/python3-geopmpy.spec
@@ -55,7 +55,7 @@ popd
 
 %check
 pushd %{buildroot}%{python3_sitearch}
-python3 -m unittest discover -p 'Test*.py' -v %{_builddir}/%{prj_name}-%{version}/test
+python3 -m unittest discover -p 'Test*.py' -v %{_builddir}/geopm-%{version}/%{prj_name}/test
 popd
 
 %files


### PR DESCRIPTION
- Add options to skip unit tests in production openSUSE spec files
  + Used as a work around for OS distributions using gtest 10
- Drop parenthesis that are breaking some fedora builds
- Add version and license install files to fedora packaging