### PR TITLE
Fix CI: Pandas and distutils

### DIFF
--- a/geopmpy/geopmpy/io.py
+++ b/geopmpy/geopmpy/io.py
@@ -25,7 +25,7 @@ import hashlib
 if os.getenv('GEOPM_USE_UNSAFE_HDF5') is not None:
     from pandas import read_hdf
 else:
-    def read_hdf(path, name):
+    def read_hdf(path, key=None, **kwargs):
         if not os.path.exists(path):
             raise IOError(f'Trace HDF5 file {path} not detected')
         raise ImportWarning('Refusing to read HDF5 format files: file format could result in arbitrary code execution. To enable "export GEOPM_USE_UNSAFE_HDF5=1"')
@@ -111,7 +111,7 @@ class AppOutput(object):
 
                 do_load_raw = True
                 try:
-                    self._traces_df = read_hdf(trace_h5_name, 'trace')
+                    self._traces_df = read_hdf(trace_h5_name, key='trace')
                     do_load_raw = False
                     if verbose:
                         sys.stdout.write(f'Loaded traces from {trace_h5_name}.\n')
@@ -125,7 +125,7 @@ class AppOutput(object):
                     try:
                         if verbose:
                             sys.stdout.write('Generating HDF5 files... ')
-                        self._traces_df.to_hdf(trace_h5_name, 'trace')
+                        self._traces_df.to_hdf(trace_h5_name, key='trace')
                     except ImportError as error:
                         sys.stderr.write(f'Warning: <geopm> geopmpy.io: Unable to write HDF5 file: {error}\n')
 
@@ -878,16 +878,16 @@ class RawReportCollection(object):
                     sys.stdout.write('Attempting to read {}...\n'.format(self._report_h5_name))
                 # load dataframes from cache
                 try:
-                    self._reports_df = read_hdf(self._report_h5_name, 'report')
+                    self._reports_df = read_hdf(self._report_h5_name, key='report')
                 except KeyError:
                     pass # No regions in cached report
-                self._app_reports_df = read_hdf(self._report_h5_name, 'app_report')
+                self._app_reports_df = read_hdf(self._report_h5_name, key='app_report')
                 try:
-                    self._unmarked_reports_df = read_hdf(self._report_h5_name, 'unmarked_report')
+                    self._unmarked_reports_df = read_hdf(self._report_h5_name, key='unmarked_report')
                 except KeyError:
                     pass
                 try:
-                    self._epoch_reports_df = read_hdf(self._report_h5_name, 'epoch_report')
+                    self._epoch_reports_df = read_hdf(self._report_h5_name, key='epoch_report')
                 except KeyError:
                     pass
                 if verbose:
@@ -902,19 +902,23 @@ class RawReportCollection(object):
 
                 # Cache report dataframe
                 cache_created = False
+                did_fixup_metadata = False
                 while not cache_created:
                     try:
                         if verbose:
                             sys.stdout.write('Generating HDF5 files... ')
-                        self._app_reports_df.to_hdf(self._report_h5_name, 'app_report', format='table')
+                        self._app_reports_df.to_hdf(self._report_h5_name, key='app_report', format='table')
                         if len(self._reports_df) > 0:
-                            self._reports_df.to_hdf(self._report_h5_name, 'report', format='table', append=True)
+                            self._reports_df.to_hdf(self._report_h5_name, key='report', format='table', append=True)
                         if len(self._unmarked_reports_df) > 0:
-                            self._unmarked_reports_df.to_hdf(self._report_h5_name, 'unmarked_report', format='table', append=True)
+                            self._unmarked_reports_df.to_hdf(self._report_h5_name, key='unmarked_report', format='table', append=True)
                         if len(self._epoch_reports_df) > 0:
-                            self._epoch_reports_df.to_hdf(self._report_h5_name, 'epoch_report', format='table', append=True)
+                            self._epoch_reports_df.to_hdf(self._report_h5_name, key='epoch_report', format='table', append=True)
                         cache_created = True
                     except TypeError as error:
+                        if did_fixup_metadata:
+                            raise
+                        did_fixup_metadata = True
                         fm = RawReportCollection.fixup_metadata
                         if verbose:
                             sys.stdout.write('Applying workaround for strings in HDF5 files... ')

--- a/geopmpy/geopmpy/io.py
+++ b/geopmpy/geopmpy/io.py
@@ -29,7 +29,7 @@ else:
         if not os.path.exists(path):
             raise IOError(f'Trace HDF5 file {path} not detected')
         raise ImportWarning('Refusing to read HDF5 format files: file format could result in arbitrary code execution. To enable "export GEOPM_USE_UNSAFE_HDF5=1"')
-from distutils.spawn import find_executable
+import shutil
 from natsort import natsorted
 from . import __version__
 
@@ -680,7 +680,7 @@ imbalance : {imbalance}
         # Using libtool causes sporadic issues with the Intel
         # toolchain.
         result = 'geopmbench'
-        path = find_executable(result)
+        path = shutil.which(result)
         source_dir = os.path.dirname(
                      os.path.dirname(
                      os.path.dirname(

--- a/integration/apps/qe/qe.py
+++ b/integration/apps/qe/qe.py
@@ -8,8 +8,19 @@
 
 import os
 import glob
-import distutils.dir_util
+import shutil
 from .. import apps
+
+
+def _copy_tree_contents(src_dir, dst_dir):
+    os.makedirs(dst_dir, exist_ok=True)
+    for entry in os.listdir(src_dir):
+        src_path = os.path.join(src_dir, entry)
+        dst_path = os.path.join(dst_dir, entry)
+        if os.path.isdir(src_path):
+            shutil.copytree(src_path, dst_path, dirs_exist_ok=True)
+        else:
+            shutil.copy2(src_path, dst_path)
 
 # Valid pool counts depend on how many k-points are in the input problem.
 # There must be at least enough pools to distribute the k-points across them.
@@ -90,9 +101,7 @@ class QuantumEspressoAppConf(apps.AppConf):
         return self._cpus_per_rank
 
     def trial_setup(self, run_id, output_dir):
-        # Unlike shutil, this copies the contents of the source dir, without
-        # the source dir itself
-        distutils.dir_util.copy_tree(self._input_dir, output_dir)
+        _copy_tree_contents(self._input_dir, output_dir)
         input_files = glob.glob(os.path.join(output_dir, '*.in'))
         if len(input_files) != 1:
             raise ValueError('Expected exactly 1 *.in file present in {}. '

--- a/integration/experiment/ffnet/gen_hdf_from_fsweep.py
+++ b/integration/experiment/ffnet/gen_hdf_from_fsweep.py
@@ -224,7 +224,7 @@ def main(output_prefix, frequency_sweep_dirs, region_ignore=None):
 
     pd \
     .concat(reports_dfs, ignore_index=True) \
-    .to_hdf(f"{output_prefix}_stats.h5", "stats", mode='w')
+    .to_hdf(f"{output_prefix}_stats.h5", key="stats", mode='w')
 
     #Creating trace hdf for training neural net, annotated with region hashes or
     #generated region names when hashes are not available
@@ -234,7 +234,7 @@ def main(output_prefix, frequency_sweep_dirs, region_ignore=None):
 
     pd \
     .concat(trace_dfs, ignore_index=True) \
-    .to_hdf(f"{output_prefix}_traces.h5", "traces", mode='w')
+    .to_hdf(f"{output_prefix}_traces.h5", key="traces", mode='w')
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/integration/experiment/sst_evaluation/gen_plot_time.py
+++ b/integration/experiment/sst_evaluation/gen_plot_time.py
@@ -267,11 +267,11 @@ if __name__ == '__main__':
     except OSError:
         # Write the preprocessed data to a cached file
         df, frequency_df, epoch_df, core_frequencies_by_time_df = reports_and_traces_to_dataframes(args.report_paths)
-        df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), 'df', 'w')
-        frequency_df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), 'frequency_df', 'a')
-        epoch_df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), 'epoch_df', 'a')
+        df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), key='df', mode='w')
+        frequency_df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), key='frequency_df', mode='a')
+        epoch_df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'), key='epoch_df', mode='a')
         core_frequencies_by_time_df.to_hdf(os.path.join(args.analysis_dir, 'cache.hdf'),
-                                           'core_frequencies_by_time_df', 'a')
+                                           key='core_frequencies_by_time_df', mode='a')
 
     df['Application'] = df['Application'].str.rsplit('_', 1).str[-1]
     epoch_df['Application'] = epoch_df['Application'].str.rsplit('_', 1).str[-1]


### PR DESCRIPTION
- Fixes #4023.
- Pandas made most arguments to ``DataFrame.to_hdf`` keyword-only starting in v3.0.0.  It was released last week when we started having CI problems.
- The reason we never see "Generating HDF5 files... Applying workaround for strings in HDF5 files..." in CI is because we're caught in an infinite loop writing that string without a carriage return at that time.
- Also purge usage of distutils since it has been deprecated since v3.10 and has now been removed:
https://docs.python.org/3/library/distutils.html
https://peps.python.org/pep-0632/

