### PR TITLE
Ensure pip is up-to-date

### DIFF
--- a/integration/config/build.sh
+++ b/integration/config/build.sh
@@ -39,6 +39,8 @@ if [[ ${1} == '--help' ]]; then
     exit 1
 fi
 
+python3 -m pip install --user --upgrade pip
+
 GEOPM_SOURCE=${GEOPM_SOURCE:-${PWD}}
 cd ${GEOPM_SOURCE}
 BUILD_ENV="integration/config/build_env.sh"


### PR DESCRIPTION
- Required to work around VERSION issues with setuptools_scm and old versions of pip.
- Especially required when no geopm packages are installed on the host.