### PR TITLE
Updating top-hash for AIB benchmark

### DIFF
--- a/integration/apps/arithmetic_intensity/build.sh
+++ b/integration/apps/arithmetic_intensity/build.sh
@@ -10,8 +10,8 @@ set -e
 source ../build_func.sh
 
 if [[ $# -eq 0 ]]; then
-    echo 'Building from 12d0c5a'
-    TOPHASH=12d0c5a
+    echo 'Building from ee57389'
+    TOPHASH=ee57389
 elif [[ $# -eq 1 ]]; then
     echo 'Building from head of main'
     TOPHASH=$1


### PR DESCRIPTION
Updating TOPHASH variable in `arithmetic_intensity/build.sh` 

Latest commit HASH: ee57389f94851dd982393a0f51e700b86110ebcb

Here's the pointer to the AIB git repo: https://github.com/dannosliwcd/arithmetic-intensity

