### PR TITLE
Heatmap agent

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -201,6 +201,7 @@ rst_files = [
     "geopmexporter.1",
     "geopm_field.3",
     "geopm_fortran.3",
+    "geopm_heatmap_agent.1",
     "geopmgrid.1",
     "geopm_hash.3",
     "geopm_imbalancer.3",

--- a/docs/source/geopm_heatmap_agent.1.rst
+++ b/docs/source/geopm_heatmap_agent.1.rst
@@ -1,0 +1,141 @@
+geopm_heatmap_agent(1) -- render a component-saturation heatmap from GEOPM telemetry
+====================================================================================
+
+Synopsis
+--------
+
+.. code-block:: bash
+
+    python -m geopmdpy.heatmap_agent [-t TIME] [-p PERIOD] [-o TRACE_OUT]
+                                     [-i CONFIG_PATH] [--heatmap-out PATH]
+                                     [--fom FOM_CSV] [--no-plot]
+                                     [--replot-csv TRACE_CSV]
+
+Sample and render (default)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    python -m geopmdpy.heatmap_agent -t 30 --heatmap-out heatmap.png
+
+Correlate against a figure of merit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    python -m geopmdpy.heatmap_agent -t 60 --heatmap-out hm.png --fom fom.csv
+
+Re-render a saved trace without sampling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    python -m geopmdpy.heatmap_agent -t 60 -o trace.csv --no-plot
+    python -m geopmdpy.heatmap_agent --replot-csv trace.csv --heatmap-out hm.png
+
+
+Description
+-----------
+
+The ``heatmap_agent`` is a pure-Python implementation of the
+:doc:`geopm::Agent(3) <geopm::Agent.3>` interface for the GEOPM Python session
+(see :doc:`geopmsession(1) <geopmsession.1>`).  It samples a set of
+per-component signals in-process through the ``geopmdpy.pio`` interface and,
+when the session ends, renders a normalized *component-saturation heatmap* with
+one row per component and time along the horizontal axis.  Each row is scaled to
+its own dynamic range, so a component pinned near its own maximum while the
+others sit idle reads out as the bottleneck for that phase of the run.
+
+The agent samples the following signals when they are granted on the platform;
+any that are unavailable are silently dropped:
+
+* ``CPU_POWER`` (CPU package power)
+* ``MSR::CPU_SCALABILITY_RATIO`` (stalled-vs-retiring proxy)
+* ``CPU_FREQUENCY_STATUS`` (core frequency)
+* ``CPU_UNCORE_FREQUENCY_STATUS`` (uncore frequency)
+* ``DRAM_POWER`` (memory power)
+* ``GPU_POWER``, ``GPU_CORE_ACTIVITY``, ``GPU_UNCORE_ACTIVITY``,
+  ``GPU_UTILIZATION`` (GPU power and activity, when a GPU IOGroup is present)
+
+When both ``CPU_INSTRUCTIONS_RETIRED`` and ``CPU_CYCLES_THREAD`` are available,
+the agent derives a per-sample **IPC** row from the deltas of the two cumulative
+counters and also emits it as an ``IPC`` column in the trace.  High IPC alongside
+modest DRAM and uncore activity indicates a compute-bound region; low IPC with
+saturated DRAM power or uncore frequency indicates a memory-bound region.
+
+Because this agent extends the session interface, it accepts all of the standard
+:doc:`geopmsession(1) <geopmsession.1>` options (for example ``-t/--time``,
+``-p/--period``, ``-o/--trace-out``, and ``-i/--signal-config``) in addition to
+the options listed below.  The agent supplies its own default signal request
+set, so no request list needs to be piped in; provide ``-i CONFIG_PATH`` to
+trace a custom set of requests instead.  The default sampling period is lowered
+to *0.05 second*; an explicit ``-p/--period`` still takes precedence.  This is a
+read-only monitoring agent and writes no controls.
+
+
+Options
+-------
+
+--heatmap-out PATH  .. _heatmapout option:
+
+    Output PNG path for the rendered heatmap.  Default:
+    ``component_heatmap.png``.
+
+--fom FOM_CSV  .. _fom option:
+
+    Overlay an external figure-of-merit time series beneath the heatmap.  The
+    CSV must have two columns, ``time_seconds`` and ``value``.  The FOM axis
+    shares the heatmap's time axis to aid correlation of the metric against the
+    telemetry.
+
+--no-plot  .. _noplot option:
+
+    Collect the trace but skip rendering the heatmap.  Useful for long or
+    high-rate captures; render the resulting trace later with ``--replot-csv``.
+
+--replot-csv TRACE_CSV  .. _replotcsv option:
+
+    Render a heatmap from an existing ``geopmsession`` trace CSV and exit without
+    opening a session.  No PlatformIO access is required.  The PNG is written to
+    ``--heatmap-out`` and ``--fom`` may be combined with it.  When the trace
+    contains the ``CPU_INSTRUCTIONS_RETIRED`` and ``CPU_CYCLES_THREAD`` counters
+    the IPC row is derived from them; otherwise an existing ``IPC`` column is
+    used if present.  This option is distinct from ``-f/--report-format``, which
+    selects the report output format.
+
+
+Requirements
+------------
+
+Rendering requires ``matplotlib`` (and ``pandas`` for the ``--fom`` overlay and
+``--replot-csv`` modes).  These are optional dependencies of ``geopmdpy`` and can
+be installed with:
+
+.. code-block:: bash
+
+    pip install geopmdpy[heatmap]
+
+Importing the module and running a ``--no-plot`` capture do not require these
+packages.
+
+
+Limitations
+-----------
+
+GEOPM exposes no NIC telemetry and has no notion of data *flowing* between
+components, so this tool visualizes per-component saturation over time rather
+than a data-flow diagram between the CPU, GPU, and other devices.  When
+rendering at the end of a run (the default), samples are accumulated in memory
+for the duration of the session; for very long or high-rate captures prefer
+``--no-plot`` and re-render the saved trace with ``--replot-csv``.
+
+
+See Also
+--------
+
+:doc:`geopm(7) <geopm.7>`\ ,
+:doc:`geopmdpy(7) <geopmdpy.7>`\ ,
+:doc:`geopmsession(1) <geopmsession.1>`\ ,
+:doc:`geopmread(1) <geopmread.1>`\ ,
+:doc:`geopmwrite(1) <geopmwrite.1>`\ ,
+:doc:`geopm::Agent(3) <geopm::Agent.3>`

--- a/docs/source/geopm_heatmap_agent.1.rst
+++ b/docs/source/geopm_heatmap_agent.1.rst
@@ -6,32 +6,32 @@ Synopsis
 
 .. code-block:: bash
 
-    python -m geopmdpy.heatmap_agent [-t TIME] [-p PERIOD] [-o TRACE_OUT]
-                                     [-i CONFIG_PATH] [--heatmap-out PATH]
-                                     [--fom FOM_CSV] [--no-plot]
-                                     [--replot-csv TRACE_CSV]
+    python3 -m geopmdpy.heatmap_agent [-t TIME] [-p PERIOD] [-o TRACE_OUT]
+                                      [-i CONFIG_PATH] [--heatmap-out PATH]
+                                      [--fom FOM_CSV] [--no-plot]
+                                      [--replot-csv TRACE_CSV]
 
 Sample and render (default)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
-    python -m geopmdpy.heatmap_agent -t 30 --heatmap-out heatmap.png
+    python3 -m geopmdpy.heatmap_agent -t 30 --heatmap-out heatmap.png
 
 Correlate against a figure of merit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
-    python -m geopmdpy.heatmap_agent -t 60 --heatmap-out hm.png --fom fom.csv
+    python3 -m geopmdpy.heatmap_agent -t 60 --heatmap-out hm.png --fom fom.csv
 
 Re-render a saved trace without sampling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
-    python -m geopmdpy.heatmap_agent -t 60 -o trace.csv --no-plot
-    python -m geopmdpy.heatmap_agent --replot-csv trace.csv --heatmap-out hm.png
+    python3 -m geopmdpy.heatmap_agent -t 60 -o trace.csv --no-plot
+    python3 -m geopmdpy.heatmap_agent --replot-csv trace.csv --heatmap-out hm.png
 
 
 Description

--- a/docs/source/geopmopt.1.rst
+++ b/docs/source/geopmopt.1.rst
@@ -481,7 +481,7 @@ Optimize GPU parameters for machine learning workloads:
               --metric-regex "Training speed: ([0-9.]+) samples/sec" \
               --trials 60 \
               --application-timeout 600 \
-              -- python train_model.py
+              -- python3 train_model.py
 
 Complex multi-dimensional optimization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/geopmsession.1.rst
+++ b/docs/source/geopmsession.1.rst
@@ -631,7 +631,7 @@ customize session behavior. This example shows a simple agent that monitors the
 
 .. code-block:: python
 
-   #!/usr/bin/env python
+   #!/usr/bin/env python3
    # File: cpu_power_agent.py
    from geopmdpy.session import main
    from geopmdpy.session import Agent

--- a/geopmdpy/OPTIMIZER_README.md
+++ b/geopmdpy/OPTIMIZER_README.md
@@ -82,7 +82,7 @@ geopmopt \
     --verbosity 2 \
     --print-stdout \
     --output-file geopmwrite.config \
-    -- python my_ml_training.py
+    -- python3 my_ml_training.py
 ```
 
 #### Minimize Energy Consumption with Full Debug Output

--- a/geopmdpy/geopmdpy/heatmap_agent.py
+++ b/geopmdpy/geopmdpy/heatmap_agent.py
@@ -1,0 +1,855 @@
+#!/usr/bin/python3
+#
+#  Copyright (c) 2015 - 2026 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+"""Component-saturation heatmap agent for the GEOPM Python session interface.
+
+This module provides a ``HeatmapAgent`` for use with the GEOPM Python
+session interface.  It samples a set of per-component signals (CPU, DRAM,
+uncore, and GPU power/activity/frequency) in-process through
+``geopmdpy.pio`` and, when the session ends, renders a normalized heatmap
+(one row per component instance -- every package and every GPU -- and
+columns = time) that shows which component is saturated over the course of a
+run.  A component pinned near its own maximum while the others sit idle reads
+out as the bottleneck.
+
+When both ``CPU_INSTRUCTIONS_RETIRED`` and ``CPU_CYCLES_THREAD`` are
+available the agent derives one ``IPC`` row per package (socket) from the
+per-sample counter deltas read at the package domain, and also emits each as
+a trace column.  High IPC alongside modest DRAM/uncore
+activity indicates a compute-bound region; low IPC with saturated DRAM or
+uncore indicates a memory-bound region.  An external figure-of-merit (FOM)
+time series may be overlaid with ``--fom`` to correlate FOM against the
+telemetry.
+
+The agent supplies its own default signal request set via
+``signal_config_override``; users may pipe their own request list to
+override it.  Rendering requires ``matplotlib`` (and ``pandas`` for the FOM
+overlay); install them with ``pip install geopmdpy[heatmap]``.
+
+Note: GEOPM has no NIC telemetry and no notion of data *flowing* between
+components, so this shows per-component saturation over time rather than a
+data-flow diagram.
+
+Example usage:
+    python -m geopmdpy.heatmap_agent -t 30
+    python -m geopmdpy.heatmap_agent -t 60 --heatmap-out hm.png --fom fom.csv
+    python -m geopmdpy.heatmap_agent -t 30 -o trace.csv --no-plot
+    python -m geopmdpy.heatmap_agent --replot-csv trace.csv --heatmap-out hm.png
+"""
+
+import re
+import sys
+
+from . import pio
+from . import topo
+from .session import main
+from .session import Agent
+
+# The component heatmap benefits from finer sampling than the session's
+# 100 ms default; an explicit '-p/--period' on the command line still takes
+# precedence.
+_PERIOD_DEFAULT = 0.05
+
+# Candidate signals to sample, in the order they should appear (top to
+# bottom).  Each entry is (signal_name, domain, human_label).  Every
+# available domain index of the given domain is sampled, producing one row
+# per index (e.g. one per package and one per GPU); any signal not granted
+# on the platform is silently dropped.
+_CANDIDATE_SIGNALS = (
+    ('CPU_POWER', 'package', 'CPU power'),
+    ('MSR::CPU_SCALABILITY_RATIO', 'package', 'CPU scalability'),
+    ('CPU_FREQUENCY_STATUS', 'package', 'CPU core freq'),
+    ('CPU_UNCORE_FREQUENCY_STATUS', 'package', 'CPU uncore freq'),
+    ('DRAM_POWER', 'package', 'DRAM power'),
+    ('GPU_POWER', 'gpu', 'GPU power'),
+    ('GPU_CORE_ACTIVITY', 'gpu', 'GPU core activity'),
+    ('GPU_UNCORE_ACTIVITY', 'gpu', 'GPU mem activity'),
+    ('GPU_UTILIZATION', 'gpu', 'GPU utilization'),
+)
+
+# Short per-domain tag used to disambiguate row labels when a signal is
+# sampled at more than one domain index (e.g. "CPU power pkg0").
+_DOMAIN_TAG = {'package': 'pkg', 'gpu': 'gpu'}
+
+# Signals that are physically bounded to the unit interval [0, 1].  Level Zero
+# occasionally reports activity/utilization values outside this range; such
+# readings are treated as missing (NaN) so they are ignored rather than
+# clipped -- a single erroneous spike would otherwise dominate the per-row
+# percentile normalization and wash the rest of the row to black.
+_UNIT_INTERVAL_SIGNALS = frozenset((
+    'GPU_CORE_ACTIVITY', 'GPU_UNCORE_ACTIVITY', 'GPU_UTILIZATION'))
+
+# Cumulative counters used to derive the IPC rows.  Both must be granted for
+# the derived IPC rows to appear.  They are read at the package domain so the
+# derived value is per-socket, matching the other CPU signals; one IPC row is
+# produced per package.
+_IPC_INSTR = 'CPU_INSTRUCTIONS_RETIRED'
+_IPC_CYCLES = 'CPU_CYCLES_THREAD'
+_IPC_DOMAIN = 'package'
+_IPC_LABEL = 'CPU IPC'
+
+# Component groups rendered as separate, labeled heatmap panels (subplots),
+# stacked top to bottom and sharing the time axis.  Each entry is
+# (group_title, ordered base row labels, accent color).  The base labels must
+# match the human labels in _CANDIDATE_SIGNALS (and _IPC_LABEL); every row
+# whose base label falls in a group is drawn in that group's panel, in the
+# order listed here.  This is also what fixes the row order (e.g. GPU
+# utilization above GPU core activity within the GPU compute panel).
+_ROW_GROUPS = (
+    ('CPU compute',
+     ('CPU power', 'CPU IPC', 'CPU scalability', 'CPU core freq'),
+     'tab:blue'),
+    ('CPU memory',
+     ('CPU uncore freq', 'DRAM power'),
+     'tab:green'),
+    ('GPU compute',
+     ('GPU power', 'GPU utilization', 'GPU core activity'),
+     'tab:red'),
+    ('GPU memory',
+     ('GPU mem activity',),
+     'tab:orange'),
+)
+
+# Physically achievable IPC upper bound.  A near-zero cycle delta (counter
+# read jitter) can otherwise yield a huge IPC spike that dominates the
+# per-row min-max normalization and washes the whole IPC row to black.
+_IPC_MAX = 8.0
+
+# Controls that turn on the fixed performance counters backing the IPC
+# signals.  On some platforms FIXED_CTR0 (INST_RETIRED_ANY) is left disabled
+# while FIXED_CTR1 (CPU_CLK_UNHALTED_THREAD) runs, so CPU_INSTRUCTIONS_RETIRED
+# reads a constant and the derived IPC is a flat zero.  These are written
+# inside the session at run_begin and reverted automatically on exit because
+# the session snapshots (save_control) and restores every control it touched.
+_IPC_ENABLE_CONTROLS = (
+    'MSR::FIXED_CTR_CTRL:EN0_OS',
+    'MSR::FIXED_CTR_CTRL:EN0_USR',
+    'MSR::FIXED_CTR_CTRL:EN1_OS',
+    'MSR::FIXED_CTR_CTRL:EN1_USR',
+    'MSR::PERF_GLOBAL_CTRL:EN_FIXED_CTR0',
+    'MSR::PERF_GLOBAL_CTRL:EN_FIXED_CTR1',
+)
+
+
+class HeatmapAgent(Agent):
+    """Agent that renders a component-saturation heatmap for a GEOPM session.
+
+    The session drives the timed loop and calls ``pio.read_batch()`` before
+    each ``update_loop()``; this agent samples the cached signals, derives a
+    per-sample IPC value, and renders the heatmap in ``run_end()``.  It is a
+    monitoring agent: the only controls it writes are the fixed-counter enable
+    bits needed for the derived IPC rows, and the session reverts those
+    automatically when it ends.
+
+    Command-line options:
+      --heatmap-out   Output PNG path for the heatmap.
+      --fom           Optional FOM CSV to overlay (columns: time_seconds,value).
+      --no-plot       Collect the trace but skip rendering the heatmap.
+      --replot-csv    Render an existing geopmsession trace and exit (no
+                      session is run).
+
+    Example:
+        python -m geopmdpy.heatmap_agent -t 30 --heatmap-out heatmap.png
+    """
+
+    def __init__(self):
+        """Initialize the HeatmapAgent."""
+        self._out_path = 'component_heatmap.png'
+        self._fom_path = None
+        self._no_plot = False
+        self._replot_csv = None
+
+        # Signals selected for plotting, resolved from availability.
+        self._signals = []
+
+        # Batch indices for pushed signals.
+        self._time_idx = None
+        self._signal_idx = []
+        self._instr_idx = []
+        self._cycles_idx = []
+        self._ipc_packages = []
+        self._ipc_resolved = False
+        self._counters_enabled = False
+
+        # Accumulated samples.
+        self._times = []
+        self._rows = []
+        self._ipc = []
+        self._prev_counts = None
+        self._cur_ipc = []
+
+    def help(self):
+        """Help documentation.
+
+        """
+        return ('The heatmap agent samples per-component power, activity, and '
+                'frequency signals and renders a normalized component-saturation '
+                'heatmap (rows=components, cols=time) when the session ends. It '
+                'adds a derived IPC row and an optional --fom overlay to help '
+                'distinguish compute-bound from memory-bound regions.')
+
+    def update_parser(self, parser):
+        """Add the heatmap options and adjust session defaults.
+
+        Args:
+            parser (argparse.ArgumentParser): The parser to update.
+
+        Returns:
+            argparse.ArgumentParser: The updated parser.
+        """
+        parser.add_argument('--heatmap-out', dest='heatmap_out',
+                            default='component_heatmap.png',
+                            help='Output PNG path for the heatmap. '
+                                 'Default %(default)s.')
+        parser.add_argument('--fom', dest='fom', default=None,
+                            help='Optional figure-of-merit CSV to overlay '
+                                 '(columns: time_seconds,value).')
+        parser.add_argument('--no-plot', dest='no_plot', action='store_true',
+                            help='Collect the trace but skip rendering the heatmap.')
+        parser.add_argument('--replot-csv', dest='replot_csv', default=None,
+                            help='Render a heatmap from an existing geopmsession '
+                                 'trace CSV and exit without running a session. '
+                                 'The PNG is written to --heatmap-out.')
+        # Override the session's 100 ms default sampling period with a finer
+        # default.  An explicit '-p/--period' on the command line still takes
+        # precedence.
+        parser.set_defaults(period=_PERIOD_DEFAULT)
+        # The session's default '-' would read signal requests from standard
+        # input, but this agent supplies its own default signal set via
+        # signal_config_override(); correct the option's documentation.
+        for action in parser._actions:
+            if action.dest == 'config_path':
+                action.help = (
+                    'Input file containing GEOPM signal requests. The default '
+                    '"-" uses the heatmap agent\'s built-in signal set of '
+                    'available CPU, DRAM, uncore, and GPU metrics. Specify a '
+                    'file path to trace a custom set of signal requests instead.')
+                break
+        return parser
+
+    def update_args(self, args):
+        """Store the heatmap options in the agent.
+
+        Args:
+            args (argparse.Namespace): Parsed command-line arguments.
+
+        Returns:
+            argparse.Namespace: The (possibly updated) arguments.
+        """
+        self._out_path = args.heatmap_out
+        self._fom_path = args.fom
+        self._no_plot = args.no_plot
+        self._replot_csv = getattr(args, 'replot_csv', None)
+        if self._replot_csv is not None:
+            # Render the existing trace and exit before any session is opened;
+            # no PlatformIO access or signal pushing is required.
+            times, labels, rows, ipc_rows = _load_trace(self._replot_csv)
+            _render_heatmap(times, labels, rows, ipc_rows, self._fom_path,
+                            self._out_path)
+            sys.exit(0)
+        return args
+
+    def signal_config_override(self):
+        """Provide a default signal configuration for the heatmap.
+
+        Selects the candidate component signals that are granted on this
+        platform and requests every domain index of each with the "*"
+        wildcard (e.g. all packages, all GPUs), prefixed by TIME for the
+        heatmap's x-axis.
+
+        Returns:
+            str: Signal configuration string for the session.
+        """
+        names = set(pio.signal_names())
+        granted = [(name, domain)
+                   for name, domain, _ in _CANDIDATE_SIGNALS
+                   if name in names]
+        if not granted:
+            raise RuntimeError(
+                'HeatmapAgent: none of the candidate signals are available '
+                'on this platform')
+        lines = ['TIME board 0']
+        lines += [f'{name} {domain} *' for name, domain in granted]
+        return '\n'.join(lines) + '\n'
+
+    def _resolve_ipc_packages(self):
+        """Determine which packages can supply a derived IPC row.
+
+        Populates ``self._ipc_packages`` from signal availability and the
+        package count.  This is idempotent and independent of ``run_begin``
+        because the session queries ``header_names`` (which needs the IPC
+        column set) *before* it calls ``run_begin``; resolving here keeps the
+        trace header and the pushed signal handles consistent.
+        """
+        if self._ipc_resolved:
+            return
+        names = set(pio.signal_names())
+        if _IPC_INSTR in names and _IPC_CYCLES in names:
+            self._ipc_packages = list(range(topo.num_domain(_IPC_DOMAIN)))
+        else:
+            self._ipc_packages = []
+            sys.stderr.write(
+                'note: skipping derived IPC rows (counters not both available)\n')
+        self._ipc_resolved = True
+
+    def _enable_ipc_counters(self):
+        """Enable the fixed performance counters backing the IPC signals.
+
+        Writes the FIXED_CTR_CTRL / PERF_GLOBAL_CTRL enable bits so
+        ``CPU_INSTRUCTIONS_RETIRED`` and ``CPU_CYCLES_THREAD`` advance during
+        the run.  Writes go through the session, which snapshots controls with
+        ``pio.save_control()`` and restores them on exit, so the counter
+        enable state is reverted automatically when the session ends.  Missing
+        controls (e.g. on a platform without MSR access) are skipped with a
+        note rather than aborting the run.
+        """
+        if self._counters_enabled or not self._ipc_packages:
+            return
+        available = set(pio.control_names())
+        controls = [c for c in _IPC_ENABLE_CONTROLS if c in available]
+        if not controls:
+            sys.stderr.write(
+                'note: fixed-counter enable controls unavailable; '
+                'derived IPC may read zero\n')
+            return
+        # Snapshot every control so the session's restore_control() reverts
+        # the counter enables when the run ends.
+        pio.save_control()
+        for name in controls:
+            domain = pio.control_domain_type(name)
+            for index in range(topo.num_domain(domain)):
+                try:
+                    pio.write_control(name, domain, index, 1.0)
+                except RuntimeError as ex:
+                    sys.stderr.write(
+                        f'note: could not enable {name}: {ex}\n')
+        self._counters_enabled = True
+
+    def run_begin(self):
+        """Push the signal handles for the sampled signals.
+
+        Pushes TIME and the resolved component signals.  When the IPC counters
+        are granted it also pushes the per-package counter handles and enables
+        the backing fixed counters; those control writes are reverted
+        automatically when the session ends.
+        """
+        if not self._signals:
+            self._signals = self._discover_signals()
+        self._time_idx = pio.push_signal('TIME', 'board', 0)
+        self._signal_idx = [pio.push_signal(name, domain, index)
+                            for name, domain, index, _ in self._signals]
+        self._resolve_ipc_packages()
+        self._enable_ipc_counters()
+        self._instr_idx = []
+        self._cycles_idx = []
+        for pkg in self._ipc_packages:
+            self._instr_idx.append(
+                pio.push_signal(_IPC_INSTR, _IPC_DOMAIN, pkg))
+            self._cycles_idx.append(
+                pio.push_signal(_IPC_CYCLES, _IPC_DOMAIN, pkg))
+        self._prev_counts = None
+        self._cur_ipc = [float('nan')] * len(self._ipc_packages)
+
+    def update_loop(self):
+        """Sample the pushed signals and derive per-package IPC for this period.
+
+        Called by the session after ``pio.read_batch()``.  Accumulates the
+        per-component samples and, when the IPC counters are present,
+        computes one IPC value per package from the counter deltas over the
+        sample interval.
+        """
+        self._times.append(pio.sample(self._time_idx))
+        self._rows.append([
+            _sanitize_unit(pio.sample(idx), name in _UNIT_INTERVAL_SIGNALS)
+            for (name, _domain, _index, _label), idx
+            in zip(self._signals, self._signal_idx)])
+        if self._instr_idx:
+            counts = [(pio.sample(i), pio.sample(c))
+                      for i, c in zip(self._instr_idx, self._cycles_idx)]
+            if self._prev_counts is not None:
+                self._cur_ipc = [
+                    _delta_ipc(cur[0] - prev[0], cur[1] - prev[1])
+                    for cur, prev in zip(counts, self._prev_counts)]
+            self._prev_counts = counts
+            self._ipc.append(list(self._cur_ipc))
+
+    def header_names(self):
+        """Return the derived trace column headers (one IPC per package).
+
+        Returns:
+            list of str: ['IPC-package-0', ...] when the counters are present,
+                else [].
+        """
+        self._resolve_ipc_packages()
+        return [f'IPC-{_IPC_DOMAIN}-{pkg}' for pkg in self._ipc_packages]
+
+    def trace_out(self):
+        """Return the derived per-package IPC values for the current period.
+
+        Returns:
+            list of str: One formatted IPC value per package, or an empty list.
+        """
+        if not self._instr_idx:
+            return []
+        return [f'{v:.4f}' for v in self._cur_ipc]
+
+    def run_end(self):
+        """Render the component-saturation heatmap to the output PNG.
+
+        Skipped when ``--no-plot`` is set or no samples were collected.
+        """
+        if self._no_plot:
+            return
+        if not self._times:
+            sys.stderr.write('note: no samples collected; nothing to plot\n')
+            return
+        labels = [label for _, _, _, label in self._signals]
+        _render_heatmap(self._times, labels, self._rows, self._ipc_rows(),
+                        self._fom_path, self._out_path)
+
+    def _ipc_rows(self):
+        """Return the derived per-package IPC rows for rendering.
+
+        Returns:
+            list of tuple: ``(label, series)`` pairs, one per package, or an
+                empty list when no IPC counters were sampled.
+        """
+        if not self._ipc_packages or not self._ipc:
+            return []
+        series = list(zip(*self._ipc))
+        multi = len(self._ipc_packages) > 1
+        rows = []
+        for pos, pkg in enumerate(self._ipc_packages):
+            label = (f'{_IPC_LABEL} {_domain_tag(_IPC_DOMAIN)}{pkg}'
+                     if multi else _IPC_LABEL)
+            rows.append((label, list(series[pos])))
+        return rows
+
+    @staticmethod
+    def _discover_signals():
+        """Return the granted candidate signals expanded over all domains.
+
+        Each granted candidate is expanded into one entry per domain index
+        of its domain type (e.g. one per package, one per GPU).  Returns a
+        list of ``(signal_name, domain, domain_index, label)`` tuples; the
+        label is suffixed with the domain index when more than one index is
+        sampled.
+        """
+        names = set(pio.signal_names())
+        signals = []
+        for name, domain, label in _CANDIDATE_SIGNALS:
+            if name not in names:
+                continue
+            count = topo.num_domain(domain)
+            for index in range(count):
+                row_label = (f'{label} {_domain_tag(domain)}{index}'
+                             if count > 1 else label)
+                signals.append((name, domain, index, row_label))
+        dropped = [name for name, _, _ in _CANDIDATE_SIGNALS if name not in names]
+        if dropped:
+            sys.stderr.write(
+                f'note: skipping unavailable signals: {", ".join(dropped)}\n')
+        if not signals:
+            raise RuntimeError(
+                'HeatmapAgent: none of the candidate signals are available '
+                'on this platform')
+        return signals
+
+
+def _domain_tag(domain):
+    """Return the short row-label tag for a domain type (e.g. package->pkg)."""
+    return _DOMAIN_TAG.get(domain, domain)
+
+
+def _signal_columns(columns, name):
+    """Return the trace columns belonging to a signal, ordered by index.
+
+    geopmsession writes board-domain signals without a suffix and other
+    domains as ``NAME-domain-index``.  Returns a list of
+    ``(domain, index, column)`` tuples ordered by domain index.
+
+    Args:
+        columns (list of str): Available trace column names.
+        name (str): Signal name.
+
+    Returns:
+        list of tuple: ``(domain, index, column)`` for each matching column.
+    """
+    pattern = re.compile(re.escape(name) + r'-([A-Za-z_]+)-(\d+)$')
+    matched = []
+    for column in columns:
+        if column == name:
+            matched.append(('board', 0, column))
+            continue
+        found = pattern.match(column)
+        if found:
+            matched.append((found.group(1), int(found.group(2)), column))
+    matched.sort(key=lambda entry: entry[1])
+    return matched
+
+
+def _match_column(columns, name, domain, index):
+    """Return the trace column for a request, or None if absent.
+
+    geopmsession writes board-domain signals without a domain suffix and
+    other domains as ``NAME-domain-index``.
+
+    Args:
+        columns (list of str): Available trace column names.
+        name (str): Signal name.
+        domain (str): Domain type name.
+        index (int): Domain index.
+
+    Returns:
+        str or None: The matching column name, or None.
+    """
+    for candidate in (f'{name}-{domain}-{index}', name):
+        if candidate in columns:
+            return candidate
+    return None
+
+
+def _sanitize_unit(value, bounded):
+    """Ignore out-of-range readings for unit-interval signals.
+
+    Args:
+        value (float): Raw sampled value.
+        bounded (bool): True when the signal is physically bounded to [0, 1].
+
+    Returns:
+        float: ``value`` unchanged, or NaN when ``bounded`` and the value
+            falls outside [0, 1] (an erroneous Level Zero reading).  NaN
+            samples are dropped by the per-row percentile normalization
+            instead of being clipped to a bound.
+    """
+    if bounded and not 0.0 <= value <= 1.0:
+        return float('nan')
+    return value
+
+
+def _delta_ipc(d_instr, d_cycles):
+    """Return a bounded IPC from a counter delta, or NaN if not derivable.
+
+    Guards against a non-positive cycle delta and clips to ``_IPC_MAX`` so a
+    near-zero denominator cannot produce a spike that dominates the per-row
+    normalization.
+
+    Args:
+        d_instr (float): Retired-instruction delta over the interval.
+        d_cycles (float): Unhalted-cycle delta over the interval.
+
+    Returns:
+        float: IPC in ``[0, _IPC_MAX]``, or NaN.
+    """
+    if d_cycles <= 0:
+        return float('nan')
+    ipc = d_instr / d_cycles
+    if ipc < 0.0:
+        return float('nan')
+    return min(ipc, _IPC_MAX)
+
+
+def _ipc_series(instr, cycles):
+    """Return a bounded per-sample IPC series from cumulative counters.
+
+    Args:
+        instr (numpy.ndarray): Cumulative retired instructions.
+        cycles (numpy.ndarray): Cumulative unhalted cycles.
+
+    Returns:
+        numpy.ndarray: Per-sample IPC, clipped to ``[0, _IPC_MAX]``, with the
+            first (delta-less) sample back-filled from the second.
+    """
+    import numpy as np
+    d_instr = np.diff(instr, prepend=np.nan)
+    d_cycles = np.diff(cycles, prepend=np.nan)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        ipc = np.where(d_cycles > 0, d_instr / d_cycles, np.nan)
+    ipc = np.clip(ipc, 0.0, _IPC_MAX)
+    if len(ipc) > 1:
+        ipc[0] = ipc[1]
+    return ipc
+
+
+def _ipc_from_trace(df, columns):
+    """Derive or read per-package IPC rows from a loaded trace.
+
+    Prefers deriving one IPC row per package from the deltas of the
+    ``CPU_INSTRUCTIONS_RETIRED`` and ``CPU_CYCLES_THREAD`` counters when both
+    are present per package; otherwise uses existing ``IPC`` columns (as
+    written by this agent's trace_out).
+
+    Args:
+        df (pandas.DataFrame): The loaded trace.
+        columns (list of str): Available trace column names.
+
+    Returns:
+        list of tuple: ``(label, series)`` pairs, one per package, or [].
+    """
+    instr_cols = _signal_columns(columns, _IPC_INSTR)
+    cycles_cols = _signal_columns(columns, _IPC_CYCLES)
+    if instr_cols and cycles_cols:
+        cyc_by_key = {(domain, index): column
+                      for domain, index, column in cycles_cols}
+        multi = len(instr_cols) > 1
+        rows = []
+        for domain, index, instr_col in instr_cols:
+            cycles_col = cyc_by_key.get((domain, index))
+            if cycles_col is None:
+                continue
+            instr = df[instr_col].astype(float).to_numpy()
+            cycles = df[cycles_col].astype(float).to_numpy()
+            label = (f'{_IPC_LABEL} {_domain_tag(domain)}{index}'
+                     if multi else _IPC_LABEL)
+            rows.append((label, _ipc_series(instr, cycles).tolist()))
+        if rows:
+            return rows
+    ipc_cols = _signal_columns(columns, 'IPC')
+    if ipc_cols:
+        multi = len(ipc_cols) > 1
+        return [((f'{_IPC_LABEL} {_domain_tag(domain)}{index}'
+                  if multi else _IPC_LABEL),
+                 df[column].astype(float).tolist())
+                for domain, index, column in ipc_cols]
+    return []
+
+
+def _load_trace(csv_path):
+    """Load a geopmsession trace CSV into heatmap render inputs.
+
+    Selects the candidate component columns that are present, resolves the
+    TIME column, and derives (or reads) an IPC series.
+
+    Args:
+        csv_path (str): Path to an existing geopmsession trace CSV.
+
+    Returns:
+        tuple: ``(times, labels, rows, ipc_rows)`` suitable for
+            ``_render_heatmap``.
+
+    Raises:
+        RuntimeError: pandas is unavailable, or the trace lacks a TIME column
+            or any of the candidate component signals.
+    """
+    try:
+        import pandas as pd
+    except ImportError as ex:
+        raise RuntimeError(
+            'HeatmapAgent --replot-csv requires pandas; install with '
+            '"pip install geopmdpy[heatmap]".') from ex
+
+    df = pd.read_csv(csv_path)
+    df.columns = [str(c).strip().strip('"') for c in df.columns]
+    columns = list(df.columns)
+
+    time_col = _match_column(columns, 'TIME', 'board', 0)
+    if time_col is None:
+        time_candidates = [c for c in columns if 'TIME' in c.upper()]
+        if not time_candidates:
+            raise RuntimeError(f'No TIME column found in {csv_path}')
+        time_col = time_candidates[0]
+    times = df[time_col].astype(float).tolist()
+
+    labels = []
+    cols = []
+    bounded_cols = set()
+    for name, domain, label in _CANDIDATE_SIGNALS:
+        matched = _signal_columns(columns, name)
+        multi = len(matched) > 1
+        for col_domain, index, column in matched:
+            labels.append(f'{label} {_domain_tag(col_domain)}{index}'
+                          if multi else label)
+            cols.append(column)
+            if name in _UNIT_INTERVAL_SIGNALS:
+                bounded_cols.add(column)
+    if not cols:
+        raise RuntimeError(
+            f'None of the expected component signal columns are in {csv_path}')
+    frame = df[cols].astype(float)
+    # Ignore (rather than clip) erroneous out-of-range readings for the
+    # unit-interval signals so a single Level Zero glitch does not distort the
+    # per-row normalization.
+    for column in bounded_cols:
+        series = frame[column]
+        frame[column] = series.where((series >= 0.0) & (series <= 1.0))
+    rows = frame.values.tolist()
+
+    ipc_rows = _ipc_from_trace(df, columns)
+    return times, labels, rows, ipc_rows
+
+
+def _base_label(label):
+    """Return a row label with any trailing domain-index suffix removed.
+
+    Multi-index rows are labeled like ``'CPU power pkg0'`` or
+    ``'GPU power gpu3'``; the group lookup keys on the base label
+    (``'CPU power'``), so strip the ``' pkg<N>'`` / ``' gpu<N>'`` suffix.
+
+    Args:
+        label (str): A row label, possibly with a domain-index suffix.
+
+    Returns:
+        str: The base label.
+    """
+    suffix = r' (?:%s)\d+$' % '|'.join(
+        re.escape(tag) for tag in _DOMAIN_TAG.values())
+    return re.sub(suffix, '', label)
+
+
+def _group_rows(series_by_label):
+    """Partition rows into the labeled component panels.
+
+    Args:
+        series_by_label (list of tuple): ``(label, row)`` pairs in the order
+            they were sampled.
+
+    Returns:
+        list of tuple: ``(group_title, accent_color, [(label, row), ...])``
+            for each non-empty group, in ``_ROW_GROUPS`` order, with any rows
+            not matched by a group collected into a trailing "Other" panel.
+    """
+    by_base = {}
+    for label, row in series_by_label:
+        by_base.setdefault(_base_label(label), []).append((label, row))
+
+    panels = []
+    consumed = set()
+    for title, base_labels, color in _ROW_GROUPS:
+        rows_p = []
+        for base in base_labels:
+            for pair in by_base.get(base, []):
+                rows_p.append(pair)
+                consumed.add(pair[0])
+        if rows_p:
+            panels.append((title, color, rows_p))
+
+    leftovers = [(label, row) for label, row in series_by_label
+                 if label not in consumed]
+    if leftovers:
+        panels.append(('Other', '0.4', leftovers))
+    return panels
+
+
+def _render_heatmap(times, labels, rows, ipc_rows, fom_path, out_path):
+    """Render the accumulated samples as a normalized heatmap PNG.
+
+    Heavy plotting dependencies are imported here so that importing this
+    module (and running the unit tests) does not require matplotlib.
+
+    Each component group is drawn in its own labeled, color-accented panel
+    (subplot), stacked top to bottom and sharing the time axis, with an
+    optional figure-of-merit panel at the bottom.
+
+    Args:
+        times (list of float): Sample timestamps in seconds.
+        labels (list of str): Component row labels.
+        rows (list of list of float): Per-sample component values.
+        ipc_rows (list of tuple): ``(label, series)`` pairs for derived IPC
+            rows (one per package); may be empty.
+        fom_path (str or None): Optional FOM CSV path to overlay.
+        out_path (str): Output PNG path.
+    """
+    try:
+        import numpy as np
+        import matplotlib
+        matplotlib.use('Agg')  # headless-safe
+        import matplotlib.pyplot as plt
+    except ImportError as ex:
+        raise RuntimeError(
+            'HeatmapAgent rendering requires matplotlib (and numpy); install '
+            'with "pip install geopmdpy[heatmap]" or pass --no-plot.') from ex
+
+    times = np.asarray(times, dtype=float)
+    times = times - times[0]
+
+    # Assemble every row (component signals then derived IPC) as a
+    # (label, series) pair; grouping and ordering are resolved by label.
+    series_by_label = []
+    comp_matrix = np.asarray(rows, dtype=float).T
+    for label, row in zip(labels, comp_matrix):
+        series_by_label.append((label, row))
+    for ipc_label, ipc_series in (ipc_rows or []):
+        ipc_row = np.asarray(ipc_series, dtype=float)
+        if len(ipc_row) > 1 and np.isnan(ipc_row[0]):
+            ipc_row[0] = ipc_row[1]  # first period has no delta; back-fill
+        series_by_label.append((ipc_label, ipc_row))
+
+    # Normalize each row to its own 1st-99th percentile range rather than its
+    # raw min-max.  A single garbage sample (e.g. a Level Zero counter glitch
+    # reporting GPU_UTILIZATION in the thousands, or an MSR ratio spike) would
+    # otherwise blow out the min-max scale and collapse every real value to
+    # ~0, washing the whole row to black.  Percentile clipping ignores those
+    # rare outliers so the row's actual dynamics remain visible.
+    matrix = np.vstack([row for _, row in series_by_label])
+    lo = np.nanpercentile(matrix, 1, axis=1, keepdims=True)
+    hi = np.nanpercentile(matrix, 99, axis=1, keepdims=True)
+    norm = np.clip((matrix - lo) / (hi - lo + 1e-9), 0.0, 1.0)
+    norm_by_label = {label: norm[idx]
+                     for idx, (label, _) in enumerate(series_by_label)}
+
+    # Ignored samples (out-of-range unit-interval readings set to NaN) are
+    # drawn in a neutral gray so they read as "no data" rather than as a
+    # zero-activity (black) or full-activity (bright) cell.
+    cmap = matplotlib.colormaps['magma'].copy()
+    cmap.set_bad(color='0.5')
+
+    panels = _group_rows(
+        [(label, norm_by_label[label]) for label, _ in series_by_label])
+    row_counts = [len(rows_p) for _, _, rows_p in panels]
+    total_rows = sum(row_counts) or 1
+
+    have_fom = fom_path is not None
+    height_ratios = list(row_counts) + ([2] if have_fom else [])
+    n_axes = len(panels) + (1 if have_fom else 0)
+
+    # Keep each heatmap row thin, add a little padding per panel, and cap the
+    # overall height so many-socket/many-GPU nodes stay readable.
+    fig_h = min(0.3 * total_rows + 0.55 * len(panels)
+                + (1.5 if have_fom else 0.5), 20.0)
+    fig, axes = plt.subplots(
+        n_axes, 1, figsize=(12, fig_h), sharex=True, squeeze=False,
+        gridspec_kw={'height_ratios': height_ratios}, layout='constrained')
+    axes = axes[:, 0]
+    heat_axes = axes[:len(panels)]
+
+    im = None
+    x0, x1 = float(times[0]), float(times[-1])
+    for ax, (title, color, rows_p) in zip(heat_axes, panels):
+        panel = np.vstack([row for _, row in rows_p])
+        n = len(rows_p)
+        im = ax.imshow(panel, aspect='auto', cmap=cmap,
+                       interpolation='nearest', extent=[x0, x1, n, 0],
+                       vmin=0.0, vmax=1.0)
+        ax.set_yticks(np.arange(n) + 0.5)
+        ax.set_yticklabels([label for label, _ in rows_p])
+        ax.set_ylabel(title, color=color, fontweight='bold')
+        # Accent the panel frame in the group color to highlight the grouping.
+        for spine in ax.spines.values():
+            spine.set_color(color)
+            spine.set_linewidth(2.0)
+
+    fig.colorbar(im, ax=list(heat_axes), fraction=0.025, pad=0.02,
+                 label='normalized activity (per-row 1st-99th pctile)')
+
+    if have_fom:
+        import pandas as pd
+        ax_fom = axes[-1]
+        fom = pd.read_csv(fom_path)
+        fom.columns = [str(c).strip() for c in fom.columns]
+        ft = fom.iloc[:, 0].astype(float)
+        fv = fom.iloc[:, 1].astype(float)
+        ax_fom.plot(ft - ft.iloc[0], fv, color='tab:blue')
+        ax_fom.set_ylabel('FOM')
+        ax_fom.grid(True, alpha=0.3)
+    axes[-1].set_xlabel('time (s)')
+
+    fig.suptitle('GEOPM component-saturation heatmap')
+    fig.savefig(out_path, dpi=120)
+    sys.stderr.write(f'wrote {out_path}\n')
+
+
+if __name__ == '__main__':
+    sys.exit(main(HeatmapAgent()))

--- a/geopmdpy/geopmdpy/heatmap_agent.py
+++ b/geopmdpy/geopmdpy/heatmap_agent.py
@@ -34,10 +34,10 @@ components, so this shows per-component saturation over time rather than a
 data-flow diagram.
 
 Example usage:
-    python -m geopmdpy.heatmap_agent -t 30
-    python -m geopmdpy.heatmap_agent -t 60 --heatmap-out hm.png --fom fom.csv
-    python -m geopmdpy.heatmap_agent -t 30 -o trace.csv --no-plot
-    python -m geopmdpy.heatmap_agent --replot-csv trace.csv --heatmap-out hm.png
+    python3 -m geopmdpy.heatmap_agent -t 30
+    python3 -m geopmdpy.heatmap_agent -t 60 --heatmap-out hm.png --fom fom.csv
+    python3 -m geopmdpy.heatmap_agent -t 30 -o trace.csv --no-plot
+    python3 -m geopmdpy.heatmap_agent --replot-csv trace.csv --heatmap-out hm.png
 """
 
 import re
@@ -152,7 +152,7 @@ class HeatmapAgent(Agent):
                       session is run).
 
     Example:
-        python -m geopmdpy.heatmap_agent -t 30 --heatmap-out heatmap.png
+        python3 -m geopmdpy.heatmap_agent -t 30 --heatmap-out heatmap.png
     """
 
     def __init__(self):

--- a/geopmdpy/pyproject.toml
+++ b/geopmdpy/pyproject.toml
@@ -73,6 +73,12 @@ optimize = [
     "scikit-optimize>=0.9.0",
 ]
 
+heatmap = [
+    "matplotlib>=3.3.0",
+    "numpy>=1.19.0",
+    "pandas>=1.1.0",
+]
+
 [project.scripts]
 geopmd = "geopmdpy.__main__:main"
 geopmaccess = "geopmdpy.access:main"

--- a/geopmdpy/setup.cfg
+++ b/geopmdpy/setup.cfg
@@ -22,6 +22,10 @@ stats =
     seaborn>=0.11.2
     pyyaml>=6.0.0
     prometheus_client>=0.7.1
+heatmap =
+    matplotlib>=3.3.0
+    numpy>=1.19.0
+    pandas>=1.1.0
 dbus_xml =
     docstring-parser>0.13
 grpc =

--- a/geopmdpy/test/TestHeatmapAgent.py
+++ b/geopmdpy/test/TestHeatmapAgent.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2026 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+import math
+import unittest
+from unittest import mock
+from argparse import ArgumentParser
+from argparse import Namespace
+
+# Patch dlopen to allow the tests to run when there is no build
+with mock.patch('cffi.FFI.dlopen', return_value=mock.MagicMock()):
+    from geopmdpy import heatmap_agent
+    from geopmdpy.heatmap_agent import HeatmapAgent
+    from geopmdpy.session import get_parser
+
+
+class TestHeatmapAgent(unittest.TestCase):
+    def setUp(self):
+        self._test_name = 'TestHeatmapAgent'
+
+    def test_help_nonempty(self):
+        self.assertIsInstance(HeatmapAgent().help(), str)
+        self.assertTrue(HeatmapAgent().help())
+
+    def test_update_parser_adds_options(self):
+        agent = HeatmapAgent()
+        parser = agent.update_parser(get_parser())
+        args = parser.parse_args([])
+        self.assertEqual('component_heatmap.png', args.heatmap_out)
+        self.assertIsNone(args.fom)
+        self.assertFalse(args.no_plot)
+        self.assertIsNone(args.replot_csv)
+        # The agent lowers the default sampling period.
+        self.assertEqual(heatmap_agent._PERIOD_DEFAULT, args.period)
+        args = parser.parse_args(['--heatmap-out', 'hm.png', '--fom', 'f.csv',
+                                  '--no-plot', '--replot-csv', 'trace.csv'])
+        self.assertEqual('hm.png', args.heatmap_out)
+        self.assertEqual('f.csv', args.fom)
+        self.assertTrue(args.no_plot)
+        self.assertEqual('trace.csv', args.replot_csv)
+
+    def test_update_parser_corrects_signal_config_help(self):
+        # The agent supplies a default signal set, so the -i/--signal-config
+        # help must not claim standard input is the default.
+        agent = HeatmapAgent()
+        parser = agent.update_parser(get_parser())
+        help_text = next(action.help for action in parser._actions
+                         if action.dest == 'config_path')
+        self.assertNotIn('standard input', help_text)
+        self.assertIn('built-in signal set', help_text)
+
+    def test_update_args_sets_options(self):
+        agent = HeatmapAgent()
+        agent.update_args(Namespace(heatmap_out='hm.png', fom='f.csv',
+                                    no_plot=True, replot_csv=None))
+        self.assertEqual('hm.png', agent._out_path)
+        self.assertEqual('f.csv', agent._fom_path)
+        self.assertTrue(agent._no_plot)
+
+    def test_signal_config_override_selects_available(self):
+        # Only granted candidate signals appear, prefixed by TIME, and every
+        # domain index is requested with the '*' wildcard.
+        names = ['TIME', 'CPU_POWER', 'DRAM_POWER', 'CPU_FREQUENCY_STATUS']
+        agent = HeatmapAgent()
+        with mock.patch.object(heatmap_agent.pio, 'signal_names',
+                               return_value=names):
+            override = agent.signal_config_override()
+        self.assertEqual('TIME board 0\n'
+                         'CPU_POWER package *\n'
+                         'CPU_FREQUENCY_STATUS package *\n'
+                         'DRAM_POWER package *\n', override)
+
+    def test_signal_config_override_no_signals_raises(self):
+        agent = HeatmapAgent()
+        with mock.patch.object(heatmap_agent.pio, 'signal_names',
+                               return_value=['SOME_OTHER_SIGNAL']):
+            with self.assertRaises(RuntimeError):
+                agent.signal_config_override()
+
+    def test_discover_signals_expands_all_domains(self):
+        # Each granted candidate is expanded to one row per domain index, with
+        # the domain index appended to the label when more than one exists.
+        names = ['CPU_POWER', 'GPU_POWER']
+
+        def fake_num_domain(domain):
+            return {'package': 2, 'gpu': 3}.get(domain, 1)
+
+        with mock.patch.object(heatmap_agent.pio, 'signal_names',
+                               return_value=names), \
+                mock.patch.object(heatmap_agent.topo, 'num_domain',
+                                  side_effect=fake_num_domain):
+            signals = HeatmapAgent._discover_signals()
+        self.assertEqual(
+            [('CPU_POWER', 'package', 0, 'CPU power pkg0'),
+             ('CPU_POWER', 'package', 1, 'CPU power pkg1'),
+             ('GPU_POWER', 'gpu', 0, 'GPU power gpu0'),
+             ('GPU_POWER', 'gpu', 1, 'GPU power gpu1'),
+             ('GPU_POWER', 'gpu', 2, 'GPU power gpu2')],
+            signals)
+
+    def test_ipc_derivation_and_trace(self):
+        names = ['TIME', 'CPU_POWER', 'CPU_INSTRUCTIONS_RETIRED',
+                 'CPU_CYCLES_THREAD']
+        # push_signal hands out sequential handles mapped back to signal names.
+        handle_name = {}
+
+        def fake_push(name, domain, index):
+            handle = len(handle_name)
+            handle_name[handle] = name
+            return handle
+
+        # Two periods of samples per signal; counters advance by 200 instr /
+        # 100 cycles between periods -> IPC == 2.0 on the second period.
+        sample_values = {
+            'TIME': [0.0, 0.05],
+            'CPU_POWER': [50.0, 60.0],
+            'CPU_INSTRUCTIONS_RETIRED': [1000.0, 1200.0],
+            'CPU_CYCLES_THREAD': [500.0, 600.0],
+        }
+        cursor = {}
+
+        def fake_sample(handle):
+            name = handle_name[handle]
+            index = cursor.get(handle, 0)
+            cursor[handle] = index + 1
+            return sample_values[name][index]
+
+        agent = HeatmapAgent()
+        agent.update_args(Namespace(heatmap_out='x.png', fom=None,
+                                    no_plot=True, replot_csv=None))
+        with mock.patch.object(heatmap_agent.pio, 'signal_names',
+                               return_value=names), \
+                mock.patch.object(heatmap_agent.pio, 'control_names',
+                                  return_value=[]), \
+                mock.patch.object(heatmap_agent.topo, 'num_domain',
+                                  return_value=1), \
+                mock.patch.object(heatmap_agent.pio, 'push_signal',
+                                  side_effect=fake_push), \
+                mock.patch.object(heatmap_agent.pio, 'sample',
+                                  side_effect=fake_sample):
+            agent.run_begin()
+            self.assertEqual(['IPC-package-0'], agent.header_names())
+            agent.update_loop()  # first period: no delta yet
+            agent.update_loop()  # second period: IPC = 200 / 100
+
+        self.assertEqual([2.0], agent._ipc[-1])
+        self.assertEqual(['2.0000'], agent.trace_out())
+        ipc_rows = agent._ipc_rows()
+        self.assertEqual(1, len(ipc_rows))
+        self.assertEqual('CPU IPC', ipc_rows[0][0])
+        self.assertEqual(2.0, ipc_rows[0][1][-1])
+
+    def test_ipc_is_per_package(self):
+        names = ['TIME', 'CPU_POWER', 'CPU_INSTRUCTIONS_RETIRED',
+                 'CPU_CYCLES_THREAD']
+        handle_name = {}
+
+        def fake_push(name, domain, index):
+            handle = len(handle_name)
+            handle_name[handle] = (name, index)
+            return handle
+
+        # package 0: 200 instr / 100 cycles -> IPC 2.0; package 1: 300 / 100.
+        per_pkg = {
+            ('CPU_POWER', 0): [50.0, 60.0],
+            ('CPU_POWER', 1): [55.0, 65.0],
+            ('CPU_INSTRUCTIONS_RETIRED', 0): [1000.0, 1200.0],
+            ('CPU_INSTRUCTIONS_RETIRED', 1): [2000.0, 2300.0],
+            ('CPU_CYCLES_THREAD', 0): [500.0, 600.0],
+            ('CPU_CYCLES_THREAD', 1): [700.0, 800.0],
+            ('TIME', 0): [0.0, 0.05],
+        }
+        cursor = {}
+
+        def fake_sample(handle):
+            key = handle_name[handle]
+            index = cursor.get(handle, 0)
+            cursor[handle] = index + 1
+            return per_pkg[key][index]
+
+        agent = HeatmapAgent()
+        agent.update_args(Namespace(heatmap_out='x.png', fom=None,
+                                    no_plot=True, replot_csv=None))
+        with mock.patch.object(heatmap_agent.pio, 'signal_names',
+                               return_value=names), \
+                mock.patch.object(heatmap_agent.pio, 'control_names',
+                                  return_value=[]), \
+                mock.patch.object(heatmap_agent.topo, 'num_domain',
+                                  return_value=2), \
+                mock.patch.object(heatmap_agent.pio, 'push_signal',
+                                  side_effect=fake_push), \
+                mock.patch.object(heatmap_agent.pio, 'sample',
+                                  side_effect=fake_sample):
+            agent.run_begin()
+            self.assertEqual(['IPC-package-0', 'IPC-package-1'],
+                             agent.header_names())
+            agent.update_loop()  # first period: no delta yet
+            agent.update_loop()  # second period
+
+        self.assertEqual([2.0, 3.0], agent._ipc[-1])
+        ipc_rows = agent._ipc_rows()
+        self.assertEqual(['CPU IPC pkg0', 'CPU IPC pkg1'],
+                         [label for label, _ in ipc_rows])
+        self.assertEqual(2.0, ipc_rows[0][1][-1])
+        self.assertEqual(3.0, ipc_rows[1][1][-1])
+
+    def test_header_names_before_run_begin(self):
+        # Regression: the session calls header_names() BEFORE run_begin(), so
+        # the IPC columns must resolve without relying on run_begin, otherwise
+        # the agent-derived IPC columns never reach the -o trace.
+        names = ['TIME', 'CPU_POWER', 'CPU_INSTRUCTIONS_RETIRED',
+                 'CPU_CYCLES_THREAD']
+        agent = HeatmapAgent()
+        with mock.patch.object(heatmap_agent.pio, 'signal_names',
+                               return_value=names), \
+                mock.patch.object(heatmap_agent.topo, 'num_domain',
+                                  return_value=2):
+            # No run_begin() call here, mirroring the session's ordering.
+            self.assertEqual(['IPC-package-0', 'IPC-package-1'],
+                             agent.header_names())
+
+    def test_run_begin_enables_fixed_counters(self):
+        # The fixed counters backing IPC can be left disabled on the platform,
+        # so run_begin must enable them (snapshotting first for auto-revert)
+        # for every enable control and every domain index.
+        names = ['TIME', 'CPU_POWER', 'CPU_INSTRUCTIONS_RETIRED',
+                 'CPU_CYCLES_THREAD']
+        agent = HeatmapAgent()
+        with mock.patch.object(heatmap_agent.pio, 'signal_names',
+                               return_value=names), \
+                mock.patch.object(heatmap_agent.pio, 'control_names',
+                                  return_value=list(
+                                      heatmap_agent._IPC_ENABLE_CONTROLS)), \
+                mock.patch.object(heatmap_agent.pio, 'control_domain_type',
+                                  return_value='cpu'), \
+                mock.patch.object(heatmap_agent.topo, 'num_domain',
+                                  side_effect=lambda d: 2 if d == 'cpu' else 1), \
+                mock.patch.object(heatmap_agent.pio, 'push_signal',
+                                  return_value=0), \
+                mock.patch.object(heatmap_agent.pio, 'save_control') as save, \
+                mock.patch.object(heatmap_agent.pio, 'write_control') as write:
+            agent.run_begin()
+
+        save.assert_called_once()
+        # Every enable control written to both CPU domain indices with value 1.
+        written = {(c.args[0], c.args[2]) for c in write.call_args_list}
+        expected = {(name, idx)
+                    for name in heatmap_agent._IPC_ENABLE_CONTROLS
+                    for idx in (0, 1)}
+        self.assertEqual(expected, written)
+        self.assertTrue(all(c.args[3] == 1.0 for c in write.call_args_list))
+        self.assertTrue(agent._counters_enabled)
+
+    def test_run_begin_without_enable_controls_skips(self):
+        # When the enable controls are absent (e.g. no MSR access) run_begin
+        # must not attempt any control write and must not snapshot controls.
+        names = ['TIME', 'CPU_POWER', 'CPU_INSTRUCTIONS_RETIRED',
+                 'CPU_CYCLES_THREAD']
+        agent = HeatmapAgent()
+        with mock.patch.object(heatmap_agent.pio, 'signal_names',
+                               return_value=names), \
+                mock.patch.object(heatmap_agent.pio, 'control_names',
+                                  return_value=[]), \
+                mock.patch.object(heatmap_agent.topo, 'num_domain',
+                                  return_value=1), \
+                mock.patch.object(heatmap_agent.pio, 'push_signal',
+                                  return_value=0), \
+                mock.patch.object(heatmap_agent.pio, 'save_control') as save, \
+                mock.patch.object(heatmap_agent.pio, 'write_control') as write:
+            agent.run_begin()
+
+        save.assert_not_called()
+        write.assert_not_called()
+        self.assertFalse(agent._counters_enabled)
+
+    def test_sanitize_unit_ignores_out_of_range(self):
+        # Unbounded signals pass through unchanged.
+        self.assertEqual(1234.0, heatmap_agent._sanitize_unit(1234.0, False))
+        # Bounded signals keep in-range values, including the endpoints.
+        self.assertEqual(0.0, heatmap_agent._sanitize_unit(0.0, True))
+        self.assertEqual(0.5, heatmap_agent._sanitize_unit(0.5, True))
+        self.assertEqual(1.0, heatmap_agent._sanitize_unit(1.0, True))
+        # Out-of-range readings for bounded signals become NaN (ignored).
+        self.assertTrue(math.isnan(heatmap_agent._sanitize_unit(10090.0, True)))
+        self.assertTrue(math.isnan(heatmap_agent._sanitize_unit(-0.1, True)))
+
+    def test_update_loop_ignores_out_of_range_activity(self):
+        # A GPU_UTILIZATION reading outside [0, 1] is stored as NaN so it is
+        # dropped by the normalization instead of clipped.
+        names = ['TIME', 'GPU_UTILIZATION']
+        handle_name = {}
+
+        def fake_push(name, domain, index):
+            handle = len(handle_name)
+            handle_name[handle] = name
+            return handle
+
+        values = {'TIME': [0.0], 'GPU_UTILIZATION': [10090.0]}
+        cursor = {}
+
+        def fake_sample(handle):
+            name = handle_name[handle]
+            index = cursor.get(handle, 0)
+            cursor[handle] = index + 1
+            return values[name][index]
+
+        agent = HeatmapAgent()
+        with mock.patch.object(heatmap_agent.pio, 'signal_names',
+                               return_value=names), \
+                mock.patch.object(heatmap_agent.pio, 'control_names',
+                                  return_value=[]), \
+                mock.patch.object(heatmap_agent.topo, 'num_domain',
+                                  return_value=1), \
+                mock.patch.object(heatmap_agent.pio, 'push_signal',
+                                  side_effect=fake_push), \
+                mock.patch.object(heatmap_agent.pio, 'sample',
+                                  side_effect=fake_sample):
+            agent.run_begin()
+            agent.update_loop()
+
+        self.assertTrue(math.isnan(agent._rows[-1][0]))
+
+    def test_delta_ipc_clips_spikes(self):
+        # A tiny positive cycle delta must not yield an unbounded IPC spike.
+        self.assertEqual(heatmap_agent._IPC_MAX,
+                         heatmap_agent._delta_ipc(1e9, 1.0))
+        self.assertEqual(2.0, heatmap_agent._delta_ipc(200.0, 100.0))
+        self.assertTrue(heatmap_agent._delta_ipc(200.0, 0.0) != # NaN guard
+                        heatmap_agent._delta_ipc(200.0, 0.0))
+
+    def test_replot_csv_renders_and_exits(self):
+        agent = HeatmapAgent()
+        loaded = ([0.0, 0.05], ['CPU power'], [[50.0], [60.0]], None)
+        with mock.patch.object(heatmap_agent, '_load_trace',
+                               return_value=loaded) as load_mock, \
+                mock.patch.object(heatmap_agent, '_render_heatmap') as render_mock:
+            with self.assertRaises(SystemExit) as ctx:
+                agent.update_args(Namespace(heatmap_out='hm.png', fom='f.csv',
+                                            no_plot=False, replot_csv='trace.csv'))
+        self.assertEqual(0, ctx.exception.code)
+        load_mock.assert_called_once_with('trace.csv')
+        render_mock.assert_called_once_with([0.0, 0.05], ['CPU power'],
+                                            [[50.0], [60.0]], None, 'f.csv',
+                                            'hm.png')
+
+    def test_match_column_prefers_domain_suffix(self):
+        columns = ['TIME', 'CPU_POWER-package-0', 'DRAM_POWER']
+        self.assertEqual('CPU_POWER-package-0',
+                         heatmap_agent._match_column(columns, 'CPU_POWER',
+                                                     'package', 0))
+        # Board-domain signals are written without a suffix.
+        self.assertEqual('DRAM_POWER',
+                         heatmap_agent._match_column(columns, 'DRAM_POWER',
+                                                     'package', 0))
+        self.assertIsNone(heatmap_agent._match_column(columns, 'GPU_POWER',
+                                                      'board', 0))
+
+    def test_signal_columns_orders_all_indices(self):
+        columns = ['TIME', 'CPU_POWER-package-1', 'CPU_POWER-package-0',
+                   'GPU_POWER-gpu-0', 'GPU_POWER-gpu-1', 'DRAM_POWER']
+        self.assertEqual(
+            [('package', 0, 'CPU_POWER-package-0'),
+             ('package', 1, 'CPU_POWER-package-1')],
+            heatmap_agent._signal_columns(columns, 'CPU_POWER'))
+        self.assertEqual(
+            [('gpu', 0, 'GPU_POWER-gpu-0'), ('gpu', 1, 'GPU_POWER-gpu-1')],
+            heatmap_agent._signal_columns(columns, 'GPU_POWER'))
+        # Board-domain signals are written without a suffix.
+        self.assertEqual([('board', 0, 'DRAM_POWER')],
+                         heatmap_agent._signal_columns(columns, 'DRAM_POWER'))
+
+    def test_header_and_trace_without_counters(self):
+        names = ['TIME', 'CPU_POWER']
+        agent = HeatmapAgent()
+        with mock.patch.object(heatmap_agent.pio, 'signal_names',
+                               return_value=names), \
+                mock.patch.object(heatmap_agent.topo, 'num_domain',
+                                  return_value=1), \
+                mock.patch.object(heatmap_agent.pio, 'push_signal',
+                                  side_effect=lambda *a: 0), \
+                mock.patch.object(heatmap_agent.pio, 'sample',
+                                  return_value=1.0):
+            agent.run_begin()
+            self.assertEqual([], agent.header_names())
+            self.assertEqual([], agent.trace_out())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/geopmpy/geopmpy/monitor.py
+++ b/geopmpy/geopmpy/monitor.py
@@ -13,8 +13,8 @@ a monitoring session with a default set of signals, and supports
 a --hi-res option to sample all signals at their native resolution.
 
 Example usage:
-    python -m geopmpy.monitor
-    python -m geopmpy.monitor --hi-res
+    python3 -m geopmpy.monitor
+    python3 -m geopmpy.monitor --hi-res
 """
 
 from geopmdpy import pio
@@ -34,7 +34,7 @@ class MonitorAgent(Agent):
       --hi-res   Measure signals at finest granularity (all domains/indices).
 
     Example:
-        python -m geopmpy.monitor --hi-res
+        python3 -m geopmpy.monitor --hi-res
 
     """
     def __init__(self):

--- a/integration/config/smng_env.sh
+++ b/integration/config/smng_env.sh
@@ -14,9 +14,9 @@
 unset OMP_NUM_THREADS # Set to 1 by a default lmod module
 
 # One time setup:
-# python -m pip install --user -U pip
-# python -m pip install --user --ignore-installed -r geopm/scripts/requirements.txt
-# python -m pip install --user --ignore-installed -r geopm/service/requirements.txt
+# python3 -m pip install --user -U pip
+# python3 -m pip install --user --ignore-installed -r geopm/scripts/requirements.txt
+# python3 -m pip install --user --ignore-installed -r geopm/service/requirements.txt
 
 export CC=icc
 export CXX=icpc

--- a/integration/experiment/outlier/README.md
+++ b/integration/experiment/outlier/README.md
@@ -4,7 +4,7 @@ been collected from a benchmark run, the outlier run is invoked with the
 individual trace files as arguments:
 
 ```
-$ python outlierdetection.py trace_dir/*.trace
+$ python3 outlierdetection.py trace_dir/*.trace
 ```
 
 This will (eventually) emit a table out outlier nodes:

--- a/integration/experiment/plotting.py
+++ b/integration/experiment/plotting.py
@@ -304,7 +304,7 @@ import code
 
 try:
     with open(os.devnull, 'w') as FNULL:
-        subprocess.check_call("python -c 'import matplotlib.pyplot'", stdout=FNULL, stderr=FNULL, shell=True)
+        subprocess.check_call("python3 -c 'import matplotlib.pyplot'", stdout=FNULL, stderr=FNULL, shell=True)
 except subprocess.CalledProcessError:
     sys.stderr.write('Warning: Unable to use default matplotlib backend ({}).  For interactive plotting,'
                      ' please install Tkinter support in the OS.  '

--- a/integration/test_skipped/test_levelzero_signals.py
+++ b/integration/test_skipped/test_levelzero_signals.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2015 - 2025 Intel Corporation
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/integration/tutorial/tutorial_env.sh
+++ b/integration/tutorial/tutorial_env.sh
@@ -45,7 +45,7 @@ if [ ! "$GEOPMPY_PKGDIR" ]; then
             echo 1>&2 "         Assuming GEOPMPY_PKGDIR=${GEOPMPY_PKGDIR}."
         fi
     else
-        if ! python -c 'import geopmdpy; import geopmpy' 2>/dev/null; then
+        if ! python3 -c 'import geopmdpy; import geopmpy' 2>/dev/null; then
             echo 1>&2 "Warning: Unable to find python site-packages in $GEOPM_LIB"
         fi
     fi


### PR DESCRIPTION
Add a pure-Python session Agent (run via 'python -m geopmdpy.heatmap_agent') that samples per-component power, activity, and frequency signals in-process through geopmdpy.pio and renders a normalized component-saturation heatmap (rows=components, cols=time) when the session ends. A component pinned near its own maximum while the others sit idle reads out as the bottleneck.

When CPU_INSTRUCTIONS_RETIRED and CPU_CYCLES_THREAD are both available, the agent derives a per-sample IPC row from their counter deltas and emits it as a trace column to help distinguish compute-bound from memory-bound regions. An external figure-of-merit series can be overlaid with --fom, and an existing geopmsession trace can be re-rendered with --replot-csv without running a session. Heavy plotting dependencies (numpy, matplotlib, pandas) are imported lazily so importing the module needs none of them.

Add TestHeatmapAgent unit tests covering help text, argument parsing, signal-config override, IPC derivation, trace columns, replot, and column matching.

Add a geopm_heatmap_agent(1) man page documenting the synopsis, options, requirements, and limitations, and register it in the docs man-page list.

<img width="1440" height="1620" alt="component_heatmap-ze_peer" src="https://github.com/user-attachments/assets/a08d28ed-6e39-4ebc-b7b4-74e121fb4f76" />
<img width="1440" height="1620" alt="component_heatmap-ze_peak" src="https://github.com/user-attachments/assets/ec0f2d4b-e112-4ac1-a461-ad13a7520caf" />
