### PR TITLE
Build a LevelZero plugin

### DIFF
--- a/libgeopmd/src/IOGroup.cpp
+++ b/libgeopmd/src/IOGroup.cpp
@@ -158,6 +158,13 @@ namespace geopm
             register_plugin(ServiceIOGroup::plugin_name(),
                             ServiceIOGroup::make_plugin);
 #endif
+#ifdef GEOPM_ENABLE_LEVELZERO
+            // Allow non-root users to opt-in to LevelZeroIOGroup via env override
+            if (!geopm::get_env("GEOPM_LEVELZERO_OVERRIDE").empty()) {
+                register_plugin(LevelZeroIOGroup::plugin_name(),
+                                LevelZeroIOGroup::make_plugin);
+            }
+#endif
         }
         register_plugin(TimeIOGroup::plugin_name(),
                         TimeIOGroup::make_plugin);


### PR DESCRIPTION
- This enables users to override the system installed version of the LevelZeroIOGroup as provided by the GEOPM Access service.
- TODO: Add documentation about how to use the plugin