### PR TITLE
GPUActivityAgent: fix policy file requirement and missing min freq control

### DIFF
--- a/libgeopm/src/Controller.cpp
+++ b/libgeopm/src/Controller.cpp
@@ -261,9 +261,21 @@ namespace geopm
         , m_do_restore(false)
     {
         if (m_num_send_down > 0 && !(m_do_policy || m_do_endpoint)) {
-            throw Exception("Controller(): at least one of policy or endpoint path"
-                            " must be provided.", GEOPM_ERROR_INVALID,
-                            __FILE__, __LINE__);
+            // Allow proceeding without a policy file if validate_policy() can
+            // fill every NaN entry with a default value.
+            std::vector<double> trial(m_num_send_down, NAN);
+            bool has_all_defaults = false;
+            try {
+                m_agent[0]->validate_policy(trial);
+                has_all_defaults = std::none_of(trial.begin(), trial.end(),
+                                                [](double v) { return std::isnan(v); });
+            }
+            catch (...) {}
+            if (!has_all_defaults) {
+                throw Exception("Controller(): at least one of policy or endpoint path"
+                                " must be provided.", GEOPM_ERROR_INVALID,
+                                __FILE__, __LINE__);
+            }
         }
         // Three dimensional vector over levels, children, and message
         // index.  These are used as temporary storage when passing

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -44,6 +44,7 @@ namespace geopm
         , M_NUM_CHIP_PER_GPU(M_NUM_GPU == 0 ? 0 : M_NUM_GPU_CHIP / M_NUM_GPU)
         , m_do_write_batch(false)
         , m_do_send_policy(true)
+        , m_has_freq_min_control(false)
         , m_agent_domain_count(0)
         , m_agent_domain(0)
         , m_gpu_frequency_requests(0.0)
@@ -80,9 +81,17 @@ namespace geopm
     void GPUActivityAgent::init_platform_io(void)
     {
 
+        const auto ALL_CTRL_NAMES = m_platform_io.control_names();
+        m_has_freq_min_control =
+            ALL_CTRL_NAMES.count("GPU_CORE_FREQUENCY_MIN_CONTROL") != 0;
+
         std::vector<int> control_domains;
-        control_domains.push_back(m_platform_io.control_domain_type("GPU_CORE_FREQUENCY_MIN_CONTROL"));
-        control_domains.push_back(m_platform_io.control_domain_type("GPU_CORE_FREQUENCY_MAX_CONTROL"));
+        if (m_has_freq_min_control) {
+            control_domains.push_back(
+                m_platform_io.control_domain_type("GPU_CORE_FREQUENCY_MIN_CONTROL"));
+        }
+        control_domains.push_back(
+            m_platform_io.control_domain_type("GPU_CORE_FREQUENCY_MAX_CONTROL"));
 
         std::vector<int> signal_domains;
         signal_domains.push_back(m_platform_io.signal_domain_type("GPU_CORE_FREQUENCY_STATUS"));
@@ -126,9 +135,12 @@ namespace geopm
                                          domain_idx), NAN});
 
             // Controls
-            m_gpu_freq_min_control.push_back(m_control{m_platform_io.push_control("GPU_CORE_FREQUENCY_MIN_CONTROL",
-                                                       m_agent_domain,
-                                                       domain_idx), NAN});
+            if (m_has_freq_min_control) {
+                m_gpu_freq_min_control.push_back(
+                    m_control{m_platform_io.push_control("GPU_CORE_FREQUENCY_MIN_CONTROL",
+                                                         m_agent_domain,
+                                                         domain_idx), NAN});
+            }
             m_gpu_freq_max_control.push_back(m_control{m_platform_io.push_control("GPU_CORE_FREQUENCY_MAX_CONTROL",
                                                        m_agent_domain,
                                                        domain_idx), NAN});
@@ -328,16 +340,21 @@ namespace geopm
 
         // set frequency control per gpu
         for (int domain_idx = 0; domain_idx < m_agent_domain_count; ++domain_idx) {
-            if (gpu_freq_request.at(domain_idx) !=
-                m_gpu_freq_min_control.at(domain_idx).last_setting ||
+            bool needs_update =
                 gpu_freq_request.at(domain_idx) !=
-                m_gpu_freq_max_control.at(domain_idx).last_setting) {
-
-                m_platform_io.adjust(m_gpu_freq_min_control.at(domain_idx).batch_idx,
-                                     gpu_freq_request.at(domain_idx));
-                m_gpu_freq_min_control.at(domain_idx).last_setting =
-                                     gpu_freq_request.at(domain_idx);
-
+                m_gpu_freq_max_control.at(domain_idx).last_setting;
+            if (m_has_freq_min_control) {
+                needs_update = needs_update ||
+                    gpu_freq_request.at(domain_idx) !=
+                    m_gpu_freq_min_control.at(domain_idx).last_setting;
+            }
+            if (needs_update) {
+                if (m_has_freq_min_control) {
+                    m_platform_io.adjust(m_gpu_freq_min_control.at(domain_idx).batch_idx,
+                                         gpu_freq_request.at(domain_idx));
+                    m_gpu_freq_min_control.at(domain_idx).last_setting =
+                                         gpu_freq_request.at(domain_idx);
+                }
                 m_platform_io.adjust(m_gpu_freq_max_control.at(domain_idx).batch_idx,
                                      gpu_freq_request.at(domain_idx));
                 m_gpu_freq_max_control.at(domain_idx).last_setting =

--- a/libgeopm/src/GPUActivityAgent.hpp
+++ b/libgeopm/src/GPUActivityAgent.hpp
@@ -59,6 +59,7 @@ namespace geopm
             const int M_NUM_CHIP_PER_GPU;
             bool m_do_write_batch;
             bool m_do_send_policy;
+            bool m_has_freq_min_control;
 
             int m_agent_domain_count;
             int m_agent_domain;

--- a/libgeopm/test/GPUActivityAgentTest.cpp
+++ b/libgeopm/test/GPUActivityAgentTest.cpp
@@ -138,6 +138,12 @@ void GPUActivityAgentTest::SetUp()
 
     ON_CALL(*m_platform_io, signal_names()).WillByDefault(Return(signal_name_set));
 
+    std::set<std::string> ctrl_name_set = {
+        "GPU_CORE_FREQUENCY_MIN_CONTROL",
+        "GPU_CORE_FREQUENCY_MAX_CONTROL"
+    };
+    ON_CALL(*m_platform_io, control_names()).WillByDefault(Return(ctrl_name_set));
+
     m_agent = geopm::make_unique<GPUActivityAgent>(*m_platform_io, *m_platform_topo, m_waiter);
     m_num_policy = m_agent->policy_names().size();
 
@@ -288,6 +294,39 @@ TEST_F(GPUActivityAgentTest, adjust_platform_signal_out_of_bounds_low)
     double mock_util = 1.0;
     test_adjust_platform(policy, mock_active, mock_util, M_FREQ_EFFICIENT);
 
+}
+
+TEST_F(GPUActivityAgentTest, adjust_platform_no_min_control)
+{
+    // Simulate a GPU (e.g. Battlemage) that exposes only a max frequency control.
+    std::set<std::string> ctrl_names_no_min = {"GPU_CORE_FREQUENCY_MAX_CONTROL"};
+    ON_CALL(*m_platform_io, control_names()).WillByDefault(Return(ctrl_names_no_min));
+
+    auto agent = geopm::make_unique<GPUActivityAgent>(*m_platform_io, *m_platform_topo, m_waiter);
+    agent->init(0, {}, false);
+
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    set_up_val_policy_expectations();
+    EXPECT_NO_THROW(agent->validate_policy(policy));
+
+    std::vector<double> tmp;
+    EXPECT_CALL(*m_platform_io, sample(GPU_CORE_ACTIVITY_IDX))
+                .WillRepeatedly(Return(1.0));
+    EXPECT_CALL(*m_platform_io, sample(GPU_UTILIZATION_IDX))
+                .WillRepeatedly(Return(1.0));
+    EXPECT_CALL(*m_platform_io, sample(GPU_ENERGY_IDX))
+                .WillRepeatedly(Return(123456789));
+    EXPECT_CALL(*m_platform_io, sample(TIME_IDX))
+                .Times(1);
+    agent->sample_platform(tmp);
+
+    // Min control must not be written; only max control is set.
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, _)).Times(0);
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, M_FREQ_MAX))
+                .Times(M_NUM_GPU_CHIP);
+
+    agent->adjust_platform(policy);
+    EXPECT_TRUE(agent->do_write_batch());
 }
 
 TEST_F(GPUActivityAgentTest, invalid_fe)


### PR DESCRIPTION
Two bugs prevented the gpu_activity agent from running on Battlemage (Intel Xe2) GPU systems:

1. Policy file required even when all policy values have defaults

   The Controller constructor threw an error when GEOPM_POLICY was unset, even though GPUActivityAgent's only policy value (GPU_PHI) has a well-defined default of 0.5 and validate_policy() already converts NaN to that default.  The check is relaxed: before throwing, the Controller calls validate_policy() on an all-NaN trial vector; if every entry is filled in, the agent is allowed to run without a policy file.

2. GPU_CORE_FREQUENCY_MIN_CONTROL assumed to always be present

   init_platform_io() unconditionally called control_domain_type() and push_control() for GPU_CORE_FREQUENCY_MIN_CONTROL, which is not exposed by Battlemage (Level Zero only provides a max frequency control).  A new boolean member m_has_freq_min_control is set by checking control_names() at init time.  The min control is only pushed and written when it is available; otherwise only the max frequency control is used.

A new unit test (adjust_platform_no_min_control) verifies the min-control-absent path.

- Fixes #4037
