### PR TITLE
Add a library that can be preloaded to set controls

### DIFF
--- a/libgeopm/Makefile.am
+++ b/libgeopm/Makefile.am
@@ -14,6 +14,7 @@ pkglibdir=$(libdir)/geopm
 
 # THINGS THAT ARE INSTALLED
 lib_LTLIBRARIES = libgeopm.la \
+                  libgeopm_init.la \
                   # end
 
 bin_PROGRAMS = geopmadmin \
@@ -290,6 +291,13 @@ pkglib_LTLIBRARIES = libgeopmiogroup_profile.la
 libgeopmiogroup_profile_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(geopm_abi_version)
 libgeopmiogroup_profile_la_LIBADD = libgeopm.la
 libgeopmiogroup_profile_la_SOURCES = src/ProfileIOGroupLib.cpp src/EpochIOGroupLib.cpp
+
+
+libgeopm_init_la_LDFLAGS = $(AM_LDFLAGS) $(MATH_CLDFLAGS) -version-info $(geopm_abi_version)
+libgeopm_init_la_CFLAGS = $(AM_CFLAGS)
+libgeopm_init_la_CXXFLAGS = $(AM_CXXFLAGS)
+
+libgeopm_init_la_SOURCES = src/geopm_control_load.cpp
 
 beta_source_files = src/Daemon.cpp \
                     src/DaemonImp.hpp \

--- a/libgeopm/src/geopm_control_load.cpp
+++ b/libgeopm/src/geopm_control_load.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2015 - 2025 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "InitControl.hpp"
+#include "geopm/Environment.hpp"
+
+namespace geopm
+{
+    static void __attribute__((constructor)) geopm_init_control_constructor(void)
+    {
+        if (environment().do_init_control()) {
+            auto init_control = InitControl::make_unique();
+            init_control->parse_input(environment().init_control());
+        }
+    }
+}


### PR DESCRIPTION
- Can be used with LD_PRELOAD in place of geopmwrite when inserting geopmwrite into the process session is otherwise difficult.
- [ ] Add documentation on how to use