### PR TITLE
geopmopt: rollover-safe energy optimization, optional --metric-regex, and failure penalties

### DIFF
--- a/docs/source/geopmopt.1.rst
+++ b/docs/source/geopmopt.1.rst
@@ -36,10 +36,13 @@ Synopsis
                     [--prefetch-disable-max PREFETCH_DISABLE_MAX]
                     [--prefetch-disable-step PREFETCH_DISABLE_STEP]
                     [--trials TRIALS] [--n-initial-points N_INITIAL_POINTS]
-                    --metric-regex METRIC_REGEX [--minimize] [--random-seed RANDOM_SEED]
+                    [--metric-regex METRIC_REGEX] [--minimize]
+                    [--random-seed RANDOM_SEED]
                     [--application-timeout APPLICATION_TIMEOUT]
                     [--output-file OUTPUT_FILE] [--verbosity {0,1,2,3}]
                     [--print-stdout] [--defer-write] [--efficiency EFFICIENCY_DOMAIN]
+                    [--metric-bound METRIC_BOUND] [--sample-period SAMPLE_PERIOD]
+                    [--penalty PENALTY]
                     [-- LAUNCH ...]
 
 Optimize CPU frequency for performance
@@ -106,8 +109,11 @@ The optimizer works by:
    functions to intelligently explore the parameter space, focusing on
    promising regions.
 
-4. **Metric Extraction**: Parses application output using Python regular
-   expressions to extract numeric performance metrics.
+4. **Metric Extraction**: Optionally parses application output using Python
+   regular expressions to extract a numeric performance metric. When no
+   ``--metric-regex`` is supplied the objective defaults to total wall-clock
+   runtime, or to total energy over the ``--efficiency`` domain when that option
+   is also given.
 
 The tool requires the ``scikit-optimize`` package for Bayesian optimization
 functionality: ``python3 -m pip install scikit-optimize``
@@ -272,14 +278,18 @@ Optimization Configuration
 
 --metric-regex METRIC_REGEX  .. _metric-regex option:
 
-    Python-style regular expression to extract the performance metric from
-    application output. The regex must capture the numeric value in a group.
-    Required option.
+    Python-style regular expression to extract the figure of merit from the
+    application's standard output. The regex must capture the numeric value in a
+    group. Optional: when omitted, the objective defaults to total wall-clock
+    runtime, or to total energy over the ``--efficiency`` domain when that option
+    is also provided.
 
 --minimize  .. _minimize option:
 
     Minimize the extracted metric instead of maximizing it. Useful for
-    optimizing energy consumption, execution time, or error rates.
+    optimizing energy consumption, execution time, or error rates. When
+    ``--metric-regex`` is omitted the objective (runtime or energy) is always
+    minimized regardless of this flag.
 
 --random-seed RANDOM_SEED  .. _random-seed option:
 
@@ -292,13 +302,51 @@ Optimization Configuration
 
 --efficiency EFFICIENCY_DOMAIN  .. _efficiency option:
 
-    Optimize for efficiency by dividing the extracted metric by average power
-    consumption. This finds configurations that maximize performance per watt.
-    When the ``--minimize`` option is provided, the average power consumption is
-    multiplied rather than divided.  This will minimize energy to completion if
-    the metric is time to completion.  The EFFICIENCY_DOMAIN determines the
-    components included in the power calculation and valid values are 'board',
-    'cpu', or 'gpu'.
+    Optimize for efficiency using the average power consumed over the specified
+    domain. When ``--metric-regex`` is provided, the extracted metric is divided
+    by average power (multiplied instead when ``--minimize`` is set, which
+    minimizes energy to completion if the metric is time to completion). When
+    ``--metric-regex`` is omitted, the objective becomes total energy over this
+    domain, measured directly from a ``geopmsession`` energy trace. The
+    EFFICIENCY_DOMAIN determines the components included in the power calculation
+    and valid values are ``board``, ``cpu``, or ``gpu``.
+
+--metric-bound METRIC_BOUND  .. _metric-bound option:
+
+    Minimize energy over the ``--efficiency`` domain subject to keeping the
+    ``--metric-regex`` figure of merit at or above this bound (at or below when
+    ``--minimize`` is set). This turns the run into a constrained optimization:
+    configurations that violate the bound are treated as infeasible and only the
+    feasible configuration with the lowest energy is reported. Requires both
+    ``--metric-regex`` and ``--efficiency``.
+
+--sample-period SAMPLE_PERIOD  .. _sample-period option:
+
+    ``geopmsession`` sampling period in seconds used when collecting the energy
+    trace for energy-based objectives (``--efficiency`` without a metric regex,
+    or ``--metric-bound``). Shorter periods improve energy-integration accuracy
+    at the cost of additional sampling overhead. Default: 0.01.
+
+--penalty PENALTY  .. _penalty option:
+
+    How to handle a *recoverable* trial failure (an application timeout, a
+    non-zero exit code, a missing or unparsable figure of merit, or a
+    non-positive power/runtime report). The value is one of:
+
+    ``auto`` (default)
+        Assign the failed trial an objective value strictly worse than every
+        successful trial observed so far, so the optimizer learns to avoid that
+        region and the run continues. If a failure occurs before any success,
+        a finite bootstrap penalty is used and a warning is logged.
+
+    ``none``
+        Abort the whole run on the first failed trial (the legacy behavior).
+
+    ``<number>``
+        Use this fixed numeric objective value for every failed trial.
+
+    Fatal errors (command not found, permission denied, configuration or report
+    parsing errors) always abort the run regardless of this setting.
 
 Output and Logging
 ~~~~~~~~~~~~~~~~~~
@@ -420,7 +468,8 @@ The resulting configuration file can be applied with:
 Minimization optimization
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Minimize execution time or energy consumption:
+Minimize a metric scraped from application output, such as an execution time it
+prints itself:
 
 .. code-block:: shell-session
 
@@ -429,6 +478,51 @@ Minimize execution time or energy consumption:
               --minimize \
               --trials 40 \
               -- ./timed_benchmark
+
+Minimize runtime without a metric regex
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the application does not print a figure of merit, omit ``--metric-regex``
+and ``geopmopt`` minimizes the total wall-clock runtime of the launch command
+directly:
+
+.. code-block:: shell-session
+
+   $ geopmopt --cpu-frequency package \
+              --cpu-uncore-frequency package \
+              --trials 40 \
+              -- ./timed_benchmark
+
+Minimize energy without a metric regex
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Combine ``--efficiency`` with no ``--metric-regex`` to minimize total energy
+over a domain, measured from a ``geopmsession`` energy trace rather than scraped
+from stdout:
+
+.. code-block:: shell-session
+
+   $ geopmopt --cpu-frequency package \
+              --cpu-uncore-frequency package \
+              --efficiency cpu \
+              --sample-period 0.01 \
+              --trials 40 \
+              -- ./compute_kernel
+
+Bounded-energy optimization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Minimize energy while holding a performance figure of merit at or above a bound.
+Configurations that drop below the bound are treated as infeasible:
+
+.. code-block:: shell-session
+
+   $ geopmopt --cpu-frequency package \
+              --metric-regex 'Throughput: ([0-9.]+)' \
+              --efficiency cpu \
+              --metric-bound 1200.0 \
+              --trials 40 \
+              -- ./throughput_app
 
 Energy efficiency optimization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -502,9 +596,11 @@ Optimize across all available control dimensions:
 Metric Extraction
 -----------------
 
-The ``--metric-regex`` option uses Python regular expressions to extract
-performance metrics from application output. The regex must capture the
-numeric value in a parenthesized group.
+The optional ``--metric-regex`` option uses Python regular expressions to
+extract performance metrics from application output. When supplied, the regex
+must capture the numeric value in a parenthesized group. When omitted, no
+scraping is performed and the objective defaults to runtime (or energy with
+``--efficiency``).
 
 Valid regex examples:
 
@@ -543,22 +639,40 @@ especially for expensive function evaluations.
 Error Handling
 --------------
 
-The optimizer handles various failure scenarios:
+The optimizer sorts evaluation failures into two categories.
 
-**Application Timeouts:** Applications exceeding ``--application-timeout`` are
-terminated and receive a penalty score.
+**Recoverable failures** do not abort the run. By default (``--penalty auto``)
+the failed trial is assigned an objective worse than every success, is logged at
+warning level, and is excluded from best-configuration selection, so a single
+flaky trial no longer discards the measurements already collected. The
+recoverable set is:
 
-**Configuration Errors:** Invalid control parameters are detected early using
-the GEOPM PIO interface.
+- **Application Timeouts:** Applications exceeding ``--application-timeout`` are
+  terminated and the trial is penalized.
+- **Application Failures:** Non-zero exit codes (with captured stderr) penalize
+  the trial.
+- **Metric Scrape Misses:** A ``--metric-regex`` that does not match, or a
+  matched value that cannot be parsed as a number, penalizes the trial.
+- **No Output:** A trial that produces no stdout when a metric is expected is
+  penalized.
+- **Bad Energy Report:** A ``geopmsession`` energy trace with non-positive
+  runtime or non-positive power penalizes the trial.
 
-**Regex Failures:** Missing or invalid metric patterns are reported with
-suggestions for debugging.
+Use ``--penalty none`` to restore the legacy behavior of aborting on the first
+recoverable failure, or ``--penalty <number>`` to assign a fixed penalty value.
 
-**Application Failures:** Non-zero exit codes and stderr output are captured
-and logged.
+**Fatal errors** always abort the run regardless of ``--penalty``:
 
-**Optimization Failures:** Issues with the Bayesian optimization algorithm
-are reported with diagnostic information.
+- **Missing Command / Permissions:** A launch command that cannot be found or
+  executed.
+- **Configuration Errors:** Invalid control parameters, detected early using the
+  GEOPM PIO interface.
+- **Report Parsing Errors:** A missing or malformed ``geopmsession`` report.
+- **Optimization Failures:** Issues with the Bayesian optimization algorithm
+  are reported with diagnostic information.
+
+If *every* trial fails, the run stops with a clear "All trials failed" error
+rather than emitting a meaningless configuration.
 
 
 Best Practices

--- a/geopmdpy/geopmdpy/optimizer.py
+++ b/geopmdpy/geopmdpy/optimizer.py
@@ -48,6 +48,12 @@ except ImportError:
 # what makes the report energy delta rollover-safe (issue #4043).
 _DEFAULT_SAMPLE_PERIOD = 0.01
 
+# Default weight applied to the bound-violation penalty of the ENERGY_BOUNDED
+# objective. The penalty is scaled by the observed energy magnitude so that a
+# fully violated bound is at least as costly as a representative trial's energy;
+# the weight lets that penalty be tuned relative to energy differences.
+_DEFAULT_BOUND_PENALTY_WEIGHT = 1.0
+
 # Module-level logger
 logger = logging.getLogger(__name__)
 
@@ -496,6 +502,11 @@ class BayesianOptimizer:
         self.evaluation_history = []
         self.config_file = config_file
 
+        # ENERGY_BOUNDED state, (re)initialized at the start of optimize().
+        self._metric_bound = None
+        self._penalty_weight = _DEFAULT_BOUND_PENALTY_WEIGHT
+        self._energy_scale = None
+
         logger.debug(f"Initialized optimizer with {len(self.space)} dimensions")
 
     def _create_search_space(self) -> List[Integer]:
@@ -569,13 +580,36 @@ class BayesianOptimizer:
 
         return self.evaluator.evaluate(self.control_grid, coordinate, self.config_file)
 
+    def _bound_violation(self, fom: float) -> float:
+        """Return the normalized amount by which a FoM misses the bound.
+
+        The violation is expressed as a fraction of the bound magnitude so it
+        is dimensionless and comparable across problems. It is zero for a
+        feasible trial and positive for an infeasible one. When maximizing the
+        figure of merit the bound is a floor (feasible when ``fom >= bound``);
+        when minimizing it is a ceiling (feasible when ``fom <= bound``).
+
+        Args:
+            fom: Figure of merit scraped from the trial.
+
+        Returns:
+            float: Non-negative normalized bound violation.
+        """
+        bound = self._metric_bound
+        scale = abs(bound) if bound != 0 else 1.0
+        if self.evaluator.maximize:
+            return max(0.0, bound - fom) / scale
+        return max(0.0, fom - bound) / scale
+
     def _score_result(self, trial: TrialResult,
                       objective_mode: ObjectiveMode) -> float:
         """Reduce a TrialResult to the scalar objective value to minimize.
 
         Runtime and energy objectives are minimized directly. For the figure
         of merit objectives the maximize/minimize sign convention is applied
-        and, for the efficiency objective, average power is folded in.
+        and, for the efficiency objective, average power is folded in. The
+        energy-bounded objective minimizes energy with a soft penalty applied
+        when the figure-of-merit bound is violated.
 
         Args:
             trial: Raw measurements from :meth:`_evaluate_coordinate`.
@@ -589,8 +623,7 @@ class BayesianOptimizer:
         if objective_mode == ObjectiveMode.ENERGY:
             return trial.energy
         if objective_mode == ObjectiveMode.ENERGY_BOUNDED:
-            raise NotImplementedError(
-                "The ENERGY_BOUNDED objective is implemented in a later phase")
+            return self._score_energy_bounded(trial)
 
         # RAW_METRIC and EFFICIENCY optimize the figure of merit.
         if self.evaluator.maximize:
@@ -608,25 +641,62 @@ class BayesianOptimizer:
                 metric *= average_power
         return metric
 
-    def _record_history(self, coordinate: List[int], metric: float) -> None:
+    def _score_energy_bounded(self, trial: TrialResult) -> float:
+        """Score an energy-bounded trial as energy plus a bound-violation penalty.
+
+        Feasible trials score their plain energy. Infeasible trials score
+        strictly higher: ``energy + penalty_weight * energy_scale * violation``,
+        where ``energy_scale`` tracks the largest energy magnitude observed so
+        far so the penalty stays commensurate with energy differences.
+
+        Args:
+            trial: Raw measurements, with ``fom`` and ``energy`` populated.
+
+        Returns:
+            float: The penalized energy objective to minimize.
+        """
+        energy = trial.energy
+        magnitude = abs(energy)
+        if self._energy_scale is None:
+            self._energy_scale = magnitude
+        else:
+            self._energy_scale = max(self._energy_scale, magnitude)
+
+        violation = self._bound_violation(trial.fom)
+        if violation <= 0.0:
+            return energy
+        return energy + self._penalty_weight * self._energy_scale * violation
+
+    def _record_history(self, coordinate: List[int], metric: float,
+                        trial: 'TrialResult' = None,
+                        objective_mode: ObjectiveMode = None) -> None:
         """Append a completed trial to the evaluation history and log it.
 
         Args:
             coordinate: Grid coordinate that was evaluated.
             metric: Scalar objective value produced by :meth:`_score_result`.
+            trial: Raw measurements, used to record energy-bounded feasibility.
+            objective_mode: The active objective, used to decide what to record.
         """
-        self.evaluation_history.append({
+        entry = {
             'coordinate': coordinate.copy(),
             'metric': metric,
             'config_commands': self.control_grid.get_config_str(coordinate)
-        })
+        }
+        if objective_mode == ObjectiveMode.ENERGY_BOUNDED and trial is not None:
+            entry['fom'] = trial.fom
+            entry['energy'] = trial.energy
+            entry['feasible'] = self._bound_violation(trial.fom) <= 0.0
+        self.evaluation_history.append(entry)
 
         logger.info(f"Evaluation {len(self.evaluation_history)}: "
                    f"coordinate={coordinate}, metric={metric}")
 
     def optimize(self, trials: int = 50, n_initial_points: int = 10,
                  random_state: int = 42,
-                 objective_mode: ObjectiveMode = ObjectiveMode.RAW_METRIC) -> dict:
+                 objective_mode: ObjectiveMode = ObjectiveMode.RAW_METRIC,
+                 metric_bound: float = None,
+                 penalty_weight: float = _DEFAULT_BOUND_PENALTY_WEIGHT) -> dict:
         """Run Bayesian optimization.
 
         Args:
@@ -634,10 +704,18 @@ class BayesianOptimizer:
             n_initial_points: Number of random initial evaluations
             random_state: Random seed for reproducibility
             objective_mode: The resolved optimization objective.
+            metric_bound: Figure-of-merit bound for the ENERGY_BOUNDED
+                objective. Trials whose FoM violates the bound are penalized.
+            penalty_weight: Weight of the bound-violation penalty for the
+                ENERGY_BOUNDED objective.
 
         Returns:
             dict: Optimization results including best configuration and value
         """
+        # (Re)initialize the energy-bounded penalty state for this run.
+        self._metric_bound = metric_bound
+        self._penalty_weight = penalty_weight
+        self._energy_scale = None
 
         @use_named_args(self.space)
         def objective(**params):
@@ -646,7 +724,7 @@ class BayesianOptimizer:
             coordinate = [int(params[dim.name]) for dim in self.space]  # Convert numpy types to int
             trial = self._evaluate_coordinate(coordinate)
             metric = self._score_result(trial, objective_mode)
-            self._record_history(coordinate, metric)
+            self._record_history(coordinate, metric, trial, objective_mode)
             return metric
 
 
@@ -664,6 +742,9 @@ class BayesianOptimizer:
 
         # Store best result
         self.best_result = result
+
+        if objective_mode == ObjectiveMode.ENERGY_BOUNDED:
+            return self._build_bounded_result(result)
 
         # Convert best coordinate to actual configuration
         best_coordinate = [int(x) for x in result.x]
@@ -683,6 +764,61 @@ class BayesianOptimizer:
             'n_evaluations': len(result.func_vals),
             'optimization_result': result
         }
+
+    def _build_bounded_result(self, result) -> dict:
+        """Assemble the result for the ENERGY_BOUNDED objective.
+
+        Prefers the feasible trial with the lowest energy. When no trial
+        satisfied the bound, falls back to the point that minimized the
+        penalized objective (the least-infeasible trial) and marks the result
+        as not satisfying the bound.
+
+        Args:
+            result: The scikit-optimize result from ``gp_minimize``.
+
+        Returns:
+            dict: Result including ``bound_satisfied`` and ``best_fom``.
+        """
+        feasible = [h for h in self.evaluation_history if h.get('feasible')]
+        if feasible:
+            best = min(feasible, key=lambda h: h['energy'])
+            bound_satisfied = True
+        else:
+            best = min(self.evaluation_history, key=lambda h: h['metric'])
+            bound_satisfied = False
+
+        best_coordinate = list(best['coordinate'])
+        best_config = self.control_grid.get_config_str(best_coordinate)
+        return {
+            'best_coordinate': best_coordinate,
+            'best_metric': best['energy'],
+            'best_config': best_config,
+            'best_fom': best['fom'],
+            'bound_satisfied': bound_satisfied,
+            'n_evaluations': len(result.func_vals),
+            'optimization_result': result
+        }
+
+    def summarize(self, result: dict, objective_mode: ObjectiveMode) -> str:
+        """Build a human-readable summary of an optimization result.
+
+        Args:
+            result: The dictionary returned by :meth:`optimize`.
+            objective_mode: The objective the run used.
+
+        Returns:
+            str: A multi-line summary suitable for printing to the user.
+        """
+        lines = [f"Best configuration:\n{result['best_config']}"]
+        if objective_mode == ObjectiveMode.ENERGY_BOUNDED:
+            status = ('satisfied' if result.get('bound_satisfied')
+                      else 'NOT satisfied')
+            bound = self._metric_bound
+            lines.append(
+                f"Figure-of-merit bound {bound} was {status} "
+                f"(best figure of merit: {result.get('best_fom')})")
+            lines.append(f"Energy at best configuration: {result['best_metric']}")
+        return '\n'.join(lines)
 
 
 def get_parser():
@@ -768,6 +904,16 @@ def get_parser():
         help='Optimize for efficiency by dividing the metric by the average power consumed over the specified domain',
     )
     parser.add_argument(
+        '--metric-bound',
+        type=float,
+        default=None,
+        dest='metric_bound',
+        help='Minimize energy over the --efficiency domain subject to keeping '
+             'the --metric-regex figure of merit at or above this bound (at or '
+             'below when --minimize is set); requires --metric-regex and '
+             '--efficiency',
+    )
+    parser.add_argument(
         '--sample-period',
         type=float,
         default=_DEFAULT_SAMPLE_PERIOD,
@@ -848,11 +994,8 @@ def main():
             args.efficiency_domain not in ('board', 'gpu', 'cpu')):
             raise ValueError(f'Unsupported domain {args.efficiency_domain}, must be one of "board", "gpu", or "cpu"')
 
-        # The --metric-bound argument is introduced in a later phase; until
-        # then it is always absent.
-        metric_bound = getattr(args, 'metric_bound', None)
         objective_mode = resolve_objective_mode(
-            args.metric_regex, args.efficiency_domain, metric_bound,
+            args.metric_regex, args.efficiency_domain, args.metric_bound,
             args.minimize)
 
         # Create application evaluator
@@ -876,7 +1019,8 @@ def main():
             trials=args.trials,
             n_initial_points=args.n_initial_points,
             random_state=args.random_seed,
-            objective_mode=objective_mode
+            objective_mode=objective_mode,
+            metric_bound=args.metric_bound
         )
 
         # Print results
@@ -886,7 +1030,7 @@ def main():
         logger.info(f"Number of evaluations: {result['n_evaluations']}")
 
         # Always print the best configuration to stdout for user visibility
-        print(f"Best configuration:\n{result['best_config']}")
+        print(optimizer.summarize(result, objective_mode))
 
         if args.output_file != '-':
             with open(args.output_file, 'w') as fid:

--- a/geopmdpy/geopmdpy/optimizer.py
+++ b/geopmdpy/geopmdpy/optimizer.py
@@ -18,7 +18,8 @@ import subprocess
 import re
 import logging
 from argparse import ArgumentParser, REMAINDER
-from typing import List
+from dataclasses import dataclass
+from typing import List, Optional
 
 try:
     from skopt import gp_minimize
@@ -40,6 +41,32 @@ logger = logging.getLogger(__name__)
 class OptimizationError(Exception):
     """Exception raised when optimization fails."""
     pass
+
+
+@dataclass
+class TrialResult:
+    """Raw measurements produced by evaluating a single control configuration.
+
+    Fields are populated incrementally by the evaluation strategies. ``fom`` is
+    the figure of merit scraped from application stdout; ``energy``,
+    ``runtime``, and ``average_power`` are filled in when an efficiency
+    objective is active. ``failed`` / ``failure_reason`` are reserved for later
+    recoverable-failure handling and are unused today.
+
+    Attributes:
+        fom: Figure of merit extracted from application output.
+        energy: Energy consumed during the run (Joules).
+        runtime: Wall-clock or reported runtime of the run (seconds).
+        average_power: Mean power over the run (Watts).
+        failed: Whether the trial failed in a recoverable way.
+        failure_reason: Human-readable description of a recoverable failure.
+    """
+    fom: Optional[float] = None
+    energy: Optional[float] = None
+    runtime: Optional[float] = None
+    average_power: Optional[float] = None
+    failed: bool = False
+    failure_reason: Optional[str] = None
 
 
 class ApplicationEvaluator:
@@ -85,7 +112,8 @@ class ApplicationEvaluator:
             config_file: A file path to populate with the geopmwrite configuration file.
 
         Returns:
-            float: Figure of merit extracted from application output.
+            TrialResult: Container holding the raw figure of merit extracted
+                from application output in its ``fom`` field.
 
         Raises:
             OptimizationError: If evaluation fails.
@@ -124,11 +152,7 @@ class ApplicationEvaluator:
             metric = self._extract_metric(result.stdout)
             logger.debug(f"Extracted metric: {metric}")
 
-            # Convert to minimization problem if needed
-            if self.maximize:
-                return -metric  # Negate for maximization
-            else:
-                return metric
+            return TrialResult(fom=metric)
 
         except subprocess.TimeoutExpired:
             raise OptimizationError(f"Application evaluation timed out after {self.timeout} seconds")
@@ -261,6 +285,100 @@ class BayesianOptimizer:
             ))
         return space
 
+    def _evaluate_coordinate(self, coordinate: List[int], use_efficiency: int,
+                             efficiency_domain: str) -> TrialResult:
+        """Execute a single trial and return its raw measurements.
+
+        Validates the coordinate, launches the application through the
+        evaluator, and (when an efficiency objective is active) samples energy
+        and time around the run.
+
+        Args:
+            coordinate: Grid coordinate to evaluate.
+            use_efficiency: Efficiency mode (0 disabled, 1 maximize, -1 minimize).
+            efficiency_domain: Domain used to measure energy.
+
+        Returns:
+            TrialResult: Raw figure of merit, plus energy/runtime/average power
+                when an efficiency objective is active.
+        """
+        # Validate coordinate length matches expected dimensions
+        expected_dims = len(self.control_grid.control_name)
+        if len(coordinate) != expected_dims:
+            raise ValueError(
+                       f"Coordinate length mismatch: got {len(coordinate)}, "
+                       f"expected {expected_dims}. "
+                       f"Space: {len(self.space)}, "
+                       f"Grid data: {len(self.control_grid.get_grid_data())}")
+
+        # Validate coordinate values are within bounds
+        grid_data = self.control_grid.get_grid_data()
+        for idx, coord_val in enumerate(coordinate):
+            if idx >= len(grid_data):
+                raise ValueError(f"Coordinate index {idx} out of range for grid data (size {len(grid_data)})")
+
+            settings_count = len(grid_data[idx]["settings"])
+            if coord_val < 0 or coord_val >= settings_count:
+                raise ValueError(f"Coordinate value {coord_val} at index {idx} out of range [0, {settings_count-1}]")
+
+        # Evaluate application
+        if use_efficiency:
+            start_time = pio.read_signal("TIME", 0, 0)
+            start_energy = get_energy(efficiency_domain)
+        trial = self.evaluator.evaluate(self.control_grid, coordinate, self.config_file)
+        if use_efficiency:
+            end_energy = get_energy(efficiency_domain)
+            end_time = pio.read_signal("TIME", 0, 0)
+            trial.energy = end_energy - start_energy
+            trial.runtime = end_time - start_time
+            trial.average_power = trial.energy / trial.runtime
+        return trial
+
+    def _score_result(self, trial: TrialResult, use_efficiency: int) -> float:
+        """Reduce a TrialResult to the scalar objective value to minimize.
+
+        Applies the maximize/minimize sign convention and, when an efficiency
+        objective is active, folds average power into the score.
+
+        Args:
+            trial: Raw measurements from :meth:`_evaluate_coordinate`.
+            use_efficiency: Efficiency mode (0 disabled, 1 maximize, -1 minimize).
+
+        Returns:
+            float: Scalar objective value in minimization space.
+        """
+        # Convert to minimization problem if needed
+        if self.evaluator.maximize:
+            metric = -trial.fom  # Negate for maximization
+        else:
+            metric = trial.fom
+        if use_efficiency:
+            average_power = trial.average_power
+            logger.info(f"Average power consumed: {average_power} W")
+            if average_power <= 0:
+                raise OptimizationError("Average power consumed is non-positive")
+            if use_efficiency == 1:
+                metric /= average_power
+            elif use_efficiency == -1:
+                metric *= average_power
+        return metric
+
+    def _record_history(self, coordinate: List[int], metric: float) -> None:
+        """Append a completed trial to the evaluation history and log it.
+
+        Args:
+            coordinate: Grid coordinate that was evaluated.
+            metric: Scalar objective value produced by :meth:`_score_result`.
+        """
+        self.evaluation_history.append({
+            'coordinate': coordinate.copy(),
+            'metric': metric,
+            'config_commands': self.control_grid.get_config_str(coordinate)
+        })
+
+        logger.info(f"Evaluation {len(self.evaluation_history)}: "
+                   f"coordinate={coordinate}, metric={metric}")
+
     def optimize(self, trials: int = 50, n_initial_points: int = 10,
                  random_state: int = 42, use_efficiency: int = 0,
                  efficiency_domain: str = None) -> dict:
@@ -284,56 +402,10 @@ class BayesianOptimizer:
         def objective(**params):
             """Objective function for optimization."""
             # Convert parameter indices to actual coordinate values
-            # The coordinate should match the number of dimensions in the grid
             coordinate = [int(params[dim.name]) for dim in self.space]  # Convert numpy types to int
-
-            # Validate coordinate length matches expected dimensions
-            expected_dims = len(self.control_grid.control_name)
-            if len(coordinate) != expected_dims:
-                raise ValueError(
-                           f"Coordinate length mismatch: got {len(coordinate)}, "
-                           f"expected {expected_dims}. "
-                           f"Space: {len(self.space)}, "
-                           f"Grid data: {len(self.control_grid.get_grid_data())}")
-
-            # Validate coordinate values are within bounds
-            grid_data = self.control_grid.get_grid_data()
-            for idx, coord_val in enumerate(coordinate):
-                if idx >= len(grid_data):
-                    raise ValueError(f"Coordinate index {idx} out of range for grid data (size {len(grid_data)})")
-
-                settings_count = len(grid_data[idx]["settings"])
-                if coord_val < 0 or coord_val >= settings_count:
-                    raise ValueError(f"Coordinate value {coord_val} at index {idx} out of range [0, {settings_count-1}]")
-
-            # Evaluate application
-            if use_efficiency:
-                start_time = pio.read_signal("TIME", 0, 0)
-                start_energy = get_energy(efficiency_domain)
-            metric = self.evaluator.evaluate(self.control_grid, coordinate, self.config_file)
-            if use_efficiency:
-                end_energy = get_energy(efficiency_domain)
-                end_time = pio.read_signal("TIME", 0, 0)
-                average_power = (end_energy - start_energy) / (end_time - start_time)
-                logger.info(f"Average power consumed: {average_power} W")
-                if average_power <= 0:
-                    raise OptimizationError("Average power consumed is non-positive")
-                if use_efficiency == 1:
-                    metric /= average_power
-                elif use_efficiency == -1:
-                    metric *= average_power
-
-
-            # Store evaluation history
-            self.evaluation_history.append({
-                'coordinate': coordinate.copy(),
-                'metric': metric,
-                'config_commands': self.control_grid.get_config_str(coordinate)
-            })
-
-            logger.info(f"Evaluation {len(self.evaluation_history)}: "
-                       f"coordinate={coordinate}, metric={metric}")
-
+            trial = self._evaluate_coordinate(coordinate, use_efficiency, efficiency_domain)
+            metric = self._score_result(trial, use_efficiency)
+            self._record_history(coordinate, metric)
             return metric
 
 

--- a/geopmdpy/geopmdpy/optimizer.py
+++ b/geopmdpy/geopmdpy/optimizer.py
@@ -17,6 +17,8 @@ import os
 import subprocess
 import re
 import time
+import shutil
+import tempfile
 import logging
 from argparse import ArgumentParser, REMAINDER
 from dataclasses import dataclass
@@ -35,6 +37,16 @@ except ImportError:
 
 from . import pio
 from .grid import ControlGrid, _CLI_FLAG_TO_CONTROL, add_grid_cli_arguments
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+# Default geopmsession sampling period in seconds. It is small enough that the
+# RAPL energy counter is sampled several times before it can wrap, which is
+# what makes the report energy delta rollover-safe (issue #4043).
+_DEFAULT_SAMPLE_PERIOD = 0.01
 
 # Module-level logger
 logger = logging.getLogger(__name__)
@@ -144,9 +156,16 @@ class ApplicationEvaluator:
         maximize (bool): Whether to maximize or minimize the extracted metric.
         timeout (int): Timeout in seconds for the application's execution.
         print_stdout (bool): Whether to log the application's stdout to the info level.
+        objective_mode (ObjectiveMode): The resolved optimization objective.
+        efficiency_domain (str): Domain used to measure energy, or None.
+        sample_period (float): geopmsession sampling period for energy objectives.
+        needs_session (bool): Whether trials run under geopmsession for energy.
     """
     def __init__(self, launch_command: List[str], metric_regex: str = None, maximize: bool = True,
-                 timeout: int = 300, print_stdout: bool = False):
+                 timeout: int = 300, print_stdout: bool = False,
+                 objective_mode: ObjectiveMode = ObjectiveMode.RAW_METRIC,
+                 efficiency_domain: str = None,
+                 sample_period: float = _DEFAULT_SAMPLE_PERIOD):
         """Initialize the application evaluator.
 
         Args:
@@ -157,6 +176,12 @@ class ApplicationEvaluator:
             maximize: Whether to maximize (True) or minimize (False) the metric
             timeout: Timeout in seconds for application execution
             print_stdout: Whether to log application stdout to info level
+            objective_mode: The resolved optimization objective. Energy
+                objectives launch the application under geopmsession so that
+                energy and time are sampled with rollover accounting.
+            efficiency_domain: Domain used to measure energy for energy
+                objectives (``board``/``cpu``/``gpu``).
+            sample_period: geopmsession sampling period in seconds.
         """
         self.launch_command = launch_command
         self.metric_regex = metric_regex
@@ -164,8 +189,23 @@ class ApplicationEvaluator:
         self.timeout = timeout
         self.regex = re.compile(self.metric_regex) if self.metric_regex is not None else None
         self.print_stdout = print_stdout
+        self.objective_mode = objective_mode
+        self.efficiency_domain = efficiency_domain
+        self.sample_period = sample_period
+        self.needs_session = objective_mode in _ENERGY_MODES
+        self._energy_signals = None
+        if self.needs_session:
+            if yaml is None:
+                raise OptimizationError(
+                    "The pyyaml module is required for energy objectives; "
+                    "install with: python3 -m pip install pyyaml")
+            if shutil.which('geopmsession') is None:
+                raise OptimizationError(
+                    "geopmsession was not found on PATH; it is required for "
+                    "energy-based objectives (--efficiency)")
+            self._energy_signals = energy_signal_names(self.efficiency_domain)
 
-    def evaluate(self, control_grid: ControlGrid, coordinate: List[int], config_file: str = None) -> float:
+    def evaluate(self, control_grid: ControlGrid, coordinate: List[int], config_file: str = None) -> 'TrialResult':
         """Evaluate application with given control configuration.
 
         Args:
@@ -174,9 +214,10 @@ class ApplicationEvaluator:
             config_file: A file path to populate with the geopmwrite configuration file.
 
         Returns:
-            TrialResult: Container holding the application's wall-clock runtime
-                in its ``runtime`` field and, when a metric regex is configured,
-                the raw figure of merit in its ``fom`` field.
+            TrialResult: Container holding the trial's measurements. Runtime
+                objectives populate ``runtime``; figure-of-merit objectives
+                populate ``fom``; energy objectives populate ``energy``,
+                ``runtime``, and ``average_power`` from the session report.
 
         Raises:
             OptimizationError: If evaluation fails.
@@ -188,43 +229,12 @@ class ApplicationEvaluator:
                 with open(config_file, 'w') as fid:
                     fid.write(f'{control_grid.get_config_str(coordinate)}\n')
 
-            # Launch application
-            logger.debug(f"Launching application: {' '.join(self.launch_command)}")
-            start = time.monotonic()
-            result = subprocess.run(
-                self.launch_command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                universal_newlines=True,
-                timeout=self.timeout
-            )
-            runtime = time.monotonic() - start
+            if self.needs_session:
+                return self._evaluate_session()
+            return self._evaluate_direct()
 
-            if result.returncode != 0:
-                if self.print_stdout:
-                    logger.info(f"Application stdout: \n{result.stdout}\n")
-                logger.debug(f"Application stderr: \n{result.stderr}\n")
-                raise OptimizationError(
-                    f"Application failed with return code {result.returncode}: {result.stderr}"
-                )
-
-            logger.debug(f"Application stdout length: {len(result.stdout)} characters")
-            if self.print_stdout:
-                logger.info(f"Application stdout: \n{result.stdout}\n")
-
-            # Without a metric regex the objective is runtime-based; only the
-            # measured wall-clock time is required.
-            if self.regex is None:
-                return TrialResult(runtime=runtime)
-
-            # Extract metric from stdout
-            if not result.stdout:
-                raise OptimizationError("Application produced no output")
-            metric = self._extract_metric(result.stdout)
-            logger.debug(f"Extracted metric: {metric}")
-
-            return TrialResult(fom=metric, runtime=runtime)
-
+        except OptimizationError:
+            raise
         except subprocess.TimeoutExpired:
             raise OptimizationError(f"Application evaluation timed out after {self.timeout} seconds")
         except FileNotFoundError as e:
@@ -233,6 +243,148 @@ class ApplicationEvaluator:
             raise OptimizationError(f"Permission denied: {e}")
         except Exception as e:
             raise OptimizationError(f"Evaluation failed: {e}")
+
+    def _check_returncode(self, result) -> None:
+        """Raise OptimizationError when the launched application exits non-zero."""
+        if result.returncode != 0:
+            if self.print_stdout:
+                logger.info(f"Application stdout: \n{result.stdout}\n")
+            logger.debug(f"Application stderr: \n{result.stderr}\n")
+            raise OptimizationError(
+                f"Application failed with return code {result.returncode}: {result.stderr}"
+            )
+
+    def _evaluate_direct(self) -> 'TrialResult':
+        """Run the application directly and measure wall-clock runtime.
+
+        Used for the RAW_METRIC and RUNTIME objectives, which do not need
+        energy measurement.
+        """
+        logger.debug(f"Launching application: {' '.join(self.launch_command)}")
+        start = time.monotonic()
+        result = subprocess.run(
+            self.launch_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            timeout=self.timeout
+        )
+        runtime = time.monotonic() - start
+
+        self._check_returncode(result)
+
+        logger.debug(f"Application stdout length: {len(result.stdout)} characters")
+        if self.print_stdout:
+            logger.info(f"Application stdout: \n{result.stdout}\n")
+
+        # Without a metric regex the objective is runtime-based; only the
+        # measured wall-clock time is required.
+        if self.regex is None:
+            return TrialResult(runtime=runtime)
+
+        if not result.stdout:
+            raise OptimizationError("Application produced no output")
+        metric = self._extract_metric(result.stdout)
+        logger.debug(f"Extracted metric: {metric}")
+        return TrialResult(fom=metric, runtime=runtime)
+
+    def _signal_config_str(self) -> str:
+        """Build the geopmsession signal-config for the efficiency domain."""
+        lines = ['TIME board 0']
+        lines.extend(f'{name} board 0' for name in self._energy_signals)
+        return '\n'.join(lines) + '\n'
+
+    def _session_argv(self, signal_path: str, report_path: str) -> List[str]:
+        """Build the geopmsession command line that wraps the application."""
+        return [
+            'geopmsession',
+            '--period', repr(self.sample_period),
+            '--report-out', report_path,
+            '--trace-out', '/dev/null',
+            '--signal-config', signal_path,
+            '--', *self.launch_command,
+        ]
+
+    def _load_report(self, report_path: str) -> dict:
+        """Load and minimally validate the geopmsession YAML report."""
+        try:
+            with open(report_path) as fid:
+                report = yaml.safe_load(fid)
+        except FileNotFoundError:
+            raise OptimizationError("geopmsession did not produce a report")
+        if not isinstance(report, dict):
+            raise OptimizationError("geopmsession produced a malformed report")
+        return report
+
+    def _compute_energy_metrics(self, report: dict):
+        """Derive (energy, runtime, average_power) from a session report.
+
+        The energy and runtime are computed from the ``last - first`` deltas of
+        the report metrics, which are rollover-corrected by geopmsession, so a
+        RAPL wrap during the run does not corrupt the result.
+        """
+        metrics = report.get('metrics')
+        if not metrics:
+            raise OptimizationError("Session report is missing metrics")
+        if 'TIME' not in metrics:
+            raise OptimizationError("Session report is missing the TIME metric")
+        runtime = metrics['TIME']['last'] - metrics['TIME']['first']
+        energy = 0.0
+        for name in self._energy_signals:
+            if name not in metrics:
+                raise OptimizationError(f"Session report is missing the {name} metric")
+            energy += metrics[name]['last'] - metrics[name]['first']
+        if runtime <= 0:
+            raise OptimizationError("Session reported non-positive runtime")
+        average_power = energy / runtime
+        return energy, runtime, average_power
+
+    def _evaluate_session(self) -> 'TrialResult':
+        """Run the application under geopmsession and read energy from the report.
+
+        Used for the energy objectives (EFFICIENCY / ENERGY / ENERGY_BOUNDED).
+        """
+        signal_fd, signal_path = tempfile.mkstemp(prefix='geopmopt_signal_', suffix='.conf')
+        report_fd, report_path = tempfile.mkstemp(prefix='geopmopt_report_', suffix='.yaml')
+        try:
+            os.close(signal_fd)
+            os.close(report_fd)
+            with open(signal_path, 'w') as fid:
+                fid.write(self._signal_config_str())
+
+            argv = self._session_argv(signal_path, report_path)
+            logger.debug(f"Launching application under geopmsession: {' '.join(argv)}")
+            result = subprocess.run(
+                argv,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+                timeout=self.timeout
+            )
+
+            self._check_returncode(result)
+
+            if self.print_stdout:
+                logger.info(f"Application stdout: \n{result.stdout}\n")
+
+            report = self._load_report(report_path)
+            energy, runtime, average_power = self._compute_energy_metrics(report)
+
+            fom = None
+            if self.regex is not None:
+                if not result.stdout:
+                    raise OptimizationError("Application produced no output")
+                fom = self._extract_metric(result.stdout)
+
+            return TrialResult(fom=fom, energy=energy, runtime=runtime,
+                               average_power=average_power)
+        finally:
+            for path in (signal_path, report_path):
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass
+
 
     def _extract_metric(self, stdout: str) -> float:
         """Extract figure of merit from application stdout.
@@ -269,33 +421,59 @@ class ApplicationEvaluator:
                 f"Could not convert extracted value to float: {metric_str}"
             )
 
-def get_energy(domain: str):
+def energy_signal_names(domain: str) -> List[str]:
+    """Return the energy signal names used to measure the given domain.
+
+    This is the single source of truth for the domain-to-signal mapping. It is
+    used both to read energy in-process (:func:`get_energy`) and to build the
+    geopmsession signal-config for the energy objectives.
+
+    Args:
+        domain: One of ``board``, ``cpu``, or ``gpu``.
+
+    Returns:
+        List[str]: Available energy signal names whose deltas sum to the
+            domain energy. ``board`` prefers a single ``BOARD_ENERGY`` signal
+            and otherwise sums the available component signals.
+
+    Raises:
+        ValueError: If the domain is not supported.
+        OptimizationError: If no energy signals are available for the domain.
+    """
     all_signals = pio.signal_names()
-    result = 0  # Initialize result to 0 for all domains
+    names: List[str] = []
     if domain == 'board':
         if "BOARD_ENERGY" in all_signals:
-            return pio.read_signal("BOARD_ENERGY", 0, 0)
+            return ["BOARD_ENERGY"]
         # If we don't have board energy sum all components
         if "GPU_ENERGY" in all_signals:
-            result += pio.read_signal("GPU_ENERGY", 0, 0)
+            names.append("GPU_ENERGY")
         # Prefer powercap for energy measurements over default
         if "POWERCAP::CPU_ENERGY_CONSUMED" in all_signals:
-            result += pio.read_signal("POWERCAP::CPU_ENERGY_CONSUMED", 0, 0)
+            names.append("POWERCAP::CPU_ENERGY_CONSUMED")
         elif "CPU_ENERGY" in all_signals:
-            result += pio.read_signal("CPU_ENERGY", 0, 0)
+            names.append("CPU_ENERGY")
         if "DRAM_ENERGY" in all_signals:
-            result += pio.read_signal("DRAM_ENERGY", 0, 0)
+            names.append("DRAM_ENERGY")
     elif domain == 'cpu':
         # Prefer powercap for energy measurements over default
         if "POWERCAP::CPU_ENERGY_CONSUMED" in all_signals:
-            result += pio.read_signal("POWERCAP::CPU_ENERGY_CONSUMED", 0, 0)
+            names.append("POWERCAP::CPU_ENERGY_CONSUMED")
         elif "CPU_ENERGY" in all_signals:
-            result = pio.read_signal("CPU_ENERGY", 0, 0)
+            names.append("CPU_ENERGY")
     elif domain == 'gpu':
         if "GPU_ENERGY" in all_signals:
-            result = pio.read_signal("GPU_ENERGY", 0, 0)
+            names.append("GPU_ENERGY")
     else:
         raise ValueError(f'Unsupported domain {domain}, must be one of "board", "gpu", or "cpu"')
+    if not names:
+        raise OptimizationError("No energy signals available to compute efficiency")
+    return names
+
+
+def get_energy(domain: str):
+    result = sum(pio.read_signal(name, 0, 0)
+                 for name in energy_signal_names(domain))
     if result == 0:
         raise OptimizationError("No energy signals available to compute efficiency")
     return result
@@ -356,19 +534,15 @@ class BayesianOptimizer:
             ))
         return space
 
-    def _evaluate_coordinate(self, coordinate: List[int],
-                             objective_mode: ObjectiveMode,
-                             efficiency_domain: str) -> TrialResult:
+    def _evaluate_coordinate(self, coordinate: List[int]) -> TrialResult:
         """Execute a single trial and return its raw measurements.
 
-        Validates the coordinate, launches the application through the
-        evaluator, and (when an energy objective is active) samples energy
-        and time around the run.
+        Validates the coordinate and launches the application through the
+        evaluator. The evaluator selects the direct or geopmsession execution
+        strategy and populates the energy fields for energy objectives.
 
         Args:
             coordinate: Grid coordinate to evaluate.
-            objective_mode: The resolved optimization objective.
-            efficiency_domain: Domain used to measure energy.
 
         Returns:
             TrialResult: Figure of merit and/or wall-clock runtime, plus
@@ -393,19 +567,7 @@ class BayesianOptimizer:
             if coord_val < 0 or coord_val >= settings_count:
                 raise ValueError(f"Coordinate value {coord_val} at index {idx} out of range [0, {settings_count-1}]")
 
-        # Evaluate application
-        needs_energy = objective_mode in _ENERGY_MODES
-        if needs_energy:
-            start_time = pio.read_signal("TIME", 0, 0)
-            start_energy = get_energy(efficiency_domain)
-        trial = self.evaluator.evaluate(self.control_grid, coordinate, self.config_file)
-        if needs_energy:
-            end_energy = get_energy(efficiency_domain)
-            end_time = pio.read_signal("TIME", 0, 0)
-            trial.energy = end_energy - start_energy
-            trial.runtime = end_time - start_time
-            trial.average_power = trial.energy / trial.runtime
-        return trial
+        return self.evaluator.evaluate(self.control_grid, coordinate, self.config_file)
 
     def _score_result(self, trial: TrialResult,
                       objective_mode: ObjectiveMode) -> float:
@@ -464,8 +626,7 @@ class BayesianOptimizer:
 
     def optimize(self, trials: int = 50, n_initial_points: int = 10,
                  random_state: int = 42,
-                 objective_mode: ObjectiveMode = ObjectiveMode.RAW_METRIC,
-                 efficiency_domain: str = None) -> dict:
+                 objective_mode: ObjectiveMode = ObjectiveMode.RAW_METRIC) -> dict:
         """Run Bayesian optimization.
 
         Args:
@@ -473,7 +634,6 @@ class BayesianOptimizer:
             n_initial_points: Number of random initial evaluations
             random_state: Random seed for reproducibility
             objective_mode: The resolved optimization objective.
-            efficiency_domain: Domain to measure energy for energy objectives.
 
         Returns:
             dict: Optimization results including best configuration and value
@@ -484,7 +644,7 @@ class BayesianOptimizer:
             """Objective function for optimization."""
             # Convert parameter indices to actual coordinate values
             coordinate = [int(params[dim.name]) for dim in self.space]  # Convert numpy types to int
-            trial = self._evaluate_coordinate(coordinate, objective_mode, efficiency_domain)
+            trial = self._evaluate_coordinate(coordinate)
             metric = self._score_result(trial, objective_mode)
             self._record_history(coordinate, metric)
             return metric
@@ -607,6 +767,14 @@ def get_parser():
         dest='efficiency_domain',
         help='Optimize for efficiency by dividing the metric by the average power consumed over the specified domain',
     )
+    parser.add_argument(
+        '--sample-period',
+        type=float,
+        default=_DEFAULT_SAMPLE_PERIOD,
+        dest='sample_period',
+        help='geopmsession sampling period in seconds for energy-based '
+             'objectives; shorter periods add overhead (default: %(default)s)',
+    )
 
     # Application launch command
     parser.add_argument(
@@ -675,19 +843,7 @@ def main():
             if len(settings) == 0:
                 raise RuntimeError(f"Error: Control '{dim['control']}' on domain '{dim['domain']}' "
                                    f"index {dim['domain_idx']} has no available settings.")
-        # Create application evaluator
-        evaluator = ApplicationEvaluator(
-            launch_command=launch_command,
-            metric_regex=args.metric_regex,
-            maximize=not args.minimize,
-            timeout=args.application_timeout,
-            print_stdout=args.print_stdout
-        )
-        # Create and run optimizer
-        config_file = None
-        if args.defer_write:
-            config_file = args.output_file
-        optimizer = BayesianOptimizer(control_grid, evaluator, config_file)
+
         if (args.efficiency_domain is not None and
             args.efficiency_domain not in ('board', 'gpu', 'cpu')):
             raise ValueError(f'Unsupported domain {args.efficiency_domain}, must be one of "board", "gpu", or "cpu"')
@@ -699,12 +855,28 @@ def main():
             args.metric_regex, args.efficiency_domain, metric_bound,
             args.minimize)
 
+        # Create application evaluator
+        evaluator = ApplicationEvaluator(
+            launch_command=launch_command,
+            metric_regex=args.metric_regex,
+            maximize=not args.minimize,
+            timeout=args.application_timeout,
+            print_stdout=args.print_stdout,
+            objective_mode=objective_mode,
+            efficiency_domain=args.efficiency_domain,
+            sample_period=args.sample_period
+        )
+        # Create and run optimizer
+        config_file = None
+        if args.defer_write:
+            config_file = args.output_file
+        optimizer = BayesianOptimizer(control_grid, evaluator, config_file)
+
         result = optimizer.optimize(
             trials=args.trials,
             n_initial_points=args.n_initial_points,
             random_state=args.random_seed,
-            objective_mode=objective_mode,
-            efficiency_domain=args.efficiency_domain
+            objective_mode=objective_mode
         )
 
         # Print results

--- a/geopmdpy/geopmdpy/optimizer.py
+++ b/geopmdpy/geopmdpy/optimizer.py
@@ -16,9 +16,11 @@ import sys
 import os
 import subprocess
 import re
+import time
 import logging
 from argparse import ArgumentParser, REMAINDER
 from dataclasses import dataclass
+from enum import Enum
 from typing import List, Optional
 
 try:
@@ -41,6 +43,64 @@ logger = logging.getLogger(__name__)
 class OptimizationError(Exception):
     """Exception raised when optimization fails."""
     pass
+
+
+class ObjectiveMode(Enum):
+    """The optimization objective resolved from the command-line inputs.
+
+    The mode is a function of whether ``--metric-regex``, ``--efficiency``,
+    and ``--metric-bound`` are supplied; see :func:`resolve_objective_mode`
+    and the objective matrix in the geopmopt documentation.
+    """
+    #: Optimize the figure of merit scraped from stdout (``--minimize`` toggles).
+    RAW_METRIC = 'raw_metric'
+    #: Optimize figure of merit per average power over the efficiency domain.
+    EFFICIENCY = 'efficiency'
+    #: Minimize total wall-clock runtime (no figure of merit required).
+    RUNTIME = 'runtime'
+    #: Minimize total energy over the efficiency domain (no FoM required).
+    ENERGY = 'energy'
+    #: Minimize energy subject to a bound on the figure of merit.
+    ENERGY_BOUNDED = 'energy_bounded'
+
+
+#: Objective modes that require sampling energy around each trial.
+_ENERGY_MODES = frozenset(
+    {ObjectiveMode.EFFICIENCY, ObjectiveMode.ENERGY, ObjectiveMode.ENERGY_BOUNDED})
+
+
+def resolve_objective_mode(metric_regex, efficiency_domain, metric_bound,
+                           minimize):
+    """Resolve the optimization objective from the command-line inputs.
+
+    Args:
+        metric_regex: The ``--metric-regex`` value, or None when omitted.
+        efficiency_domain: The ``--efficiency`` domain, or None when omitted.
+        metric_bound: The ``--metric-bound`` value, or None when omitted.
+        minimize: Whether ``--minimize`` was requested. The optimization
+            direction does not change which objective is selected; it is
+            accepted here so this function is the single place that consumes
+            all objective-determining inputs.
+
+    Returns:
+        ObjectiveMode: The resolved objective.
+
+    Raises:
+        ValueError: If the combination of inputs is invalid.
+    """
+    if metric_bound is not None:
+        if metric_regex is None:
+            raise ValueError('--metric-bound requires --metric-regex')
+        if efficiency_domain is None:
+            raise ValueError('--metric-bound requires --efficiency')
+        return ObjectiveMode.ENERGY_BOUNDED
+    if metric_regex is not None:
+        if efficiency_domain is not None:
+            return ObjectiveMode.EFFICIENCY
+        return ObjectiveMode.RAW_METRIC
+    if efficiency_domain is not None:
+        return ObjectiveMode.ENERGY
+    return ObjectiveMode.RUNTIME
 
 
 @dataclass
@@ -85,13 +145,15 @@ class ApplicationEvaluator:
         timeout (int): Timeout in seconds for the application's execution.
         print_stdout (bool): Whether to log the application's stdout to the info level.
     """
-    def __init__(self, launch_command: List[str], metric_regex: str, maximize: bool = True,
+    def __init__(self, launch_command: List[str], metric_regex: str = None, maximize: bool = True,
                  timeout: int = 300, print_stdout: bool = False):
         """Initialize the application evaluator.
 
         Args:
             launch_command: Command and arguments to launch the application
-            metric_regex: Python-style regex to extract figure of merit from stdout
+            metric_regex: Python-style regex to extract figure of merit from
+                stdout. When None, no figure of merit is scraped and only the
+                application's wall-clock runtime is measured.
             maximize: Whether to maximize (True) or minimize (False) the metric
             timeout: Timeout in seconds for application execution
             print_stdout: Whether to log application stdout to info level
@@ -100,7 +162,7 @@ class ApplicationEvaluator:
         self.metric_regex = metric_regex
         self.maximize = maximize
         self.timeout = timeout
-        self.regex = re.compile(self.metric_regex)
+        self.regex = re.compile(self.metric_regex) if self.metric_regex is not None else None
         self.print_stdout = print_stdout
 
     def evaluate(self, control_grid: ControlGrid, coordinate: List[int], config_file: str = None) -> float:
@@ -112,8 +174,9 @@ class ApplicationEvaluator:
             config_file: A file path to populate with the geopmwrite configuration file.
 
         Returns:
-            TrialResult: Container holding the raw figure of merit extracted
-                from application output in its ``fom`` field.
+            TrialResult: Container holding the application's wall-clock runtime
+                in its ``runtime`` field and, when a metric regex is configured,
+                the raw figure of merit in its ``fom`` field.
 
         Raises:
             OptimizationError: If evaluation fails.
@@ -127,6 +190,7 @@ class ApplicationEvaluator:
 
             # Launch application
             logger.debug(f"Launching application: {' '.join(self.launch_command)}")
+            start = time.monotonic()
             result = subprocess.run(
                 self.launch_command,
                 stdout=subprocess.PIPE,
@@ -134,6 +198,7 @@ class ApplicationEvaluator:
                 universal_newlines=True,
                 timeout=self.timeout
             )
+            runtime = time.monotonic() - start
 
             if result.returncode != 0:
                 if self.print_stdout:
@@ -143,16 +208,22 @@ class ApplicationEvaluator:
                     f"Application failed with return code {result.returncode}: {result.stderr}"
                 )
 
-            # Extract metric from stdout
             logger.debug(f"Application stdout length: {len(result.stdout)} characters")
             if self.print_stdout:
                 logger.info(f"Application stdout: \n{result.stdout}\n")
+
+            # Without a metric regex the objective is runtime-based; only the
+            # measured wall-clock time is required.
+            if self.regex is None:
+                return TrialResult(runtime=runtime)
+
+            # Extract metric from stdout
             if not result.stdout:
                 raise OptimizationError("Application produced no output")
             metric = self._extract_metric(result.stdout)
             logger.debug(f"Extracted metric: {metric}")
 
-            return TrialResult(fom=metric)
+            return TrialResult(fom=metric, runtime=runtime)
 
         except subprocess.TimeoutExpired:
             raise OptimizationError(f"Application evaluation timed out after {self.timeout} seconds")
@@ -285,22 +356,23 @@ class BayesianOptimizer:
             ))
         return space
 
-    def _evaluate_coordinate(self, coordinate: List[int], use_efficiency: int,
+    def _evaluate_coordinate(self, coordinate: List[int],
+                             objective_mode: ObjectiveMode,
                              efficiency_domain: str) -> TrialResult:
         """Execute a single trial and return its raw measurements.
 
         Validates the coordinate, launches the application through the
-        evaluator, and (when an efficiency objective is active) samples energy
+        evaluator, and (when an energy objective is active) samples energy
         and time around the run.
 
         Args:
             coordinate: Grid coordinate to evaluate.
-            use_efficiency: Efficiency mode (0 disabled, 1 maximize, -1 minimize).
+            objective_mode: The resolved optimization objective.
             efficiency_domain: Domain used to measure energy.
 
         Returns:
-            TrialResult: Raw figure of merit, plus energy/runtime/average power
-                when an efficiency objective is active.
+            TrialResult: Figure of merit and/or wall-clock runtime, plus
+                energy/runtime/average power when an energy objective is active.
         """
         # Validate coordinate length matches expected dimensions
         expected_dims = len(self.control_grid.control_name)
@@ -322,11 +394,12 @@ class BayesianOptimizer:
                 raise ValueError(f"Coordinate value {coord_val} at index {idx} out of range [0, {settings_count-1}]")
 
         # Evaluate application
-        if use_efficiency:
+        needs_energy = objective_mode in _ENERGY_MODES
+        if needs_energy:
             start_time = pio.read_signal("TIME", 0, 0)
             start_energy = get_energy(efficiency_domain)
         trial = self.evaluator.evaluate(self.control_grid, coordinate, self.config_file)
-        if use_efficiency:
+        if needs_energy:
             end_energy = get_energy(efficiency_domain)
             end_time = pio.read_signal("TIME", 0, 0)
             trial.energy = end_energy - start_energy
@@ -334,32 +407,42 @@ class BayesianOptimizer:
             trial.average_power = trial.energy / trial.runtime
         return trial
 
-    def _score_result(self, trial: TrialResult, use_efficiency: int) -> float:
+    def _score_result(self, trial: TrialResult,
+                      objective_mode: ObjectiveMode) -> float:
         """Reduce a TrialResult to the scalar objective value to minimize.
 
-        Applies the maximize/minimize sign convention and, when an efficiency
-        objective is active, folds average power into the score.
+        Runtime and energy objectives are minimized directly. For the figure
+        of merit objectives the maximize/minimize sign convention is applied
+        and, for the efficiency objective, average power is folded in.
 
         Args:
             trial: Raw measurements from :meth:`_evaluate_coordinate`.
-            use_efficiency: Efficiency mode (0 disabled, 1 maximize, -1 minimize).
+            objective_mode: The resolved optimization objective.
 
         Returns:
             float: Scalar objective value in minimization space.
         """
-        # Convert to minimization problem if needed
+        if objective_mode == ObjectiveMode.RUNTIME:
+            return trial.runtime
+        if objective_mode == ObjectiveMode.ENERGY:
+            return trial.energy
+        if objective_mode == ObjectiveMode.ENERGY_BOUNDED:
+            raise NotImplementedError(
+                "The ENERGY_BOUNDED objective is implemented in a later phase")
+
+        # RAW_METRIC and EFFICIENCY optimize the figure of merit.
         if self.evaluator.maximize:
             metric = -trial.fom  # Negate for maximization
         else:
             metric = trial.fom
-        if use_efficiency:
+        if objective_mode == ObjectiveMode.EFFICIENCY:
             average_power = trial.average_power
             logger.info(f"Average power consumed: {average_power} W")
             if average_power <= 0:
                 raise OptimizationError("Average power consumed is non-positive")
-            if use_efficiency == 1:
+            if self.evaluator.maximize:
                 metric /= average_power
-            elif use_efficiency == -1:
+            else:
                 metric *= average_power
         return metric
 
@@ -380,7 +463,8 @@ class BayesianOptimizer:
                    f"coordinate={coordinate}, metric={metric}")
 
     def optimize(self, trials: int = 50, n_initial_points: int = 10,
-                 random_state: int = 42, use_efficiency: int = 0,
+                 random_state: int = 42,
+                 objective_mode: ObjectiveMode = ObjectiveMode.RAW_METRIC,
                  efficiency_domain: str = None) -> dict:
         """Run Bayesian optimization.
 
@@ -388,11 +472,8 @@ class BayesianOptimizer:
             trials: Number of optimization iterations
             n_initial_points: Number of random initial evaluations
             random_state: Random seed for reproducibility
-            use_efficiency: Whether to optimize for efficiency
-                0: use metric directly
-                1: maximizing, divide by average power
-                -1: minimizing, multiply by average power
-            efficiency_domain: Domain to measure energy
+            objective_mode: The resolved optimization objective.
+            efficiency_domain: Domain to measure energy for energy objectives.
 
         Returns:
             dict: Optimization results including best configuration and value
@@ -403,8 +484,8 @@ class BayesianOptimizer:
             """Objective function for optimization."""
             # Convert parameter indices to actual coordinate values
             coordinate = [int(params[dim.name]) for dim in self.space]  # Convert numpy types to int
-            trial = self._evaluate_coordinate(coordinate, use_efficiency, efficiency_domain)
-            metric = self._score_result(trial, use_efficiency)
+            trial = self._evaluate_coordinate(coordinate, objective_mode, efficiency_domain)
+            metric = self._score_result(trial, objective_mode)
             self._record_history(coordinate, metric)
             return metric
 
@@ -428,9 +509,11 @@ class BayesianOptimizer:
         best_coordinate = [int(x) for x in result.x]
         best_config = self.control_grid.get_config_str(best_coordinate)
 
-        # Convert metric back if maximizing
+        # Convert metric back if maximizing. Runtime and energy objectives are
+        # already reported in their natural (minimized) units.
         best_metric = result.fun
-        if self.evaluator.maximize:
+        if (objective_mode in (ObjectiveMode.RAW_METRIC, ObjectiveMode.EFFICIENCY)
+                and self.evaluator.maximize):
             best_metric = -best_metric
 
         return {
@@ -466,8 +549,11 @@ def get_parser():
 
     parser.add_argument(
         '--metric-regex',
-        required=True,
-        help='Python-style regex to extract figure of merit from application stdout'
+        default=None,
+        help='Python-style regex to extract the figure of merit from '
+             'application stdout. When omitted, the objective defaults to '
+             'total wall-clock runtime, or total energy when --efficiency is '
+             'also provided.'
     )
 
     parser.add_argument(
@@ -602,21 +688,22 @@ def main():
         if args.defer_write:
             config_file = args.output_file
         optimizer = BayesianOptimizer(control_grid, evaluator, config_file)
-        if args.efficiency_domain is None:
-            efficiency = 0
-        elif args.minimize:
-            efficiency = -1
-        else:
-            efficiency = 1
         if (args.efficiency_domain is not None and
             args.efficiency_domain not in ('board', 'gpu', 'cpu')):
             raise ValueError(f'Unsupported domain {args.efficiency_domain}, must be one of "board", "gpu", or "cpu"')
+
+        # The --metric-bound argument is introduced in a later phase; until
+        # then it is always absent.
+        metric_bound = getattr(args, 'metric_bound', None)
+        objective_mode = resolve_objective_mode(
+            args.metric_regex, args.efficiency_domain, metric_bound,
+            args.minimize)
 
         result = optimizer.optimize(
             trials=args.trials,
             n_initial_points=args.n_initial_points,
             random_state=args.random_seed,
-            use_efficiency=efficiency,
+            objective_mode=objective_mode,
             efficiency_domain=args.efficiency_domain
         )
 

--- a/geopmdpy/geopmdpy/optimizer.py
+++ b/geopmdpy/geopmdpy/optimizer.py
@@ -17,10 +17,11 @@ import os
 import subprocess
 import re
 import time
+import math
 import shutil
 import tempfile
 import logging
-from argparse import ArgumentParser, REMAINDER
+from argparse import ArgumentParser, ArgumentTypeError, REMAINDER
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
@@ -54,12 +55,28 @@ _DEFAULT_SAMPLE_PERIOD = 0.01
 # the weight lets that penalty be tuned relative to energy differences.
 _DEFAULT_BOUND_PENALTY_WEIGHT = 1.0
 
+# Objective value assigned to a recoverable failure that occurs before any
+# trial has succeeded, when the automatic penalty cannot yet be derived from
+# observed successes. It is finite so it never corrupts the surrogate model.
+_BOOTSTRAP_PENALTY = 1e9
+
 # Module-level logger
 logger = logging.getLogger(__name__)
 
 
 class OptimizationError(Exception):
-    """Exception raised when optimization fails."""
+    """Exception raised when optimization fails fatally and must abort the run."""
+    pass
+
+
+class RecoverableEvaluationError(Exception):
+    """A trial-level failure that can be penalized instead of aborting the run.
+
+    Raised internally by the evaluation strategies for the recoverable failure
+    set (timeout, non-zero exit, figure-of-merit scrape miss, non-positive
+    power/runtime). :meth:`ApplicationEvaluator.evaluate` converts it into a
+    failed :class:`TrialResult` rather than propagating it.
+    """
     pass
 
 
@@ -239,10 +256,15 @@ class ApplicationEvaluator:
                 return self._evaluate_session()
             return self._evaluate_direct()
 
+        except RecoverableEvaluationError as e:
+            logger.warning(f"Trial failed (recoverable): {e}")
+            return TrialResult(failed=True, failure_reason=str(e))
+        except subprocess.TimeoutExpired:
+            reason = f"Application evaluation timed out after {self.timeout} seconds"
+            logger.warning(f"Trial failed (recoverable): {reason}")
+            return TrialResult(failed=True, failure_reason=reason)
         except OptimizationError:
             raise
-        except subprocess.TimeoutExpired:
-            raise OptimizationError(f"Application evaluation timed out after {self.timeout} seconds")
         except FileNotFoundError as e:
             raise OptimizationError(f"Command not found: {e}")
         except PermissionError as e:
@@ -251,12 +273,12 @@ class ApplicationEvaluator:
             raise OptimizationError(f"Evaluation failed: {e}")
 
     def _check_returncode(self, result) -> None:
-        """Raise OptimizationError when the launched application exits non-zero."""
+        """Flag a non-zero application exit as a recoverable trial failure."""
         if result.returncode != 0:
             if self.print_stdout:
                 logger.info(f"Application stdout: \n{result.stdout}\n")
             logger.debug(f"Application stderr: \n{result.stderr}\n")
-            raise OptimizationError(
+            raise RecoverableEvaluationError(
                 f"Application failed with return code {result.returncode}: {result.stderr}"
             )
 
@@ -289,7 +311,7 @@ class ApplicationEvaluator:
             return TrialResult(runtime=runtime)
 
         if not result.stdout:
-            raise OptimizationError("Application produced no output")
+            raise RecoverableEvaluationError("Application produced no output")
         metric = self._extract_metric(result.stdout)
         logger.debug(f"Extracted metric: {metric}")
         return TrialResult(fom=metric, runtime=runtime)
@@ -341,8 +363,10 @@ class ApplicationEvaluator:
                 raise OptimizationError(f"Session report is missing the {name} metric")
             energy += metrics[name]['last'] - metrics[name]['first']
         if runtime <= 0:
-            raise OptimizationError("Session reported non-positive runtime")
+            raise RecoverableEvaluationError("Session reported non-positive runtime")
         average_power = energy / runtime
+        if average_power <= 0:
+            raise RecoverableEvaluationError("Session reported non-positive power")
         return energy, runtime, average_power
 
     def _evaluate_session(self) -> 'TrialResult':
@@ -379,7 +403,7 @@ class ApplicationEvaluator:
             fom = None
             if self.regex is not None:
                 if not result.stdout:
-                    raise OptimizationError("Application produced no output")
+                    raise RecoverableEvaluationError("Application produced no output")
                 fom = self._extract_metric(result.stdout)
 
             return TrialResult(fom=fom, energy=energy, runtime=runtime,
@@ -402,12 +426,13 @@ class ApplicationEvaluator:
             float: Extracted metric value
 
         Raises:
-            OptimizationError: If metric cannot be extracted
+            RecoverableEvaluationError: If the metric cannot be scraped or
+                parsed; the trial is penalized rather than aborting the run.
         """
         match = self.regex.search(stdout)
         if not match:
             logger.debug(f"Failed to match regex '{self.metric_regex}' in stdout (first 200 chars): {stdout[:200]}")
-            raise OptimizationError(
+            raise RecoverableEvaluationError(
                 f"Could not extract metric from output using pattern: {self.metric_regex}"
             )
 
@@ -423,7 +448,7 @@ class ApplicationEvaluator:
             logger.debug(f"Extracted metric string: '{metric_str}'")
             return float(metric_str)
         except ValueError:
-            raise OptimizationError(
+            raise RecoverableEvaluationError(
                 f"Could not convert extracted value to float: {metric_str}"
             )
 
@@ -506,6 +531,9 @@ class BayesianOptimizer:
         self._metric_bound = None
         self._penalty_weight = _DEFAULT_BOUND_PENALTY_WEIGHT
         self._energy_scale = None
+
+        # Recoverable-failure penalty policy, set at the start of optimize().
+        self._penalty = 'auto'
 
         logger.debug(f"Initialized optimizer with {len(self.space)} dimensions")
 
@@ -667,6 +695,62 @@ class BayesianOptimizer:
             return energy
         return energy + self._penalty_weight * self._energy_scale * violation
 
+    def _penalty_value(self) -> float:
+        """Return the objective value assigned to a recoverable failure.
+
+        For the ``auto`` policy the penalty is derived to be strictly worse
+        (larger, since the objective is minimized) than every successful trial
+        observed so far, so the surrogate model learns to avoid the failing
+        region without an infinite objective. The value is always finite. When
+        a failure precedes any success the automatic value cannot be derived,
+        so a finite bootstrap penalty is used and a warning is emitted.
+
+        Returns:
+            float: The finite penalty objective for a failed trial.
+        """
+        if isinstance(self._penalty, (int, float)):
+            return float(self._penalty)
+
+        successes = [h['metric'] for h in self.evaluation_history
+                     if not h.get('failed')]
+        if not successes:
+            logger.warning(
+                "A trial failed before any trial succeeded; using a bootstrap "
+                f"penalty of {_BOOTSTRAP_PENALTY}")
+            return float(_BOOTSTRAP_PENALTY)
+
+        worst = max(successes)
+        spread = worst - min(successes)
+        # Keep the penalty strictly worse than the worst success even when all
+        # successes tie (spread == 0).
+        margin = spread if spread > 0 else (abs(worst) if worst != 0 else 1.0)
+        penalty = worst + margin
+        if not math.isfinite(penalty):
+            penalty = sys.float_info.max
+        return penalty
+
+    def _handle_failed_trial(self, trial: TrialResult) -> float:
+        """Turn a failed trial into an objective value per the penalty policy.
+
+        Args:
+            trial: The failed :class:`TrialResult`.
+
+        Returns:
+            float: The penalty objective to report to the optimizer.
+
+        Raises:
+            OptimizationError: When the penalty policy is ``none``, restoring
+                the legacy behavior of aborting the run on any failure.
+        """
+        if self._penalty == 'none':
+            raise OptimizationError(
+                f"Trial failed and --penalty is 'none': {trial.failure_reason}")
+        penalty = self._penalty_value()
+        logger.warning(
+            f"Penalizing failed trial ({trial.failure_reason}) "
+            f"with objective {penalty}")
+        return penalty
+
     def _record_history(self, coordinate: List[int], metric: float,
                         trial: 'TrialResult' = None,
                         objective_mode: ObjectiveMode = None) -> None:
@@ -683,7 +767,13 @@ class BayesianOptimizer:
             'metric': metric,
             'config_commands': self.control_grid.get_config_str(coordinate)
         }
-        if objective_mode == ObjectiveMode.ENERGY_BOUNDED and trial is not None:
+        if trial is not None and trial.failed:
+            entry['failed'] = True
+            entry['failure_reason'] = trial.failure_reason
+            # A failed trial can never satisfy a figure-of-merit bound.
+            if objective_mode == ObjectiveMode.ENERGY_BOUNDED:
+                entry['feasible'] = False
+        elif objective_mode == ObjectiveMode.ENERGY_BOUNDED and trial is not None:
             entry['fom'] = trial.fom
             entry['energy'] = trial.energy
             entry['feasible'] = self._bound_violation(trial.fom) <= 0.0
@@ -696,7 +786,8 @@ class BayesianOptimizer:
                  random_state: int = 42,
                  objective_mode: ObjectiveMode = ObjectiveMode.RAW_METRIC,
                  metric_bound: float = None,
-                 penalty_weight: float = _DEFAULT_BOUND_PENALTY_WEIGHT) -> dict:
+                 penalty_weight: float = _DEFAULT_BOUND_PENALTY_WEIGHT,
+                 penalty='auto') -> dict:
         """Run Bayesian optimization.
 
         Args:
@@ -708,6 +799,9 @@ class BayesianOptimizer:
                 objective. Trials whose FoM violates the bound are penalized.
             penalty_weight: Weight of the bound-violation penalty for the
                 ENERGY_BOUNDED objective.
+            penalty: Recoverable-failure policy: ``'auto'`` derives a finite
+                penalty worse than every success, ``'none'`` re-raises on any
+                failure (legacy behavior), or a float sets a fixed penalty.
 
         Returns:
             dict: Optimization results including best configuration and value
@@ -716,6 +810,7 @@ class BayesianOptimizer:
         self._metric_bound = metric_bound
         self._penalty_weight = penalty_weight
         self._energy_scale = None
+        self._penalty = penalty
 
         @use_named_args(self.space)
         def objective(**params):
@@ -723,7 +818,10 @@ class BayesianOptimizer:
             # Convert parameter indices to actual coordinate values
             coordinate = [int(params[dim.name]) for dim in self.space]  # Convert numpy types to int
             trial = self._evaluate_coordinate(coordinate)
-            metric = self._score_result(trial, objective_mode)
+            if trial.failed:
+                metric = self._handle_failed_trial(trial)
+            else:
+                metric = self._score_result(trial, objective_mode)
             self._record_history(coordinate, metric, trial, objective_mode)
             return metric
 
@@ -746,13 +844,12 @@ class BayesianOptimizer:
         if objective_mode == ObjectiveMode.ENERGY_BOUNDED:
             return self._build_bounded_result(result)
 
-        # Convert best coordinate to actual configuration
-        best_coordinate = [int(x) for x in result.x]
+        # Select the best successful trial, excluding penalized failures.
+        best_coordinate, best_metric = self._select_best(result)
         best_config = self.control_grid.get_config_str(best_coordinate)
 
         # Convert metric back if maximizing. Runtime and energy objectives are
         # already reported in their natural (minimized) units.
-        best_metric = result.fun
         if (objective_mode in (ObjectiveMode.RAW_METRIC, ObjectiveMode.EFFICIENCY)
                 and self.evaluator.maximize):
             best_metric = -best_metric
@@ -765,26 +862,62 @@ class BayesianOptimizer:
             'optimization_result': result
         }
 
+    def _select_best(self, result):
+        """Return the best successful coordinate and its minimization metric.
+
+        Failed trials are excluded from selection. When the evaluation history
+        is available it is the source of truth; a run in which every trial
+        failed raises a clear error. When the history is empty (for example
+        under a mocked optimizer) the scikit-optimize result is used directly.
+
+        Args:
+            result: The scikit-optimize result from ``gp_minimize``.
+
+        Returns:
+            tuple: ``(best_coordinate, best_metric)`` in minimization space.
+
+        Raises:
+            OptimizationError: If every recorded trial failed.
+        """
+        successes = [h for h in self.evaluation_history if not h.get('failed')]
+        if self.evaluation_history and not successes:
+            raise OptimizationError(
+                "All trials failed; no successful configuration was found")
+        if successes:
+            best = min(successes, key=lambda h: h['metric'])
+            return list(best['coordinate']), best['metric']
+        # Fallback for callers that do not populate history (mocked runs).
+        return [int(x) for x in result.x], result.fun
+
     def _build_bounded_result(self, result) -> dict:
         """Assemble the result for the ENERGY_BOUNDED objective.
 
         Prefers the feasible trial with the lowest energy. When no trial
-        satisfied the bound, falls back to the point that minimized the
-        penalized objective (the least-infeasible trial) and marks the result
-        as not satisfying the bound.
+        satisfied the bound, falls back to the successful trial that minimized
+        the penalized objective (the least-infeasible trial) and marks the
+        result as not satisfying the bound. Failed trials are never selected,
+        and a run in which every trial failed raises a clear error.
 
         Args:
             result: The scikit-optimize result from ``gp_minimize``.
 
         Returns:
             dict: Result including ``bound_satisfied`` and ``best_fom``.
+
+        Raises:
+            OptimizationError: If every recorded trial failed.
         """
-        feasible = [h for h in self.evaluation_history if h.get('feasible')]
+        non_failed = [h for h in self.evaluation_history if not h.get('failed')]
+        if self.evaluation_history and not non_failed:
+            raise OptimizationError(
+                "All trials failed; no successful configuration was found")
+
+        feasible = [h for h in non_failed if h.get('feasible')]
         if feasible:
             best = min(feasible, key=lambda h: h['energy'])
             bound_satisfied = True
         else:
-            best = min(self.evaluation_history, key=lambda h: h['metric'])
+            best = min(non_failed, key=lambda h: h['metric'])
             bound_satisfied = False
 
         best_coordinate = list(best['coordinate'])
@@ -819,6 +952,27 @@ class BayesianOptimizer:
                 f"(best figure of merit: {result.get('best_fom')})")
             lines.append(f"Energy at best configuration: {result['best_metric']}")
         return '\n'.join(lines)
+
+
+def _penalty_arg(value):
+    """Parse the ``--penalty`` argument into ``'auto'``, ``'none'``, or a float.
+
+    Args:
+        value: The raw command-line string.
+
+    Returns:
+        The literal ``'auto'`` / ``'none'`` or the parsed float value.
+
+    Raises:
+        ArgumentTypeError: If the value is neither keyword nor a valid float.
+    """
+    if value in ('auto', 'none'):
+        return value
+    try:
+        return float(value)
+    except ValueError:
+        raise ArgumentTypeError(
+            f"--penalty must be 'auto', 'none', or a number, not {value!r}")
 
 
 def get_parser():
@@ -921,6 +1075,16 @@ def get_parser():
         help='geopmsession sampling period in seconds for energy-based '
              'objectives; shorter periods add overhead (default: %(default)s)',
     )
+    parser.add_argument(
+        '--penalty',
+        type=_penalty_arg,
+        default='auto',
+        help="How to handle a recoverable trial failure (timeout, non-zero "
+             "exit, figure-of-merit scrape miss, non-positive power/runtime): "
+             "'auto' penalizes the trial with a value worse than every success, "
+             "'none' aborts the run on any failure, or a number sets a fixed "
+             "penalty (default: %(default)s)",
+    )
 
     # Application launch command
     parser.add_argument(
@@ -1020,7 +1184,8 @@ def main():
             n_initial_points=args.n_initial_points,
             random_state=args.random_seed,
             objective_mode=objective_mode,
-            metric_bound=args.metric_bound
+            metric_bound=args.metric_bound,
+            penalty=args.penalty
         )
 
         # Print results

--- a/geopmdpy/integration_test/TestGeopmoptObjective.py
+++ b/geopmdpy/integration_test/TestGeopmoptObjective.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2026 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+"""geopmopt Phase 0 end-to-end regression integration test.
+
+Phase 0 of the geopmopt enhancement plan (#4043 / #4044 / #3927) is a
+behavior-preserving refactor: the ``BayesianOptimizer.optimize`` objective
+closure is split into helper methods and ``ApplicationEvaluator.evaluate``
+now returns a ``TrialResult`` container instead of a bare float.  The mocked
+unit suite under ``geopmdpy/test`` verifies the refactor's internals but
+never launches the real CLI.  This live-hardware test closes that gap: it
+runs the real ``geopmopt`` (``python -m geopmdpy.optimizer``) end to end and
+asserts that the two objectives that existed before Phase 0 still work --
+
+* a raw-metric maximize run selects the highest frequency in the grid for a
+  CPU-bound workload (the throughput objective), and
+* an ``--efficiency cpu`` run completes and selects a frequency from the grid
+  (the efficiency objective, which exercises the energy/time sampling path).
+
+It requires a live GEOPM service that grants the CPU core-frequency control,
+scikit-optimize, and a shell to run the probe workload.  Without them the
+test skips cleanly.  It lives in the independent ``integration_test``
+directory and is run explicitly.
+
+Environment overrides (optional):
+  GEOPMOPT_PROBE_ITERS   Busy-loop iteration count in the probe (default 3e6).
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from . import _geopmopt_util as gu
+
+# Figure-of-merit pattern printed by apps/cpu_frequency_probe.sh.
+_METRIC_REGEX = r'GEOPMOPT-FOM: ([0-9.]+)'
+
+
+class _GeopmoptHarness(unittest.TestCase):
+    """Shared orchestration: run geopmopt once in ``setUpClass`` and expose
+    the resulting best configuration to the test methods.
+
+    Subclasses set ``EFFICIENCY_DOMAIN`` / ``MINIMIZE`` and are decorated with
+    the skip guards.  This base defines no ``test_*`` methods, so unittest
+    collects nothing from it.
+    """
+
+    #: ``--efficiency`` domain, or None for the raw-metric objective.
+    EFFICIENCY_DOMAIN = None
+    #: Whether to pass ``--minimize`` (default is maximize).
+    MINIMIZE = False
+
+    @classmethod
+    def setUpClass(cls):
+        cls._freq_low, cls._freq_high = gu.cpu_frequency_bounds()
+        cls._tmpdir = tempfile.mkdtemp(prefix=f'geopmopt-{cls.__name__}-')
+        cls._config_path = os.path.join(cls._tmpdir, 'best.config')
+        cls._command = gu.geopmopt_command(
+            cls._config_path, _METRIC_REGEX, cls._freq_low, cls._freq_high,
+            minimize=cls.MINIMIZE, efficiency_domain=cls.EFFICIENCY_DOMAIN)
+        proc = subprocess.run(
+            cls._command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f'geopmopt failed ({cls.__name__}) with return code '
+                f'{proc.returncode}\n'
+                f'command: {" ".join(cls._command)}\n'
+                f'stdout:\n{proc.stdout}\n'
+                f'stderr:\n{proc.stderr}')
+        with open(cls._config_path) as fid:
+            cls._config_text = fid.read()
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls._tmpdir, ignore_errors=True)
+
+    def _best_frequency(self):
+        freq = gu.best_cpu_frequency(self._config_text)
+        self.assertIsNotNone(
+            freq,
+            msg=('geopmopt best configuration did not contain '
+                 f'CPU_FREQUENCY_MAX_CONTROL:\n{self._config_text}'))
+        return freq
+
+
+@gu.skip_unless_skopt()
+@gu.skip_unless_cpu_frequency_control()
+class TestGeopmoptRawMetric(_GeopmoptHarness):
+    """Raw-metric maximize objective (unchanged by Phase 0)."""
+
+    EFFICIENCY_DOMAIN = None
+    MINIMIZE = False
+
+    def test_selects_max_frequency(self):
+        """Maximizing CPU-bound throughput selects the highest grid frequency.
+
+        Higher CPU core frequency shortens the single-threaded busy loop, so
+        the throughput FoM is monotonically increasing in frequency and the
+        optimizer must choose the grid's high endpoint.
+        """
+        self.assertEqual(
+            self._best_frequency(), float(self._freq_high),
+            msg=('maximizing throughput did not select the highest grid '
+                 f'frequency {self._freq_high}'))
+
+
+@gu.skip_unless_skopt()
+@gu.skip_unless_cpu_frequency_control()
+@gu.skip_unless_cpu_energy()
+class TestGeopmoptEfficiency(_GeopmoptHarness):
+    """Efficiency objective (``--efficiency cpu``) exercised end to end.
+
+    The efficiency winner is hardware dependent, so this is a smoke/regression
+    check: the refactored energy/time sampling path must complete and yield a
+    configuration drawn from the search grid.
+    """
+
+    EFFICIENCY_DOMAIN = 'cpu'
+    MINIMIZE = False
+
+    def test_completes_and_selects_grid_frequency(self):
+        """The efficiency run completes and selects a grid-endpoint frequency."""
+        freq = self._best_frequency()
+        self.assertIn(
+            freq, (float(self._freq_low), float(self._freq_high)),
+            msg=(f'selected frequency {freq} is not one of the grid endpoints '
+                 f'{self._freq_low}/{self._freq_high}'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/geopmdpy/integration_test/__init__.py
+++ b/geopmdpy/integration_test/__init__.py
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2015 - 2026 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+"""GEOPM Python session-agent integration tests.
+
+This package holds live-hardware effectiveness tests for the geopmdpy
+session agents (e.g. the GPU activity agent).  Unlike the hermetic unit
+tests under ``geopmdpy/test`` (which mock ``pio``/``topo`` and never touch
+hardware), these tests require a running GEOPM service, real hardware
+(e.g. a GPU), and a workload.  They are NOT collected by ``make check``; run
+them explicitly from this independent ``integration_test`` directory.  See
+``README.md`` in this directory.
+"""

--- a/geopmdpy/integration_test/__main__.py
+++ b/geopmdpy/integration_test/__main__.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2015 - 2026 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+"""Explicit runner for the geopmdpy session-agent integration tests.
+
+Discovers ``Test*`` modules in this directory only, so the hermetic unit
+suite under ``geopmdpy/test`` is never pulled in.  ``integration_test`` is a
+top-level package that sits *beside* the installed ``geopmdpy`` module (not
+inside it), so run it from the ``geopm/geopmdpy`` source directory::
+
+    cd geopm/geopmdpy
+    python -m integration_test
+"""
+import os
+import sys
+import unittest
+
+if __name__ == '__main__':
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    top_dir = os.path.join(tests_dir, '..')
+    loader = unittest.TestLoader()
+    tests = loader.discover(start_dir=tests_dir, pattern='Test*',
+                            top_level_dir=top_dir)
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(tests)
+    sys.exit(not result.wasSuccessful())

--- a/geopmdpy/integration_test/_geopmopt_util.py
+++ b/geopmdpy/integration_test/_geopmopt_util.py
@@ -1,0 +1,168 @@
+#
+#  Copyright (c) 2015 - 2026 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+"""Skip guards and orchestration helpers for the geopmopt Phase 0
+regression integration test.
+
+Like the GPU activity agent helpers in ``_util.py``, these helpers are
+geopmdpy-native: they probe the platform through ``geopmdpy.pio`` /
+``geopmdpy.topo`` and drive ``geopmopt`` (``python -m geopmdpy.optimizer``)
+as a subprocess, so the test carries no dependency on the HPC-runtime test
+infrastructure under ``geopm/integration`` (``geopm_test_launcher``,
+``geopmpy.io``, MPI).
+
+Phase 0 of the geopmopt enhancement plan is a behavior-preserving refactor
+(objective-helper extraction plus the ``TrialResult`` container).  These
+helpers exist so the accompanying test can exercise the real end-to-end CLI
+path -- which the mocked ``geopmdpy/test`` unit suite cannot -- and confirm
+that the raw-metric and ``--efficiency`` workflows still run and select a
+sane configuration.
+"""
+
+import os
+import sys
+import unittest
+
+# CPU core-frequency control that ``geopmopt --cpu-frequency`` writes.
+_CPU_FREQUENCY_CONTROL = 'CPU_FREQUENCY_MAX_CONTROL'
+# Spread (Hz) between the low and high grid frequencies.  Wide enough that a
+# single-threaded CPU-bound loop is measurably faster at the high setting.
+_FREQUENCY_SPREAD_HZ = 500000000
+
+
+def skip_unless_skopt():
+    """Class/method decorator: skip when scikit-optimize is unavailable.
+
+    ``geopmopt`` imports ``skopt`` at module load, so without it the tool
+    cannot run at all.
+    """
+    try:
+        import skopt  # noqa: F401
+    except Exception:
+        return unittest.skip(
+            'scikit-optimize (skopt) is required to run geopmopt')
+    return lambda obj: obj
+
+
+def skip_unless_cpu_frequency_control():
+    """Class/method decorator: skip when no live GEOPM service exposes a
+    writable CPU core-frequency control.
+
+    ``geopmopt`` applies the frequency cap live for every trial, so the
+    control must be present in the session's control list (which reflects the
+    GEOPM Access Service allow-list) and the service must be answering reads.
+    """
+    try:
+        from geopmdpy import pio
+        from geopmdpy import topo
+        if _CPU_FREQUENCY_CONTROL not in pio.control_names():
+            return unittest.skip(
+                f'{_CPU_FREQUENCY_CONTROL} unavailable; no CPU frequency '
+                'control granted or no live GEOPM service')
+        # A readable sticker frequency confirms the service is answering.
+        pio.read_signal('CPU_FREQUENCY_STICKER', topo.DOMAIN_BOARD, 0)
+    except Exception:
+        return unittest.skip(
+            'unable to query the CPU frequency control from the GEOPM service')
+    return lambda obj: obj
+
+
+def skip_unless_cpu_energy():
+    """Class/method decorator: skip when CPU energy is unreadable, which the
+    ``--efficiency cpu`` objective requires.
+    """
+    try:
+        from geopmdpy.optimizer import get_energy
+        get_energy('cpu')
+    except Exception:
+        return unittest.skip(
+            'CPU energy is unreadable; --efficiency cpu cannot be measured')
+    return lambda obj: obj
+
+
+def apps_dir():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'apps')
+
+
+def probe_command():
+    """Path to the trivial CPU-bound, frequency-sensitive workload script."""
+    return os.path.join(apps_dir(), 'cpu_frequency_probe.sh')
+
+
+def cpu_frequency_bounds():
+    """Return two valid CPU core-frequency settings ``(low, high)`` in Hz.
+
+    ``high`` is the platform sticker frequency; ``low`` is
+    ``_FREQUENCY_SPREAD_HZ`` below it, clamped to the minimum available
+    frequency.  The spread is wide enough that the CPU-bound probe is
+    measurably faster at ``high`` than at ``low``, giving the optimizer an
+    unambiguous, monotonic signal.
+    """
+    from geopmdpy import pio
+    from geopmdpy import topo
+    high = pio.read_signal('CPU_FREQUENCY_STICKER', topo.DOMAIN_BOARD, 0)
+    try:
+        floor = pio.read_signal(
+            'CPU_FREQUENCY_MIN_AVAIL', topo.DOMAIN_BOARD, 0)
+    except Exception:
+        floor = high - _FREQUENCY_SPREAD_HZ
+    low = max(floor, high - _FREQUENCY_SPREAD_HZ)
+    return int(low), int(high)
+
+
+def geopmopt_command(output_file, metric_regex, freq_low, freq_high,
+                     minimize=False, efficiency_domain=None, trials=6,
+                     n_initial_points=3, application_timeout=120):
+    """Build the ``python -m geopmdpy.optimizer`` argv for a two-point CPU
+    frequency sweep that runs the probe workload.
+
+    The step is set to ``freq_high - freq_low`` so the search grid holds
+    exactly the two endpoint frequencies.  ``--defer-write`` is intentionally
+    omitted so geopmopt applies each candidate frequency live (with
+    save/restore auto-revert) instead of delegating the write to the
+    workload.
+    """
+    step = freq_high - freq_low
+    cmd = [sys.executable, '-m', 'geopmdpy.optimizer',
+           '--cpu-frequency', 'board',
+           '--cpu-frequency-min', str(freq_low),
+           '--cpu-frequency-max', str(freq_high),
+           '--cpu-frequency-step', str(step),
+           '--trials', str(trials),
+           '--n-initial-points', str(n_initial_points),
+           '--application-timeout', str(application_timeout),
+           '--metric-regex', metric_regex,
+           '--output-file', output_file,
+           '--verbosity', '2']
+    if minimize:
+        cmd.append('--minimize')
+    if efficiency_domain is not None:
+        cmd += ['--efficiency', efficiency_domain]
+    cmd += ['--', probe_command()]
+    return cmd
+
+
+def parse_best_config(text):
+    """Parse a geopmopt configuration into ``{control_name: value}``.
+
+    Each configuration line is ``CONTROL_NAME domain domain_idx value``; the
+    control name and its numeric value are returned.
+    """
+    config = {}
+    for line in text.splitlines():
+        fields = line.split()
+        if len(fields) < 4:
+            continue
+        try:
+            config[fields[0]] = float(fields[3])
+        except ValueError:
+            continue
+    return config
+
+
+def best_cpu_frequency(config_text):
+    """Return the CPU core-frequency (Hz) selected in a geopmopt config, or
+    ``None`` when the control is absent."""
+    return parse_best_config(config_text).get(_CPU_FREQUENCY_CONTROL)

--- a/geopmdpy/integration_test/apps/cpu_frequency_probe.sh
+++ b/geopmdpy/integration_test/apps/cpu_frequency_probe.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+#  Copyright (c) 2015 - 2026 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+# Trivial CPU-bound, frequency-sensitive workload for the geopmopt Phase 0
+# regression integration test.  It performs a fixed-size integer busy loop,
+# times it, and prints a throughput figure of merit:
+#
+#     GEOPMOPT-FOM: <iterations-per-second>
+#
+# The loop is compute-bound and single-threaded, so a higher CPU core
+# frequency yields a higher throughput.  A maximizing geopmopt run must
+# therefore prefer the highest frequency in the search grid.  geopmopt applies
+# the candidate frequency cap live before launching this script, so the
+# workload itself performs no control writes.  The iteration count is tunable
+# through GEOPMOPT_PROBE_ITERS for slower or faster hosts.
+
+set -euo pipefail
+
+iterations="${GEOPMOPT_PROBE_ITERS:-3000000}"
+
+start_ns=$(date +%s%N)
+sum=0
+for (( i = 0; i < iterations; i++ )); do
+    # Assignment form (not a bare "(( ))" command) so a zero result does not
+    # trip "set -e"; integer wraparound is harmless because sum is unused.
+    sum=$(( sum + i ))
+done
+end_ns=$(date +%s%N)
+
+elapsed_ns=$(( end_ns - start_ns ))
+if (( elapsed_ns <= 0 )); then
+    elapsed_ns=1
+fi
+
+# throughput = iterations / seconds = iterations * 1e9 / elapsed_ns
+fom=$(awk -v it="${iterations}" -v ns="${elapsed_ns}" \
+    'BEGIN { printf "%.3f", it * 1.0e9 / ns }')
+echo "GEOPMOPT-FOM: ${fom}"

--- a/geopmdpy/test/TestOptimizer.py
+++ b/geopmdpy/test/TestOptimizer.py
@@ -13,6 +13,8 @@ import tempfile
 import os
 import sys
 import re
+import math
+from argparse import ArgumentTypeError
 
 # Skip test if skopt not available
 skip_test = False
@@ -132,7 +134,7 @@ class TestApplicationEvaluator(unittest.TestCase):
 
     @patch('subprocess.run')
     def test_evaluate_failed_process(self, mock_run):
-        """Test evaluation with failed subprocess."""
+        """A non-zero exit is a recoverable failure surfaced as trial data."""
         mock_result = MagicMock()
         mock_result.returncode = 1
         mock_result.stderr = "Error occurred"
@@ -142,27 +144,27 @@ class TestApplicationEvaluator(unittest.TestCase):
         mock_grid = MagicMock()
         coordinate = [0]
 
-        with self.assertRaises(optimizer.OptimizationError) as context:
-            self.evaluator.evaluate(mock_grid, coordinate)
+        result = self.evaluator.evaluate(mock_grid, coordinate)
 
-        self.assertIn("Application failed", str(context.exception))
+        self.assertTrue(result.failed)
+        self.assertIn("Application failed", result.failure_reason)
 
     @patch('subprocess.run')
     def test_evaluate_timeout(self, mock_run):
-        """Test evaluation with subprocess timeout."""
+        """A timeout is a recoverable failure surfaced as trial data."""
         mock_run.side_effect = subprocess.TimeoutExpired("cmd", 300)
 
         mock_grid = MagicMock()
         coordinate = [0]
 
-        with self.assertRaises(optimizer.OptimizationError) as context:
-            self.evaluator.evaluate(mock_grid, coordinate)
+        result = self.evaluator.evaluate(mock_grid, coordinate)
 
-        self.assertIn("timed out after 300 seconds", str(context.exception))
+        self.assertTrue(result.failed)
+        self.assertIn("timed out after 300 seconds", result.failure_reason)
 
     @patch('subprocess.run')
     def test_evaluate_custom_timeout(self, mock_run):
-        """Test evaluation with custom timeout."""
+        """A custom timeout is reported in the recoverable failure reason."""
         evaluator = optimizer.ApplicationEvaluator(
             self.launch_command, self.metric_regex, timeout=600
         )
@@ -170,14 +172,14 @@ class TestApplicationEvaluator(unittest.TestCase):
         mock_run.side_effect = subprocess.TimeoutExpired("cmd", 600)
         mock_grid = MagicMock()
 
-        with self.assertRaises(optimizer.OptimizationError) as context:
-            evaluator.evaluate(mock_grid, [0])
+        result = evaluator.evaluate(mock_grid, [0])
 
-        self.assertIn("timed out after 600 seconds", str(context.exception))
+        self.assertTrue(result.failed)
+        self.assertIn("timed out after 600 seconds", result.failure_reason)
 
     @patch('subprocess.run')
     def test_evaluate_no_output(self, mock_run):
-        """Test evaluation with no stdout."""
+        """Missing output when a metric is expected is a recoverable failure."""
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stdout = ""
@@ -185,10 +187,10 @@ class TestApplicationEvaluator(unittest.TestCase):
 
         mock_grid = MagicMock()
 
-        with self.assertRaises(optimizer.OptimizationError) as context:
-            self.evaluator.evaluate(mock_grid, [0])
+        result = self.evaluator.evaluate(mock_grid, [0])
 
-        self.assertIn("produced no output", str(context.exception))
+        self.assertTrue(result.failed)
+        self.assertIn("produced no output", result.failure_reason)
 
     @patch('subprocess.run')
     def test_evaluate_no_regex_returns_runtime(self, mock_run):
@@ -212,7 +214,7 @@ class TestApplicationEvaluator(unittest.TestCase):
 
     @patch('subprocess.run')
     def test_evaluate_no_regex_failed_process(self, mock_run):
-        """A non-zero return code still raises even without a metric regex."""
+        """A non-zero exit is recoverable even without a metric regex."""
         evaluator = optimizer.ApplicationEvaluator(
             self.launch_command, metric_regex=None
         )
@@ -223,9 +225,27 @@ class TestApplicationEvaluator(unittest.TestCase):
         mock_run.return_value = mock_result
 
         mock_grid = MagicMock()
+        result = evaluator.evaluate(mock_grid, [0])
+        self.assertTrue(result.failed)
+        self.assertIn("Application failed", result.failure_reason)
+
+    @patch('subprocess.run')
+    def test_evaluate_command_not_found_is_fatal(self, mock_run):
+        """A missing command is a fatal error, not a recoverable failure."""
+        mock_run.side_effect = FileNotFoundError("no such file")
+        mock_grid = MagicMock()
         with self.assertRaises(optimizer.OptimizationError) as context:
-            evaluator.evaluate(mock_grid, [0])
-        self.assertIn("Application failed", str(context.exception))
+            self.evaluator.evaluate(mock_grid, [0])
+        self.assertIn("Command not found", str(context.exception))
+
+    @patch('subprocess.run')
+    def test_evaluate_permission_denied_is_fatal(self, mock_run):
+        """A permission error is a fatal error, not a recoverable failure."""
+        mock_run.side_effect = PermissionError("denied")
+        mock_grid = MagicMock()
+        with self.assertRaises(optimizer.OptimizationError) as context:
+            self.evaluator.evaluate(mock_grid, [0])
+        self.assertIn("Permission denied", str(context.exception))
 
     def test_extract_metric_success(self):
         """Test successful metric extraction."""
@@ -243,22 +263,22 @@ class TestApplicationEvaluator(unittest.TestCase):
         self.assertEqual(metric, 123.45)
 
     def test_extract_metric_no_match(self):
-        """Test metric extraction with no match."""
+        """A regex miss is a recoverable failure."""
         stdout = "Application output without metric"
 
-        with self.assertRaises(optimizer.OptimizationError) as context:
+        with self.assertRaises(optimizer.RecoverableEvaluationError) as context:
             self.evaluator._extract_metric(stdout)
 
         self.assertIn("Could not extract metric", str(context.exception))
 
     def test_extract_metric_invalid_value(self):
-        """Test metric extraction with invalid numeric value."""
+        """An unparsable matched value is a recoverable failure."""
         evaluator = optimizer.ApplicationEvaluator(
             ["echo", "test"], "Performance: ([a-z]+)", maximize=True
         )
         stdout = "Performance: invalid"
 
-        with self.assertRaises(optimizer.OptimizationError) as context:
+        with self.assertRaises(optimizer.RecoverableEvaluationError) as context:
             evaluator._extract_metric(stdout)
 
         self.assertIn("Could not convert", str(context.exception))
@@ -601,6 +621,134 @@ class TestBayesianOptimizer(unittest.TestCase):
         summary = opt.summarize(result, optimizer.ObjectiveMode.RUNTIME)
         self.assertEqual(summary, 'Best configuration:\nCONFIG')
 
+    def test_penalty_value_auto_worse_than_successes(self):
+        """The auto penalty is strictly worse than every observed success."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._penalty = 'auto'
+        opt.evaluation_history = [
+            {'coordinate': [0], 'metric': 10.0},
+            {'coordinate': [1], 'metric': 30.0},
+            {'coordinate': [2], 'metric': 20.0},
+        ]
+        penalty = opt._penalty_value()
+        # worst = 30, spread = 20, penalty = 50
+        self.assertEqual(penalty, 50.0)
+        self.assertGreater(penalty, 30.0)
+        self.assertTrue(math.isfinite(penalty))
+
+    def test_penalty_value_auto_tie(self):
+        """When all successes tie, the auto penalty still exceeds them."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._penalty = 'auto'
+        opt.evaluation_history = [
+            {'coordinate': [0], 'metric': 10.0},
+            {'coordinate': [1], 'metric': 10.0},
+        ]
+        penalty = opt._penalty_value()
+        self.assertGreater(penalty, 10.0)
+        self.assertTrue(math.isfinite(penalty))
+
+    def test_penalty_value_auto_excludes_failed(self):
+        """Prior failed trials do not inflate the auto penalty."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._penalty = 'auto'
+        opt.evaluation_history = [
+            {'coordinate': [0], 'metric': 10.0},
+            {'coordinate': [1], 'metric': 999.0, 'failed': True},
+        ]
+        # Only the success (10.0) is considered: worst=10, spread=0 -> +10 -> 20
+        self.assertEqual(opt._penalty_value(), 20.0)
+
+    def test_penalty_value_auto_bootstrap_warns(self):
+        """A failure before any success uses a finite bootstrap penalty."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._penalty = 'auto'
+        opt.evaluation_history = []
+        with self.assertLogs('geopmdpy.optimizer', level='WARNING'):
+            penalty = opt._penalty_value()
+        self.assertEqual(penalty, float(optimizer._BOOTSTRAP_PENALTY))
+        self.assertTrue(math.isfinite(penalty))
+
+    def test_penalty_value_fixed(self):
+        """A fixed numeric penalty policy returns that value verbatim."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._penalty = 123.5
+        opt.evaluation_history = [{'coordinate': [0], 'metric': 10.0}]
+        self.assertEqual(opt._penalty_value(), 123.5)
+
+    def test_handle_failed_trial_none_raises(self):
+        """The 'none' policy re-raises, aborting the run on any failure."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._penalty = 'none'
+        trial = optimizer.TrialResult(failed=True, failure_reason='boom')
+        with self.assertRaises(optimizer.OptimizationError) as context:
+            opt._handle_failed_trial(trial)
+        self.assertIn('boom', str(context.exception))
+
+    def test_handle_failed_trial_auto_warns(self):
+        """The 'auto' policy penalizes and logs the failure at WARNING."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._penalty = 'auto'
+        opt.evaluation_history = [{'coordinate': [0], 'metric': 10.0}]
+        trial = optimizer.TrialResult(failed=True, failure_reason='boom')
+        with self.assertLogs('geopmdpy.optimizer', level='WARNING'):
+            penalty = opt._handle_failed_trial(trial)
+        self.assertEqual(penalty, 20.0)
+
+    def test_handle_failed_trial_fixed(self):
+        """A fixed penalty policy returns the configured value."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._penalty = 5.0
+        trial = optimizer.TrialResult(failed=True, failure_reason='boom')
+        with self.assertLogs('geopmdpy.optimizer', level='WARNING'):
+            self.assertEqual(opt._handle_failed_trial(trial), 5.0)
+
+    def test_record_history_failed_trial(self):
+        """A failed trial is marked failed and infeasible for energy-bounded."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        trial = optimizer.TrialResult(failed=True, failure_reason='boom')
+        opt._record_history([0], 999.0, trial,
+                            optimizer.ObjectiveMode.ENERGY_BOUNDED)
+        entry = opt.evaluation_history[0]
+        self.assertTrue(entry['failed'])
+        self.assertEqual(entry['failure_reason'], 'boom')
+        self.assertFalse(entry['feasible'])
+
+    def test_select_best_excludes_failed(self):
+        """Best selection ignores penalized failed trials."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt.evaluation_history = [
+            {'coordinate': [0], 'metric': 10.0},
+            {'coordinate': [1], 'metric': 5.0, 'failed': True},
+            {'coordinate': [2], 'metric': 20.0},
+        ]
+        coordinate, metric = opt._select_best(MagicMock())
+        self.assertEqual(coordinate, [0])
+        self.assertEqual(metric, 10.0)
+
+    def test_select_best_all_failed_raises(self):
+        """A run where every trial failed raises a clear summary error."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt.evaluation_history = [
+            {'coordinate': [0], 'metric': 999.0, 'failed': True},
+            {'coordinate': [1], 'metric': 999.0, 'failed': True},
+        ]
+        with self.assertRaises(optimizer.OptimizationError) as context:
+            opt._select_best(MagicMock())
+        self.assertIn('All trials failed', str(context.exception))
+
+    def test_build_bounded_result_all_failed_raises(self):
+        """An all-failed energy-bounded run raises a clear summary error."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._metric_bound = 100.0
+        opt.evaluation_history = [
+            {'coordinate': [0], 'metric': 999.0, 'failed': True,
+             'feasible': False},
+        ]
+        with self.assertRaises(optimizer.OptimizationError) as context:
+            opt._build_bounded_result(MagicMock())
+        self.assertIn('All trials failed', str(context.exception))
+
     def test_record_history(self):
         """History records the coordinate, metric, and config commands."""
         opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
@@ -836,14 +984,14 @@ class TestSessionStrategy(unittest.TestCase):
             evaluator._compute_energy_metrics(report)
 
     def test_compute_energy_metrics_non_positive_runtime(self):
-        """A non-positive runtime is rejected."""
+        """A non-positive runtime is a recoverable failure."""
         evaluator = self._make_energy_evaluator(domain='cpu',
                                                 signals=('CPU_ENERGY',))
         report = {'metrics': {
             'TIME': {'first': 5.0, 'last': 5.0},
             'CPU_ENERGY': {'first': 0.0, 'last': 1.0},
         }}
-        with self.assertRaises(optimizer.OptimizationError):
+        with self.assertRaises(optimizer.RecoverableEvaluationError):
             evaluator._compute_energy_metrics(report)
 
     def test_load_report_missing_file(self):
@@ -916,7 +1064,7 @@ class TestSessionStrategy(unittest.TestCase):
                    return_value=mock_result), \
              patch('geopmdpy.optimizer.tempfile.mkstemp',
                    side_effect=tracking_mkstemp):
-            with self.assertRaises(optimizer.OptimizationError):
+            with self.assertRaises(optimizer.RecoverableEvaluationError):
                 evaluator._evaluate_session()
 
         self.assertEqual(len(created), 2)
@@ -943,6 +1091,23 @@ class TestSessionStrategy(unittest.TestCase):
             trial = evaluator._evaluate_session()
         self.assertEqual(trial.fom, 42.0)
         self.assertEqual(trial.energy, 10.0)
+
+    def test_evaluate_wraps_recoverable_session_failure(self):
+        """evaluate() turns a recoverable session failure into trial data."""
+        evaluator = self._make_energy_evaluator(domain='cpu',
+                                                signals=('CPU_ENERGY',))
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "boom"
+        mock_grid = MagicMock()
+        with patch('geopmdpy.optimizer.subprocess.run',
+                   return_value=mock_result), \
+             patch('geopmdpy.optimizer.tempfile.mkstemp',
+                   side_effect=tempfile.mkstemp):
+            trial = evaluator.evaluate(mock_grid, [0])
+        self.assertTrue(trial.failed)
+        self.assertIn("Application failed", trial.failure_reason)
 
 
 @unittest.skipIf(skip_test, skip_msg)
@@ -1207,6 +1372,7 @@ class TestGetParser(unittest.TestCase):
             '--efficiency', 'cpu',
             '--metric-bound', '100.0',
             '--sample-period', '0.25',
+            '--penalty', '250.0',
             'echo', 'test'
         ])
 
@@ -1225,6 +1391,7 @@ class TestGetParser(unittest.TestCase):
         self.assertEqual(args.efficiency_domain, 'cpu')
         self.assertEqual(args.metric_bound, 100.0)
         self.assertEqual(args.sample_period, 0.25)
+        self.assertEqual(args.penalty, 250.0)
         self.assertEqual(args.launch, ['echo', 'test'])
 
     def test_parser_defaults(self):
@@ -1249,6 +1416,42 @@ class TestGetParser(unittest.TestCase):
         self.assertIsNone(args.efficiency_domain)
         self.assertIsNone(args.metric_bound)
         self.assertEqual(args.sample_period, optimizer._DEFAULT_SAMPLE_PERIOD)
+        self.assertEqual(args.penalty, 'auto')
+
+    def test_parser_penalty_none(self):
+        """--penalty accepts the 'none' policy."""
+        parser = optimizer.get_parser()
+        args = parser.parse_args([
+            '--cpu-frequency', 'package', '--metric-regex', 'test',
+            '--penalty', 'none', 'echo', 'hello'
+        ])
+        self.assertEqual(args.penalty, 'none')
+
+    def test_parser_penalty_numeric(self):
+        """--penalty accepts a numeric policy parsed as a float."""
+        parser = optimizer.get_parser()
+        args = parser.parse_args([
+            '--cpu-frequency', 'package', '--metric-regex', 'test',
+            '--penalty', '42.5', 'echo', 'hello'
+        ])
+        self.assertEqual(args.penalty, 42.5)
+
+    def test_parser_penalty_invalid(self):
+        """--penalty rejects a value that is neither a policy nor a number."""
+        parser = optimizer.get_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args([
+                '--cpu-frequency', 'package', '--metric-regex', 'test',
+                '--penalty', 'bogus', 'echo', 'hello'
+            ])
+
+    def test_penalty_arg_helper(self):
+        """_penalty_arg normalizes policies and numbers, rejecting garbage."""
+        self.assertEqual(optimizer._penalty_arg('auto'), 'auto')
+        self.assertEqual(optimizer._penalty_arg('none'), 'none')
+        self.assertEqual(optimizer._penalty_arg('3.5'), 3.5)
+        with self.assertRaises(ArgumentTypeError):
+            optimizer._penalty_arg('bogus')
 
     def test_parser_metric_regex_optional(self):
         """--metric-regex is optional and defaults to None."""

--- a/geopmdpy/test/TestOptimizer.py
+++ b/geopmdpy/test/TestOptimizer.py
@@ -80,8 +80,8 @@ class TestApplicationEvaluator(unittest.TestCase):
         coordinate = [2]
         result = self.evaluator.evaluate(mock_grid, coordinate)
 
-        # Should return negative value for maximization
-        self.assertEqual(result, -123.45)
+        # Raw figure of merit is returned; sign convention is applied at scoring
+        self.assertEqual(result.fom, 123.45)
         mock_grid.write_config.assert_called_once_with(coordinate)
         mock_run.assert_called_once_with(
             self.launch_command,
@@ -107,8 +107,8 @@ class TestApplicationEvaluator(unittest.TestCase):
         coordinate = [1]
         result = evaluator.evaluate(mock_grid, coordinate)
 
-        # Should return positive value for minimization
-        self.assertEqual(result, 456.78)
+        # Raw figure of merit is returned regardless of maximize/minimize
+        self.assertEqual(result.fom, 456.78)
 
     @patch('subprocess.run')
     def test_evaluate_with_config_file(self, mock_run):
@@ -126,7 +126,7 @@ class TestApplicationEvaluator(unittest.TestCase):
             config_file = "/tmp/test_config.conf"
             result = self.evaluator.evaluate(mock_grid, coordinate, config_file)
 
-            self.assertEqual(result, -789.01)
+            self.assertEqual(result.fom, 789.01)
             mock_file.assert_called_once_with(config_file, 'w')
             mock_grid.get_config_str.assert_called_once_with(coordinate)
 
@@ -289,6 +289,28 @@ class TestGetEnergy(unittest.TestCase):
 
 
 @unittest.skipIf(skip_test, skip_msg)
+class TestTrialResult(unittest.TestCase):
+    def test_defaults(self):
+        """A TrialResult defaults to empty measurements and not-failed."""
+        trial = optimizer.TrialResult()
+        self.assertIsNone(trial.fom)
+        self.assertIsNone(trial.energy)
+        self.assertIsNone(trial.runtime)
+        self.assertIsNone(trial.average_power)
+        self.assertFalse(trial.failed)
+        self.assertIsNone(trial.failure_reason)
+
+    def test_fields(self):
+        """Fields are populated positionally/by keyword as expected."""
+        trial = optimizer.TrialResult(fom=1.0, energy=2.0, runtime=4.0,
+                                      average_power=0.5)
+        self.assertEqual(trial.fom, 1.0)
+        self.assertEqual(trial.energy, 2.0)
+        self.assertEqual(trial.runtime, 4.0)
+        self.assertEqual(trial.average_power, 0.5)
+
+
+@unittest.skipIf(skip_test, skip_msg)
 class TestBayesianOptimizer(unittest.TestCase):
     def setUp(self):
         # Mock the control grid without using spec
@@ -380,6 +402,70 @@ class TestBayesianOptimizer(unittest.TestCase):
             optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
 
         self.assertIn("Grid data dimensions", str(context.exception))
+
+    def test_score_result_maximize(self):
+        """Maximize converts the raw FoM to its negation (minimization space)."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        trial = optimizer.TrialResult(fom=123.45)
+        self.assertEqual(opt._score_result(trial, 0), -123.45)
+
+    def test_score_result_minimize(self):
+        """Minimize keeps the raw FoM sign."""
+        self.mock_evaluator.maximize = False
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        trial = optimizer.TrialResult(fom=123.45)
+        self.assertEqual(opt._score_result(trial, 0), 123.45)
+
+    def test_score_result_efficiency_maximize(self):
+        """Maximizing efficiency divides the negated FoM by average power."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        trial = optimizer.TrialResult(fom=1000.0, average_power=100.0)
+        self.assertEqual(opt._score_result(trial, 1), -10.0)
+
+    def test_score_result_efficiency_minimize(self):
+        """Minimizing efficiency multiplies the FoM by average power."""
+        self.mock_evaluator.maximize = False
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        trial = optimizer.TrialResult(fom=10.0, average_power=5.0)
+        self.assertEqual(opt._score_result(trial, -1), 50.0)
+
+    def test_score_result_nonpositive_power_raises(self):
+        """Non-positive average power raises OptimizationError."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        trial = optimizer.TrialResult(fom=1.0, average_power=0.0)
+        with self.assertRaises(optimizer.OptimizationError) as context:
+            opt._score_result(trial, 1)
+        self.assertIn("non-positive", str(context.exception))
+
+    def test_record_history(self):
+        """History records the coordinate, metric, and config commands."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._record_history([1], 42.0)
+        self.assertEqual(len(opt.evaluation_history), 1)
+        self.assertEqual(opt.evaluation_history[0]['coordinate'], [1])
+        self.assertEqual(opt.evaluation_history[0]['metric'], 42.0)
+
+    def test_evaluate_coordinate_no_efficiency(self):
+        """Without efficiency the evaluator result is returned unchanged."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        self.mock_evaluator.evaluate.return_value = optimizer.TrialResult(fom=7.0)
+        trial = opt._evaluate_coordinate([1], 0, None)
+        self.assertEqual(trial.fom, 7.0)
+        self.assertIsNone(trial.average_power)
+        self.mock_evaluator.evaluate.assert_called_once()
+
+    @patch('geopmdpy.optimizer.pio')
+    @patch('geopmdpy.optimizer.get_energy')
+    def test_evaluate_coordinate_efficiency(self, mock_get_energy, mock_pio):
+        """With efficiency, energy/runtime/power deltas are computed."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        self.mock_evaluator.evaluate.return_value = optimizer.TrialResult(fom=7.0)
+        mock_pio.read_signal.side_effect = [1000.0, 1010.0]  # start/end time
+        mock_get_energy.side_effect = [500.0, 600.0]  # start/end energy
+        trial = opt._evaluate_coordinate([1], 1, 'cpu')
+        self.assertEqual(trial.energy, 100.0)
+        self.assertEqual(trial.runtime, 10.0)
+        self.assertEqual(trial.average_power, 10.0)
 
     @patch('geopmdpy.optimizer.gp_minimize')
     def test_optimize_basic(self, mock_gp_minimize):

--- a/geopmdpy/test/TestOptimizer.py
+++ b/geopmdpy/test/TestOptimizer.py
@@ -492,12 +492,114 @@ class TestBayesianOptimizer(unittest.TestCase):
         self.assertEqual(
             opt._score_result(trial, optimizer.ObjectiveMode.ENERGY), 987.0)
 
-    def test_score_result_energy_bounded_not_implemented(self):
-        """The energy-bounded objective is not implemented in this phase."""
+    def test_score_result_energy_bounded_feasible(self):
+        """A feasible energy-bounded trial scores its plain energy."""
         opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
-        trial = optimizer.TrialResult(fom=1.0, energy=1.0)
-        with self.assertRaises(NotImplementedError):
-            opt._score_result(trial, optimizer.ObjectiveMode.ENERGY_BOUNDED)
+        opt._metric_bound = 100.0
+        opt._penalty_weight = 1.0
+        # maximize (default): feasible when fom >= bound
+        trial = optimizer.TrialResult(fom=120.0, energy=500.0)
+        self.assertEqual(
+            opt._score_result(trial, optimizer.ObjectiveMode.ENERGY_BOUNDED),
+            500.0)
+
+    def test_score_result_energy_bounded_infeasible(self):
+        """An infeasible energy-bounded trial scores strictly above its energy."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._metric_bound = 100.0
+        opt._penalty_weight = 1.0
+        # violation = (100 - 50) / 100 = 0.5; energy_scale = 500;
+        # penalty = 1.0 * 500 * 0.5 = 250
+        trial = optimizer.TrialResult(fom=50.0, energy=500.0)
+        score = opt._score_result(trial, optimizer.ObjectiveMode.ENERGY_BOUNDED)
+        self.assertGreater(score, 500.0)
+        self.assertEqual(score, 750.0)
+
+    def test_score_result_energy_bounded_minimize(self):
+        """When minimizing the FoM the bound is a ceiling."""
+        self.mock_evaluator.maximize = False
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._metric_bound = 100.0
+        opt._penalty_weight = 1.0
+        # feasible when fom <= bound
+        feasible = optimizer.TrialResult(fom=80.0, energy=500.0)
+        self.assertEqual(
+            opt._score_result(feasible, optimizer.ObjectiveMode.ENERGY_BOUNDED),
+            500.0)
+        # infeasible when fom > bound: violation = (150 - 100) / 100 = 0.5
+        infeasible = optimizer.TrialResult(fom=150.0, energy=500.0)
+        score = opt._score_result(
+            infeasible, optimizer.ObjectiveMode.ENERGY_BOUNDED)
+        self.assertEqual(score, 750.0)
+
+    def test_build_bounded_result_prefers_feasible(self):
+        """The best feasible point is chosen even if infeasible energy is lower."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._metric_bound = 100.0
+        opt.evaluation_history = [
+            {'coordinate': [0], 'metric': 100.0, 'energy': 100.0,
+             'fom': 50.0, 'feasible': False},
+            {'coordinate': [1], 'metric': 300.0, 'energy': 300.0,
+             'fom': 120.0, 'feasible': True},
+            {'coordinate': [2], 'metric': 250.0, 'energy': 250.0,
+             'fom': 110.0, 'feasible': True},
+        ]
+        mock_result = MagicMock()
+        mock_result.func_vals = [1, 2, 3]
+        out = opt._build_bounded_result(mock_result)
+        self.assertTrue(out['bound_satisfied'])
+        self.assertEqual(out['best_coordinate'], [2])
+        self.assertEqual(out['best_metric'], 250.0)
+        self.assertEqual(out['best_fom'], 110.0)
+
+    def test_build_bounded_result_all_infeasible(self):
+        """With no feasible point the least-penalized trial is reported."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._metric_bound = 100.0
+        opt.evaluation_history = [
+            {'coordinate': [0], 'metric': 900.0, 'energy': 400.0,
+             'fom': 50.0, 'feasible': False},
+            {'coordinate': [1], 'metric': 600.0, 'energy': 500.0,
+             'fom': 80.0, 'feasible': False},
+        ]
+        mock_result = MagicMock()
+        mock_result.func_vals = [1, 2]
+        out = opt._build_bounded_result(mock_result)
+        self.assertFalse(out['bound_satisfied'])
+        # The trial with the lowest penalized metric (600.0) is reported.
+        self.assertEqual(out['best_coordinate'], [1])
+        self.assertEqual(out['best_fom'], 80.0)
+
+    def test_summarize_energy_bounded_satisfied(self):
+        """The summary reports bound feasibility and the best figure of merit."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._metric_bound = 100.0
+        result = {
+            'best_config': 'CONFIG', 'best_metric': 250.0,
+            'best_fom': 110.0, 'bound_satisfied': True,
+        }
+        summary = opt.summarize(result, optimizer.ObjectiveMode.ENERGY_BOUNDED)
+        self.assertIn('satisfied', summary)
+        self.assertIn('110.0', summary)
+        self.assertNotIn('NOT satisfied', summary)
+
+    def test_summarize_energy_bounded_violated(self):
+        """The summary flags a violated bound."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._metric_bound = 100.0
+        result = {
+            'best_config': 'CONFIG', 'best_metric': 250.0,
+            'best_fom': 80.0, 'bound_satisfied': False,
+        }
+        summary = opt.summarize(result, optimizer.ObjectiveMode.ENERGY_BOUNDED)
+        self.assertIn('NOT satisfied', summary)
+
+    def test_summarize_non_bounded(self):
+        """Non-bounded objectives summarize just the best configuration."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        result = {'best_config': 'CONFIG', 'best_metric': 1.0}
+        summary = opt.summarize(result, optimizer.ObjectiveMode.RUNTIME)
+        self.assertEqual(summary, 'Best configuration:\nCONFIG')
 
     def test_record_history(self):
         """History records the coordinate, metric, and config commands."""
@@ -506,6 +608,21 @@ class TestBayesianOptimizer(unittest.TestCase):
         self.assertEqual(len(opt.evaluation_history), 1)
         self.assertEqual(opt.evaluation_history[0]['coordinate'], [1])
         self.assertEqual(opt.evaluation_history[0]['metric'], 42.0)
+
+    def test_record_history_energy_bounded_feasibility(self):
+        """Energy-bounded history entries record feasibility, fom, and energy."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        opt._metric_bound = 100.0
+        feasible = optimizer.TrialResult(fom=120.0, energy=500.0)
+        opt._record_history([0], 500.0, feasible,
+                            optimizer.ObjectiveMode.ENERGY_BOUNDED)
+        infeasible = optimizer.TrialResult(fom=50.0, energy=400.0)
+        opt._record_history([1], 700.0, infeasible,
+                            optimizer.ObjectiveMode.ENERGY_BOUNDED)
+        self.assertTrue(opt.evaluation_history[0]['feasible'])
+        self.assertEqual(opt.evaluation_history[0]['fom'], 120.0)
+        self.assertEqual(opt.evaluation_history[0]['energy'], 500.0)
+        self.assertFalse(opt.evaluation_history[1]['feasible'])
 
     def test_evaluate_coordinate_delegates(self):
         """_evaluate_coordinate validates and returns the evaluator's result."""
@@ -860,6 +977,8 @@ class TestOptimizerMain(unittest.TestCase):
             'best_config': 'CPU_FREQUENCY_MAX_CONTROL package 0 2000000',
             'n_evaluations': 10
         }
+        mock_optimizer.summarize.return_value = (
+            "Best configuration:\nCPU_FREQUENCY_MAX_CONTROL package 0 2000000")
         mock_optimizer_class.return_value = mock_optimizer
 
         with patch('builtins.print') as mock_print:
@@ -1086,6 +1205,7 @@ class TestGetParser(unittest.TestCase):
             '--print-stdout',
             '--defer-write',
             '--efficiency', 'cpu',
+            '--metric-bound', '100.0',
             '--sample-period', '0.25',
             'echo', 'test'
         ])
@@ -1103,6 +1223,7 @@ class TestGetParser(unittest.TestCase):
         self.assertTrue(args.print_stdout)
         self.assertTrue(args.defer_write)
         self.assertEqual(args.efficiency_domain, 'cpu')
+        self.assertEqual(args.metric_bound, 100.0)
         self.assertEqual(args.sample_period, 0.25)
         self.assertEqual(args.launch, ['echo', 'test'])
 
@@ -1126,6 +1247,7 @@ class TestGetParser(unittest.TestCase):
         self.assertFalse(args.print_stdout)
         self.assertFalse(args.defer_write)
         self.assertIsNone(args.efficiency_domain)
+        self.assertIsNone(args.metric_bound)
         self.assertEqual(args.sample_period, optimizer._DEFAULT_SAMPLE_PERIOD)
 
     def test_parser_metric_regex_optional(self):

--- a/geopmdpy/test/TestOptimizer.py
+++ b/geopmdpy/test/TestOptimizer.py
@@ -507,39 +507,13 @@ class TestBayesianOptimizer(unittest.TestCase):
         self.assertEqual(opt.evaluation_history[0]['coordinate'], [1])
         self.assertEqual(opt.evaluation_history[0]['metric'], 42.0)
 
-    def test_evaluate_coordinate_no_efficiency(self):
-        """Without an energy objective the evaluator result is unchanged."""
+    def test_evaluate_coordinate_delegates(self):
+        """_evaluate_coordinate validates and returns the evaluator's result."""
         opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
         self.mock_evaluator.evaluate.return_value = optimizer.TrialResult(fom=7.0)
-        trial = opt._evaluate_coordinate([1], optimizer.ObjectiveMode.RAW_METRIC, None)
+        trial = opt._evaluate_coordinate([1])
         self.assertEqual(trial.fom, 7.0)
-        self.assertIsNone(trial.average_power)
         self.mock_evaluator.evaluate.assert_called_once()
-
-    @patch('geopmdpy.optimizer.pio')
-    @patch('geopmdpy.optimizer.get_energy')
-    def test_evaluate_coordinate_efficiency(self, mock_get_energy, mock_pio):
-        """With an energy objective, energy/runtime/power deltas are computed."""
-        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
-        self.mock_evaluator.evaluate.return_value = optimizer.TrialResult(fom=7.0)
-        mock_pio.read_signal.side_effect = [1000.0, 1010.0]  # start/end time
-        mock_get_energy.side_effect = [500.0, 600.0]  # start/end energy
-        trial = opt._evaluate_coordinate([1], optimizer.ObjectiveMode.EFFICIENCY, 'cpu')
-        self.assertEqual(trial.energy, 100.0)
-        self.assertEqual(trial.runtime, 10.0)
-        self.assertEqual(trial.average_power, 10.0)
-
-    @patch('geopmdpy.optimizer.pio')
-    @patch('geopmdpy.optimizer.get_energy')
-    def test_evaluate_coordinate_runtime_skips_energy(self, mock_get_energy, mock_pio):
-        """The runtime objective does not sample energy or time signals."""
-        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
-        self.mock_evaluator.evaluate.return_value = optimizer.TrialResult(runtime=4.0)
-        trial = opt._evaluate_coordinate([1], optimizer.ObjectiveMode.RUNTIME, None)
-        self.assertEqual(trial.runtime, 4.0)
-        self.assertIsNone(trial.energy)
-        mock_get_energy.assert_not_called()
-        mock_pio.read_signal.assert_not_called()
 
     @patch('geopmdpy.optimizer.gp_minimize')
     def test_optimize_basic(self, mock_gp_minimize):
@@ -570,10 +544,9 @@ class TestBayesianOptimizer(unittest.TestCase):
         self.assertEqual(call_args[1]['n_initial_points'], 2)
         self.assertEqual(call_args[1]['random_state'], 42)
 
-    @patch('geopmdpy.optimizer.pio')
     @patch('geopmdpy.optimizer.gp_minimize')
-    def test_optimize_with_efficiency(self, mock_gp_minimize, mock_pio):
-        """Test optimization with efficiency calculation."""
+    def test_optimize_with_efficiency(self, mock_gp_minimize):
+        """Test optimization in the efficiency objective mode."""
         # Mock optimization result
         mock_result = MagicMock()
         mock_result.x = [1]
@@ -581,29 +554,278 @@ class TestBayesianOptimizer(unittest.TestCase):
         mock_result.func_vals = [-50.0]
         mock_gp_minimize.return_value = mock_result
 
-        # Mock time and energy readings
-        mock_pio.read_signal.side_effect = [1000.0, 1010.0]  # 10 second runtime
-        mock_pio.signal_names.return_value = ["CPU_ENERGY", "TIME"]
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
 
-        # Mock get_energy function
-        with patch('geopmdpy.optimizer.get_energy') as mock_get_energy:
-            mock_get_energy.side_effect = [500.0, 600.0]  # Start and end energy
+        result = opt.optimize(
+            trials=1,
+            n_initial_points=1,
+            objective_mode=optimizer.ObjectiveMode.EFFICIENCY
+        )
 
-            # Mock evaluator to return metric
-            self.mock_evaluator.evaluate.return_value = 1000.0  # Base metric
+        # Just verify the optimize method was called without errors
+        self.assertIsNotNone(result)
+        self.assertIn('best_coordinate', result)
 
-            opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
 
-            result = opt.optimize(
-                trials=1,
-                n_initial_points=1,
-                objective_mode=optimizer.ObjectiveMode.EFFICIENCY,
-                efficiency_domain='cpu'
-            )
+@unittest.skipIf(skip_test, skip_msg)
+class TestSessionStrategy(unittest.TestCase):
+    """Tests for the geopmsession-wrapped energy evaluation strategy."""
 
-            # Just verify the optimize method was called without errors
-            self.assertIsNotNone(result)
-            self.assertIn('best_coordinate', result)
+    def _make_energy_evaluator(self, domain='cpu', signals=('CPU_ENERGY',),
+                               mode=None, sample_period=0.01, metric_regex=None):
+        """Construct an energy-objective evaluator with preflight mocked out."""
+        if mode is None:
+            mode = optimizer.ObjectiveMode.EFFICIENCY
+        with patch('geopmdpy.optimizer.shutil.which',
+                   return_value='/usr/bin/geopmsession'), \
+             patch('geopmdpy.optimizer.pio') as mock_pio:
+            mock_pio.signal_names.return_value = list(signals)
+            evaluator = optimizer.ApplicationEvaluator(
+                ["app"], metric_regex=metric_regex, maximize=True,
+                objective_mode=mode, efficiency_domain=domain,
+                sample_period=sample_period)
+        return evaluator
+
+    def test_needs_session_for_energy_modes(self):
+        """Energy objectives route through geopmsession; others stay direct."""
+        for mode in (optimizer.ObjectiveMode.EFFICIENCY,
+                     optimizer.ObjectiveMode.ENERGY,
+                     optimizer.ObjectiveMode.ENERGY_BOUNDED):
+            evaluator = self._make_energy_evaluator(mode=mode)
+            self.assertTrue(evaluator.needs_session)
+        for mode in (optimizer.ObjectiveMode.RAW_METRIC,
+                     optimizer.ObjectiveMode.RUNTIME):
+            evaluator = optimizer.ApplicationEvaluator(
+                ["app"], objective_mode=mode)
+            self.assertFalse(evaluator.needs_session)
+
+    def test_init_missing_geopmsession_raises(self):
+        """A missing geopmsession is caught at construction time."""
+        with patch('geopmdpy.optimizer.shutil.which', return_value=None), \
+             patch('geopmdpy.optimizer.pio'):
+            with self.assertRaises(optimizer.OptimizationError) as ctx:
+                optimizer.ApplicationEvaluator(
+                    ["app"], objective_mode=optimizer.ObjectiveMode.EFFICIENCY,
+                    efficiency_domain='cpu')
+            self.assertIn("geopmsession", str(ctx.exception))
+
+    def test_init_missing_yaml_raises(self):
+        """A missing pyyaml module is caught at construction time."""
+        with patch('geopmdpy.optimizer.yaml', None), \
+             patch('geopmdpy.optimizer.shutil.which',
+                   return_value='/usr/bin/geopmsession'), \
+             patch('geopmdpy.optimizer.pio'):
+            with self.assertRaises(optimizer.OptimizationError) as ctx:
+                optimizer.ApplicationEvaluator(
+                    ["app"], objective_mode=optimizer.ObjectiveMode.EFFICIENCY,
+                    efficiency_domain='cpu')
+            self.assertIn("pyyaml", str(ctx.exception))
+
+    def test_init_non_energy_mode_skips_preflight(self):
+        """Non-energy objectives do not require geopmsession or pyyaml."""
+        with patch('geopmdpy.optimizer.shutil.which', return_value=None):
+            evaluator = optimizer.ApplicationEvaluator(
+                ["app"], objective_mode=optimizer.ObjectiveMode.RUNTIME)
+        self.assertFalse(evaluator.needs_session)
+        self.assertIsNone(evaluator._energy_signals)
+
+    def test_signal_config_cpu(self):
+        """CPU domain emits TIME plus the CPU energy signal."""
+        evaluator = self._make_energy_evaluator(domain='cpu',
+                                                signals=('CPU_ENERGY',))
+        self.assertEqual(evaluator._signal_config_str(),
+                         'TIME board 0\nCPU_ENERGY board 0\n')
+
+    def test_signal_config_gpu(self):
+        """GPU domain emits TIME plus the GPU energy signal."""
+        evaluator = self._make_energy_evaluator(domain='gpu',
+                                                signals=('GPU_ENERGY',))
+        self.assertEqual(evaluator._signal_config_str(),
+                         'TIME board 0\nGPU_ENERGY board 0\n')
+
+    def test_signal_config_board_component_sum(self):
+        """Without BOARD_ENERGY the board domain sums component signals."""
+        evaluator = self._make_energy_evaluator(
+            domain='board',
+            signals=('GPU_ENERGY', 'POWERCAP::CPU_ENERGY_CONSUMED',
+                     'DRAM_ENERGY'))
+        self.assertEqual(
+            evaluator._signal_config_str(),
+            'TIME board 0\nGPU_ENERGY board 0\n'
+            'POWERCAP::CPU_ENERGY_CONSUMED board 0\nDRAM_ENERGY board 0\n')
+
+    def test_session_argv(self):
+        """The geopmsession command line wraps the launch command exactly."""
+        evaluator = self._make_energy_evaluator(domain='cpu',
+                                                signals=('CPU_ENERGY',),
+                                                sample_period=0.05)
+        evaluator.launch_command = ["mybin", "--flag", "1"]
+        argv = evaluator._session_argv('/tmp/sig.conf', '/tmp/rep.yaml')
+        self.assertEqual(argv, [
+            'geopmsession',
+            '--period', repr(0.05),
+            '--report-out', '/tmp/rep.yaml',
+            '--trace-out', '/dev/null',
+            '--signal-config', '/tmp/sig.conf',
+            '--', 'mybin', '--flag', '1',
+        ])
+
+    def test_compute_energy_metrics(self):
+        """Energy and runtime come from the last-first metric deltas."""
+        evaluator = self._make_energy_evaluator(domain='cpu',
+                                                signals=('CPU_ENERGY',))
+        report = {'metrics': {
+            'TIME': {'first': 1000.0, 'last': 1010.0},
+            'CPU_ENERGY': {'first': 500.0, 'last': 600.0},
+        }}
+        energy, runtime, average_power = evaluator._compute_energy_metrics(report)
+        self.assertEqual(energy, 100.0)
+        self.assertEqual(runtime, 10.0)
+        self.assertEqual(average_power, 10.0)
+
+    def test_compute_energy_metrics_rollover(self):
+        """A RAPL rollover corrected by the report yields positive energy.
+
+        A naive two-point read of the raw counter would go negative when the
+        counter wraps, but the report's ``last`` value is rollover-corrected so
+        ``last - first`` stays positive.
+        """
+        evaluator = self._make_energy_evaluator(domain='cpu',
+                                                signals=('CPU_ENERGY',))
+        report = {'metrics': {
+            'TIME': {'first': 0.0, 'last': 5.0},
+            # Raw counter wrapped from 90 back to 10, but report corrects to 130
+            'CPU_ENERGY': {'first': 90.0, 'last': 130.0},
+        }}
+        energy, runtime, average_power = evaluator._compute_energy_metrics(report)
+        self.assertEqual(energy, 40.0)
+        self.assertEqual(runtime, 5.0)
+        self.assertEqual(average_power, 8.0)
+
+    def test_compute_energy_metrics_missing_time(self):
+        """A report without TIME is rejected."""
+        evaluator = self._make_energy_evaluator(domain='cpu',
+                                                signals=('CPU_ENERGY',))
+        report = {'metrics': {'CPU_ENERGY': {'first': 0.0, 'last': 1.0}}}
+        with self.assertRaises(optimizer.OptimizationError):
+            evaluator._compute_energy_metrics(report)
+
+    def test_compute_energy_metrics_missing_signal(self):
+        """A report missing an energy signal is rejected."""
+        evaluator = self._make_energy_evaluator(domain='cpu',
+                                                signals=('CPU_ENERGY',))
+        report = {'metrics': {'TIME': {'first': 0.0, 'last': 1.0}}}
+        with self.assertRaises(optimizer.OptimizationError):
+            evaluator._compute_energy_metrics(report)
+
+    def test_compute_energy_metrics_non_positive_runtime(self):
+        """A non-positive runtime is rejected."""
+        evaluator = self._make_energy_evaluator(domain='cpu',
+                                                signals=('CPU_ENERGY',))
+        report = {'metrics': {
+            'TIME': {'first': 5.0, 'last': 5.0},
+            'CPU_ENERGY': {'first': 0.0, 'last': 1.0},
+        }}
+        with self.assertRaises(optimizer.OptimizationError):
+            evaluator._compute_energy_metrics(report)
+
+    def test_load_report_missing_file(self):
+        """A missing report file raises a clear error."""
+        evaluator = self._make_energy_evaluator()
+        with self.assertRaises(optimizer.OptimizationError):
+            evaluator._load_report('/nonexistent/geopmopt_report.yaml')
+
+    def test_load_report_malformed(self):
+        """A non-mapping report is rejected."""
+        evaluator = self._make_energy_evaluator()
+        with patch('geopmdpy.optimizer.yaml') as mock_yaml, \
+             patch('builtins.open', mock_open(read_data='- a\n- b\n')):
+            mock_yaml.safe_load.return_value = ['a', 'b']
+            with self.assertRaises(optimizer.OptimizationError):
+                evaluator._load_report('/tmp/report.yaml')
+
+    def test_evaluate_session_success_and_cleanup(self):
+        """A successful session run returns metrics and cleans up temp files."""
+        evaluator = self._make_energy_evaluator(domain='cpu',
+                                                signals=('CPU_ENERGY',))
+        report = {'metrics': {
+            'TIME': {'first': 0.0, 'last': 10.0},
+            'CPU_ENERGY': {'first': 0.0, 'last': 200.0},
+        }}
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        created = []
+        real_mkstemp = tempfile.mkstemp
+
+        def tracking_mkstemp(*args, **kwargs):
+            fd, path = real_mkstemp(*args, **kwargs)
+            created.append(path)
+            return fd, path
+
+        with patch('geopmdpy.optimizer.subprocess.run',
+                   return_value=mock_result) as mock_run, \
+             patch('geopmdpy.optimizer.tempfile.mkstemp',
+                   side_effect=tracking_mkstemp), \
+             patch.object(evaluator, '_load_report', return_value=report):
+            trial = evaluator._evaluate_session()
+
+        self.assertEqual(trial.energy, 200.0)
+        self.assertEqual(trial.runtime, 10.0)
+        self.assertEqual(trial.average_power, 20.0)
+        self.assertIsNone(trial.fom)
+        mock_run.assert_called_once()
+        self.assertEqual(len(created), 2)
+        for path in created:
+            self.assertFalse(os.path.exists(path))
+
+    def test_evaluate_session_cleanup_on_error(self):
+        """Temp files are removed even when the session fails."""
+        evaluator = self._make_energy_evaluator(domain='cpu',
+                                                signals=('CPU_ENERGY',))
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "boom"
+        created = []
+        real_mkstemp = tempfile.mkstemp
+
+        def tracking_mkstemp(*args, **kwargs):
+            fd, path = real_mkstemp(*args, **kwargs)
+            created.append(path)
+            return fd, path
+
+        with patch('geopmdpy.optimizer.subprocess.run',
+                   return_value=mock_result), \
+             patch('geopmdpy.optimizer.tempfile.mkstemp',
+                   side_effect=tracking_mkstemp):
+            with self.assertRaises(optimizer.OptimizationError):
+                evaluator._evaluate_session()
+
+        self.assertEqual(len(created), 2)
+        for path in created:
+            self.assertFalse(os.path.exists(path))
+
+    def test_evaluate_session_extracts_fom(self):
+        """When a regex is provided the session run also scrapes the FOM."""
+        evaluator = self._make_energy_evaluator(
+            domain='cpu', signals=('CPU_ENERGY',),
+            metric_regex=r'FOM: ([0-9.]+)')
+        report = {'metrics': {
+            'TIME': {'first': 0.0, 'last': 2.0},
+            'CPU_ENERGY': {'first': 0.0, 'last': 10.0},
+        }}
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "FOM: 42.0\n"
+        with patch('geopmdpy.optimizer.subprocess.run',
+                   return_value=mock_result), \
+             patch('geopmdpy.optimizer.tempfile.mkstemp',
+                   side_effect=tempfile.mkstemp), \
+             patch.object(evaluator, '_load_report', return_value=report):
+            trial = evaluator._evaluate_session()
+        self.assertEqual(trial.fom, 42.0)
+        self.assertEqual(trial.energy, 10.0)
 
 
 @unittest.skipIf(skip_test, skip_msg)
@@ -864,6 +1086,7 @@ class TestGetParser(unittest.TestCase):
             '--print-stdout',
             '--defer-write',
             '--efficiency', 'cpu',
+            '--sample-period', '0.25',
             'echo', 'test'
         ])
 
@@ -880,6 +1103,7 @@ class TestGetParser(unittest.TestCase):
         self.assertTrue(args.print_stdout)
         self.assertTrue(args.defer_write)
         self.assertEqual(args.efficiency_domain, 'cpu')
+        self.assertEqual(args.sample_period, 0.25)
         self.assertEqual(args.launch, ['echo', 'test'])
 
     def test_parser_defaults(self):
@@ -902,6 +1126,7 @@ class TestGetParser(unittest.TestCase):
         self.assertFalse(args.print_stdout)
         self.assertFalse(args.defer_write)
         self.assertIsNone(args.efficiency_domain)
+        self.assertEqual(args.sample_period, optimizer._DEFAULT_SAMPLE_PERIOD)
 
     def test_parser_metric_regex_optional(self):
         """--metric-regex is optional and defaults to None."""

--- a/geopmdpy/test/TestOptimizer.py
+++ b/geopmdpy/test/TestOptimizer.py
@@ -190,6 +190,43 @@ class TestApplicationEvaluator(unittest.TestCase):
 
         self.assertIn("produced no output", str(context.exception))
 
+    @patch('subprocess.run')
+    def test_evaluate_no_regex_returns_runtime(self, mock_run):
+        """Without a metric regex, evaluate measures runtime and skips the FoM."""
+        evaluator = optimizer.ApplicationEvaluator(
+            self.launch_command, metric_regex=None
+        )
+        self.assertIsNone(evaluator.regex)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""  # No output is fine when no metric is scraped
+        mock_run.return_value = mock_result
+
+        mock_grid = MagicMock()
+        result = evaluator.evaluate(mock_grid, [0])
+
+        self.assertIsNone(result.fom)
+        self.assertIsNotNone(result.runtime)
+        self.assertGreaterEqual(result.runtime, 0.0)
+
+    @patch('subprocess.run')
+    def test_evaluate_no_regex_failed_process(self, mock_run):
+        """A non-zero return code still raises even without a metric regex."""
+        evaluator = optimizer.ApplicationEvaluator(
+            self.launch_command, metric_regex=None
+        )
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "boom"
+        mock_result.stdout = ""
+        mock_run.return_value = mock_result
+
+        mock_grid = MagicMock()
+        with self.assertRaises(optimizer.OptimizationError) as context:
+            evaluator.evaluate(mock_grid, [0])
+        self.assertIn("Application failed", str(context.exception))
+
     def test_extract_metric_success(self):
         """Test successful metric extraction."""
         stdout = "Application output\nPerformance: 456.78 GFLOPS\nMore output"
@@ -407,35 +444,60 @@ class TestBayesianOptimizer(unittest.TestCase):
         """Maximize converts the raw FoM to its negation (minimization space)."""
         opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
         trial = optimizer.TrialResult(fom=123.45)
-        self.assertEqual(opt._score_result(trial, 0), -123.45)
+        self.assertEqual(
+            opt._score_result(trial, optimizer.ObjectiveMode.RAW_METRIC), -123.45)
 
     def test_score_result_minimize(self):
         """Minimize keeps the raw FoM sign."""
         self.mock_evaluator.maximize = False
         opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
         trial = optimizer.TrialResult(fom=123.45)
-        self.assertEqual(opt._score_result(trial, 0), 123.45)
+        self.assertEqual(
+            opt._score_result(trial, optimizer.ObjectiveMode.RAW_METRIC), 123.45)
 
     def test_score_result_efficiency_maximize(self):
         """Maximizing efficiency divides the negated FoM by average power."""
         opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
         trial = optimizer.TrialResult(fom=1000.0, average_power=100.0)
-        self.assertEqual(opt._score_result(trial, 1), -10.0)
+        self.assertEqual(
+            opt._score_result(trial, optimizer.ObjectiveMode.EFFICIENCY), -10.0)
 
     def test_score_result_efficiency_minimize(self):
         """Minimizing efficiency multiplies the FoM by average power."""
         self.mock_evaluator.maximize = False
         opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
         trial = optimizer.TrialResult(fom=10.0, average_power=5.0)
-        self.assertEqual(opt._score_result(trial, -1), 50.0)
+        self.assertEqual(
+            opt._score_result(trial, optimizer.ObjectiveMode.EFFICIENCY), 50.0)
 
     def test_score_result_nonpositive_power_raises(self):
         """Non-positive average power raises OptimizationError."""
         opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
         trial = optimizer.TrialResult(fom=1.0, average_power=0.0)
         with self.assertRaises(optimizer.OptimizationError) as context:
-            opt._score_result(trial, 1)
+            opt._score_result(trial, optimizer.ObjectiveMode.EFFICIENCY)
         self.assertIn("non-positive", str(context.exception))
+
+    def test_score_result_runtime(self):
+        """The runtime objective minimizes wall-clock time directly."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        trial = optimizer.TrialResult(runtime=12.5)
+        self.assertEqual(
+            opt._score_result(trial, optimizer.ObjectiveMode.RUNTIME), 12.5)
+
+    def test_score_result_energy(self):
+        """The energy objective minimizes measured energy directly."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        trial = optimizer.TrialResult(energy=987.0)
+        self.assertEqual(
+            opt._score_result(trial, optimizer.ObjectiveMode.ENERGY), 987.0)
+
+    def test_score_result_energy_bounded_not_implemented(self):
+        """The energy-bounded objective is not implemented in this phase."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        trial = optimizer.TrialResult(fom=1.0, energy=1.0)
+        with self.assertRaises(NotImplementedError):
+            opt._score_result(trial, optimizer.ObjectiveMode.ENERGY_BOUNDED)
 
     def test_record_history(self):
         """History records the coordinate, metric, and config commands."""
@@ -446,10 +508,10 @@ class TestBayesianOptimizer(unittest.TestCase):
         self.assertEqual(opt.evaluation_history[0]['metric'], 42.0)
 
     def test_evaluate_coordinate_no_efficiency(self):
-        """Without efficiency the evaluator result is returned unchanged."""
+        """Without an energy objective the evaluator result is unchanged."""
         opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
         self.mock_evaluator.evaluate.return_value = optimizer.TrialResult(fom=7.0)
-        trial = opt._evaluate_coordinate([1], 0, None)
+        trial = opt._evaluate_coordinate([1], optimizer.ObjectiveMode.RAW_METRIC, None)
         self.assertEqual(trial.fom, 7.0)
         self.assertIsNone(trial.average_power)
         self.mock_evaluator.evaluate.assert_called_once()
@@ -457,15 +519,27 @@ class TestBayesianOptimizer(unittest.TestCase):
     @patch('geopmdpy.optimizer.pio')
     @patch('geopmdpy.optimizer.get_energy')
     def test_evaluate_coordinate_efficiency(self, mock_get_energy, mock_pio):
-        """With efficiency, energy/runtime/power deltas are computed."""
+        """With an energy objective, energy/runtime/power deltas are computed."""
         opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
         self.mock_evaluator.evaluate.return_value = optimizer.TrialResult(fom=7.0)
         mock_pio.read_signal.side_effect = [1000.0, 1010.0]  # start/end time
         mock_get_energy.side_effect = [500.0, 600.0]  # start/end energy
-        trial = opt._evaluate_coordinate([1], 1, 'cpu')
+        trial = opt._evaluate_coordinate([1], optimizer.ObjectiveMode.EFFICIENCY, 'cpu')
         self.assertEqual(trial.energy, 100.0)
         self.assertEqual(trial.runtime, 10.0)
         self.assertEqual(trial.average_power, 10.0)
+
+    @patch('geopmdpy.optimizer.pio')
+    @patch('geopmdpy.optimizer.get_energy')
+    def test_evaluate_coordinate_runtime_skips_energy(self, mock_get_energy, mock_pio):
+        """The runtime objective does not sample energy or time signals."""
+        opt = optimizer.BayesianOptimizer(self.mock_grid, self.mock_evaluator)
+        self.mock_evaluator.evaluate.return_value = optimizer.TrialResult(runtime=4.0)
+        trial = opt._evaluate_coordinate([1], optimizer.ObjectiveMode.RUNTIME, None)
+        self.assertEqual(trial.runtime, 4.0)
+        self.assertIsNone(trial.energy)
+        mock_get_energy.assert_not_called()
+        mock_pio.read_signal.assert_not_called()
 
     @patch('geopmdpy.optimizer.gp_minimize')
     def test_optimize_basic(self, mock_gp_minimize):
@@ -523,7 +597,7 @@ class TestBayesianOptimizer(unittest.TestCase):
             result = opt.optimize(
                 trials=1,
                 n_initial_points=1,
-                use_efficiency=1,  # Maximizing efficiency
+                objective_mode=optimizer.ObjectiveMode.EFFICIENCY,
                 efficiency_domain='cpu'
             )
 
@@ -720,6 +794,42 @@ class TestOptimizerMain(unittest.TestCase):
         evaluator = args[1]
         self.assertFalse(evaluator.maximize)
 
+    @patch('sys.argv', ['optimizer.py', '--cpu-frequency', 'package',
+                       'echo', 'hello'])
+    @patch('geopmdpy.optimizer.pio')
+    @patch('geopmdpy.optimizer.ControlGrid')
+    @patch('geopmdpy.optimizer.BayesianOptimizer')
+    def test_main_runtime_default(self, mock_optimizer_class, mock_grid_class, mock_pio):
+        """With no metric regex and no efficiency, main uses the runtime objective."""
+        mock_pio.save_control = MagicMock()
+        mock_pio.restore_control = MagicMock()
+        mock_grid = MagicMock()
+        mock_grid.control_name = ['cpu_frequency']
+        mock_grid.get_grid_data.return_value = [
+            {"control": "CPU_FREQUENCY_MAX_CONTROL", "domain": "package",
+             "domain_idx": 0, "settings": [1000000, 2000000]}
+        ]
+        mock_grid_class.return_value = mock_grid
+        mock_optimizer = MagicMock()
+        mock_optimizer.optimize.return_value = {
+            'best_metric': 1.5,
+            'best_coordinate': [1],
+            'best_config': 'CPU_FREQUENCY_MAX_CONTROL package 0 2000000',
+            'n_evaluations': 10
+        }
+        mock_optimizer_class.return_value = mock_optimizer
+
+        with patch('builtins.print'):
+            result = optimizer.main()
+        self.assertEqual(result, 0)
+        # The evaluator has no metric regex and optimize gets the runtime mode.
+        args, kwargs = mock_optimizer_class.call_args
+        evaluator = args[1]
+        self.assertIsNone(evaluator.metric_regex)
+        _, optimize_kwargs = mock_optimizer.optimize.call_args
+        self.assertEqual(optimize_kwargs['objective_mode'],
+                         optimizer.ObjectiveMode.RUNTIME)
+
 
 @unittest.skipIf(skip_test, skip_msg)
 class TestGetParser(unittest.TestCase):
@@ -793,13 +903,67 @@ class TestGetParser(unittest.TestCase):
         self.assertFalse(args.defer_write)
         self.assertIsNone(args.efficiency_domain)
 
-    def test_parser_required_arguments(self):
-        """Test parser with missing required arguments."""
+    def test_parser_metric_regex_optional(self):
+        """--metric-regex is optional and defaults to None."""
         parser = optimizer.get_parser()
 
-        # Missing metric-regex should raise SystemExit
-        with self.assertRaises(SystemExit):
-            parser.parse_args(['--cpu-frequency', 'package', 'echo', 'test'])
+        # Omitting --metric-regex is allowed; it defaults to None.
+        args = parser.parse_args(['--cpu-frequency', 'package', 'echo', 'test'])
+        self.assertIsNone(args.metric_regex)
+        self.assertEqual(args.launch, ['echo', 'test'])
+
+
+@unittest.skipIf(skip_test, skip_msg)
+class TestResolveObjectiveMode(unittest.TestCase):
+    def test_raw_metric(self):
+        """Regex without efficiency selects the raw figure of merit."""
+        mode = optimizer.resolve_objective_mode(
+            'FOM: ([0-9.]+)', None, None, False)
+        self.assertEqual(mode, optimizer.ObjectiveMode.RAW_METRIC)
+
+    def test_efficiency(self):
+        """Regex with efficiency selects the efficiency objective."""
+        mode = optimizer.resolve_objective_mode(
+            'FOM: ([0-9.]+)', 'cpu', None, False)
+        self.assertEqual(mode, optimizer.ObjectiveMode.EFFICIENCY)
+
+    def test_runtime(self):
+        """No regex and no efficiency selects the runtime objective."""
+        mode = optimizer.resolve_objective_mode(None, None, None, False)
+        self.assertEqual(mode, optimizer.ObjectiveMode.RUNTIME)
+
+    def test_energy(self):
+        """Efficiency without a regex selects the energy objective."""
+        mode = optimizer.resolve_objective_mode(None, 'cpu', None, False)
+        self.assertEqual(mode, optimizer.ObjectiveMode.ENERGY)
+
+    def test_energy_bounded(self):
+        """A metric bound with regex and efficiency selects energy-bounded."""
+        mode = optimizer.resolve_objective_mode(
+            'FOM: ([0-9.]+)', 'cpu', 100.0, False)
+        self.assertEqual(mode, optimizer.ObjectiveMode.ENERGY_BOUNDED)
+
+    def test_direction_does_not_change_mode(self):
+        """The minimize flag does not change the resolved mode."""
+        for minimize in (True, False):
+            self.assertEqual(
+                optimizer.resolve_objective_mode('FOM: ([0-9.]+)', None, None, minimize),
+                optimizer.ObjectiveMode.RAW_METRIC)
+            self.assertEqual(
+                optimizer.resolve_objective_mode(None, None, None, minimize),
+                optimizer.ObjectiveMode.RUNTIME)
+
+    def test_metric_bound_without_regex_raises(self):
+        """A metric bound requires a metric regex."""
+        with self.assertRaises(ValueError) as context:
+            optimizer.resolve_objective_mode(None, 'cpu', 100.0, False)
+        self.assertIn('--metric-regex', str(context.exception))
+
+    def test_metric_bound_without_efficiency_raises(self):
+        """A metric bound requires an efficiency domain."""
+        with self.assertRaises(ValueError) as context:
+            optimizer.resolve_objective_mode('FOM: ([0-9.]+)', None, 100.0, False)
+        self.assertIn('--efficiency', str(context.exception))
 
 
 @unittest.skipIf(skip_test, skip_msg)

--- a/integration/service/test/check_geopmopt_dgemm_bench_run.sh
+++ b/integration/service/test/check_geopmopt_dgemm_bench_run.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2025 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+
+# Plain dgemm workload for the geopmopt runtime, energy, and bounded-energy
+# objectives.  geopmopt applies the control settings itself (direct write) and,
+# for the energy objectives, wraps this script in geopmsession to sample energy,
+# so this workload only needs to run the benchmark and print a wall-clock figure
+# of merit.  Any argument (for example a --defer-write config path) is ignored.
+
+set -euo pipefail
+set -x
+
+bench_conf=$(mktemp -p "${PWD}" geopmopt_dgemm_bench_wl.XXXXXX)
+
+cleanup() {
+  rm -f "${bench_conf}"
+}
+trap cleanup EXIT
+
+cat <<EOF >"${bench_conf}"
+{
+  "loop-count": 10,
+  "region": ["dgemm"],
+  "big-o": [0.2]
+}
+EOF
+
+start=$(date +%s.%N)
+geopmbench --verbose "${bench_conf}"
+end=$(date +%s.%N)
+
+python3 -c "import sys; print(f'GEOPMOPT-FOM: {float(sys.argv[2]) - float(sys.argv[1]):.4f}')" "${start}" "${end}"

--- a/integration/service/test/check_geopmopt_freq_sleep_run.sh
+++ b/integration/service/test/check_geopmopt_freq_sleep_run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2025 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+
+# Workload for the geopmopt recoverable timeout-penalty test.  It sleeps for a
+# time inversely proportional to the applied CPU max-frequency control, so that
+# low frequencies deterministically exceed a short --application-timeout (which
+# exercises the recoverable-failure penalty path) while high frequencies
+# complete.  A figure of merit equal to the sleep time is printed so the run can
+# also be driven with --metric-regex.  Any argument is ignored.
+
+set -euo pipefail
+set -x
+
+freq=$(geopmread CPU_FREQUENCY_MAX_CONTROL board 0)
+sleep_s=$(python3 -c "import sys; print(f'{4.0e9 / float(sys.argv[1]):.3f}')" "${freq}")
+
+sleep "${sleep_s}"
+
+echo "GEOPMOPT-FOM: ${sleep_s}"

--- a/integration/service/test/test_geopmopt_dgemm_session_bounded.sh
+++ b/integration/service/test/test_geopmopt_dgemm_session_bounded.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2025 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+
+# Exercise the #4043 bounded-energy objective: minimize energy subject to a
+# figure-of-merit constraint.  The figure of merit here is the dgemm wall-clock
+# time (lower is better, so --minimize), and the bound is set generously so the
+# feasible region is non-empty on any hardware.  The run must complete, report
+# that the bound was satisfied, and emit a valid control configuration.
+
+set -euo pipefail
+set -x
+
+output_config="optimal-frequency.config"
+summary_log="bounded-summary.log"
+
+cleanup() {
+    rm -f "${output_config}" "${summary_log}"
+}
+trap cleanup EXIT
+
+STICKER_FREQ=$(geopmread CPU_FREQUENCY_STICKER board 0)
+MAX_FREQ=$((STICKER_FREQ - 300000000))
+
+# A one-hour figure-of-merit bound is always satisfiable, so the optimizer
+# minimizes energy over the feasible region rather than reporting a violation.
+geopmopt --verbosity=2 \
+         --cpu-frequency=board \
+         --cpu-frequency-max=${MAX_FREQ} \
+         --efficiency=cpu \
+         --metric-regex='GEOPMOPT-FOM: ([0-9.]+)' \
+         --metric-bound=3600 \
+         --minimize \
+         --output-file="${output_config}" \
+         --trials=20 \
+         -- ./check_geopmopt_dgemm_bench_run.sh | tee "${summary_log}"
+
+grep -q "CPU_FREQUENCY_MAX_CONTROL board 0" "${output_config}"
+grep -q "was satisfied" "${summary_log}"

--- a/integration/service/test/test_geopmopt_dgemm_session_energy.sh
+++ b/integration/service/test/test_geopmopt_dgemm_session_energy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2025 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+
+# Exercise the #4044 + #4043 energy objective: with --efficiency and no
+# --metric-regex, geopmopt minimizes total energy measured from a rollover-safe
+# geopmsession energy trace.  The run must complete without a "non-positive
+# power" abort and emit a valid control configuration.
+
+set -euo pipefail
+set -x
+
+output_config="optimal-frequency.config"
+
+cleanup() {
+    rm -f "${output_config}"
+}
+trap cleanup EXIT
+
+STICKER_FREQ=$(geopmread CPU_FREQUENCY_STICKER board 0)
+MAX_FREQ=$((STICKER_FREQ - 300000000))
+
+geopmopt --verbosity=2 \
+         --cpu-frequency=board \
+         --cpu-frequency-max=${MAX_FREQ} \
+         --efficiency=cpu \
+         --output-file="${output_config}" \
+         --trials=20 \
+         -- ./check_geopmopt_dgemm_bench_run.sh
+
+# The energy objective ran to completion and selected a CPU frequency setting.
+# The energy-optimal frequency is hardware dependent, so assert only that a
+# valid configuration was produced rather than pinning a specific frequency.
+grep -q "CPU_FREQUENCY_MAX_CONTROL board 0" "${output_config}"

--- a/integration/service/test/test_geopmopt_dgemm_session_runtime.sh
+++ b/integration/service/test/test_geopmopt_dgemm_session_runtime.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2025 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+
+# Exercise the #4044 default objective: with no --metric-regex, geopmopt
+# minimizes the wall-clock runtime of the launch command directly.  dgemm is
+# compute bound, so the maximum allowed frequency should minimize runtime.
+
+set -euo pipefail
+set -x
+
+output_config="optimal-frequency.config"
+
+cleanup() {
+    rm -f "${output_config}"
+}
+trap cleanup EXIT
+
+STICKER_FREQ=$(geopmread CPU_FREQUENCY_STICKER board 0)
+MAX_FREQ=$((STICKER_FREQ - 300000000))
+
+geopmopt --verbosity=2 \
+         --cpu-frequency=board \
+         --cpu-frequency-max=${MAX_FREQ} \
+         --minimize \
+         --output-file="${output_config}" \
+         --trials=20 \
+         -- ./check_geopmopt_dgemm_bench_run.sh
+
+# For compute-bound DGEMM the maximum allowed frequency minimizes runtime.
+grep -q ${MAX_FREQ} "${output_config}"

--- a/integration/service/test/test_geopmopt_session_timeout.sh
+++ b/integration/service/test/test_geopmopt_session_timeout.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2025 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+
+# Exercise the #3927 recoverable timeout-penalty path.  The frequency-scaled
+# sleep workload combined with a short --application-timeout makes low-frequency
+# trials time out.  With the default --penalty=auto those trials are penalized
+# and logged rather than aborting the run, so the optimization completes and
+# still emits a control configuration.
+
+set -euo pipefail
+set -x
+
+output_config="optimal-frequency.config"
+run_log="timeout-run.log"
+
+cleanup() {
+    rm -f "${output_config}" "${run_log}"
+}
+trap cleanup EXIT
+
+geopmopt --verbosity=2 \
+         --cpu-frequency=board \
+         --minimize \
+         --metric-regex='GEOPMOPT-FOM: ([0-9.]+)' \
+         --application-timeout=2 \
+         --trials=8 \
+         --n-initial-points=4 \
+         --output-file="${output_config}" \
+         -- ./check_geopmopt_freq_sleep_run.sh 2>&1 | tee "${run_log}"
+
+# The run completed despite one or more timeouts and produced a configuration.
+grep -q "CPU_FREQUENCY_MAX_CONTROL board 0" "${output_config}"
+# At least one recoverable timeout was penalized rather than aborting the run.
+grep -qi "Penalizing failed trial" "${run_log}"


### PR DESCRIPTION
- Relates to #4043 [energy counter rollover with `--efficiency`] from github issues
- Relates to #4044 [`--metric-regex` should not be required] from github issues
- Relates to #3927 [penalty metric instead of aborting on failures] from github issues

## Brief description of the change

This is a **draft** PR that reworks `geopmopt` optimization to be more robust and flexible. Work is organized as a sequence of focused commits.

### Objective-mode refactor (#4044)
- Extract objective helpers and add a `TrialResult` container.
- Make `--metric-regex` optional and resolve the objective mode automatically (runtime vs. energy) instead of requiring a metric regex for every run.

### Rollover-safe energy optimization (#4043)
- Run energy objectives under `geopmsession` so energy is derived from a bounded sampling window rather than a raw monotonic counter, avoiding the energy-counter rollover seen with `--efficiency`.
- Add performance-bounded energy optimization (`--metric-bound`) so energy can be minimized subject to a runtime/throughput constraint.

### Failure handling as a penalty (#3927)
- Penalize recoverable trial failures instead of aborting the whole optimization. Distinguishes `RecoverableEvaluationError` (penalized) from fatal `OptimizationError` (aborts), with an `auto`/`none`/`float` `--penalty` policy and a bootstrap penalty fallback.

### Documentation
- Update the `geopmopt.1` man page: optional metric, energy modes, penalty policy, and new examples.

### Integration tests
- Add `geopmopt` runtime, energy, bounded-energy, and timeout-penalty integration tests under `integration/service/test`.

## Commits

- `9fb5ae50f` geopmopt: extract objective helpers and add TrialResult container
- `d599f0fde` geopmopt: add Phase 0 end-to-end regression integration test
- `ad778e6bb` geopmopt: optional --metric-regex and objective-mode resolution
- `3ff734b1d` geopmopt: run energy objectives under geopmsession (#4043)
- `4e823ac69` geopmopt: add performance-bounded energy optimization (#4043)
- `2206132c7` geopmopt: penalize recoverable trial failures instead of aborting (#3927)
- `95deaf01e` geopmopt: document optional metric, energy modes, and penalty policy (#4043) (#4044) (#3927)
- `4941a9e3d` integration: add geopmopt runtime, energy, bounded, and timeout tests (#4043) (#4044) (#3927)

_Note_: opened as a draft for early review; validated with 107 `TestOptimizer` unit tests plus on-hardware smoke tests of all objective modes and both penalty policies.