### PR TITLE
Remove duplicate devel entry in the toc tree

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -905,5 +905,4 @@ Further Documentation
    geopmaccess.1
    install_rolling
    build
-   devel
    spack


### PR DESCRIPTION
Fix for double expand of LHS menu:

https://geopm.github.io/devel.html