### PR TITLE
Fix integration test so it uses restart not stop start

### DIFF
--- a/integration/service/test/test_su_restart.sh
+++ b/integration/service/test/test_su_restart.sh
@@ -28,9 +28,7 @@ fi
 ${TEST_SCRIPT} &
 test_pid=$!
 sleep 2
-sudo systemctl stop geopm
-sleep 1
-sudo systemctl start geopm
+sudo systemctl restart geopm
 wait $test_pid
 result=$?
 if [ $result -eq 0 ]; then


### PR DESCRIPTION
- Relates to #3865

Update integration test to use restart where stop/start was used previously