### PR TITLE
Bring back the python runtime implementation

### DIFF
--- a/geopmdpy/geopmdpy/session.py
+++ b/geopmdpy/geopmdpy/session.py
@@ -317,6 +317,7 @@ class Session:
         """
         self._delimiter = delimiter
         self._agent = agent_factory(agent)
+        self._num_agent_trace = 0
 
     def format_signals(self, signals, signal_format):
         """Format a list of signal values for printing
@@ -398,8 +399,11 @@ class Session:
             if out_stream is not None:
                 signals = [pio.sample(handle) for handle in signal_handles]
                 line = self.format_signals(signals, requests.get_formats())
-                agent_line = self._delimiter.join(self._agent.trace_out())
-                if agent_line != '':
+                if self._num_agent_trace != 0:
+                    agent_trace = self._agent.trace_out()
+                    if len(agent_trace) != self._num_agent_trace:
+                        raise RuntimeError('Agent provided trace data of length inconsistent with the header length')
+                    agent_line = self._delimiter.join(agent_trace)
                     line = f'{line[:-1]}{self._delimiter}{agent_line}\n'
                 out_stream.write(line)
             if stats_collector is not None:
@@ -502,7 +506,9 @@ class Session:
         result = [f'"{name}-{topo.domain_name(domain)}-{domain_idx}"'
                   if topo.domain_name(domain) != 'board' else f'"{name}"'
                   for name, domain, domain_idx in requests]
-        result.extend(self._agent.header_names())
+        agent_header = self._agent.header_names()
+        self._num_agent_trace = len(agent_header)
+        result.extend(agent_header)
         return result
 
     def run(self, run_time, period, pid, print_header,

--- a/geopmdpy/geopmdpy/session.py
+++ b/geopmdpy/geopmdpy/session.py
@@ -187,6 +187,7 @@ class Agent:
                 pass
 
         main(agent=MyAgent())
+
     """
     def __init__(self):
         """Initialize the agent. Override to set up agent state."""
@@ -200,6 +201,7 @@ class Agent:
 
         Returns:
             argparse.ArgumentParser: The updated parser.
+
         """
         return parser
 
@@ -211,6 +213,7 @@ class Agent:
 
         Returns:
             argparse.Namespace: The (possibly updated) arguments.
+
         """
         return args
 
@@ -219,28 +222,38 @@ class Agent:
 
         Returns:
             str or None: A string containing the signal configuration,
-                         or None to use the session default (stdin).
+                         or None to use the Session default (stdin).
+
         """
         return None
 
     def run_begin(self):
         """Called by Session at the start of each run.
 
-        Override to perform setup before the session starts.
+        Override to perform setup before the session starts. Calls to
+        pio.push_signal() and pio.push_control() may be made here.
+
         """
         pass
 
     def run_end(self):
         """Called by Session at the end of each run.
 
-        Override to perform cleanup after the session ends.
+        Override to perform cleanup after the session ends.  Releases any
+        resources allocated in the run_begin() method.
+
         """
         pass
 
     def update_loop(self):
         """Called periodically by Session during the run.
 
-        Override to implement periodic agent logic.
+        Override to implement periodic agent logic. This method is called by the
+        Session implementation just after a call to pio.read_batch() in the
+        timed loop, so the Agent implementation should not call
+        pio.read_batch().  Calls to pio.sample(), pio.adjust() and
+        pio.write_batch() may be part of the update_loop() implementation.
+
         """
         pass
 
@@ -249,14 +262,19 @@ class Agent:
 
         Returns:
             list of str: List of header names for custom trace columns.
+
         """
         return []
 
     def trace_out(self):
         """Return additional trace values provided by the agent.
 
+        The agent is responsible for the string format of the values returned,
+        numeric values are not allowed.
+
         Returns:
             list of str: List of string values for custom trace columns.
+
         """
         return []
 
@@ -271,6 +289,7 @@ def agent_factory(agent):
 
     Raises:
         RuntimeError: If agent is not None and not an Agent.
+
     """
     if agent is None:
         return Agent()
@@ -396,6 +415,7 @@ class Session:
 
         Returns:
            bool: True if pid is active, False otherwise
+
         """
         try:
             os.kill(pid, 0)
@@ -448,6 +468,7 @@ class Session:
 
         Raises:
             ValueError: An invalid request is present in the request queue.
+
         """
         for name, dom, dom_idx in requests:
             domain_name = topo.domain_name(dom)
@@ -476,10 +497,11 @@ class Session:
 
         Returns:
             list of str: List of header names for the trace output.
+
         """
         result = [f'"{name}-{topo.domain_name(domain)}-{domain_idx}"'
-                if topo.domain_name(domain) != 'board' else f'"{name}"'
-                for name, domain, domain_idx in requests]
+                  if topo.domain_name(domain) != 'board' else f'"{name}"'
+                  for name, domain, domain_idx in requests]
         result.extend(self._agent.header_names())
         return result
 
@@ -816,6 +838,7 @@ def main(agent=None):
 
     Returns:
         int: 0 on success, nonzero on error.
+
     """
     err = 0
     trace_out = None

--- a/geopmdpy/geopmdpy/session.py
+++ b/geopmdpy/geopmdpy/session.py
@@ -156,25 +156,148 @@ class _MPISessionIO:
     def is_rank_zero(self):
         return self._rank == 0
 
+class Agent:
+    """Base class for user-defined agents in GEOPM sessions.
+
+    Agents encapsulate custom logic for controlling and monitoring
+    GEOPM sessions. To use an agent, subclass this class and override
+    any of the methods to customize argument parsing, signal configuration,
+    trace output, and periodic update behavior.
+
+    Methods that can be overridden:
+      - update_parser: Add custom command-line arguments.
+      - update_args: Process parsed arguments.
+      - signal_config_override: Provide a custom signal configuration string.
+      - run_begin: Called at the start of a session run.
+      - run_end: Called at the end of a session run.
+      - update_loop: Called at each sampling period.
+      - header_names: Add custom trace column headers.
+      - trace_out: Provide custom trace output values.
+
+    Example usage:
+        class MyAgent(Agent):
+            def update_parser(self, parser):
+                parser.add_argument('--foo', ...)
+                return parser
+            def update_args(self, args):
+                self._foo = args.foo
+                return args
+            def update_loop(self):
+                # Custom logic here
+                pass
+
+        main(agent=MyAgent())
+    """
+    def __init__(self):
+        """Initialize the agent. Override to set up agent state."""
+        pass
+
+    def update_parser(self, parser):
+        """Update the argument parser with agent-specific options.
+
+        Args:
+            parser (argparse.ArgumentParser): The parser to update.
+
+        Returns:
+            argparse.ArgumentParser: The updated parser.
+        """
+        return parser
+
+    def update_args(self, args):
+        """Process parsed arguments and update agent state.
+
+        Args:
+            args (argparse.Namespace): Parsed command-line arguments.
+
+        Returns:
+            argparse.Namespace: The (possibly updated) arguments.
+        """
+        return args
+
+    def signal_config_override(self):
+        """Override the default signal configuration.
+
+        Returns:
+            str or None: A string containing the signal configuration,
+                         or None to use the session default (stdin).
+        """
+        return None
+
+    def run_begin(self):
+        """Called by Session at the start of each run.
+
+        Override to perform setup before the session starts.
+        """
+        pass
+
+    def run_end(self):
+        """Called by Session at the end of each run.
+
+        Override to perform cleanup after the session ends.
+        """
+        pass
+
+    def update_loop(self):
+        """Called periodically by Session during the run.
+
+        Override to implement periodic agent logic.
+        """
+        pass
+
+    def header_names(self):
+        """Return additional trace column headers provided by the agent.
+
+        Returns:
+            list of str: List of header names for custom trace columns.
+        """
+        return []
+
+    def trace_out(self):
+        """Return additional trace values provided by the agent.
+
+        Returns:
+            list of str: List of string values for custom trace columns.
+        """
+        return []
+
+def agent_factory(agent):
+    """Ensure the agent parameter is an Agent instance.
+
+    Args:
+        agent (Agent or None): The agent to use.
+
+    Returns:
+        Agent: An instance of Agent or a subclass.
+
+    Raises:
+        RuntimeError: If agent is not None and not an Agent.
+    """
+    if agent is None:
+        return Agent()
+    if not isinstance(agent, Agent):
+        raise RuntimeError('The agent parameter must be derived from the Agent class')
+    return agent
+
 class Session:
-    """Object responsible for creating a GEOPM batch read session
+    """Object responsible for creating and running a GEOPM batch read session.
 
-    This object's run() method is the main entry point for
-    geopmsession command line tool.  The inputs to run() are derived
-    from the command line options provided by the user.
+    The Session object manages the main loop for reading signals,
+    formatting output, and integrating with user-defined agents.
 
-    The Session object depends on the RequestQueue object to parse the
-    input request buffer from the user.  The Session object also
-    depends on the loop.TimedLoop object when executing a periodic
-    read session.
+    Args:
+        delimiter (str): Delimiter for CSV output.
+        agent (Agent or None): Optional agent object to customize session behavior.
 
     """
+    def __init__(self, delimiter=',', agent=None):
+        """Initialize the Session.
 
-    def __init__(self, delimiter=','):
-        """Constructor for Session class
-
+        Args:
+            delimiter (str): Delimiter for CSV output.
+            agent (Agent or None): Optional agent object.
         """
-        self._delimiter=delimiter
+        self._delimiter = delimiter
+        self._agent = agent_factory(agent)
 
     def format_signals(self, signals, signal_format):
         """Format a list of signal values for printing
@@ -252,9 +375,13 @@ class Session:
         for sample_idx in loop.TimedLoop(period, num_period):
             if sample_idx != 0:
                 pio.read_batch()
+            self._agent.update_loop()
             if out_stream is not None:
                 signals = [pio.sample(handle) for handle in signal_handles]
                 line = self.format_signals(signals, requests.get_formats())
+                agent_line = self._delimiter.join(self._agent.trace_out())
+                if agent_line != '':
+                    line = f'{line[:-1]}{self._delimiter}{agent_line}\n'
                 out_stream.write(line)
             if stats_collector is not None:
                 stats_collector.update()
@@ -265,6 +392,11 @@ class Session:
                 stats_collector.reset()
 
     def is_pid_active(self, pid):
+        """Check if pid is active
+
+        Returns:
+           bool: True if pid is active, False otherwise
+        """
         try:
             os.kill(pid, 0)
             result = True
@@ -332,17 +464,24 @@ class Session:
 
 
     def header_names(self, requests):
-        """Format trace CSV header strings for the set of requests
+        """Format trace CSV header strings for the set of requests.
+
+        Includes both the default signal headers and any additional
+        headers provided by the agent.
 
         Args:
             requests (list(tuple(str, int, int))):
                 List of request tuples. Each request comprises a signal name,
                 domain type, and domain index.
 
+        Returns:
+            list of str: List of header names for the trace output.
         """
-        return [f'"{name}-{topo.domain_name(domain)}-{domain_idx}"'
+        result = [f'"{name}-{topo.domain_name(domain)}-{domain_idx}"'
                 if topo.domain_name(domain) != 'board' else f'"{name}"'
                 for name, domain, domain_idx in requests]
+        result.extend(self._agent.header_names())
+        return result
 
     def run(self, run_time, period, pid, print_header,
             request_stream=sys.stdin, out_stream=sys.stdout,
@@ -412,7 +551,8 @@ class Session:
             if do_stats:
                 report_stream = _ReportStream(stats_collector, session_io, print_header, delimiter, report_format)
             try:
-                g_session_handler = _SessionHandler(out_stream, report_stream)
+                g_session_handler = _SessionHandler(out_stream, report_stream, self._agent)
+                self._agent.run_begin()
                 self.run_read(requests, run_time, period, pid, out_stream, stats_collector, report_samples, report_stream)
             finally:
                 g_session_handler.stop()
@@ -443,15 +583,17 @@ class _ReportStream:
         self.print_header = False
 
 class _SessionHandler:
-    def __init__(self, out_stream, report_stream):
+    def __init__(self, out_stream, report_stream, agent):
         self.out_stream = out_stream
         self.report_stream = report_stream
+        self.agent = agent
 
     def stop(self):
         if self.out_stream is not None:
             self.out_stream.flush()
         if self.report_stream is not None:
             self.report_stream.write()
+        self.agent.run_end()
 
 class RequestQueue:
     """Object derived from user input that provides request information
@@ -509,8 +651,22 @@ class RequestQueue:
 
 
 class ReadRequestQueue(RequestQueue):
+    """Class to encapsulate session signal configuration requests.
+
+    """
     def __init__(self, request_stream):
-        """Constructor for ReadRequestQueue object
+        """Initialize the request queue
+
+        The constructor parses the input stream and stores the
+        requests for reading signals.  The input stream is expected
+        to contain a list of requests, one per line.  Each request
+        is a string of three words separated by white space.  The
+        first word is the signal name, the second word is the domain
+        type, and the third word is the domain index.  The domain
+        type is specified as the name string, i.e one of the
+        following strings: "board", "package", "core", "cpu",
+        "memory", "package_integrated_memory", "nic",
+        "package_integrated_nic", "gpu", "package_integrated_gpu".
 
         Args:
             request_stream (typing.IO): Input from user describing the
@@ -609,6 +765,11 @@ class ReadRequestQueue(RequestQueue):
         return self._formats
 
     def get_raw(self):
+        """Get raw string representation
+
+        Returns:
+           str: The request as a string
+        """
         return self._raw
 
 def get_parser():
@@ -643,14 +804,18 @@ def get_parser():
 
     return parser
 
-def main():
+def main(agent=None):
     """Command line interface for the geopm service batch read features.
 
-    The input to the command line tool has one request per line.  A
-    request for reading is made of up three strings separated by white
-    space.  The first string is the signal name, the second string is
-    the domain name, and the third string is the domain index.
+    This function can be used as a script entry point or called directly
+    from Python. To use a custom agent, pass an instance of a subclass
+    of Agent as the `agent` argument.
 
+    Args:
+        agent (Agent or None): Optional agent object to customize session behavior.
+
+    Returns:
+        int: 0 on success, nonzero on error.
     """
     err = 0
     trace_out = None
@@ -658,8 +823,12 @@ def main():
     _config_stream = None
     signal(SIGTERM, _term_handler)
     signal(SIGINT, _term_handler)
+    agent = agent_factory(agent)
     try:
-        args = get_parser().parse_args()
+        parser = get_parser()
+        parser = agent.update_parser(parser)
+        args = parser.parse_args()
+        args = agent.update_args(args)
         if args.version:
             print(__version_str__)
             return 0
@@ -668,7 +837,11 @@ def main():
         if args.report_samples is not None and args.trace_out == args.report_out:
             raise RuntimeError('When using the --report-samples option the trace and report output must differ, use --report-out or --trace-out to specify a unique value')
         if args.config_path == '-':
-            config_stream = sys.stdin
+            override = agent.signal_config_override()
+            if override is None:
+                config_stream = sys.stdin
+            else:
+                config_stream = StringIO(override)
         else:
             _config_stream = open(args.config_path)
             config_stream = _config_stream
@@ -677,7 +850,7 @@ def main():
         else:
             session_io = _SessionIO(request_stream=config_stream, trace_path=args.trace_out, report_path=args.report_out)
         trace_out = session_io.open_trace_stream()
-        sess = Session(args.delimiter)
+        sess = Session(args.delimiter, agent)
         sess.run(run_time=args.time, period=args.period, pid=args.pid, print_header=not args.no_header,
                  request_stream=None, out_stream=trace_out, report_path=None, session_io=session_io,
                  report_format=args.report_format, delimiter=args.delimiter, report_samples=args.report_samples)

--- a/geopmdpy/test/TestSession.py
+++ b/geopmdpy/test/TestSession.py
@@ -17,6 +17,39 @@ with mock.patch('cffi.FFI.dlopen', return_value=mock.MagicMock()):
     from geopmdpy.session import Session
     from geopmdpy.session import RequestQueue
     from geopmdpy.session import ReadRequestQueue
+    from geopmdpy.session import Agent
+
+class DummyAgent(Agent):
+    def __init__(self):
+        super().__init__()
+        self.parser_updated = False
+        self.args_updated = False
+        self.run_begin_called = False
+        self.run_end_called = False
+        self.loop_count = 0
+        self._trace_header = ['extra_col']
+        self._trace_out = ['extra_val']
+        self._override = 'signal1 board 0\n'
+    def update_parser(self, parser):
+        self.parser_updated = True
+        parser.add_argument('--dummy', action='store_true')
+        return parser
+    def update_args(self, args):
+        self.args_updated = True
+        self._dummy = getattr(args, 'dummy', False)
+        return args
+    def signal_config_override(self):
+        return self._override
+    def run_begin(self):
+        self.run_begin_called = True
+    def run_end(self):
+        self.run_end_called = True
+    def update_loop(self):
+        self.loop_count += 1
+    def header_names(self):
+        return self._trace_header
+    def trace_out(self):
+        return self._trace_out
 
 class TestSession(unittest.TestCase):
     def setUp(self):
@@ -236,6 +269,58 @@ class TestSession(unittest.TestCase):
                               runtime, period, None, False,
                               request_stream=request_stream, out_stream=out_stream)
 
+    def test_agent_update_parser_and_args(self):
+        agent = DummyAgent()
+        parser = mock.MagicMock()
+        parser.add_argument = mock.MagicMock(return_value=None)
+        updated_parser = agent.update_parser(parser)
+        self.assertTrue(agent.parser_updated)
+        args = mock.MagicMock()
+        args.dummy = True
+        updated_args = agent.update_args(args)
+        self.assertTrue(agent.args_updated)
+        self.assertTrue(agent._dummy)
+
+    def test_agent_signal_config_override(self):
+        agent = DummyAgent()
+        self.assertEqual(agent.signal_config_override(), 'signal1 board 0\n')
+
+    def test_agent_header_names_and_trace_out(self):
+        agent = DummyAgent()
+        session = Session(agent=agent)
+        # Simulate requests
+        requests = [('signal1', 0, 0)]
+        headers = session.header_names(requests)
+        self.assertIn('extra_col', headers)
+        # Simulate trace output
+        with mock.patch('geopmdpy.pio.push_signal', return_value=0), \
+             mock.patch('geopmdpy.pio.read_batch'), \
+             mock.patch('geopmdpy.pio.sample', return_value=1.0), \
+             mock.patch('geopmdpy.session.Session.format_signals', return_value='1.0,'):
+            out_stream = StringIO()
+            session.run_read(mock.MagicMock(__iter__=lambda self: iter(requests), get_formats=lambda: [0]), 1, 1, None, out_stream)
+            self.assertIn('extra_val', out_stream.getvalue())
+
+    def test_agent_run_begin_and_end(self):
+        agent = DummyAgent()
+        session = Session(agent=agent)
+        # Patch run_read to avoid actual execution
+        with mock.patch.object(session, 'run_read'):
+            session.run(1, 1, None, False, request_stream=StringIO('TIME board 0\n'), out_stream=StringIO())
+        self.assertTrue(agent.run_begin_called)
+        self.assertTrue(agent.run_end_called)
+
+    def test_agent_update_loop_called(self):
+        agent = DummyAgent()
+        session = Session(agent=agent)
+        requests = [('signal1', 0, 0)]
+        with mock.patch('geopmdpy.pio.push_signal', return_value=0), \
+             mock.patch('geopmdpy.pio.read_batch'), \
+             mock.patch('geopmdpy.pio.sample', return_value=1.0), \
+             mock.patch('geopmdpy.session.Session.format_signals', return_value='1.0,'):
+            out_stream = StringIO()
+            session.run_read(mock.MagicMock(__iter__=lambda self: iter(requests), get_formats=lambda: [0]), 2, 1, None, out_stream)
+            self.assertGreater(agent.loop_count, 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/geopmpy/geopmpy/monitor.py
+++ b/geopmpy/geopmpy/monitor.py
@@ -1,0 +1,84 @@
+#!/usr/bin/python3
+#
+#  Copyright (c) 2015 - 2025 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+"""
+Monitor agent for GEOPM Python interface.
+
+This module provides a MonitorAgent class for use with the GEOPM
+Python session interface. The MonitorAgent can be used to run
+a monitoring session with a default set of signals, and supports
+a --hi-res option to sample all signals at their native resolution.
+
+Example usage:
+    python -m geopmpy.monitor
+    python -m geopmpy.monitor --hi-res
+"""
+
+from geopmdpy import pio
+
+from geopmdpy.session import main
+from geopmdpy.session import Agent
+from geopmdpy.exporter import default_requests
+
+class MonitorAgent(Agent):
+    """Agent for monitoring a default set of signals in a GEOPM session.
+
+    The MonitorAgent provides a --hi-res option to sample all signals
+    at their native resolution (all domains and indices). By default,
+    signals are sampled at the board domain.
+
+    Command-line options:
+      --hi-res   Measure signals at native resolution (all domains/indices).
+
+    Example:
+        python -m geopmpy.monitor --hi-res
+    """
+    def __init__(self):
+        """Initialize the MonitorAgent."""
+        super().__init__()
+        self._hi_res = False
+
+    def update_parser(self, parser):
+        """Add --hi-res argument to the parser.
+
+        Args:
+            parser (argparse.ArgumentParser): The parser to update.
+
+        Returns:
+            argparse.ArgumentParser: The updated parser.
+        """
+        parser.add_argument('--hi-res', action='store_true',
+                            help='Measure signals at native resolution (all domains/indices)')
+        return parser
+
+    def update_args(self, args):
+        """Store the --hi-res argument in the agent.
+
+        Args:
+            args (argparse.Namespace): Parsed command-line arguments.
+
+        Returns:
+            argparse.Namespace: The (possibly updated) arguments.
+        """
+        self._hi_res = args.hi_res
+        return args
+
+    def signal_config_override(self):
+        """Provide a default signal configuration for monitoring.
+
+        Returns:
+            str: Signal configuration string for the session.
+        """
+        if self._hi_res:
+            suffix = ' * *\n'
+        else:
+            suffix = ' board 0\n'
+        signals = [dd[0] for dd in default_requests()]
+        return 'TIME board 0\n' + suffix.join(signals) + suffix
+
+if __name__ == '__main__':
+    main(MonitorAgent())
+


### PR DESCRIPTION
- Fixes #3854 

Current PR contains the ffnet agent and the monitor agent as examples.  Might consider moving the ffnet agent into a separate PR prior to merging.  

TODOs
- [x] Better documentation
- [x] More testing
- [x] Fix sphinx doc string issue breaking CI
