### PR TITLE
Add pure-Python cpu_activity session agent for non-HPC deployment 

### DIFF
--- a/geopmdpy/geopmdpy/cpu_activity_agent.py
+++ b/geopmdpy/geopmdpy/cpu_activity_agent.py
@@ -84,6 +84,7 @@ class CPUActivityAgent(Agent):
     def __init__(self):
         """Initialize the CPUActivityAgent."""
         self._phi = _POLICY_PHI_DEFAULT
+        self._hi_res = False
 
         # CLI-supplied characterization; None means "resolve from platform".
         self._cpu_freq_efficient_arg = None
@@ -175,6 +176,8 @@ class CPUActivityAgent(Agent):
                                  'bandwidth in bytes/s achievable at that '
                                  'frequency. May be given multiple times. When '
                                  'omitted the agent runs in core-only mode.')
+        parser.add_argument('--hi-res', action='store_true',
+                            help='Measure signals at finest granularity (all domains/indices)')
         return parser
 
     def update_args(self, args):
@@ -204,6 +207,7 @@ class CPUActivityAgent(Agent):
             args.cpu_uncore_bandwidth)
         self._uncore_bandwidth_freqs = sorted(self._uncore_bandwidth_map)
         self._uncore_enabled = bool(self._uncore_bandwidth_map)
+        self._hi_res = getattr(args, 'hi_res', False)
         return args
 
     @staticmethod
@@ -261,13 +265,16 @@ class CPUActivityAgent(Agent):
             str: Signal configuration string for the session.
         """
         names = pio.signal_names()
+        suffix = ' * *' if self._hi_res else ' board 0'
         lines = ['TIME board 0']
         if 'MSR::CPU_SCALABILITY_RATIO' in names:
-            lines.append('MSR::CPU_SCALABILITY_RATIO board 0')
+            lines.append('MSR::CPU_SCALABILITY_RATIO' + suffix)
         if 'MSR::QM_CTR_SCALED_RATE' in names:
-            lines.append('MSR::QM_CTR_SCALED_RATE board 0')
+            lines.append('MSR::QM_CTR_SCALED_RATE' + suffix)
+        if 'CPU_FREQUENCY_STATUS' in names:
+            lines.append('CPU_FREQUENCY_STATUS' + suffix)
         if 'CPU_UNCORE_FREQUENCY_STATUS' in names:
-            lines.append('CPU_UNCORE_FREQUENCY_STATUS board 0')
+            lines.append('CPU_UNCORE_FREQUENCY_STATUS' + suffix)
         return '\n'.join(lines) + '\n'
 
     def run_begin(self):

--- a/geopmdpy/geopmdpy/cpu_activity_agent.py
+++ b/geopmdpy/geopmdpy/cpu_activity_agent.py
@@ -1,0 +1,550 @@
+#!/usr/bin/python3
+#
+#  Copyright (c) 2015 - 2026 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+"""CPU activity agent for the GEOPM Python session interface.
+
+This module provides a ``CPUActivityAgent`` for use with the GEOPM
+Python session interface.  It is a pure-Python reimplementation of the
+C++ ``CPUActivityAgent`` (plugin name ``cpu_activity``) that drives CPU
+core and uncore frequency based on CPU compute scalability and memory
+bandwidth utilization, without requiring the GEOPM HPC Runtime
+(Controller, MPI/OpenMP interposition, or DBus profile registration).
+
+The agent steers two frequency domains:
+
+* **Core** frequency is interpolated between an efficient frequency and
+  the maximum available frequency using ``MSR::CPU_SCALABILITY_RATIO``.
+* **Uncore** frequency is interpolated using a memory-bandwidth
+  utilization derived from ``MSR::QM_CTR_SCALED_RATE`` normalized by a
+  characterized maximum bandwidth for the current uncore frequency.
+
+Unlike the C++ agent, all static characterization input (the efficient
+frequencies and the uncore-frequency-to-maximum-bandwidth table) is
+supplied through command-line arguments rather than the
+``ConstConfigIOGroup``:
+
+* ``--cpu-freq-efficient`` core efficient frequency in Hz.  Defaults to
+  the platform ``CPU_FREQUENCY_MIN_AVAIL``.
+* ``--cpu-uncore-freq-efficient`` uncore efficient frequency in Hz.
+  Defaults to the current ``CPU_UNCORE_FREQUENCY_MIN_CONTROL``.
+* ``--cpu-uncore-bandwidth`` a repeatable ``FREQ:BW`` pair giving an
+  uncore frequency (Hz) and the maximum memory bandwidth (bytes/s)
+  achievable at that frequency.  When no pairs are supplied the agent
+  runs in **core-only mode** and leaves the uncore frequency untouched.
+
+A single ``--phi`` knob (0.0 - 1.0) biases the frequency selection
+toward performance (phi < 0.5) or energy savings (phi > 0.5).
+
+Example usage:
+    python -m geopmdpy.cpu_activity_agent -t 30 -p 0.02
+    python -m geopmdpy.cpu_activity_agent -t 30 -p 0.02 --phi 0.8 \\
+        --cpu-freq-efficient 1.8e9 --cpu-uncore-freq-efficient 1.6e9 \\
+        --cpu-uncore-bandwidth 1.6e9:1.4e11 --cpu-uncore-bandwidth 2.4e9:2.0e11
+"""
+
+import bisect
+import math
+import sys
+
+from . import pio
+from . import topo
+from .session import main
+from .session import Agent
+
+_POLICY_PHI_DEFAULT = 0.5
+
+# QM event ID 0x2 selects Total Memory Bandwidth Monitoring, matching the
+# configuration used to generate the bandwidth characterization data.
+_QM_EVENT_ID_TOTAL_MEM_BW = 2
+
+
+class CPUActivityAgent(Agent):
+    """Agent that sets CPU core and uncore frequency based on activity.
+
+    The agent reimplements the control logic of the C++
+    ``CPUActivityAgent`` plugin for use with the GEOPM Python session.
+    The session drives the timed loop and calls ``pio.read_batch()``
+    before each ``update_loop()``; this agent samples the cached
+    signals, computes core and uncore frequency requests, and writes the
+    frequency controls when a request changes.
+
+    Command-line options:
+      --phi                       CPU frequency bias in [0.0, 1.0].
+      --cpu-freq-efficient        Core efficient frequency in Hz.
+      --cpu-uncore-freq-efficient Uncore efficient frequency in Hz.
+      --cpu-uncore-bandwidth      Repeatable FREQ:BW characterization pair.
+
+    Example:
+        python -m geopmdpy.cpu_activity_agent -t 30 -p 0.02 --phi 0.5
+    """
+
+    def __init__(self):
+        """Initialize the CPUActivityAgent."""
+        self._phi = _POLICY_PHI_DEFAULT
+
+        # CLI-supplied characterization; None means "resolve from platform".
+        self._cpu_freq_efficient_arg = None
+        self._cpu_uncore_freq_efficient_arg = None
+        # uncore frequency (Hz) -> maximum memory bandwidth (bytes/s)
+        self._uncore_bandwidth_map = {}
+        # sorted keys of the bandwidth map for the lookup in update_loop
+        self._uncore_bandwidth_freqs = []
+
+        # Whether uncore steering is enabled (bandwidth pairs supplied).
+        self._uncore_enabled = False
+
+        self._core_domain = None
+        self._core_domain_count = 0
+        self._uncore_domain = None
+        self._uncore_domain_count = 0
+
+        # batch indices for pushed signals/controls, per domain
+        self._scalability_idx = []
+        self._core_freq_min_idx = []
+        self._core_freq_max_idx = []
+        self._qm_rate_idx = []
+        self._uncore_status_idx = []
+        self._uncore_freq_min_idx = []
+        self._uncore_freq_max_idx = []
+        # last value written to each control, used for change detection
+        self._core_freq_min_last = []
+        self._core_freq_max_last = []
+        self._uncore_freq_min_last = []
+        self._uncore_freq_max_last = []
+
+        self._freq_core_min = 0.0
+        self._freq_core_max = 0.0
+        self._freq_core_efficient = 0.0
+        self._freq_uncore_min = 0.0
+        self._freq_uncore_max = 0.0
+        self._freq_uncore_efficient = 0.0
+
+        # Resolved values after phi is applied, retained for the summary.
+        self._resolved_f_core_max = 0.0
+        self._resolved_f_core_efficient = 0.0
+        self._resolved_f_uncore_max = 0.0
+        self._resolved_f_uncore_efficient = 0.0
+
+        self._core_frequency_requests = 0
+        self._core_frequency_clipped = 0
+        self._uncore_frequency_requests = 0
+        self._uncore_frequency_clipped = 0
+
+    def help(self):
+        """Help documentation.
+
+        """
+        return ('The cpu_activity agent sets CPU core and uncore frequency '
+                'based on CPU compute scalability and memory bandwidth '
+                'utilization. Use --phi to bias frequency selection toward '
+                'performance (phi < 0.5) or energy savings (phi > 0.5). '
+                'Supply --cpu-uncore-bandwidth FREQ:BW pairs to enable uncore '
+                'frequency steering; without them the agent steers only the '
+                'core frequency.')
+
+    def update_parser(self, parser):
+        """Add the agent-specific arguments to the parser.
+
+        Args:
+            parser (argparse.ArgumentParser): The parser to update.
+
+        Returns:
+            argparse.ArgumentParser: The updated parser.
+        """
+        parser.add_argument('--phi', dest='phi', type=float,
+                            default=_POLICY_PHI_DEFAULT,
+                            help='CPU frequency bias in the range [0.0, 1.0]. '
+                                 'Lower values favor performance, higher values '
+                                 'favor energy savings. Default %(default)s.')
+        parser.add_argument('--cpu-freq-efficient', dest='cpu_freq_efficient',
+                            type=float, default=None,
+                            help='Core efficient frequency in Hz. Default: the '
+                                 'platform CPU_FREQUENCY_MIN_AVAIL.')
+        parser.add_argument('--cpu-uncore-freq-efficient',
+                            dest='cpu_uncore_freq_efficient',
+                            type=float, default=None,
+                            help='Uncore efficient frequency in Hz. Default: '
+                                 'the current CPU_UNCORE_FREQUENCY_MIN_CONTROL.')
+        parser.add_argument('--cpu-uncore-bandwidth', dest='cpu_uncore_bandwidth',
+                            action='append', default=None, metavar='FREQ:BW',
+                            help='Uncore characterization pair FREQ:BW giving an '
+                                 'uncore frequency in Hz and the maximum memory '
+                                 'bandwidth in bytes/s achievable at that '
+                                 'frequency. May be given multiple times. When '
+                                 'omitted the agent runs in core-only mode.')
+        return parser
+
+    def update_args(self, args):
+        """Validate and store the agent-specific arguments.
+
+        Args:
+            args (argparse.Namespace): Parsed command-line arguments.
+
+        Returns:
+            argparse.Namespace: The (possibly updated) arguments.
+
+        Raises:
+            RuntimeError: An argument value is invalid.
+        """
+        if math.isnan(args.phi) or args.phi < 0.0 or args.phi > 1.0:
+            raise RuntimeError(
+                f'--phi value out of range: {args.phi}. '
+                'Acceptable values are in the range [0.0, 1.0].')
+        self._phi = args.phi
+
+        self._cpu_freq_efficient_arg = self._validate_positive_freq(
+            args.cpu_freq_efficient, '--cpu-freq-efficient')
+        self._cpu_uncore_freq_efficient_arg = self._validate_positive_freq(
+            args.cpu_uncore_freq_efficient, '--cpu-uncore-freq-efficient')
+
+        self._uncore_bandwidth_map = self._parse_bandwidth_pairs(
+            args.cpu_uncore_bandwidth)
+        self._uncore_bandwidth_freqs = sorted(self._uncore_bandwidth_map)
+        self._uncore_enabled = bool(self._uncore_bandwidth_map)
+        return args
+
+    @staticmethod
+    def _validate_positive_freq(value, name):
+        """Validate an optional positive frequency argument."""
+        if value is None:
+            return None
+        if math.isnan(value) or value <= 0.0:
+            raise RuntimeError(
+                f'{name} value must be a positive frequency in Hz: {value}.')
+        return value
+
+    @staticmethod
+    def _parse_bandwidth_pairs(pairs):
+        """Parse the --cpu-uncore-bandwidth FREQ:BW pairs into a map.
+
+        Args:
+            pairs (list of str or None): Raw FREQ:BW argument values.
+
+        Returns:
+            dict: Mapping of uncore frequency (Hz) to maximum memory
+                bandwidth (bytes/s).
+
+        Raises:
+            RuntimeError: A pair is malformed or non-positive.
+        """
+        result = {}
+        for item in pairs or []:
+            tokens = item.split(':')
+            if len(tokens) != 2:
+                raise RuntimeError(
+                    f'--cpu-uncore-bandwidth value must be FREQ:BW: {item}.')
+            try:
+                freq = float(tokens[0])
+                bandwidth = float(tokens[1])
+            except ValueError:
+                raise RuntimeError(
+                    f'--cpu-uncore-bandwidth value must be FREQ:BW: {item}.')
+            if (math.isnan(freq) or math.isnan(bandwidth) or
+                    freq <= 0.0 or bandwidth <= 0.0):
+                raise RuntimeError(
+                    '--cpu-uncore-bandwidth FREQ and BW must be positive: '
+                    f'{item}.')
+            result[freq] = bandwidth
+        return result
+
+    def signal_config_override(self):
+        """Provide a default trace configuration.
+
+        Provided so the agent can be run with ``--signal-config -`` and
+        an empty stdin.  Users may pipe their own request list to
+        override this default.
+
+        Returns:
+            str: Signal configuration string for the session.
+        """
+        names = pio.signal_names()
+        lines = ['TIME board 0']
+        if 'MSR::CPU_SCALABILITY_RATIO' in names:
+            lines.append('MSR::CPU_SCALABILITY_RATIO board 0')
+        if 'MSR::QM_CTR_SCALED_RATE' in names:
+            lines.append('MSR::QM_CTR_SCALED_RATE board 0')
+        if 'CPU_UNCORE_FREQUENCY_STATUS' in names:
+            lines.append('CPU_UNCORE_FREQUENCY_STATUS board 0')
+        return '\n'.join(lines) + '\n'
+
+    def run_begin(self):
+        """Resolve the agent domains and push signals and controls.
+
+        Determines the core control domain, optionally the uncore
+        (package) domain, pushes the per-domain signals and controls,
+        reads the static frequency characterization, and saves the
+        current control settings for restoration on exit.
+
+        Raises:
+            RuntimeError: No CPUs are present or a resolved efficient
+                frequency is out of range.
+        """
+        num_core = topo.num_domain(topo.DOMAIN_CORE)
+        if num_core == 0:
+            raise RuntimeError('CPUActivityAgent requires at least one CPU core')
+
+        # Use the coarsest granularity supported by the core controls and the
+        # scalability signal.  In GEOPM the coarsest domain has the smallest
+        # domain-type value.
+        self._core_domain = min(
+            pio.control_domain_type('CPU_FREQUENCY_MIN_CONTROL'),
+            pio.control_domain_type('CPU_FREQUENCY_MAX_CONTROL'),
+            pio.signal_domain_type('MSR::CPU_SCALABILITY_RATIO'))
+        self._core_domain_count = topo.num_domain(self._core_domain)
+
+        # Snapshot controls before any modification so restore_control()
+        # reverts the platform to its pre-agent state on exit.
+        pio.save_control()
+
+        self._scalability_idx = []
+        self._core_freq_min_idx = []
+        self._core_freq_max_idx = []
+        for domain_idx in range(self._core_domain_count):
+            self._scalability_idx.append(
+                pio.push_signal('MSR::CPU_SCALABILITY_RATIO',
+                                self._core_domain, domain_idx))
+            self._core_freq_min_idx.append(
+                pio.push_control('CPU_FREQUENCY_MIN_CONTROL',
+                                 self._core_domain, domain_idx))
+            self._core_freq_max_idx.append(
+                pio.push_control('CPU_FREQUENCY_MAX_CONTROL',
+                                 self._core_domain, domain_idx))
+        self._core_freq_min_last = [math.nan] * self._core_domain_count
+        self._core_freq_max_last = [math.nan] * self._core_domain_count
+
+        self._freq_core_min = pio.read_signal('CPU_FREQUENCY_MIN_AVAIL',
+                                              topo.DOMAIN_BOARD, 0)
+        self._freq_core_max = pio.read_signal('CPU_FREQUENCY_MAX_AVAIL',
+                                              topo.DOMAIN_BOARD, 0)
+
+        if self._cpu_freq_efficient_arg is not None:
+            self._freq_core_efficient = self._cpu_freq_efficient_arg
+        else:
+            self._freq_core_efficient = self._freq_core_min
+        if (self._freq_core_efficient > self._freq_core_max or
+                self._freq_core_efficient < self._freq_core_min):
+            raise RuntimeError(
+                'CPUActivityAgent: core efficient frequency out of range: '
+                f'{self._freq_core_efficient}')
+
+        if self._uncore_enabled:
+            self._run_begin_uncore()
+
+        self._core_frequency_requests = 0
+        self._core_frequency_clipped = 0
+        self._uncore_frequency_requests = 0
+        self._uncore_frequency_clipped = 0
+
+    def _run_begin_uncore(self):
+        """Set up the uncore (package) domain signals and controls."""
+        # Configure QM counters to measure total memory bandwidth.  Assign all
+        # cores to resource monitoring association ID 0 and select the total
+        # memory bandwidth event so MSR::QM_CTR_SCALED_RATE reports it.
+        pio.write_control('MSR::PQR_ASSOC:RMID', topo.DOMAIN_BOARD, 0, 0)
+        pio.write_control('MSR::QM_EVTSEL:RMID', topo.DOMAIN_BOARD, 0, 0)
+        pio.write_control('MSR::QM_EVTSEL:EVENT_ID', topo.DOMAIN_BOARD, 0,
+                          _QM_EVENT_ID_TOTAL_MEM_BW)
+
+        self._uncore_domain = topo.DOMAIN_PACKAGE
+        self._uncore_domain_count = topo.num_domain(self._uncore_domain)
+
+        self._qm_rate_idx = []
+        self._uncore_status_idx = []
+        self._uncore_freq_min_idx = []
+        self._uncore_freq_max_idx = []
+        for domain_idx in range(self._uncore_domain_count):
+            self._qm_rate_idx.append(
+                pio.push_signal('MSR::QM_CTR_SCALED_RATE',
+                                self._uncore_domain, domain_idx))
+            self._uncore_status_idx.append(
+                pio.push_signal('CPU_UNCORE_FREQUENCY_STATUS',
+                                self._uncore_domain, domain_idx))
+            self._uncore_freq_min_idx.append(
+                pio.push_control('CPU_UNCORE_FREQUENCY_MIN_CONTROL',
+                                 self._uncore_domain, domain_idx))
+            self._uncore_freq_max_idx.append(
+                pio.push_control('CPU_UNCORE_FREQUENCY_MAX_CONTROL',
+                                 self._uncore_domain, domain_idx))
+        self._uncore_freq_min_last = [math.nan] * self._uncore_domain_count
+        self._uncore_freq_max_last = [math.nan] * self._uncore_domain_count
+
+        # These reflect the currently-set uncore bounds, matching the C++ agent.
+        self._freq_uncore_min = pio.read_signal('CPU_UNCORE_FREQUENCY_MIN_CONTROL',
+                                               topo.DOMAIN_BOARD, 0)
+        self._freq_uncore_max = pio.read_signal('CPU_UNCORE_FREQUENCY_MAX_CONTROL',
+                                               topo.DOMAIN_BOARD, 0)
+
+        if self._cpu_uncore_freq_efficient_arg is not None:
+            self._freq_uncore_efficient = self._cpu_uncore_freq_efficient_arg
+        else:
+            self._freq_uncore_efficient = self._freq_uncore_min
+        if (self._freq_uncore_efficient > self._freq_uncore_max or
+                self._freq_uncore_efficient < self._freq_uncore_min):
+            raise RuntimeError(
+                'CPUActivityAgent: uncore efficient frequency out of range: '
+                f'{self._freq_uncore_efficient}')
+
+    @staticmethod
+    def _resolve_phi_range(freq_min_anchor, freq_efficient, freq_max, phi):
+        """Apply phi to an efficient/max frequency range.
+
+        Returns the resolved (efficient, max) pair.  phi == 0.5 spans the
+        full efficient-to-max range; phi > 0.5 scales the max down toward
+        the efficient frequency (energy biased); phi < 0.5 scales the
+        efficient frequency up toward the max (performance biased).
+        """
+        f_range = freq_max - freq_efficient
+        resolved_max = freq_max
+        resolved_efficient = freq_efficient
+        if phi > 0.5:
+            resolved_max = max(freq_efficient,
+                               freq_max - f_range * (phi - 0.5) / 0.5)
+        elif phi < 0.5:
+            resolved_efficient = min(freq_max,
+                                     freq_efficient + f_range * (0.5 - phi) / 0.5)
+        return resolved_efficient, resolved_max
+
+    def _max_bandwidth_for(self, uncore_freq):
+        """Look up the characterized max bandwidth for an uncore frequency.
+
+        Returns the bandwidth associated with the largest characterization
+        frequency that is less than or equal to ``uncore_freq``.  If
+        ``uncore_freq`` is below the smallest key (or is NaN), the bandwidth
+        of the smallest key is used (mirrors the C++ ``upper_bound() - 1``
+        clamped at ``begin()``).
+        """
+        freqs = self._uncore_bandwidth_freqs
+        if not freqs:
+            return math.nan
+        if math.isnan(uncore_freq):
+            return self._uncore_bandwidth_map[freqs[0]]
+        pos = bisect.bisect_right(freqs, uncore_freq)
+        if pos == 0:
+            pos = 1
+        return self._uncore_bandwidth_map[freqs[pos - 1]]
+
+    def update_loop(self):
+        """Sample CPU activity and adjust core and uncore frequency.
+
+        Called by the session after ``pio.read_batch()``.  Samples the
+        cached scalability and bandwidth signals, computes per-domain
+        frequency requests, and writes the frequency controls when a
+        request differs from the last written value.
+        """
+        phi = self._phi
+
+        self._resolved_f_core_efficient, self._resolved_f_core_max = \
+            self._resolve_phi_range(self._freq_core_min,
+                                    self._freq_core_efficient,
+                                    self._freq_core_max, phi)
+        f_core_range = self._resolved_f_core_max - self._resolved_f_core_efficient
+
+        do_write_batch = False
+
+        # Per core-domain frequency request from CPU scalability.
+        for domain_idx in range(self._core_domain_count):
+            scalability = pio.sample(self._scalability_idx[domain_idx])
+            if math.isnan(scalability):
+                scalability = 1.0
+
+            f_request = self._resolved_f_core_efficient + f_core_range * scalability
+
+            if (f_request > self._resolved_f_core_max or
+                    f_request < self._resolved_f_core_efficient):
+                self._core_frequency_clipped += 1
+            f_request = min(f_request, self._resolved_f_core_max)
+            f_request = max(f_request, self._resolved_f_core_efficient)
+
+            if (f_request != self._core_freq_min_last[domain_idx] or
+                    f_request != self._core_freq_max_last[domain_idx]):
+                pio.adjust(self._core_freq_min_idx[domain_idx], f_request)
+                pio.adjust(self._core_freq_max_idx[domain_idx], f_request)
+                self._core_freq_min_last[domain_idx] = f_request
+                self._core_freq_max_last[domain_idx] = f_request
+                self._core_frequency_requests += 1
+                do_write_batch = True
+
+        if self._uncore_enabled:
+            do_write_batch |= self._update_loop_uncore(phi)
+
+        if do_write_batch:
+            pio.write_batch()
+
+    def _update_loop_uncore(self, phi):
+        """Compute and write the per-package uncore frequency requests.
+
+        Returns:
+            bool: True if any uncore control was adjusted.
+        """
+        self._resolved_f_uncore_efficient, self._resolved_f_uncore_max = \
+            self._resolve_phi_range(self._freq_uncore_min,
+                                    self._freq_uncore_efficient,
+                                    self._freq_uncore_max, phi)
+        f_uncore_range = (self._resolved_f_uncore_max -
+                          self._resolved_f_uncore_efficient)
+
+        do_write_batch = False
+        for domain_idx in range(self._uncore_domain_count):
+            uncore_status = pio.sample(self._uncore_status_idx[domain_idx])
+            qm_rate = pio.sample(self._qm_rate_idx[domain_idx])
+            max_bandwidth = self._max_bandwidth_for(uncore_status)
+
+            scalability = 1.0
+            if (not math.isnan(qm_rate) and not math.isnan(max_bandwidth) and
+                    max_bandwidth != 0):
+                scalability = qm_rate / max_bandwidth
+
+            f_request = (self._resolved_f_uncore_efficient +
+                         f_uncore_range * scalability)
+
+            if (f_request > self._resolved_f_uncore_max or
+                    f_request < self._resolved_f_uncore_efficient):
+                self._uncore_frequency_clipped += 1
+            f_request = min(f_request, self._resolved_f_uncore_max)
+            f_request = max(f_request, self._resolved_f_uncore_efficient)
+
+            if math.isnan(f_request):
+                f_request = self._freq_uncore_max
+
+            if (f_request != self._uncore_freq_min_last[domain_idx] or
+                    f_request != self._uncore_freq_max_last[domain_idx]):
+                pio.adjust(self._uncore_freq_min_idx[domain_idx], f_request)
+                pio.adjust(self._uncore_freq_max_idx[domain_idx], f_request)
+                self._uncore_freq_min_last[domain_idx] = f_request
+                self._uncore_freq_max_last[domain_idx] = f_request
+                self._uncore_frequency_requests += 1
+                do_write_batch = True
+        return do_write_batch
+
+    def run_end(self):
+        """Print a summary of the agent's activity to stderr."""
+        if self._core_domain is None:
+            return
+        lines = [
+            'cpu_activity agent summary:',
+            f'  Core Domain: {topo.domain_name(self._core_domain)}',
+            f'  Core Frequency Requests: {self._core_frequency_requests}',
+            f'  Core Clipped Frequency Requests: {self._core_frequency_clipped}',
+            f'  Resolved Max Core Frequency: {self._resolved_f_core_max}',
+            f'  Resolved Efficient Core Frequency: {self._resolved_f_core_efficient}',
+        ]
+        if self._uncore_enabled:
+            lines.extend([
+                f'  Uncore Domain: {topo.domain_name(self._uncore_domain)}',
+                f'  Uncore Frequency Requests: {self._uncore_frequency_requests}',
+                '  Uncore Clipped Frequency Requests: '
+                f'{self._uncore_frequency_clipped}',
+                f'  Resolved Max Uncore Frequency: {self._resolved_f_uncore_max}',
+                '  Resolved Efficient Uncore Frequency: '
+                f'{self._resolved_f_uncore_efficient}',
+            ])
+        else:
+            lines.append('  Uncore: disabled (core-only mode)')
+        sys.stderr.write('\n'.join(lines) + '\n')
+
+
+if __name__ == '__main__':
+    sys.exit(main(CPUActivityAgent()))

--- a/geopmdpy/test/TestCPUActivityAgent.py
+++ b/geopmdpy/test/TestCPUActivityAgent.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2026 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+import unittest
+from unittest import mock
+from argparse import ArgumentParser
+from argparse import Namespace
+
+# Patch dlopen to allow the tests to run when there is no build
+with mock.patch('cffi.FFI.dlopen', return_value=mock.MagicMock()):
+    from geopmdpy import cpu_activity_agent
+    from geopmdpy.cpu_activity_agent import CPUActivityAgent
+
+# Domain type values used by the mocked topo module.  The exact numbers do
+# not matter as long as the board/package/core domains are distinct and the
+# coarser domains are numbered smaller (as in GEOPM).
+_DOMAIN_BOARD = 0
+_DOMAIN_PACKAGE = 1
+_DOMAIN_CORE = 2
+
+# Static frequency characterization shared by most tests.
+_CORE_MIN = 1.0e9
+_CORE_MAX = 3.0e9
+_UNCORE_MIN = 1.0e9
+_UNCORE_MAX = 2.4e9
+
+# Default uncore bandwidth characterization pairs (FREQ:BW).
+_BW_PAIRS = ['1.0e9:1.0e11', '2.0e9:2.0e11']
+
+
+class TestCPUActivityAgent(unittest.TestCase):
+    def setUp(self):
+        self._test_name = 'TestCPUActivityAgent'
+
+        self._signal_names = {
+            'MSR::CPU_SCALABILITY_RATIO',
+            'MSR::QM_CTR_SCALED_RATE',
+            'CPU_UNCORE_FREQUENCY_STATUS',
+            'TIME',
+        }
+        # control_domain_type() and signal_domain_type() both resolve to the
+        # core domain so the agent's core control domain is DOMAIN_CORE.
+        self._control_domain = _DOMAIN_CORE
+        self._signal_domain = _DOMAIN_CORE
+        # Number of domains reported by topo.num_domain() per domain type.
+        self._domain_counts = {_DOMAIN_CORE: 1, _DOMAIN_PACKAGE: 1}
+        self._read_values = {
+            'CPU_FREQUENCY_MIN_AVAIL': _CORE_MIN,
+            'CPU_FREQUENCY_MAX_AVAIL': _CORE_MAX,
+            'CPU_UNCORE_FREQUENCY_MIN_CONTROL': _UNCORE_MIN,
+            'CPU_UNCORE_FREQUENCY_MAX_CONTROL': _UNCORE_MAX,
+        }
+        # Values returned by pio.sample(), keyed by the token returned from
+        # push_signal()/push_control() ("<name>:<domain_idx>").
+        self._sample_values = {}
+
+        self._patch(mock.patch.object(cpu_activity_agent.topo, 'DOMAIN_BOARD', _DOMAIN_BOARD))
+        self._patch(mock.patch.object(cpu_activity_agent.topo, 'DOMAIN_PACKAGE', _DOMAIN_PACKAGE))
+        self._patch(mock.patch.object(cpu_activity_agent.topo, 'DOMAIN_CORE', _DOMAIN_CORE))
+
+        self._num_domain = self._patch(
+            mock.patch.object(cpu_activity_agent.topo, 'num_domain',
+                              side_effect=self._num_domain_impl))
+        self._domain_name = self._patch(
+            mock.patch.object(cpu_activity_agent.topo, 'domain_name',
+                              return_value='core'))
+
+        self._signal_names_mock = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'signal_names',
+                              side_effect=lambda: set(self._signal_names)))
+        self._control_domain_type = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'control_domain_type',
+                              side_effect=lambda name: self._control_domain))
+        self._signal_domain_type = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'signal_domain_type',
+                              side_effect=lambda name: self._signal_domain))
+        self._push_signal = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'push_signal',
+                              side_effect=lambda name, dom, idx: f'{name}:{idx}'))
+        self._push_control = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'push_control',
+                              side_effect=lambda name, dom, idx: f'{name}:{idx}'))
+        self._read_signal = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'read_signal',
+                              side_effect=lambda name, dom, idx: self._read_values[name]))
+        self._sample = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'sample',
+                              side_effect=lambda token: self._sample_values[token]))
+        self._adjust = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'adjust'))
+        self._write_batch = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'write_batch'))
+        self._write_control = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'write_control'))
+        self._save_control = self._patch(
+            mock.patch.object(cpu_activity_agent.pio, 'save_control'))
+
+    def _patch(self, patcher):
+        started = patcher.start()
+        self.addCleanup(patcher.stop)
+        return started
+
+    def _num_domain_impl(self, domain):
+        return self._domain_counts.get(domain, 1)
+
+    def _make_agent(self, phi=0.5, cpu_freq_efficient=None,
+                    cpu_uncore_freq_efficient=None, cpu_uncore_bandwidth=None):
+        agent = CPUActivityAgent()
+        agent.update_args(Namespace(
+            phi=phi,
+            cpu_freq_efficient=cpu_freq_efficient,
+            cpu_uncore_freq_efficient=cpu_uncore_freq_efficient,
+            cpu_uncore_bandwidth=cpu_uncore_bandwidth))
+        return agent
+
+    def _adjust_values(self):
+        return [call.args[1] for call in self._adjust.call_args_list]
+
+    # ---- argument handling ------------------------------------------------
+
+    def test_update_parser_adds_args(self):
+        agent = CPUActivityAgent()
+        parser = agent.update_parser(ArgumentParser())
+        args = parser.parse_args([
+            '--phi', '0.7',
+            '--cpu-freq-efficient', '1.5e9',
+            '--cpu-uncore-freq-efficient', '1.2e9',
+            '--cpu-uncore-bandwidth', '1.0e9:1.0e11',
+            '--cpu-uncore-bandwidth', '2.0e9:2.0e11'])
+        self.assertAlmostEqual(0.7, args.phi)
+        self.assertAlmostEqual(1.5e9, args.cpu_freq_efficient)
+        self.assertAlmostEqual(1.2e9, args.cpu_uncore_freq_efficient)
+        self.assertEqual(['1.0e9:1.0e11', '2.0e9:2.0e11'],
+                         args.cpu_uncore_bandwidth)
+
+    def test_update_parser_defaults(self):
+        agent = CPUActivityAgent()
+        parser = agent.update_parser(ArgumentParser())
+        args = parser.parse_args([])
+        self.assertAlmostEqual(0.5, args.phi)
+        self.assertIsNone(args.cpu_freq_efficient)
+        self.assertIsNone(args.cpu_uncore_freq_efficient)
+        self.assertIsNone(args.cpu_uncore_bandwidth)
+
+    def test_update_args_valid_phi(self):
+        for phi in (0.0, 0.25, 0.5, 0.75, 1.0):
+            agent = self._make_agent(phi=phi)
+            self.assertAlmostEqual(phi, agent._phi)
+
+    def test_update_args_phi_out_of_range_high(self):
+        with self.assertRaisesRegex(RuntimeError, 'phi value out of range'):
+            self._make_agent(phi=1.5)
+
+    def test_update_args_phi_out_of_range_low(self):
+        with self.assertRaisesRegex(RuntimeError, 'phi value out of range'):
+            self._make_agent(phi=-0.1)
+
+    def test_update_args_phi_nan(self):
+        with self.assertRaisesRegex(RuntimeError, 'phi value out of range'):
+            self._make_agent(phi=float('nan'))
+
+    def test_update_args_bandwidth_builds_map(self):
+        agent = self._make_agent(cpu_uncore_bandwidth=list(_BW_PAIRS))
+        self.assertTrue(agent._uncore_enabled)
+        self.assertEqual({1.0e9: 1.0e11, 2.0e9: 2.0e11},
+                         agent._uncore_bandwidth_map)
+        self.assertEqual([1.0e9, 2.0e9], agent._uncore_bandwidth_freqs)
+
+    def test_update_args_no_bandwidth_core_only(self):
+        agent = self._make_agent()
+        self.assertFalse(agent._uncore_enabled)
+        self.assertEqual({}, agent._uncore_bandwidth_map)
+
+    def test_update_args_bandwidth_malformed(self):
+        for bad in (['no_colon'], ['1.0e9:bad'], ['bad:1.0e11'],
+                    ['1.0e9:2.0e11:3'], ['-1.0e9:2.0e11'], ['1.0e9:0']):
+            with self.assertRaisesRegex(RuntimeError, 'cpu-uncore-bandwidth'):
+                self._make_agent(cpu_uncore_bandwidth=bad)
+
+    def test_update_args_efficient_negative(self):
+        with self.assertRaisesRegex(RuntimeError, 'cpu-freq-efficient'):
+            self._make_agent(cpu_freq_efficient=-1.0e9)
+        with self.assertRaisesRegex(RuntimeError, 'cpu-uncore-freq-efficient'):
+            self._make_agent(cpu_uncore_freq_efficient=-1.0e9)
+
+    def test_help_nonempty(self):
+        self.assertIsInstance(CPUActivityAgent().help(), str)
+        self.assertTrue(CPUActivityAgent().help())
+
+    # ---- signal_config_override -------------------------------------------
+
+    def test_signal_config_override(self):
+        agent = self._make_agent()
+        override = agent.signal_config_override()
+        self.assertIn('TIME board 0', override)
+        self.assertIn('MSR::CPU_SCALABILITY_RATIO board 0', override)
+        self.assertIn('MSR::QM_CTR_SCALED_RATE board 0', override)
+        self.assertIn('CPU_UNCORE_FREQUENCY_STATUS board 0', override)
+        self.assertTrue(override.endswith('\n'))
+
+    def test_signal_config_override_subset(self):
+        self._signal_names = {'MSR::CPU_SCALABILITY_RATIO', 'TIME'}
+        agent = self._make_agent()
+        override = agent.signal_config_override()
+        self.assertIn('MSR::CPU_SCALABILITY_RATIO board 0', override)
+        self.assertNotIn('MSR::QM_CTR_SCALED_RATE', override)
+        self.assertNotIn('CPU_UNCORE_FREQUENCY_STATUS', override)
+
+    # ---- run_begin --------------------------------------------------------
+
+    def test_run_begin_no_core(self):
+        self._domain_counts[_DOMAIN_CORE] = 0
+        agent = self._make_agent()
+        with self.assertRaisesRegex(RuntimeError, 'at least one CPU core'):
+            agent.run_begin()
+
+    def test_run_begin_core_only(self):
+        agent = self._make_agent()
+        agent.run_begin()
+        # Core signal and controls pushed.
+        pushed_signals = [c.args[0] for c in self._push_signal.call_args_list]
+        pushed_controls = [c.args[0] for c in self._push_control.call_args_list]
+        self.assertIn('MSR::CPU_SCALABILITY_RATIO', pushed_signals)
+        self.assertIn('CPU_FREQUENCY_MIN_CONTROL', pushed_controls)
+        self.assertIn('CPU_FREQUENCY_MAX_CONTROL', pushed_controls)
+        # No uncore signals/controls, no RMID/QM event writes.
+        self.assertNotIn('MSR::QM_CTR_SCALED_RATE', pushed_signals)
+        self.assertNotIn('CPU_UNCORE_FREQUENCY_MIN_CONTROL', pushed_controls)
+        self._write_control.assert_not_called()
+        self._save_control.assert_called_once()
+        self.assertAlmostEqual(_CORE_MIN, agent._freq_core_efficient)
+
+    def test_run_begin_core_efficient_arg(self):
+        agent = self._make_agent(cpu_freq_efficient=1.8e9)
+        agent.run_begin()
+        self.assertAlmostEqual(1.8e9, agent._freq_core_efficient)
+
+    def test_run_begin_core_efficient_out_of_range(self):
+        agent = self._make_agent(cpu_freq_efficient=5.0e9)
+        with self.assertRaisesRegex(RuntimeError,
+                                    'core efficient frequency out of range'):
+            agent.run_begin()
+
+    def test_run_begin_uncore_enabled(self):
+        agent = self._make_agent(cpu_uncore_bandwidth=list(_BW_PAIRS))
+        agent.run_begin()
+        pushed_signals = [c.args[0] for c in self._push_signal.call_args_list]
+        pushed_controls = [c.args[0] for c in self._push_control.call_args_list]
+        self.assertIn('MSR::QM_CTR_SCALED_RATE', pushed_signals)
+        self.assertIn('CPU_UNCORE_FREQUENCY_STATUS', pushed_signals)
+        self.assertIn('CPU_UNCORE_FREQUENCY_MIN_CONTROL', pushed_controls)
+        self.assertIn('CPU_UNCORE_FREQUENCY_MAX_CONTROL', pushed_controls)
+        # RMID / QM event-selection controls written for bandwidth monitoring.
+        written = [c.args[0] for c in self._write_control.call_args_list]
+        self.assertIn('MSR::PQR_ASSOC:RMID', written)
+        self.assertIn('MSR::QM_EVTSEL:RMID', written)
+        self.assertIn('MSR::QM_EVTSEL:EVENT_ID', written)
+        self.assertAlmostEqual(_UNCORE_MIN, agent._freq_uncore_efficient)
+
+    def test_run_begin_uncore_efficient_out_of_range(self):
+        agent = self._make_agent(cpu_uncore_freq_efficient=5.0e9,
+                                 cpu_uncore_bandwidth=list(_BW_PAIRS))
+        with self.assertRaisesRegex(RuntimeError,
+                                    'uncore efficient frequency out of range'):
+            agent.run_begin()
+
+    # ---- update_loop: core ------------------------------------------------
+
+    def _set_core_samples(self, values):
+        """values: list of scalability per core domain index."""
+        for idx, val in enumerate(values):
+            self._sample_values[f'MSR::CPU_SCALABILITY_RATIO:{idx}'] = val
+
+    def test_update_loop_core_phi_neutral(self):
+        agent = self._make_agent(phi=0.5)
+        agent.run_begin()
+        self._set_core_samples([0.5])
+        agent.update_loop()
+        # eff=1e9, max=3e9, range=2e9; req = 1e9 + 2e9*0.5 = 2e9
+        for value in self._adjust_values():
+            self.assertAlmostEqual(2.0e9, value, delta=1.0)
+        self._write_batch.assert_called_once()
+
+    def test_update_loop_core_scalability_nan(self):
+        agent = self._make_agent(phi=0.5)
+        agent.run_begin()
+        self._set_core_samples([float('nan')])
+        agent.update_loop()
+        # NaN scalability -> 1.0; req = 1e9 + 2e9 = 3e9 (== max)
+        for value in self._adjust_values():
+            self.assertAlmostEqual(3.0e9, value, delta=1.0)
+
+    def test_update_loop_core_energy_bias(self):
+        agent = self._make_agent(phi=0.75)
+        agent.run_begin()
+        self._set_core_samples([1.0])
+        agent.update_loop()
+        # resolved_max = 3e9 - 2e9*0.5 = 2e9; eff = 1e9; range = 1e9
+        # req = 1e9 + 1e9*1.0 = 2e9
+        for value in self._adjust_values():
+            self.assertAlmostEqual(2.0e9, value, delta=1.0)
+
+    def test_update_loop_core_performance_bias(self):
+        agent = self._make_agent(phi=0.25)
+        agent.run_begin()
+        self._set_core_samples([0.0])
+        agent.update_loop()
+        # resolved_eff = 1e9 + 2e9*0.5 = 2e9; max = 3e9
+        # req = 2e9 + range*0.0 = 2e9
+        for value in self._adjust_values():
+            self.assertAlmostEqual(2.0e9, value, delta=1.0)
+
+    def test_update_loop_core_clamp_counts_clip(self):
+        agent = self._make_agent(phi=0.5)
+        agent.run_begin()
+        self._set_core_samples([2.0])
+        agent.update_loop()
+        # req = 1e9 + 2e9*2.0 = 5e9 -> clamped to max 3e9
+        for value in self._adjust_values():
+            self.assertAlmostEqual(3.0e9, value, delta=1.0)
+        self.assertEqual(1, agent._core_frequency_clipped)
+
+    def test_update_loop_core_no_write_when_unchanged(self):
+        agent = self._make_agent(phi=0.5)
+        agent.run_begin()
+        self._set_core_samples([0.5])
+        agent.update_loop()
+        first = self._adjust.call_count
+        self._write_batch.reset_mock()
+        agent.update_loop()
+        self.assertEqual(first, self._adjust.call_count)
+        self._write_batch.assert_not_called()
+
+    def test_update_loop_multi_core(self):
+        self._domain_counts[_DOMAIN_CORE] = 2
+        agent = self._make_agent(phi=0.5)
+        agent.run_begin()
+        self._set_core_samples([0.5, 0.5])
+        agent.update_loop()
+        # Two core domains, each writes min and max -> 4 adjusts.
+        self.assertEqual(4, self._adjust.call_count)
+        self.assertEqual(2, agent._core_frequency_requests)
+
+    # ---- update_loop: uncore ----------------------------------------------
+
+    def _set_uncore_samples(self, status_values, qm_values):
+        for idx, val in enumerate(status_values):
+            self._sample_values[f'CPU_UNCORE_FREQUENCY_STATUS:{idx}'] = val
+        for idx, val in enumerate(qm_values):
+            self._sample_values[f'MSR::QM_CTR_SCALED_RATE:{idx}'] = val
+
+    def test_update_loop_uncore_bandwidth_exact_key(self):
+        agent = self._make_agent(phi=0.5, cpu_uncore_bandwidth=list(_BW_PAIRS))
+        agent.run_begin()
+        self._set_core_samples([0.0])
+        # status 2.0e9 -> exact key -> max_bw 2.0e11; qm 1.0e11 -> scal 0.5
+        self._set_uncore_samples([2.0e9], [1.0e11])
+        agent.update_loop()
+        # uncore eff=1e9, max=2.4e9, range=1.4e9; req = 1e9 + 1.4e9*0.5 = 1.7e9
+        uncore_values = [c.args[1] for c in self._adjust.call_args_list
+                         if c.args[0].startswith('CPU_UNCORE_FREQUENCY')]
+        self.assertTrue(uncore_values)
+        for value in uncore_values:
+            self.assertAlmostEqual(1.7e9, value, delta=1.0)
+
+    def test_update_loop_uncore_bandwidth_between_keys(self):
+        agent = self._make_agent(phi=0.5, cpu_uncore_bandwidth=list(_BW_PAIRS))
+        agent.run_begin()
+        self._set_core_samples([0.0])
+        # status 1.5e9 -> largest key <= 1.5e9 is 1.0e9 -> max_bw 1.0e11
+        # qm 0.5e11 -> scal 0.5 -> req = 1e9 + 1.4e9*0.5 = 1.7e9
+        self._set_uncore_samples([1.5e9], [0.5e11])
+        agent.update_loop()
+        uncore_values = [c.args[1] for c in self._adjust.call_args_list
+                         if c.args[0].startswith('CPU_UNCORE_FREQUENCY')]
+        for value in uncore_values:
+            self.assertAlmostEqual(1.7e9, value, delta=1.0)
+
+    def test_update_loop_uncore_clamp_counts_clip(self):
+        agent = self._make_agent(phi=0.5, cpu_uncore_bandwidth=list(_BW_PAIRS))
+        agent.run_begin()
+        self._set_core_samples([0.0])
+        # qm hugely exceeds max_bw -> scalability > 1 -> request clamped to max
+        self._set_uncore_samples([2.0e9], [1.0e12])
+        agent.update_loop()
+        uncore_values = [c.args[1] for c in self._adjust.call_args_list
+                         if c.args[0].startswith('CPU_UNCORE_FREQUENCY')]
+        for value in uncore_values:
+            self.assertAlmostEqual(_UNCORE_MAX, value, delta=1.0)
+        self.assertEqual(1, agent._uncore_frequency_clipped)
+
+    def test_update_loop_core_only_leaves_uncore_untouched(self):
+        agent = self._make_agent()
+        agent.run_begin()
+        self._set_core_samples([0.5])
+        agent.update_loop()
+        self.assertFalse(agent._uncore_enabled)
+        uncore_values = [c.args[1] for c in self._adjust.call_args_list
+                         if c.args[0].startswith('CPU_UNCORE_FREQUENCY')]
+        self.assertEqual([], uncore_values)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/geopmdpy/test/TestCPUActivityAgent.py
+++ b/geopmdpy/test/TestCPUActivityAgent.py
@@ -38,6 +38,7 @@ class TestCPUActivityAgent(unittest.TestCase):
         self._signal_names = {
             'MSR::CPU_SCALABILITY_RATIO',
             'MSR::QM_CTR_SCALED_RATE',
+            'CPU_FREQUENCY_STATUS',
             'CPU_UNCORE_FREQUENCY_STATUS',
             'TIME',
         }
@@ -107,13 +108,15 @@ class TestCPUActivityAgent(unittest.TestCase):
         return self._domain_counts.get(domain, 1)
 
     def _make_agent(self, phi=0.5, cpu_freq_efficient=None,
-                    cpu_uncore_freq_efficient=None, cpu_uncore_bandwidth=None):
+                    cpu_uncore_freq_efficient=None, cpu_uncore_bandwidth=None,
+                    hi_res=False):
         agent = CPUActivityAgent()
         agent.update_args(Namespace(
             phi=phi,
             cpu_freq_efficient=cpu_freq_efficient,
             cpu_uncore_freq_efficient=cpu_uncore_freq_efficient,
-            cpu_uncore_bandwidth=cpu_uncore_bandwidth))
+            cpu_uncore_bandwidth=cpu_uncore_bandwidth,
+            hi_res=hi_res))
         return agent
 
     def _adjust_values(self):
@@ -144,6 +147,12 @@ class TestCPUActivityAgent(unittest.TestCase):
         self.assertIsNone(args.cpu_freq_efficient)
         self.assertIsNone(args.cpu_uncore_freq_efficient)
         self.assertIsNone(args.cpu_uncore_bandwidth)
+
+    def test_update_parser_hi_res(self):
+        agent = CPUActivityAgent()
+        parser = agent.update_parser(ArgumentParser())
+        self.assertFalse(parser.parse_args([]).hi_res)
+        self.assertTrue(parser.parse_args(['--hi-res']).hi_res)
 
     def test_update_args_valid_phi(self):
         for phi in (0.0, 0.25, 0.5, 0.75, 1.0):
@@ -198,8 +207,19 @@ class TestCPUActivityAgent(unittest.TestCase):
         self.assertIn('TIME board 0', override)
         self.assertIn('MSR::CPU_SCALABILITY_RATIO board 0', override)
         self.assertIn('MSR::QM_CTR_SCALED_RATE board 0', override)
+        self.assertIn('CPU_FREQUENCY_STATUS board 0', override)
         self.assertIn('CPU_UNCORE_FREQUENCY_STATUS board 0', override)
         self.assertTrue(override.endswith('\n'))
+
+    def test_signal_config_override_hi_res(self):
+        agent = self._make_agent(hi_res=True)
+        override = agent.signal_config_override()
+        # TIME stays board-level; other signals use the wildcard domain/index.
+        self.assertIn('TIME board 0', override)
+        self.assertIn('MSR::CPU_SCALABILITY_RATIO * *', override)
+        self.assertIn('MSR::QM_CTR_SCALED_RATE * *', override)
+        self.assertIn('CPU_FREQUENCY_STATUS * *', override)
+        self.assertIn('CPU_UNCORE_FREQUENCY_STATUS * *', override)
 
     def test_signal_config_override_subset(self):
         self._signal_names = {'MSR::CPU_SCALABILITY_RATIO', 'TIME'}


### PR DESCRIPTION
Add a pure-Python CPUActivityAgent for the GEOPM Python session interface, porting the C++ cpu_activity agent. The agent steers CPU core frequency from MSR::CPU_SCALABILITY_RATIO and, when an uncore memory-bandwidth characterization is supplied, steers uncore frequency from MSR::QM_CTR_SCALED_RATE normalized by the characterized maximum bandwidth for the current uncore frequency. A single --phi knob biases selection toward performance or energy savings.

All static characterization previously read from the ConstConfigIOGroup is supplied via command-line arguments instead: --cpu-freq-efficient and --cpu-uncore-freq-efficient (defaulting to the platform minimums) and repeatable --cpu-uncore-bandwidth FREQ:BW pairs. When no bandwidth pairs are provided the agent runs in core-only mode and leaves the uncore frequency untouched, so it is usable with zero configuration.

Add TestCPUActivityAgent.py covering argument parsing and validation, signal configuration override, run_begin domain resolution and core-only versus uncore-enabled setup, and the update_loop control math for both core and uncore (phi bias, scalability handling, bandwidth lookup, and clamp counting).
