### PR TITLE
get_cpuset: Handle cases when cpuset does not exist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
       if: matrix.service-asan-flag != 'enable-asan' && matrix.base-asan-flag != 'enable-asan'
       working-directory: geopmpy
       env:
-        LD_LIBRARY_PATH: ../libgeopm/.libs:${LD_LIBRARY_PATH}
+        LD_LIBRARY_PATH: ../libgeopm/.libs:../libgeopmd/.libs:${LD_LIBRARY_PATH}
       run: python3 test
     - name: test geopmdgo
       if: matrix.service-asan-flag != 'enable-asan'

--- a/geopmpy/geopmpy/launcher.py
+++ b/geopmpy/geopmpy/launcher.py
@@ -31,7 +31,7 @@ import tempfile
 
 from collections import OrderedDict
 from . import __version__
-
+from geopmdpy import topo
 
 class Factory(object):
     def __init__(self):
@@ -111,45 +111,43 @@ def _get_cpuset():
     Returns a list of valid CPUs for the current process.
     Ported from C++ Helper::get_cpuset().
     """
-    proc_path = '/proc/self/cpuset'
-    try:
-        with open(proc_path) as f:
-            cpuset_cgroup = f.read().strip()
-    except Exception as ex:
-        raise RuntimeError(f'<geopm> geopmpy.launcher: Failed to read {proc_path}: {ex}')
-
-    possible_paths = [
-        f'/sys/fs/cgroup/cpuset{cpuset_cgroup}/cpuset.effective_cpus',
-        f'/sys/fs/cgroup{cpuset_cgroup}/cpuset.cpus.effective'
-    ]
-
-    cpus_content = None
-    cpuset_file = None
-    for path in possible_paths:
-        try:
-            with open(path) as f:
-                cpus_content = f.read().strip()
-            cpuset_file = path
-            break
-        except Exception:
-            continue
-
-    if cpus_content is None:
-        raise RuntimeError('<geopm> geopmpy.launcher: Failed to read cpuset.cpus.effective from any expected location')
-
     result = []
-    for part in cpus_content.split(','):
-        if '-' in part: # CPU range (e.g., "0-207")
+    cpuset_path = '/proc/self/cpuset'
+
+    try:
+        with open(cpuset_path) as f:
+            cpuset_cgroup = f.read().strip()
+
+        possible_paths = [
+            f'/sys/fs/cgroup/cpuset{cpuset_cgroup}/cpuset.effective_cpus',
+            f'/sys/fs/cgroup{cpuset_cgroup}/cpuset.cpus.effective'
+        ]
+
+        for path in possible_paths:
             try:
-                start, end = map(int, part.split('-'))
-                result.extend(range(start, end + 1))
-            except Exception as ex:
-                raise RuntimeError(f'<geopm> geopmpy.launcher: Invalid CPU range in {cpuset_file}: {ex}')
-        elif part: # Single CPU number
-            try:
-                result.append(int(part))
-            except Exception as ex:
-                raise RuntimeError(f'<geopm> geopmpy.launcher: Invalid CPU number in {cpuset_file}: {ex}')
+                with open(path) as f:
+                    cpus_content = f.read().strip()
+
+                # Parse CPU ranges and build result list
+                for part in cpus_content.split(','):
+                    if '-' in part:  # CPU range (e.g., "0-207")
+                        start, end = map(int, part.split('-'))
+                        result.extend(range(start, end + 1))
+                    elif part:  # Single CPU number
+                        result.append(int(part))
+
+                # If we successfully parsed this path, stop trying others
+                break
+            except Exception:
+                # Try next path
+                continue
+    except Exception:
+        # Fall through to default behavior if we can't read cpuset_path
+        pass
+
+    if len(result) == 0:
+        result = list(range(topo.num_domain(topo.DOMAIN_CPU)))
+
     return result
 
 

--- a/libgeopm/src/ApplicationSampler.cpp
+++ b/libgeopm/src/ApplicationSampler.cpp
@@ -454,11 +454,27 @@ namespace geopm
         return result;
     }
 
+    std::set<int> ApplicationSamplerImp::get_cpuset_fallback(void)
+    {
+        std::set<int> allowed_cpus;
+        try {
+            allowed_cpus = geopm::get_cpuset(0);
+        }
+        catch (const geopm::Exception &ex) {
+            // If /proc/self/cpuset is unavailable, fall back to all CPUs
+            int num_cpu = m_topo.num_domain(GEOPM_DOMAIN_CPU);
+            for (int cpu_idx = 0; cpu_idx < num_cpu; ++cpu_idx) {
+                allowed_cpus.insert(cpu_idx);
+            }
+        }
+        return allowed_cpus;
+    }
+
     int ApplicationSamplerImp::sampler_cpu(void)
     {
         int result = m_num_cpu - 1;
         int num_core = m_topo.num_domain(GEOPM_DOMAIN_CORE);
-        std::set<int> allowed_cpus = geopm::get_cpuset(0);
+        std::set<int> allowed_cpus = get_cpuset_fallback();
         bool found_inactive_core = false;
         bool found_inactive_cpu = false;
         std::vector<bool> is_core_active(num_core, false);

--- a/libgeopm/src/ApplicationSamplerImp.hpp
+++ b/libgeopm/src/ApplicationSamplerImp.hpp
@@ -61,6 +61,7 @@ namespace geopm
             void update_cpu_active(void);
             void update_start(void);
             void update_stop(void);
+            std::set<int> get_cpuset_fallback(void);
             std::vector<record_s> m_record_buffer;
             std::vector<short_region_s> m_short_region_buffer;
             std::shared_ptr<ApplicationStatus> m_status;


### PR DESCRIPTION
- Relates to #3869.
- Refactor to fallback to using all cores when cpuset files are not present.