### PR TITLE
Fix geopmsession not honoring -t option

### DIFF
--- a/geopmdpy/geopmdpy/session.py
+++ b/geopmdpy/geopmdpy/session.py
@@ -408,7 +408,7 @@ class Session:
 
         """
         num_period = 0
-        if any(x is not None for x in (pid, ready_fd, launch)):
+        if pid is not None or ready_fd is not None or launch:
             num_period = None
         elif period != 0:
             num_period = math.ceil(duration / period)


### PR DESCRIPTION
## Summary

Fixes #4009.

`geopmsession -p <period> -t <duration>` was running indefinitely instead of stopping after the requested duration when neither `--pid`, `--daemon`, nor a launch command was provided.

## Root Cause

In `Session.run_read()` (`geopmdpy/geopmdpy/session.py`), the logic that decides whether to bound the timed loop by `num_period` was:

```python
num_period = 0
if any(x is not None for x in (pid, ready_fd, launch)):
    num_period = None
elif period != 0:
    num_period = math.ceil(duration / period)
```

The `launch` argument is parsed by `argparse` with `nargs=REMAINDER`, which defaults to an **empty list** (`[]`), not `None`. Consequently `launch is not None` was always true, forcing `num_period = None` and causing `TimedLoop` to iterate forever regardless of `-t/--time`.

The launch-mode code path itself worked correctly only because the later check (`if launch:`) and `check_read_args()` use truthiness rather than identity comparison.

## Fix

Test `launch` for truthiness instead of `is not None`, so the no-launch case (default empty list) allows `num_period` to be computed from `duration` and `period`:

```python
if pid is not None or ready_fd is not None or launch:
    num_period = None
elif period != 0:
    num_period = math.ceil(duration / period)
```

## Verification

Expected behavior, matching the example in #4009:

```
$ echo -e "TIME board 0\nLEVELZERO::GPU_POWER gpu 0" | geopmsession -p 0.5 -t 10.0
```

now exits after roughly 10 seconds instead of running until interrupted.
