### PR TITLE
Address inversion errors

### DIFF
--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -73,7 +73,7 @@ def slowdown_at_power(power, x0, A, B, C):
 
 
 def power_at_slowdown(slowdown, x0, A, B, C):
-    return clip_list([(x0n - (-Bn + math.sqrt(Bn**2 - 4 * An * (Cn - slowdown))) / (2 * An))
+    return clip_list([(x0n - (-Bn + math.sqrt(abs(Bn**2 - 4 * An * (Cn - slowdown)))) / (2 * An))
                       for x0n, An, Bn, Cn in zip(x0, A, B, C)], 0, 1)
 
 

--- a/integration/service/open_pbs/geopm_power_limit_server.py
+++ b/integration/service/open_pbs/geopm_power_limit_server.py
@@ -104,7 +104,7 @@ def predict_power_cap_at_performance_factor(job_type, slowdown, min_power_per_no
         try:
             # Using a quadratic model: slowdown = A * (x0 - percent_of_tdp)^2 + B * (x0 - percent_of_tdp) + C
             # Solve for the positive root (less than 100% of max power) at '-slowdown' offset:
-            result = model['max_power'] * (model['x0'] - (-model['B'] + math.sqrt(model['B']**2 - 4 * model['A'] * (model['C'] - slowdown))) / (2 * model['A']))
+            result = model['max_power'] * (model['x0'] - (-model['B'] + math.sqrt(abs(model['B']**2 - 4 * model['A'] * (model['C'] - slowdown)))) / (2 * model['A']))
         except Exception as e:
             pbs.logmsg(pbs.LOG_WARNING, f'Unable to estimate job power. {str(e)}')
             do_use_model = False

--- a/integration/service/open_pbs/plot_power_limits.py
+++ b/integration/service/open_pbs/plot_power_limits.py
@@ -17,8 +17,10 @@ import numpy as np
 # Import the PBS hook so we can plot the output of its power-balancing routines
 # Mock out the GEOPM and PBS stuff since this plots what-if scenarios from the
 # hook config data and we don't intend to interact with actual system controls.
-mock.patch.dict("sys.modules", pbs=mock.MagicMock(), geopmdpy=mock.MagicMock()).start()
-import geopm_power_limit
+pbs_mock=mock.MagicMock()
+pbs_mock.hook_config_filename = None
+mock.patch.dict("sys.modules", pbs=pbs_mock, geopmdpy=mock.MagicMock()).start()
+import geopm_power_limit_compute
 
 
 parser = argparse.ArgumentParser()
@@ -44,7 +46,7 @@ if args.job_type is None:
     job_type = hook_config['node_profile_name']
 else:
     job_type = args.job_type
-host_models = geopm_power_limit.get_model_from_config(hook_config, job_type, per_host=True)
+host_models = geopm_power_limit_compute.get_model_from_config(hook_config, job_type, per_host=True)
 max_node_power = host_models['max_power']
 
 vnode_names = list(hook_config['profiles'][job_type]['hosts'])
@@ -60,13 +62,13 @@ plt.style.use('seaborn')
 
 average_caps = args.power_caps
 budget_allocations = [
-    geopm_power_limit.allocate_budget_to_nodes(average_cap * len(vnode_names), max_node_power, x0, A, B, C)
+    geopm_power_limit_compute.allocate_budget_to_nodes(average_cap * len(vnode_names), max_node_power, x0, A, B, C)
     for average_cap in average_caps
 ]
 
 # Worst/slowest node if uniform power caps are applied
 uniform_power_slowdowns = [
-    geopm_power_limit.slowdown_at_power(average_cap / max_node_power, x0, A, B, C)
+    geopm_power_limit_compute.slowdown_at_power(average_cap / max_node_power, x0, A, B, C)
     for average_cap in average_caps
 ]
 non_uniform_power_slowdowns = [


### PR DESCRIPTION
- Some model coefficients result in a negative discriminant.  Use abs() to ensure that the value is positive before trying to invert.