### PR TITLE
Relax batch write to no-op unadjusted controls (#4033)

### DIFF
--- a/docs/source/geopm_pio.3.rst
+++ b/docs/source/geopm_pio.3.rst
@@ -369,7 +369,10 @@ Batch Functions
 
 ``geopm_pio_write_batch()``
   Write all pushed controls so that values provided to
-  ``geopm_pio_adjust()`` are written to the platform.
+  ``geopm_pio_adjust()`` are written to the platform.  Any control that
+  was pushed via ``geopm_pio_push_control()`` but never adjusted is left
+  unchanged: its current value on the platform is preserved (the write is
+  a no-op for that control).
 
 ``geopm_pio_start_batch_server()``
   Creates a batch server with the following signals and controls.

--- a/libgeopmd/src/BatchServer.cpp
+++ b/libgeopmd/src/BatchServer.cpp
@@ -275,7 +275,13 @@ namespace geopm
         double *shmem_buffer = (double *)m_control_shmem->pointer();
         int buffer_idx = 0;
         for (const auto &handle : m_control_handle) {
-            m_pio.adjust(handle, shmem_buffer[buffer_idx]);
+            // An invalid (NAN) slot is a control that the client pushed but
+            // never adjusted.  Skip it so it is preserved at its current
+            // platform value rather than rejected; the IOGroup write_batch()
+            // treats an unadjusted control as a no-op.
+            if (PlatformIO::is_valid_value(shmem_buffer[buffer_idx])) {
+                m_pio.adjust(handle, shmem_buffer[buffer_idx]);
+            }
             ++buffer_idx;
         }
         m_pio.write_batch();

--- a/libgeopmd/src/MSRIOGroup.cpp
+++ b/libgeopmd/src/MSRIOGroup.cpp
@@ -830,7 +830,6 @@ namespace geopm
             result = m_control_pushed.size();
             m_control_pushed.push_back(control);
             control->setup_batch();
-            m_is_adjusted.push_back(false);
 
             if (control_name == "CPU_POWER_LIMIT_CONTROL" || control_name == "MSR::PKG_POWER_LIMIT:PL1_POWER_LIMIT") {
                 int enable_idx = push_control("MSR::PKG_POWER_LIMIT:PL1_LIMIT_ENABLE", domain_type, domain_idx);
@@ -859,10 +858,10 @@ namespace geopm
     void MSRIOGroup::write_batch(void)
     {
         if (m_control_pushed.size() != 0) {
-            if (std::any_of(m_is_adjusted.begin(), m_is_adjusted.end(), [](bool it) {return !it;})) {
-                throw Exception("MSRIOGroup::write_batch() called before all controls were adjusted",
-                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-            }
+            // A control that was pushed but never adjusted is preserved at its
+            // current platform value: the per-field write mask remains zero, so
+            // MSRIO::write_batch() leaves those bits untouched.  This silent
+            // no-op matches the behavior of the other IOGroups.
             m_msrio->write_batch();
         }
         m_is_active = true;
@@ -895,11 +894,9 @@ namespace geopm
             // If setting power limit to 0, disable the limit-enable bit, otherwise enable the bit
             double enable_val = (setting != 0.0) ? 1.0 : 0.0;
             m_control_pushed[it->second]->adjust(enable_val);
-            m_is_adjusted[it->second] = true;
         }
 
         m_control_pushed[control_idx]->adjust(setting);
-        m_is_adjusted[control_idx] = true;
     }
 
     double MSRIOGroup::read_signal(const std::string &signal_name, int domain_type, int domain_idx)

--- a/libgeopmd/src/MSRIOGroup.hpp
+++ b/libgeopmd/src/MSRIOGroup.hpp
@@ -212,7 +212,6 @@ namespace geopm
             std::shared_ptr<Cpuid> m_cpuid;
             bool m_is_active;
             bool m_is_read;
-            std::vector<bool> m_is_adjusted;
 
             // time for derivative signals
             std::shared_ptr<geopm_time_s> m_time_zero;

--- a/libgeopmd/test/BatchServerTest.cpp
+++ b/libgeopmd/test/BatchServerTest.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <unistd.h>
+#include <cmath>
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "BatchServer.hpp"
@@ -155,6 +156,21 @@ TEST_F(BatchServerTest, update_and_write)
     EXPECT_CALL(*m_control_shmem, pointer())
         .WillOnce(Return(buffer));
     EXPECT_CALL(*m_pio, adjust(_, 1.0));
+    EXPECT_CALL(*m_pio, write_batch());
+
+    m_batch_server->update_and_write();
+}
+
+TEST_F(BatchServerTest, update_and_write_skips_nan)
+{
+    check_push_requests();
+    // A NAN slot is a control that was pushed but never adjusted; it must be
+    // skipped (not passed to adjust()) so it is preserved at its current value,
+    // while the batch write still proceeds.
+    double buffer[1] = {NAN};
+    EXPECT_CALL(*m_control_shmem, pointer())
+        .WillOnce(Return(buffer));
+    EXPECT_CALL(*m_pio, adjust(_, _)).Times(0);
     EXPECT_CALL(*m_pio, write_batch());
 
     m_batch_server->update_and_write();

--- a/libgeopmd/test/MSRIOGroupTest.cpp
+++ b/libgeopmd/test/MSRIOGroupTest.cpp
@@ -910,8 +910,11 @@ TEST_F(MSRIOGroupTest, adjust)
     //EXPECT_CALL(*m_msrio, read_msr(0, pl1_limit_offset));  // cpu 0 for pkg 0
     //EXPECT_CALL(*m_msrio, read_msr(2, pl1_limit_offset));  // cpu 2 for pkg 1
     int power_idx = m_msrio_group->push_control("MSR::PKG_POWER_LIMIT:PL1_POWER_LIMIT", GEOPM_DOMAIN_PACKAGE, 0);
-    GEOPM_EXPECT_THROW_MESSAGE(m_msrio_group->write_batch(), GEOPM_ERROR_INVALID,
-                               "called before all controls were adjusted");
+    // Pushing controls without adjusting them is no longer an error:
+    // write_batch() silently preserves the current platform value (no-op) for
+    // any control that was pushed but never adjusted.
+    EXPECT_CALL(*m_msrio, write_batch());
+    EXPECT_NO_THROW(m_msrio_group->write_batch());
 
     uint64_t perf_ctl_mask = 0xFF00;
     uint64_t pl1_limit_mask = 0x7FFF;

--- a/libgeopmd/test/ServiceIOGroupTest.cpp
+++ b/libgeopmd/test/ServiceIOGroupTest.cpp
@@ -268,6 +268,29 @@ TEST_F(ServiceIOGroupTest, push_control)
     m_batch_client.reset();
 }
 
+TEST_F(ServiceIOGroupTest, write_batch_unadjusted_control)
+{
+    // A control that is pushed but never adjusted is no longer an error: the
+    // batch write still proceeds (the unadjusted slot is sent as an invalid
+    // value so the server preserves the current platform value as a no-op).
+    EXPECT_CALL(*m_proxy, platform_start_batch(_, _, _, _))
+        .WillOnce(DoAll(SetArgReferee<2>(1234),
+                        SetArgReferee<3>("1234")));
+    std::vector<double> captured;
+    EXPECT_CALL(*m_batch_client, write_batch(_))
+        .WillOnce([&captured](std::vector<double> settings) { captured = settings; });
+    int control_handle_0 = m_serviceio_group->push_control("control1", GEOPM_DOMAIN_BOARD, 0);
+    m_serviceio_group->push_control("control2", GEOPM_DOMAIN_PACKAGE, 0);
+    m_serviceio_group->adjust(control_handle_0, 4.5);
+    EXPECT_NO_THROW(m_serviceio_group->write_batch());
+    ASSERT_EQ(2u, captured.size());
+    EXPECT_EQ(4.5, captured[0]);
+    EXPECT_FALSE(geopm::PlatformIO::is_valid_value(captured[1]));
+    EXPECT_CALL(*m_batch_client, stop_batch())
+        .Times(1);
+    m_batch_client.reset();
+}
+
 TEST_F(ServiceIOGroupTest, read_batch)
 {
     // For now this should be a noop


### PR DESCRIPTION
Pushing a control via geopm_pio_push_control() without a subsequent geopm_pio_adjust() previously caused MSRIOGroup::write_batch() to throw GEOPM_ERROR_INVALID.  In the non-root batch path this killed the geopmbatch server, and the client surfaced a misleading "server is unresponsive" error that permanently disabled the session.

Treat an unadjusted pushed control as a no-op instead, matching every other IOGroup (LevelZero, NVML, DCGM, Sysfs), which silently skip controls that were never adjusted.  The MSRIO read-modify-write already leaves a field untouched when its accumulated write mask is zero, so the current platform value is preserved.

- BatchServer::update_and_write(): skip invalid (NAN) slots via PlatformIO::is_valid_value() so the server no longer rejects them.
- MSRIOGroup::write_batch(): remove the throw and the now-unused m_is_adjusted bookkeeping; it is a silent no-op for unadjusted controls.
- Document the no-op contract for geopm_pio_write_batch() in geopm_pio.3.rst.
- Add/adjust unit tests for the relaxed behavior.

- Fixes #4033