### PR TITLE
LevelZero Tools & Metrics (ZET) support

### DIFF
--- a/docs/source/geopm_agent_gpu_activity.7.rst
+++ b/docs/source/geopm_agent_gpu_activity.7.rst
@@ -7,7 +7,8 @@ Description
 
 The goal of **GPUActivityAgent** is to save GPU energy by scaling GPU frequency
 based upon the compute activity of each GPU as provided by the
-``GPU_CORE_ACTIVITY`` signal and modified by the ``GPU_UTILIZATION`` signal.
+``GPU_CORE_ACTIVITY`` signal, modified by the ``GPU_UTILIZATION`` signal and,
+where available, discounted by the ``LEVELZERO::METRIC:XVE_STALL`` signal.
 
 The agent scales frequency in the range of ``Fe`` to ``Fmax``, where ``Fmax``
 is provided by the NVMLIOGroup or LevelZeroIOGroup and ``Fe`` is provided by the
@@ -18,9 +19,22 @@ of 0.0) run at the ``Fe`` frequency, high activity regions (compute activity of 
 run at the ``Fmax`` frequency, and regions in between the extremes run at a frequency (F)
 selected using the equation:
 
-``F = Fe + (Fmax - Fe) * GPU_CORE_ACTIVITY/GPU_UTILIZATION``
+``F = Fe + (Fmax - Fe) * A/GPU_UTILIZATION``
 
-``GPU_UTILIZATION`` is used to scale the ``GPU_CORE_ACTIVITY`` in order
+where ``A`` is the compute activity used for the frequency decision.  On systems
+that expose the Level Zero ``LEVELZERO::METRIC:XVE_STALL`` metric (a stall ratio
+in the range 0.0 to 1.0), the raw ``GPU_CORE_ACTIVITY`` is discounted by the
+stall ratio so that stalled cycles do not drive frequency up:
+
+``A = GPU_CORE_ACTIVITY * (1 - XVE_STALL)``
+
+When ``XVE_STALL`` is not available (for example on NVIDIA systems, or when the
+Level Zero metrics are not exposed) the agent falls back to the raw activity,
+``A = GPU_CORE_ACTIVITY``.  The stall adjustment only affects the frequency
+decision; the region and on-time tracking always use the raw
+``GPU_CORE_ACTIVITY``.
+
+``GPU_UTILIZATION`` is used to scale ``A`` in order
 to scale frequency selection with the percentage of time a kernel is running on
 the GPU.  This tends to help with workloads that contain short but highly
 scalable GPU phases.

--- a/geopmdpy/geopm.service
+++ b/geopmdpy/geopm.service
@@ -13,6 +13,7 @@ After=msr-safe.service
 Environment=PYTHONUNBUFFERED=true
 Environment=ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
 Environment=ZES_ENABLE_SYSMAN=1
+Environment=ZET_ENABLE_METRICS=1
 Environment=GEOPM_VERBOSITY=0
 LimitNOFILE=16384
 RestartKillSignal=SIGINT

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -72,6 +72,17 @@ namespace geopm
         m_resolved_f_gpu_efficient = 0;
         m_f_range = 0;
 
+        for (int domain_idx = 0; domain_idx < M_NUM_GPU; ++domain_idx) {
+            m_gpu_active_region_start.push_back(0.0);
+            m_gpu_active_region_stop.push_back(0.0);
+            m_gpu_active_energy_start.push_back(0.0);
+            m_gpu_active_energy_stop.push_back(0.0);
+
+            m_gpu_on_time.push_back(0.0);
+            m_gpu_on_energy.push_back(0.0);
+            m_prev_gpu_energy.push_back(0.0);
+        }
+
         if (level == 0) {
             init_platform_io();
         }
@@ -144,6 +155,8 @@ namespace geopm
             m_gpu_freq_max_control.push_back(m_control{m_platform_io.push_control("GPU_CORE_FREQUENCY_MAX_CONTROL",
                                                        m_agent_domain,
                                                        domain_idx), NAN});
+            m_gpu_idle_timer.push_back(10);
+            m_gpu_idle_samples.push_back(0);
         }
 
         // We treat energy & time as special cases and only use them at a specific domain.
@@ -159,6 +172,8 @@ namespace geopm
 
         m_freq_gpu_min = m_platform_io.read_signal("GPU_CORE_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD, 0);
         m_freq_gpu_max = m_platform_io.read_signal("GPU_CORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD, 0);
+
+        //m_platform_io.write_control("GPU_CORE_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_BOARD, 0, m_freq_gpu_min);
 
         const auto ALL_NAMES = m_platform_io.signal_names();
         // F efficient values
@@ -334,8 +349,52 @@ namespace geopm
             f_request = std::min(f_request, m_resolved_f_gpu_max);
             f_request = std::max(f_request, m_resolved_f_gpu_efficient);
 
+            if (phi >= 0.5) {
+                if (!std::isnan(gpu_utilization) &&
+                    gpu_utilization == 0) {
+                    if (m_gpu_idle_timer.at(domain_idx) > 0) {
+                        m_gpu_idle_timer.at(domain_idx) = m_gpu_idle_timer.at(domain_idx) - 1;
+                    }
+                }
+                else {
+                    m_gpu_idle_timer.at(domain_idx) = 10;
+                }
+
+                if (m_gpu_idle_timer.at(domain_idx) <= 0) {
+                    f_request = m_freq_gpu_min;
+                    m_gpu_idle_samples.at(domain_idx) = m_gpu_idle_samples.at(domain_idx) + 1;
+                }
+            }
+
             // Store frequency request
             gpu_freq_request.push_back(f_request);
+        }
+
+        // Tracking logic.  This is not needed for any performance reason,
+        // but does provide useful metrics for tracking agent behavior.  This
+        // may be removed when GPU regions are added to GEOPM.
+        if (!gpu_scoped_core_activity.empty()) {
+            for (int domain_idx = 0; domain_idx < M_NUM_GPU; ++domain_idx) {
+                if (gpu_scoped_core_activity.at(domain_idx) >= M_GPU_ACTIVITY_CUTOFF) {
+                    // ROI proxy tracking
+                    m_gpu_active_region_stop.at(domain_idx) = 0;
+                    if (m_gpu_active_region_start.at(domain_idx) == 0) {
+                        m_gpu_active_region_start.at(domain_idx) = m_time.value;
+                        m_gpu_active_energy_start.at(domain_idx) = m_gpu_energy.at(domain_idx).value;
+                    }
+
+                    // GPU on time tracking
+                    m_gpu_on_time.at(domain_idx) += m_time.value - m_prev_time;
+                    m_gpu_on_energy.at(domain_idx) += m_gpu_energy.at(domain_idx).value - m_prev_gpu_energy.at(domain_idx);
+                }
+                else {
+                    // ROI proxy tracking
+                    if (m_gpu_active_region_stop.at(domain_idx) == 0) {
+                        m_gpu_active_region_stop.at(domain_idx) = m_time.value;
+                        m_gpu_active_energy_stop.at(domain_idx) = m_gpu_energy.at(domain_idx).value;
+                    }
+                }
+            }
         }
 
         // set frequency control per gpu
@@ -387,10 +446,12 @@ namespace geopm
         }
 
         for (int domain_idx = 0; domain_idx < M_NUM_GPU; ++domain_idx) {
+            m_prev_gpu_energy.at(domain_idx) = m_gpu_energy.at(domain_idx).value;
             m_gpu_energy.at(domain_idx).value = m_platform_io.sample(m_gpu_energy.at(
                                                                      domain_idx).batch_idx);
         }
 
+        m_prev_time = m_time.value;
         m_time.value = m_platform_io.sample(m_time.batch_idx);
     }
 
@@ -417,6 +478,26 @@ namespace geopm
         result.push_back({"Resolved Max Frequency", std::to_string(m_resolved_f_gpu_max)});
         result.push_back({"Resolved Efficient Frequency", std::to_string(m_resolved_f_gpu_efficient)});
         result.push_back({"Resolved Frequency Range", std::to_string(m_f_range)});
+
+        for (int domain_idx = 0; domain_idx < M_NUM_GPU; ++domain_idx) {
+            double energy_stop = m_gpu_active_energy_stop.at(domain_idx);
+            double energy_start = m_gpu_active_energy_start.at(domain_idx);
+            double region_stop = m_gpu_active_region_stop.at(domain_idx);
+            double region_start =  m_gpu_active_region_start.at(domain_idx);
+            result.push_back({"GPU " + std::to_string(domain_idx) +
+                              " Active Region Energy", std::to_string(energy_stop - energy_start)});
+            result.push_back({"GPU " + std::to_string(domain_idx) +
+                              " Active Region Time", std::to_string(region_stop - region_start)});
+            result.push_back({"GPU " + std::to_string(domain_idx) +
+                              " On Energy", std::to_string(m_gpu_on_energy.at(domain_idx))});
+            result.push_back({"GPU " + std::to_string(domain_idx) +
+                              " On Time", std::to_string(m_gpu_on_time.at(domain_idx))});
+        }
+
+        for (int domain_idx = 0; domain_idx < m_agent_domain_count; ++domain_idx) {
+            result.push_back({"GPU Chip " + std::to_string(domain_idx) +
+                              " Idle Agent Actions", std::to_string(m_gpu_idle_samples.at(domain_idx))});
+        }
 
         return result;
     }

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -147,8 +147,6 @@ namespace geopm
                                            m_agent_domain,
                                            domain_idx), NAN});
             if (ALL_NAMES.count("LEVELZERO::METRIC:XVE_STALL") != 0) {
-                //M_WAIT_SEC = 0.015; // Currently accessing the ZET signals is slower than expecter than expecteded.
-                                    // Reducing the spin-wait time helps.
                 m_gpu_stall_activity.push_back({m_platform_io.push_signal("LEVELZERO::METRIC:XVE_STALL",
                                                m_agent_domain,
                                                domain_idx), NAN});

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -181,8 +181,6 @@ namespace geopm
         m_freq_gpu_min = m_platform_io.read_signal("GPU_CORE_FREQUENCY_MIN_AVAIL", GEOPM_DOMAIN_BOARD, 0);
         m_freq_gpu_max = m_platform_io.read_signal("GPU_CORE_FREQUENCY_MAX_AVAIL", GEOPM_DOMAIN_BOARD, 0);
 
-        //m_platform_io.write_control("GPU_CORE_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_BOARD, 0, m_freq_gpu_min);
-
         // F efficient values
         const std::string FE_CONSTCONFIG = "CONST_CONFIG::GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY";
         const std::string FE_SIG_NAME = "LEVELZERO::GPU_CORE_FREQUENCY_EFFICIENT";
@@ -524,7 +522,7 @@ namespace geopm
         std::vector<std::pair<std::string, std::string> > result;
 
         result.push_back({"Agent Domain", m_platform_topo.domain_type_to_name(m_agent_domain)});
-        if(m_gpu_stall_activity.size() > 0) {
+        if (m_gpu_stall_activity.size() > 0) {
             result.push_back({"Use Level Zero Stall Tracking", std::to_string(true)});
         }
         else {

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -37,6 +37,7 @@ namespace geopm
         : m_platform_io(plat_io)
         , m_platform_topo(topo)
         , M_POLICY_PHI_DEFAULT(0.5)
+        , M_GPU_ACTIVITY_CUTOFF(0.05)
         , M_NUM_GPU(m_platform_topo.num_domain(
                     GEOPM_DOMAIN_GPU))
         , M_NUM_GPU_CHIP(m_platform_topo.num_domain(
@@ -146,7 +147,7 @@ namespace geopm
                                            m_agent_domain,
                                            domain_idx), NAN});
             if (ALL_NAMES.count("LEVELZERO::METRIC:XVE_STALL") != 0) {
-                M_WAIT_SEC = 0.015; // Currently accessing the ZET signals is slower than expecter than expecteded.
+                //M_WAIT_SEC = 0.015; // Currently accessing the ZET signals is slower than expecter than expecteded.
                                     // Reducing the spin-wait time helps.
                 m_gpu_stall_activity.push_back({m_platform_io.push_signal("LEVELZERO::METRIC:XVE_STALL",
                                                m_agent_domain,

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -71,6 +71,7 @@ namespace geopm
         m_f_range = 0;
 
         for (int domain_idx = 0; domain_idx < M_NUM_GPU; ++domain_idx) {
+            m_gpu_region_active.push_back(false);
             m_gpu_active_region_start.push_back(0.0);
             m_gpu_active_region_stop.push_back(0.0);
             m_gpu_active_energy_start.push_back(0.0);
@@ -407,9 +408,11 @@ namespace geopm
                     continue;
                 }
                 if (gpu_scoped_core_activity.at(domain_idx) >= M_GPU_ACTIVITY_CUTOFF) {
-                    // ROI proxy tracking
-                    m_gpu_active_region_stop.at(domain_idx) = 0;
-                    if (m_gpu_active_region_start.at(domain_idx) == 0) {
+                    // ROI proxy tracking: open a new region on entry into
+                    // activity so the report reflects the current region rather
+                    // than spanning earlier regions and the idle gaps between.
+                    if (!m_gpu_region_active.at(domain_idx)) {
+                        m_gpu_region_active.at(domain_idx) = true;
                         m_gpu_active_region_start.at(domain_idx) = m_time.value;
                         m_gpu_active_energy_start.at(domain_idx) = m_gpu_energy.at(domain_idx).value;
                     }
@@ -426,12 +429,10 @@ namespace geopm
                     }
                 }
                 else {
-                    // Only close a region that actually started; otherwise stop
-                    // would subtract from a zero start and report absolute usage.
-                    // This is the first inactive sample, so close the region at
-                    // the previous sample, which was the last active one.
-                    if (m_gpu_active_region_start.at(domain_idx) != 0 &&
-                        m_gpu_active_region_stop.at(domain_idx) == 0) {
+                    // Close the region on the first inactive sample, at the
+                    // previous sample, which was the last active one.
+                    if (m_gpu_region_active.at(domain_idx)) {
+                        m_gpu_region_active.at(domain_idx) = false;
                         m_gpu_active_region_stop.at(domain_idx) = m_prev_time;
                         m_gpu_active_energy_stop.at(domain_idx) = m_prev_gpu_energy.at(domain_idx);
                     }
@@ -536,10 +537,9 @@ namespace geopm
             double energy_start = m_gpu_active_energy_start.at(domain_idx);
             double region_stop = m_gpu_active_region_stop.at(domain_idx);
             double region_start =  m_gpu_active_region_start.at(domain_idx);
-            // A region that started but has not closed still has stop == 0
-            // (reset each active sample); use the latest sample as the effective
-            // stop so the reported active-region time/energy is not negative.
-            if (region_start != 0 && region_stop == 0) {
+            // A region that is still open ends at the latest sample, so the
+            // reported active-region time/energy covers the in-progress region.
+            if (m_gpu_region_active.at(domain_idx)) {
                 region_stop = m_time.value;
                 energy_stop = m_gpu_energy.at(domain_idx).value;
             }

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -514,10 +514,10 @@ namespace geopm
 
         result.push_back({"Agent Domain", m_platform_topo.domain_type_to_name(m_agent_domain)});
         if(m_gpu_stall_activity.size() > 0) {
-            result.push_back({"Use LeveZero Stall Tracking", std::to_string(true)});
+            result.push_back({"Use Level Zero Stall Tracking", std::to_string(true)});
         }
         else {
-            result.push_back({"Use LeveZero Stall Tracking", std::to_string(false)});
+            result.push_back({"Use Level Zero Stall Tracking", std::to_string(false)});
         }
         result.push_back({"GPU Frequency Requests", std::to_string(m_gpu_frequency_requests)});
         result.push_back({"GPU Clipped Frequency Requests", std::to_string(m_gpu_frequency_clipped)});

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -107,6 +107,10 @@ namespace geopm
         std::vector<int> signal_domains;
         signal_domains.push_back(m_platform_io.signal_domain_type("GPU_CORE_FREQUENCY_STATUS"));
         signal_domains.push_back(m_platform_io.signal_domain_type("GPU_CORE_ACTIVITY"));
+        const auto ALL_NAMES = m_platform_io.signal_names();
+        if (ALL_NAMES.count("LEVELZERO::METRIC::XVE_STALL") != 0) {
+            signal_domains.push_back(m_platform_io.signal_domain_type("LEVELZERO::METRIC:XVE_STALL"));
+        }
         signal_domains.push_back(m_platform_io.signal_domain_type("GPU_UTILIZATION"));
 
         // We'll use the coarsest granularity supported by any of the controls or signals except Energy
@@ -141,6 +145,13 @@ namespace geopm
             m_gpu_core_activity.push_back({m_platform_io.push_signal("GPU_CORE_ACTIVITY",
                                            m_agent_domain,
                                            domain_idx), NAN});
+            if (ALL_NAMES.count("LEVELZERO::METRIC:XVE_STALL") != 0) {
+                M_WAIT_SEC = 0.015; // Currently accessing the ZET signals is slower than expecter than expecteded.
+                                    // Reducing the spin-wait time helps.
+                m_gpu_stall_activity.push_back({m_platform_io.push_signal("LEVELZERO::METRIC:XVE_STALL",
+                                               m_agent_domain,
+                                               domain_idx), NAN});
+            }
             m_gpu_utilization.push_back({m_platform_io.push_signal("GPU_UTILIZATION",
                                          m_agent_domain,
                                          domain_idx), NAN});
@@ -175,7 +186,6 @@ namespace geopm
 
         //m_platform_io.write_control("GPU_CORE_FREQUENCY_MIN_CONTROL", GEOPM_DOMAIN_BOARD, 0, m_freq_gpu_min);
 
-        const auto ALL_NAMES = m_platform_io.signal_names();
         // F efficient values
         const std::string FE_CONSTCONFIG = "CONST_CONFIG::GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY";
         const std::string FE_SIG_NAME = "LEVELZERO::GPU_CORE_FREQUENCY_EFFICIENT";
@@ -290,6 +300,15 @@ namespace geopm
         for (int domain_idx = 0; domain_idx < m_agent_domain_count; ++domain_idx) {
             // gpu Compute Activity - Primary signal used for frequency recommendation
             double gpu_core_activity = m_gpu_core_activity.at(domain_idx).value;
+
+            // gpu Stall Activity - Secondary signal used for frequency recommendation
+            //                      when the signal is available.  Used to reduce
+            //                      gpu Compute Activity signal.
+            double gpu_stall_activity = 0;
+            if(m_gpu_stall_activity.size() > 0) {
+                gpu_stall_activity = m_gpu_stall_activity.at(domain_idx).value;
+            }
+
             // gpu Utilization - Used to scale activity for short GPU phases
             double gpu_utilization = m_gpu_utilization.at(domain_idx).value;
 
@@ -299,6 +318,14 @@ namespace geopm
             if (!std::isnan(gpu_core_activity)) {
                 // Boundary Checking
                 gpu_core_activity = std::min(gpu_core_activity, 1.0);
+                gpu_core_activity = std::max(gpu_core_activity, 0.0);
+
+                // Stall based activity reduction
+                if (!std::isnan(gpu_stall_activity)) {
+                    gpu_stall_activity = std::max(gpu_stall_activity, 0.0);
+                    gpu_stall_activity = std::min(gpu_stall_activity, 1.0);
+                    gpu_core_activity = gpu_core_activity * (1 - gpu_stall_activity);
+                }
 
                 // Frequency selection is based upon the gpu compute activity.
                 // For active regions this means that we scale with the amount of work
@@ -351,7 +378,8 @@ namespace geopm
 
             if (phi >= 0.5) {
                 if (!std::isnan(gpu_utilization) &&
-                    gpu_utilization == 0) {
+                    (gpu_utilization == 0 ||
+                    (gpu_utilization < 0.02 && m_gpu_stall_activity.size() > 0))) { // ZET results in low level utilization
                     if (m_gpu_idle_timer.at(domain_idx) > 0) {
                         m_gpu_idle_timer.at(domain_idx) = m_gpu_idle_timer.at(domain_idx) - 1;
                     }
@@ -384,8 +412,15 @@ namespace geopm
                     }
 
                     // GPU on time tracking
-                    m_gpu_on_time.at(domain_idx) += m_time.value - m_prev_time;
-                    m_gpu_on_energy.at(domain_idx) += m_gpu_energy.at(domain_idx).value - m_prev_gpu_energy.at(domain_idx);
+                    double sample_energy_diff = m_gpu_energy.at(domain_idx).value - m_prev_gpu_energy.at(domain_idx);
+                    if(!std::isnan(sample_energy_diff)) {
+                        m_gpu_on_energy.at(domain_idx) += sample_energy_diff;
+                    }
+
+                    double sample_time_diff = m_time.value - m_prev_time;
+                    if(!std::isnan(sample_time_diff)) {
+                        m_gpu_on_time.at(domain_idx) += sample_time_diff;
+                    }
                 }
                 else {
                     // ROI proxy tracking
@@ -441,6 +476,10 @@ namespace geopm
         for (int domain_idx = 0; domain_idx < m_agent_domain_count; ++domain_idx) {
             m_gpu_core_activity.at(domain_idx).value = m_platform_io.sample(m_gpu_core_activity.at(
                                                                                domain_idx).batch_idx);
+            if(m_gpu_stall_activity.size() > 0) {
+                m_gpu_stall_activity.at(domain_idx).value = m_platform_io.sample(m_gpu_stall_activity.at(
+                                                                                   domain_idx).batch_idx);
+            }
             m_gpu_utilization.at(domain_idx).value = m_platform_io.sample(m_gpu_utilization.at(
                                                                           domain_idx).batch_idx);
         }
@@ -473,6 +512,12 @@ namespace geopm
         std::vector<std::pair<std::string, std::string> > result;
 
         result.push_back({"Agent Domain", m_platform_topo.domain_type_to_name(m_agent_domain)});
+        if(m_gpu_stall_activity.size() > 0) {
+            result.push_back({"Use LeveZero Stall Tracking", std::to_string(true)});
+        }
+        else {
+            result.push_back({"Use LeveZero Stall Tracking", std::to_string(false)});
+        }
         result.push_back({"GPU Frequency Requests", std::to_string(m_gpu_frequency_requests)});
         result.push_back({"GPU Clipped Frequency Requests", std::to_string(m_gpu_frequency_clipped)});
         result.push_back({"Resolved Max Frequency", std::to_string(m_resolved_f_gpu_max)});

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -320,6 +320,10 @@ namespace geopm
                 gpu_core_activity = std::min(gpu_core_activity, 1.0);
                 gpu_core_activity = std::max(gpu_core_activity, 0.0);
 
+                // Stall only lowers the frequency decision, so preserve the raw
+                // bounded activity for ROI/on-time tracking.
+                double gpu_tracked_activity = gpu_core_activity;
+
                 // Stall based activity reduction
                 if (!std::isnan(gpu_stall_activity)) {
                     gpu_stall_activity = std::max(gpu_stall_activity, 0.0);
@@ -365,7 +369,7 @@ namespace geopm
                 // solution to the lack of GPU region support and may be
                 // removed when that support is added to GEOPM.
                 if (domain_idx % agent_units_per_gpu == 0) {
-                    gpu_scoped_core_activity.at(domain_idx / agent_units_per_gpu) = gpu_core_activity;
+                    gpu_scoped_core_activity.at(domain_idx / agent_units_per_gpu) = gpu_tracked_activity;
                 }
             }
 

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -530,6 +530,13 @@ namespace geopm
             double energy_start = m_gpu_active_energy_start.at(domain_idx);
             double region_stop = m_gpu_active_region_stop.at(domain_idx);
             double region_start =  m_gpu_active_region_start.at(domain_idx);
+            // A region that started but has not closed still has stop == 0
+            // (reset each active sample); use the latest sample as the effective
+            // stop so the reported active-region time/energy is not negative.
+            if (region_start != 0 && region_stop == 0) {
+                region_stop = m_time.value;
+                energy_stop = m_gpu_energy.at(domain_idx).value;
+            }
             result.push_back({"GPU " + std::to_string(domain_idx) +
                               " Active Region Energy", std::to_string(energy_stop - energy_start)});
             result.push_back({"GPU " + std::to_string(domain_idx) +

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -426,8 +426,10 @@ namespace geopm
                     }
                 }
                 else {
-                    // ROI proxy tracking
-                    if (m_gpu_active_region_stop.at(domain_idx) == 0) {
+                    // Only close a region that actually started; otherwise stop
+                    // would subtract from a zero start and report absolute usage.
+                    if (m_gpu_active_region_start.at(domain_idx) != 0 &&
+                        m_gpu_active_region_stop.at(domain_idx) == 0) {
                         m_gpu_active_region_stop.at(domain_idx) = m_time.value;
                         m_gpu_active_energy_stop.at(domain_idx) = m_gpu_energy.at(domain_idx).value;
                     }

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -40,9 +40,6 @@ namespace geopm
         , M_GPU_ACTIVITY_CUTOFF(0.05)
         , M_NUM_GPU(m_platform_topo.num_domain(
                     GEOPM_DOMAIN_GPU))
-        , M_NUM_GPU_CHIP(m_platform_topo.num_domain(
-                         GEOPM_DOMAIN_GPU_CHIP))
-        , M_NUM_CHIP_PER_GPU(M_NUM_GPU == 0 ? 0 : M_NUM_GPU_CHIP / M_NUM_GPU)
         , m_do_write_batch(false)
         , m_do_send_policy(true)
         , m_has_freq_min_control(false)
@@ -266,7 +263,10 @@ namespace geopm
 
         // Per GPU freq
         std::vector<double> gpu_freq_request;
-        std::vector<double> gpu_scoped_core_activity;
+        // GPU-indexed; NaN marks a GPU with no valid first-unit sample this cycle.
+        std::vector<double> gpu_scoped_core_activity(M_NUM_GPU, NAN);
+        // Agent-domain units (GPU or GPU_CHIP) per GPU, used to pick one per GPU.
+        int agent_units_per_gpu = m_agent_domain_count / M_NUM_GPU;
 
         double f_gpu_range = m_freq_gpu_max - m_freq_gpu_efficient;
         double phi = in_policy[M_POLICY_GPU_PHI];
@@ -363,8 +363,8 @@ namespace geopm
                 // This is non-ideal, but is intended to be a temporary
                 // solution to the lack of GPU region support and may be
                 // removed when that support is added to GEOPM.
-                if (domain_idx % (M_NUM_CHIP_PER_GPU) == 0) {
-                    gpu_scoped_core_activity.push_back(gpu_core_activity);
+                if (domain_idx % agent_units_per_gpu == 0) {
+                    gpu_scoped_core_activity.at(domain_idx / agent_units_per_gpu) = gpu_core_activity;
                 }
             }
 
@@ -402,6 +402,10 @@ namespace geopm
         // may be removed when GPU regions are added to GEOPM.
         if (!gpu_scoped_core_activity.empty()) {
             for (int domain_idx = 0; domain_idx < M_NUM_GPU; ++domain_idx) {
+                if (std::isnan(gpu_scoped_core_activity.at(domain_idx))) {
+                    // No valid first-unit activity sample for this GPU this cycle.
+                    continue;
+                }
                 if (gpu_scoped_core_activity.at(domain_idx) >= M_GPU_ACTIVITY_CUTOFF) {
                     // ROI proxy tracking
                     m_gpu_active_region_stop.at(domain_idx) = 0;

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -109,7 +109,7 @@ namespace geopm
         signal_domains.push_back(m_platform_io.signal_domain_type("GPU_CORE_FREQUENCY_STATUS"));
         signal_domains.push_back(m_platform_io.signal_domain_type("GPU_CORE_ACTIVITY"));
         const auto ALL_NAMES = m_platform_io.signal_names();
-        if (ALL_NAMES.count("LEVELZERO::METRIC::XVE_STALL") != 0) {
+        if (ALL_NAMES.count("LEVELZERO::METRIC:XVE_STALL") != 0) {
             signal_domains.push_back(m_platform_io.signal_domain_type("LEVELZERO::METRIC:XVE_STALL"));
         }
         signal_domains.push_back(m_platform_io.signal_domain_type("GPU_UTILIZATION"));

--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -428,10 +428,12 @@ namespace geopm
                 else {
                     // Only close a region that actually started; otherwise stop
                     // would subtract from a zero start and report absolute usage.
+                    // This is the first inactive sample, so close the region at
+                    // the previous sample, which was the last active one.
                     if (m_gpu_active_region_start.at(domain_idx) != 0 &&
                         m_gpu_active_region_stop.at(domain_idx) == 0) {
-                        m_gpu_active_region_stop.at(domain_idx) = m_time.value;
-                        m_gpu_active_energy_stop.at(domain_idx) = m_gpu_energy.at(domain_idx).value;
+                        m_gpu_active_region_stop.at(domain_idx) = m_prev_time;
+                        m_gpu_active_energy_stop.at(domain_idx) = m_prev_gpu_energy.at(domain_idx);
                     }
                 }
             }

--- a/libgeopm/src/GPUActivityAgent.hpp
+++ b/libgeopm/src/GPUActivityAgent.hpp
@@ -56,8 +56,6 @@ namespace geopm
             const double M_POLICY_PHI_DEFAULT;
             const double M_GPU_ACTIVITY_CUTOFF;
             const int M_NUM_GPU;
-            const int M_NUM_GPU_CHIP;
-            const int M_NUM_CHIP_PER_GPU;
             bool m_do_write_batch;
             bool m_do_send_policy;
             bool m_has_freq_min_control;

--- a/libgeopm/src/GPUActivityAgent.hpp
+++ b/libgeopm/src/GPUActivityAgent.hpp
@@ -106,6 +106,7 @@ namespace geopm
             std::vector<int> m_gpu_idle_samples;
 
             std::vector<m_signal> m_gpu_core_activity;
+            std::vector<m_signal> m_gpu_stall_activity;
             std::vector<m_signal> m_gpu_utilization;
             std::vector<m_signal> m_gpu_energy;
             std::vector<int> m_gpu_idle_timer;

--- a/libgeopm/src/GPUActivityAgent.hpp
+++ b/libgeopm/src/GPUActivityAgent.hpp
@@ -54,6 +54,7 @@ namespace geopm
             const PlatformTopo &m_platform_topo;
             static constexpr double M_WAIT_SEC = 0.020; // 20ms wait default
             const double M_POLICY_PHI_DEFAULT;
+            const double M_GPU_ACTIVITY_CUTOFF;
             const int M_NUM_GPU;
             const int M_NUM_GPU_CHIP;
             const int M_NUM_CHIP_PER_GPU;

--- a/libgeopm/src/GPUActivityAgent.hpp
+++ b/libgeopm/src/GPUActivityAgent.hpp
@@ -96,6 +96,8 @@ namespace geopm
             double m_resolved_f_gpu_max;
             double m_resolved_f_gpu_efficient;
             double m_f_range;
+            // Whether each GPU is currently inside an active region (ROI proxy).
+            std::vector<bool> m_gpu_region_active;
             std::vector<double> m_gpu_active_region_start;
             std::vector<double> m_gpu_active_region_stop;
             std::vector<double> m_gpu_active_energy_start;

--- a/libgeopm/src/GPUActivityAgent.hpp
+++ b/libgeopm/src/GPUActivityAgent.hpp
@@ -97,11 +97,22 @@ namespace geopm
             double m_resolved_f_gpu_max;
             double m_resolved_f_gpu_efficient;
             double m_f_range;
+            std::vector<double> m_gpu_active_region_start;
+            std::vector<double> m_gpu_active_region_stop;
+            std::vector<double> m_gpu_active_energy_start;
+            std::vector<double> m_gpu_active_energy_stop;
+            std::vector<double> m_gpu_on_time;
+            std::vector<double> m_gpu_on_energy;
+            std::vector<int> m_gpu_idle_samples;
 
             std::vector<m_signal> m_gpu_core_activity;
             std::vector<m_signal> m_gpu_utilization;
             std::vector<m_signal> m_gpu_energy;
+            std::vector<int> m_gpu_idle_timer;
+
             m_signal m_time;
+            double m_prev_time;
+            std::vector<double> m_prev_gpu_energy;
 
             std::vector<m_control> m_gpu_freq_min_control;
             std::vector<m_control> m_gpu_freq_max_control;

--- a/libgeopm/test/GPUActivityAgentTest.cpp
+++ b/libgeopm/test/GPUActivityAgentTest.cpp
@@ -38,6 +38,7 @@ class GPUActivityAgentTest : public :: testing :: Test
     protected:
         enum mock_pio_idx_e {
             GPU_CORE_ACTIVITY_IDX,
+            GPU_STALL_ACTIVITY_IDX,
             GPU_UTILIZATION_IDX,
             GPU_ENERGY_IDX,
             GPU_FREQUENCY_CONTROL_MIN_IDX,
@@ -56,6 +57,11 @@ class GPUActivityAgentTest : public :: testing :: Test
                                   double mock_active,
                                   double mock_util,
                                   double expected_freq);
+        void test_adjust_platform_stall(std::vector<double> &policy,
+                                        double mock_active,
+                                        double mock_stall,
+                                        double mock_util,
+                                        double expected_freq);
         static const int M_NUM_CPU;
         static const int M_NUM_BOARD;
         static const int M_NUM_GPU;
@@ -241,6 +247,93 @@ void GPUActivityAgentTest::test_adjust_platform(std::vector<double> &policy,
 
     //Check a frequency decision resulted in write batch being true
     EXPECT_TRUE(m_agent->do_write_batch());
+}
+
+// Builds a fresh agent with the Level Zero stall signal available so the
+// secondary stall-based activity reduction is exercised.
+void GPUActivityAgentTest::test_adjust_platform_stall(std::vector<double> &policy,
+                                                      double mock_active,
+                                                      double mock_stall,
+                                                      double mock_util,
+                                                      double expected_freq)
+{
+    std::set<std::string> signal_name_set = {
+        "CONST_CONFIG::GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY",
+        "LEVELZERO::METRIC:XVE_STALL"
+    };
+    ON_CALL(*m_platform_io, signal_names()).WillByDefault(Return(signal_name_set));
+    ON_CALL(*m_platform_io, push_signal("LEVELZERO::METRIC:XVE_STALL", _, _))
+        .WillByDefault(Return(GPU_STALL_ACTIVITY_IDX));
+    ON_CALL(*m_platform_io, signal_domain_type("LEVELZERO::METRIC:XVE_STALL"))
+        .WillByDefault(Return(GEOPM_DOMAIN_GPU_CHIP));
+
+    auto agent = geopm::make_unique<GPUActivityAgent>(*m_platform_io, *m_platform_topo, m_waiter);
+    agent->init(0, {}, false);
+
+    set_up_val_policy_expectations();
+    EXPECT_NO_THROW(agent->validate_policy(policy));
+
+    std::vector<double> tmp;
+    EXPECT_CALL(*m_platform_io, sample(GPU_CORE_ACTIVITY_IDX))
+                .WillRepeatedly(Return(mock_active));
+    EXPECT_CALL(*m_platform_io, sample(GPU_STALL_ACTIVITY_IDX))
+                .WillRepeatedly(Return(mock_stall));
+    EXPECT_CALL(*m_platform_io, sample(GPU_UTILIZATION_IDX))
+                .WillRepeatedly(Return(mock_util));
+    EXPECT_CALL(*m_platform_io, sample(GPU_ENERGY_IDX))
+                .WillRepeatedly(Return(123456789));
+    EXPECT_CALL(*m_platform_io, sample(TIME_IDX))
+                .Times(1);
+    agent->sample_platform(tmp);
+
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, expected_freq)).Times(M_NUM_GPU_CHIP);
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, expected_freq)).Times(M_NUM_GPU_CHIP);
+
+    agent->adjust_platform(policy);
+    EXPECT_TRUE(agent->do_write_batch());
+}
+
+// A valid stall sample reduces the compute activity, lowering the request.
+TEST_F(GPUActivityAgentTest, adjust_platform_stall_valid)
+{
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    double mock_active = 1.0;
+    double mock_stall = 0.5;
+    double mock_util = 1.0;
+    double effective_active = mock_active * (1 - mock_stall);
+    double expected_freq = M_FREQ_EFFICIENT +
+            (M_FREQ_MAX - M_FREQ_EFFICIENT) * effective_active;
+    test_adjust_platform_stall(policy, mock_active, mock_stall, mock_util, expected_freq);
+}
+
+// A NaN stall sample is ignored, leaving the request at the unreduced value.
+TEST_F(GPUActivityAgentTest, adjust_platform_stall_nan)
+{
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    double mock_active = 1.0;
+    double mock_stall = NAN;
+    double mock_util = 1.0;
+    test_adjust_platform_stall(policy, mock_active, mock_stall, mock_util, M_FREQ_MAX);
+}
+
+// An out-of-range high stall sample clamps to 1.0, zeroing the activity.
+TEST_F(GPUActivityAgentTest, adjust_platform_stall_out_of_bounds_high)
+{
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    double mock_active = 1.0;
+    double mock_stall = 987654321;
+    double mock_util = 1.0;
+    test_adjust_platform_stall(policy, mock_active, mock_stall, mock_util, M_FREQ_EFFICIENT);
+}
+
+// An out-of-range low stall sample clamps to 0.0, applying no reduction.
+TEST_F(GPUActivityAgentTest, adjust_platform_stall_out_of_bounds_low)
+{
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    double mock_active = 1.0;
+    double mock_stall = -12345;
+    double mock_util = 1.0;
+    test_adjust_platform_stall(policy, mock_active, mock_stall, mock_util, M_FREQ_MAX);
 }
 
 TEST_F(GPUActivityAgentTest, adjust_platform_high)

--- a/libgeopm/test/GPUActivityAgentTest.cpp
+++ b/libgeopm/test/GPUActivityAgentTest.cpp
@@ -27,9 +27,12 @@
 
 using ::testing::_;
 using ::testing::Invoke;
+using ::testing::InvokeWithoutArgs;
 using ::testing::Sequence;
 using ::testing::Return;
 using ::testing::AtLeast;
+using ::testing::AnyNumber;
+using ::testing::SaveArg;
 using geopm::GPUActivityAgent;
 using geopm::PlatformTopo;
 
@@ -62,6 +65,7 @@ class GPUActivityAgentTest : public :: testing :: Test
                                         double mock_stall,
                                         double mock_util,
                                         double expected_freq);
+        std::unique_ptr<GPUActivityAgent> build_stall_agent();
         static const int M_NUM_CPU;
         static const int M_NUM_BOARD;
         static const int M_NUM_GPU;
@@ -250,12 +254,9 @@ void GPUActivityAgentTest::test_adjust_platform(std::vector<double> &policy,
 }
 
 // Builds a fresh agent with the Level Zero stall signal available so the
-// secondary stall-based activity reduction is exercised.
-void GPUActivityAgentTest::test_adjust_platform_stall(std::vector<double> &policy,
-                                                      double mock_active,
-                                                      double mock_stall,
-                                                      double mock_util,
-                                                      double expected_freq)
+// secondary stall-based activity reduction and stall-specific idle threshold
+// are exercised.
+std::unique_ptr<GPUActivityAgent> GPUActivityAgentTest::build_stall_agent()
 {
     std::set<std::string> signal_name_set = {
         "CONST_CONFIG::GPU_FREQUENCY_EFFICIENT_HIGH_INTENSITY",
@@ -269,6 +270,16 @@ void GPUActivityAgentTest::test_adjust_platform_stall(std::vector<double> &polic
 
     auto agent = geopm::make_unique<GPUActivityAgent>(*m_platform_io, *m_platform_topo, m_waiter);
     agent->init(0, {}, false);
+    return agent;
+}
+
+void GPUActivityAgentTest::test_adjust_platform_stall(std::vector<double> &policy,
+                                                      double mock_active,
+                                                      double mock_stall,
+                                                      double mock_util,
+                                                      double expected_freq)
+{
+    auto agent = build_stall_agent();
 
     set_up_val_policy_expectations();
     EXPECT_NO_THROW(agent->validate_policy(policy));
@@ -435,4 +446,178 @@ TEST_F(GPUActivityAgentTest, invalid_fe)
 
     GEOPM_EXPECT_THROW_MESSAGE(m_agent->init(0, {}, false), GEOPM_ERROR_INVALID,
                                 "(): GPU efficient frequency out of range: ");
+}
+
+// Zero utilization must be observed for ten samples before the request is
+// forced to the minimum frequency; the ninth idle sample must not override.
+TEST_F(GPUActivityAgentTest, adjust_platform_idle_countdown)
+{
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    set_up_val_policy_expectations();
+    EXPECT_NO_THROW(m_agent->validate_policy(policy));
+
+    EXPECT_CALL(*m_platform_io, sample(GPU_CORE_ACTIVITY_IDX)).WillRepeatedly(Return(1.0));
+    EXPECT_CALL(*m_platform_io, sample(GPU_UTILIZATION_IDX)).WillRepeatedly(Return(0.0));
+    EXPECT_CALL(*m_platform_io, sample(GPU_ENERGY_IDX)).WillRepeatedly(Return(123456789));
+    EXPECT_CALL(*m_platform_io, sample(TIME_IDX)).WillRepeatedly(Return(0.0));
+
+    double last_min = NAN;
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, _))
+                .WillRepeatedly(SaveArg<1>(&last_min));
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, _))
+                .WillRepeatedly(Return());
+
+    std::vector<double> tmp;
+    // Nine idle samples count down the timer but do not override.
+    for (int i = 0; i < 9; ++i) {
+        m_agent->sample_platform(tmp);
+        m_agent->adjust_platform(policy);
+        EXPECT_NE(M_FREQ_MIN, last_min);
+    }
+    // The tenth idle sample drives the request to the minimum frequency.
+    m_agent->sample_platform(tmp);
+    m_agent->adjust_platform(policy);
+    EXPECT_EQ(M_FREQ_MIN, last_min);
+}
+
+// A single active sample resets the idle countdown, so a fresh set of ten idle
+// samples is required before the minimum-frequency override reengages.
+TEST_F(GPUActivityAgentTest, adjust_platform_idle_reset)
+{
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    set_up_val_policy_expectations();
+    EXPECT_NO_THROW(m_agent->validate_policy(policy));
+
+    double mock_util = 0.0;
+    EXPECT_CALL(*m_platform_io, sample(GPU_CORE_ACTIVITY_IDX)).WillRepeatedly(Return(1.0));
+    EXPECT_CALL(*m_platform_io, sample(GPU_UTILIZATION_IDX))
+                .WillRepeatedly(InvokeWithoutArgs([&mock_util]() { return mock_util; }));
+    EXPECT_CALL(*m_platform_io, sample(GPU_ENERGY_IDX)).WillRepeatedly(Return(123456789));
+    EXPECT_CALL(*m_platform_io, sample(TIME_IDX)).WillRepeatedly(Return(0.0));
+
+    double last_min = NAN;
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, _))
+                .WillRepeatedly(SaveArg<1>(&last_min));
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, _))
+                .WillRepeatedly(Return());
+
+    std::vector<double> tmp;
+    // Nine idle samples, then one active sample resets the countdown.
+    for (int i = 0; i < 9; ++i) {
+        m_agent->sample_platform(tmp);
+        m_agent->adjust_platform(policy);
+    }
+    mock_util = 1.0;
+    m_agent->sample_platform(tmp);
+    m_agent->adjust_platform(policy);
+    EXPECT_NE(M_FREQ_MIN, last_min);
+
+    // After the reset, nine more idle samples still must not override.
+    mock_util = 0.0;
+    for (int i = 0; i < 9; ++i) {
+        m_agent->sample_platform(tmp);
+        m_agent->adjust_platform(policy);
+        EXPECT_NE(M_FREQ_MIN, last_min);
+    }
+    // The tenth idle sample after the reset overrides.
+    m_agent->sample_platform(tmp);
+    m_agent->adjust_platform(policy);
+    EXPECT_EQ(M_FREQ_MIN, last_min);
+}
+
+// With the stall signal present, a low but non-zero utilization (< 0.02) also
+// engages the idle countdown.
+TEST_F(GPUActivityAgentTest, adjust_platform_idle_low_util_with_stall)
+{
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    auto agent = build_stall_agent();
+    set_up_val_policy_expectations();
+    EXPECT_NO_THROW(agent->validate_policy(policy));
+
+    EXPECT_CALL(*m_platform_io, sample(GPU_CORE_ACTIVITY_IDX)).WillRepeatedly(Return(1.0));
+    EXPECT_CALL(*m_platform_io, sample(GPU_STALL_ACTIVITY_IDX)).WillRepeatedly(Return(0.0));
+    EXPECT_CALL(*m_platform_io, sample(GPU_UTILIZATION_IDX)).WillRepeatedly(Return(0.01));
+    EXPECT_CALL(*m_platform_io, sample(GPU_ENERGY_IDX)).WillRepeatedly(Return(123456789));
+    EXPECT_CALL(*m_platform_io, sample(TIME_IDX)).WillRepeatedly(Return(0.0));
+
+    double last_min = NAN;
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, _))
+                .WillRepeatedly(SaveArg<1>(&last_min));
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, _))
+                .WillRepeatedly(Return());
+
+    std::vector<double> tmp;
+    for (int i = 0; i < 9; ++i) {
+        agent->sample_platform(tmp);
+        agent->adjust_platform(policy);
+        EXPECT_NE(M_FREQ_MIN, last_min);
+    }
+    agent->sample_platform(tmp);
+    agent->adjust_platform(policy);
+    EXPECT_EQ(M_FREQ_MIN, last_min);
+}
+
+// Without the stall signal, a low but non-zero utilization must not engage the
+// idle countdown, so the minimum-frequency override never fires.
+TEST_F(GPUActivityAgentTest, adjust_platform_idle_low_util_without_stall)
+{
+    std::vector<double> policy = M_DEFAULT_POLICY;
+    set_up_val_policy_expectations();
+    EXPECT_NO_THROW(m_agent->validate_policy(policy));
+
+    EXPECT_CALL(*m_platform_io, sample(GPU_CORE_ACTIVITY_IDX)).WillRepeatedly(Return(1.0));
+    EXPECT_CALL(*m_platform_io, sample(GPU_UTILIZATION_IDX)).WillRepeatedly(Return(0.01));
+    EXPECT_CALL(*m_platform_io, sample(GPU_ENERGY_IDX)).WillRepeatedly(Return(123456789));
+    EXPECT_CALL(*m_platform_io, sample(TIME_IDX)).WillRepeatedly(Return(0.0));
+
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, _)).Times(AnyNumber());
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, _)).Times(AnyNumber());
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, M_FREQ_MIN)).Times(0);
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, M_FREQ_MIN)).Times(0);
+
+    std::vector<double> tmp;
+    for (int i = 0; i < 15; ++i) {
+        m_agent->sample_platform(tmp);
+        m_agent->adjust_platform(policy);
+    }
+}
+
+// A performance-biased policy (phi < 0.5) scales the efficient frequency up
+// toward the maximum before the activity-based selection is applied.
+TEST_F(GPUActivityAgentTest, adjust_platform_phi_perf_biased)
+{
+    std::vector<double> policy = {0.25};
+    double mock_active = 0.5;
+    double mock_util = 1.0;
+    double range = M_FREQ_MAX - M_FREQ_EFFICIENT;
+    // (0.5 - 0.25) / 0.5 == 0.5
+    double resolved_efficient = M_FREQ_EFFICIENT + range * (0.5 - 0.25) / 0.5;
+    double resolved_range = M_FREQ_MAX - resolved_efficient;
+    double expected_freq = resolved_efficient + resolved_range * mock_active;
+    test_adjust_platform(policy, mock_active, mock_util, expected_freq);
+}
+
+// The idle countdown is gated on phi >= 0.5, so a performance-biased policy
+// must never force the minimum frequency even when utilization is zero.
+TEST_F(GPUActivityAgentTest, adjust_platform_phi_perf_biased_no_idle)
+{
+    std::vector<double> policy = {0.25};
+    set_up_val_policy_expectations();
+    EXPECT_NO_THROW(m_agent->validate_policy(policy));
+
+    EXPECT_CALL(*m_platform_io, sample(GPU_CORE_ACTIVITY_IDX)).WillRepeatedly(Return(1.0));
+    EXPECT_CALL(*m_platform_io, sample(GPU_UTILIZATION_IDX)).WillRepeatedly(Return(0.0));
+    EXPECT_CALL(*m_platform_io, sample(GPU_ENERGY_IDX)).WillRepeatedly(Return(123456789));
+    EXPECT_CALL(*m_platform_io, sample(TIME_IDX)).WillRepeatedly(Return(0.0));
+
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, _)).Times(AnyNumber());
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, _)).Times(AnyNumber());
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MIN_IDX, M_FREQ_MIN)).Times(0);
+    EXPECT_CALL(*m_platform_io, adjust(GPU_FREQUENCY_CONTROL_MAX_IDX, M_FREQ_MIN)).Times(0);
+
+    std::vector<double> tmp;
+    for (int i = 0; i < 15; ++i) {
+        m_agent->sample_platform(tmp);
+        m_agent->adjust_platform(policy);
+    }
 }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -220,7 +220,7 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
-            metric_group_cache(gpu_idx);
+            metric_group_init(gpu_idx);
         }
     }
 
@@ -551,11 +551,11 @@ namespace geopm
     //      - metric group handle
     //      - sampling period
     //      - data storage for the ComputeBasics metric group
-    void LevelZeroImp::metric_group_cache(unsigned int device_idx) {
+    void LevelZeroImp::metric_group_init(unsigned int device_idx) {
         for (int subdevice_idx = 0;
              subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
              ++subdevice_idx) {
-            // Setup tracking of the caching and initilization steps
+            // Setup tracking of the caching and initialization steps
             m_devices.at(device_idx).subdevice.metric_domain_cached.push_back(false);
             m_devices.at(device_idx).subdevice.metrics_initialized.push_back(false);
 
@@ -603,70 +603,72 @@ namespace geopm
 
             for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
                  metric_group_idx++) {
-                 zet_metric_group_properties_t metric_group_properties;
-                 ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
-                                             &metric_group_properties);
-                 check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
-                                 "LevelZero::" + std::string(__func__) +
-                                 ": LevelZero Metric Group property acquisition failed",
-                                 __LINE__);
+                zet_metric_group_properties_t metric_group_properties;
+                ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
+                                            &metric_group_properties);
+                check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Metric Group property acquisition failed",
+                                __LINE__);
 
-                 std::string metric_group_name (metric_group_properties.name);
+                std::string metric_group_name (metric_group_properties.name);
 
-                 //Confirm metric groups of interest exist
-                 if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
-                     && metric_group_name == "ComputeBasic") {
+                // Confirm metric groups of interest exist
+                // Eventually the metric group of interest may be configurable,
+                // to start we're using compute basics
+                if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
+                    && metric_group_name == "ComputeBasic") {
 
-                    //cache compute basic metric group
-                    m_devices.at(device_idx).subdevice.metric_group_handle.push_back(metric_group_handle.at(metric_group_idx));
+                   //cache compute basic metric group
+                   m_devices.at(device_idx).subdevice.metric_group_handle.push_back(metric_group_handle.at(metric_group_idx));
 
-                    // could likely use metric_group_properties.metricCount instead
-                    uint32_t num_metric = 0;
-                    ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
-                    check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                    "LevelZero::" + std::string(__func__) +
-                                    ": LevelZero Metric Count query failed",
-                                    __LINE__);
+                   // could likely use metric_group_properties.metricCount instead
+                   uint32_t num_metric = 0;
+                   ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
+                   check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                   "LevelZero::" + std::string(__func__) +
+                                   ": LevelZero Metric Count query failed",
+                                   __LINE__);
 
-                    //Cache compute basic number of metrics
-                    m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
+                   //Cache compute basic number of metrics
+                   m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
 
-                    //Build metric map
-                    for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
-                    {
+                   //Build metric map
+                   for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+                   {
 
-                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
-                                                 &num_metric, metric_handle.data());
+                       std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                       ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
+                                                &num_metric, metric_handle.data());
 
-                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                        "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric handle acquisition failed",
-                                        __LINE__);
-                        zet_metric_properties_t metric_properties;
-                        ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+                       check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                       "LevelZero::" + std::string(__func__) +
+                                       ": LevelZero Metric handle acquisition failed",
+                                       __LINE__);
+                       zet_metric_properties_t metric_properties;
+                       ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
 
-                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                        "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric Property acquisition failed",
-                                        __LINE__);
+                       check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                       "LevelZero::" + std::string(__func__) +
+                                       ": LevelZero Metric Property acquisition failed",
+                                       __LINE__);
 
-                        std::string metric_name (metric_properties.name);
+                       std::string metric_name (metric_properties.name);
 
-                        //m_devices is a std::vector of structs, indexed by GPU
-                        // subdevice is a struct inside of it.  One per GPU
-                        //  m_metric_data is a vector, indexed by CHIP
-                        //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
-                        if (m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
-                            throw Exception("LevelZero::" + std::string(__func__) +
-                                            ": Metric group has two metrics with the same name",
-                                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-                        }
-                        m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
-                        m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
-                    }
-                    // Break out of loop once we've found the group of interest
-                    break;
+                       //m_devices is a std::vector of structs, indexed by GPU
+                       // subdevice is a struct inside of it.  One per GPU
+                       //  m_metric_data is a vector, indexed by CHIP
+                       //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
+                       if (m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
+                           throw Exception("LevelZero::" + std::string(__func__) +
+                                           ": Metric group has two metrics with the same name",
+                                           GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+                       }
+                       m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
+                       m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
+                   }
+                   // Break out of loop once we've found the group of interest
+                   break;
                 }
             }
             m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
@@ -675,6 +677,16 @@ namespace geopm
 
     void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
+        GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) == true,
+                           "metric caching for GPU " + std::to_string(l0_device_idx) +
+                           ", CHIP " + std::to_string(l0_domain_idx) +
+                           " not completed prior to metric_calc call.");
+
+        GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) == true,
+                           "metric initialization for GPU " + std::to_string(l0_device_idx) +
+                           ", CHIP " + std::to_string(l0_domain_idx) +
+                           " not completed prior to metric_calc call.");
+
         ze_result_t ze_result;
 
         if (m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
@@ -714,7 +726,7 @@ namespace geopm
     }
 
 
-    void LevelZeroImp::metric_init(unsigned int l0_device_idx, unsigned int l0_domain_idx)
+    void LevelZeroImp::metric_execute(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
         ze_result_t ze_result;
         ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
@@ -878,7 +890,7 @@ namespace geopm
     {
         if (m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
             if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
-                metric_init(l0_device_idx, l0_domain_idx);
+                metric_execute(l0_device_idx, l0_domain_idx);
                 m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
             }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -614,6 +614,8 @@ namespace geopm
             m_devices.at(device_idx).subdevice.metric_data.push_back({});
             m_devices.at(device_idx).subdevice.metric_data_accum.push_back({});
             m_devices.at(device_idx).subdevice.metric_active.push_back(false);
+            m_devices.at(device_idx).subdevice.metric_last_drain.push_back(
+                std::chrono::steady_clock::time_point{});
 
             for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
                  metric_group_idx++) {
@@ -822,10 +824,10 @@ namespace geopm
 
         // Use the cached name→index map to avoid calling zetMetricGet and
         // zetMetricGetProperties on every sample iteration.  The report values
-        // are appended to the accumulator under lock; the controller snapshots
-        // (moves) the accumulator into metric_data once per read_batch().
+        // are appended to the accumulator; the caller (metric_drain) holds
+        // m_metric_mutex, and the controller snapshots (moves) the accumulator
+        // into metric_data once per read_batch().
         const auto &name_idx = m_devices.at(l0_device_idx).subdevice.metric_name_idx.at(l0_domain_idx);
-        std::lock_guard<std::mutex> lock(m_metric_mutex);
         auto &accum = m_devices.at(l0_device_idx).subdevice.metric_data_accum.at(l0_domain_idx);
         for (const auto &kv : name_idx) {
             const std::string &metric_name = kv.first;
@@ -870,15 +872,27 @@ namespace geopm
             return;
         }
 
-        // Snapshot the reports accumulated by the background thread since the
-        // last read_batch() into metric_data, marking the chip active so the
-        // thread drains it.  metric_data therefore holds every report gathered
-        // over the controller period (averaged later by metric_sample).
         const auto &name_idx = m_devices.at(l0_device_idx).subdevice.metric_name_idx.at(l0_domain_idx);
         {
             std::lock_guard<std::mutex> lock(m_metric_mutex);
+
+            // Open the streamer on first use.  Done from the controller thread in
+            // chip order so the streamer vectors grow safely, and serialized with
+            // the background thread by m_metric_mutex.
+            if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
+                metric_execute(l0_device_idx, l0_domain_idx);
+                m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
+            }
             m_devices.at(l0_device_idx).subdevice.metric_active.at(l0_domain_idx) = true;
 
+            // Drain now so this sample always has fresh data, regardless of how
+            // the controller period compares to the background drain cadence.
+            metric_drain(l0_device_idx, l0_domain_idx);
+
+            // Snapshot the accumulated reports (this drain plus any the
+            // background thread gathered since the last read_batch) into
+            // metric_data.  metric_data therefore holds every report gathered
+            // over the controller period (averaged later by metric_sample).
             auto &accum = m_devices.at(l0_device_idx).subdevice.metric_data_accum.at(l0_domain_idx);
             auto &current = m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx);
             size_t num_reports = 0;
@@ -917,27 +931,27 @@ namespace geopm
 
     void LevelZeroImp::metric_sample_thread(void)
     {
+        // Keep-alive draining: the controller drains each chip itself in
+        // metric_read(), so this thread only needs to drain a chip when the
+        // controller hasn't drained it recently.  This keeps the metric streamer
+        // from stalling during long controller periods, while avoiding redundant
+        // draining (and lock contention) when the controller drains frequently.
         while (m_metric_thread_active.load()) {
+            auto now = std::chrono::steady_clock::now();
             for (unsigned int l0_device_idx = 0; l0_device_idx < m_num_gpu; ++l0_device_idx) {
                 unsigned int num_subdevice = m_devices.at(l0_device_idx).num_subdevice;
                 for (unsigned int l0_domain_idx = 0; l0_domain_idx < num_subdevice; ++l0_domain_idx) {
-                    bool active;
-                    {
-                        std::lock_guard<std::mutex> lock(m_metric_mutex);
-                        active = m_devices.at(l0_device_idx).subdevice.metric_active.at(l0_domain_idx);
-                    }
-                    if (!active ||
-                        !m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
+                    std::lock_guard<std::mutex> lock(m_metric_mutex);
+                    auto &sub = m_devices.at(l0_device_idx).subdevice;
+                    if (!sub.metric_active.at(l0_domain_idx) ||
+                        !sub.metric_domain_cached.at(l0_domain_idx) ||
+                        !sub.metrics_initialized.at(l0_domain_idx)) {
                         continue;
                     }
-
-                    // Open the streamer on first use (thread owns the streamers).
-                    if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
-                        metric_execute(l0_device_idx, l0_domain_idx);
-                        m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
+                    auto elapsed = now - sub.metric_last_drain.at(l0_domain_idx);
+                    if (elapsed >= std::chrono::microseconds(METRIC_DRAIN_PERIOD_US)) {
+                        metric_drain(l0_device_idx, l0_domain_idx);
                     }
-
-                    metric_drain(l0_device_idx, l0_domain_idx);
                 }
             }
             std::this_thread::sleep_for(std::chrono::microseconds(METRIC_DRAIN_PERIOD_US));
@@ -946,10 +960,16 @@ namespace geopm
 
     void LevelZeroImp::metric_drain(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
+        // Caller must hold m_metric_mutex.
         ze_result_t ze_result;
         uint32_t report_count_req = 1;
         zet_metric_streamer_handle_t metric_streamer =
             m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
+
+        // Record the drain attempt so the keep-alive thread can tell whether the
+        // controller is draining this chip on its own.
+        m_devices.at(l0_device_idx).subdevice.metric_last_drain.at(l0_domain_idx) =
+            std::chrono::steady_clock::now();
 
         ///////////////////
         // Read Raw Data //

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -20,12 +20,6 @@
 
 #include "LevelZeroImp.hpp"
 
-static void __attribute__((constructor)) geopm_levelzero_init(void)
-{
-    setenv("ZES_ENABLE_SYSMAN", "1", 1);
-    setenv("ZET_ENABLE_METRICS", "1", 1);
-}
-
 namespace geopm
 {
     static double convert_nan(double result)

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -629,6 +629,7 @@ namespace geopm
             m_devices.at(device_idx).subdevice.zet_data.push_back({});
             m_devices.at(device_idx).subdevice.report_byte_size.push_back(0);
 
+            bool found_group = false;
             for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
                  metric_group_idx++) {
                 zet_metric_group_properties_t metric_group_properties = {};
@@ -705,11 +706,21 @@ namespace geopm
                        }
                    }
                    m_devices.at(device_idx).subdevice.metric_name_idx.push_back(std::move(name_idx));
+                   found_group = true;
                    // Break out of the metric group for loop once we've found the group of interest (ComputeBasic, time based sampling).
                    break;
                 }
             }
-            m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
+            if (!found_group) {
+                // No time-based ComputeBasic group on this chip.  Push placeholder
+                // entries so the chip-indexed vectors stay aligned with the other
+                // per-chip state, and leave the domain uncached so its signals are
+                // pruned rather than indexing entries that were never populated.
+                m_devices.at(device_idx).subdevice.metric_group_handle.push_back(nullptr);
+                m_devices.at(device_idx).subdevice.num_metric.push_back(0);
+                m_devices.at(device_idx).subdevice.metric_name_idx.push_back({});
+            }
+            m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = found_group;
         }
     }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -873,21 +873,23 @@ namespace geopm
         }
 
         // Use the cached name→index map to avoid calling zetMetricGet and
-        // zetMetricGetProperties on every sample iteration.  The report values
-        // are appended to the accumulator; the caller (metric_drain) holds
-        // m_metric_mutex, and the controller snapshots (moves) the accumulator
-        // into metric_data once per read_batch().
+        // zetMetricGetProperties on every sample iteration.  Only the mean and
+        // report count are exposed, so accumulate a running sum and count online
+        // rather than retaining every report; the caller (metric_drain) holds
+        // m_metric_mutex, and the controller reduces this to the mean in
+        // metric_data once per read_batch().
         const auto &name_idx = m_devices.at(l0_device_idx).subdevice.metric_name_idx.at(l0_domain_idx);
         auto &accum = m_devices.at(l0_device_idx).subdevice.metric_data_accum.at(l0_domain_idx);
         for (const auto &kv : name_idx) {
             const std::string &metric_name = kv.first;
             size_t metric_idx = kv.second;
 
-            std::vector<double> &values = accum[metric_name];
+            auto &aggregate = accum[metric_name];
             for (unsigned int report_idx = 0; report_idx < num_reports; report_idx++) {
                 zet_typed_value_t data = metric_values.at(report_idx * num_metric + metric_idx);
-                values.push_back(metric_data_convert(data));
+                aggregate.sum += metric_data_convert(data);
             }
+            aggregate.count += num_reports;
         }
     }
 
@@ -952,18 +954,24 @@ namespace geopm
             // the controller period compares to the background drain cadence.
             metric_drain(l0_device_idx, l0_domain_idx);
 
-            // Snapshot the accumulated reports (this drain plus any the
-            // background thread gathered since the last read_batch) into
-            // metric_data.  metric_data therefore holds every report gathered
-            // over the controller period (averaged later by metric_sample).
+            // Reduce the accumulated reports (this drain plus any the background
+            // thread gathered since the last read_batch) to their mean in
+            // metric_data, then reset the aggregate for the next period.
             auto &accum = m_devices.at(l0_device_idx).subdevice.metric_data_accum.at(l0_domain_idx);
             auto &current = m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx);
             size_t num_reports = 0;
             for (const auto &kv : name_idx) {
                 const std::string &metric_name = kv.first;
-                current[metric_name] = std::move(accum[metric_name]);
-                accum[metric_name].clear();
-                num_reports = current[metric_name].size();
+                auto &aggregate = accum[metric_name];
+                if (aggregate.count > 0) {
+                    current[metric_name] = std::vector<double>{ aggregate.sum / aggregate.count };
+                }
+                else {
+                    current[metric_name].clear();
+                }
+                num_reports = aggregate.count;
+                aggregate.sum = 0.0;
+                aggregate.count = 0;
             }
             current["NUM_REPORTS"] = std::vector<double>{ static_cast<double>(num_reports) };
         }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -761,7 +761,7 @@ namespace geopm
         // point in time while sampling. Using a default buffer size for now...
         size_t data_size = DEFAULT_REPORT_BUFFER_SIZE;
         // ze_result = zetMetricStreamerReadData(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx),
-        //                                       UINT32_MAX, &data_size, nullptr); //TODO: this value should match the report_count_req in metric_read
+        //                                       UINT32_MAX, &data_size, nullptr); //TODO: this value should match the report count requested in metric_drain
         // check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
         //                 "LevelZero::" + std::string(__func__) +
         //                 ": LevelZero Read Data get size failed",
@@ -962,7 +962,6 @@ namespace geopm
     {
         // Caller must hold m_metric_mutex.
         ze_result_t ze_result;
-        uint32_t report_count_req = 1;
         zet_metric_streamer_handle_t metric_streamer =
             m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
 
@@ -974,9 +973,10 @@ namespace geopm
         ///////////////////
         // Read Raw Data //
         ///////////////////
-        // Always read with full buffer to drain the FIFO completely
+        // Request all queued reports; the buffer size caps the bytes read and
+        // the last-N processing below bounds the calculation work.
         size_t read_size = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).size();
-        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req,
+        ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX,
                                               &read_size,
                                               m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data());
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -866,7 +866,7 @@ namespace geopm
             data_double = data.value.fp64;
             break;
         case ZET_VALUE_TYPE_BOOL8:
-            data_double = data.value.ui32;
+            data_double = data.value.b8;
             break;
         default:
             break;

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -616,6 +616,13 @@ namespace geopm
             m_devices.at(device_idx).subdevice.metric_active.push_back(false);
             m_devices.at(device_idx).subdevice.metric_last_drain.push_back(
                 std::chrono::steady_clock::time_point{});
+            // Pre-size the streamer and read-buffer vectors so metric_execute can
+            // assign by chip index; push_signal permits chips to be read in any
+            // order, not just chip 0 first.
+            m_devices.at(device_idx).subdevice.metric_streamer.push_back(nullptr);
+            m_devices.at(device_idx).subdevice.zet_data_size.push_back(0);
+            m_devices.at(device_idx).subdevice.zet_data.push_back({});
+            m_devices.at(device_idx).subdevice.report_byte_size.push_back(0);
 
             for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
                  metric_group_idx++) {
@@ -760,8 +767,9 @@ namespace geopm
                         ": LevelZero Metric Streamer Open failed",
                         __LINE__);
 
-        // TODO: nothing guarantees CHIP 0 was called first
-        m_devices.at(l0_device_idx).subdevice.metric_streamer.push_back(metric_streamer);
+        // Assign by chip index (pre-sized in metric_group_init); push_signal
+        // permits chips to be read in any order, not just chip 0 first.
+        m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx) = metric_streamer;
 
         // Allocate memory for future reads
         // Doing a read might not be the best way to set a buffer size, as the amount of data
@@ -776,9 +784,9 @@ namespace geopm
         //                 __LINE__);
 
         std::vector<uint8_t> data(data_size);
-        m_devices.at(l0_device_idx).subdevice.zet_data_size.push_back(data_size);
-        m_devices.at(l0_device_idx).subdevice.zet_data.push_back(data);
-        m_devices.at(l0_device_idx).subdevice.report_byte_size.push_back(0);
+        m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx) = data_size;
+        m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx) = std::move(data);
+        m_devices.at(l0_device_idx).subdevice.report_byte_size.at(l0_domain_idx) = 0;
     }
 
     // TODO don't pass metric_streamer
@@ -890,9 +898,9 @@ namespace geopm
         {
             std::lock_guard<std::mutex> lock(m_metric_mutex);
 
-            // Open the streamer on first use.  Done from the controller thread in
-            // chip order so the streamer vectors grow safely, and serialized with
-            // the background thread by m_metric_mutex.
+            // Open the streamer on first use, serialized with the background
+            // thread by m_metric_mutex.  metric_execute assigns the streamer by
+            // chip index, so this is safe regardless of the order chips are read.
             if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
                 metric_execute(l0_device_idx, l0_domain_idx);
                 m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -11,8 +11,6 @@
 #include <cstdlib>
 #include <utility>
 
-#include <chrono>
-
 #include "geopm/Exception.hpp"
 #include "geopm/Agg.hpp"
 #include "geopm/Helper.hpp"
@@ -652,7 +650,6 @@ namespace geopm
         }
     }
 
-    //TODO: need metric destory
     void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
 ////        //std::cout << "ZET_DESTROY - gpu " << std::to_string(l0_device_idx) << std::endl;
@@ -760,9 +757,6 @@ namespace geopm
         //////////////////////
         // Convert Raw Data //
         //////////////////////
-        std::chrono::time_point<std::chrono::system_clock> start, end;
-        std::chrono::duration<double> elapsed_seconds;
-
         size_t data_size = 0;
         uint32_t report_count_req = 100;//UINT32_MAX; //100;
         ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr );
@@ -784,23 +778,14 @@ namespace geopm
         uint32_t num_metric_values = 0;
         uint32_t data_count = 0;
         zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
-        //ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
         ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
-
-        end = std::chrono::system_clock::now();
-        elapsed_seconds = end - start;
-//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " pre-calculate time: " << elapsed_seconds.count() << "s" << std::endl;
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric group calculate metric values to find num metrics failed",
                         __LINE__);
-//        std::cout << "\t\tNum metric values from calculate metric values: " << std::to_string(num_metric_values) << std::endl;
-//        std::cout << "\t\tNum data count from calculate metric values: " << std::to_string(data_count) << std::endl;
 
-        start = std::chrono::system_clock::now();
         std::vector<uint32_t> metric_count(data_count);
         std::vector<zet_typed_value_t> metric_values(num_metric_values);
-        //ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
         ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
 //        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
 //                        "LevelZero::" + std::string(__func__) +
@@ -809,30 +794,12 @@ namespace geopm
 //        //std::cout << "\tmetric group calculate metric values: " << std::to_string(num_metric_values) << std::endl;
 //        ze_result = ZE_RESULT_ERROR_UNKNOWN;
 
-        end = std::chrono::system_clock::now();
-        elapsed_seconds = end - start;
-//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " calculate time: " << elapsed_seconds.count() << "s" << std::endl;
-
-        //uint32_t num_metric = m_devices.at(l0_device_idx).num_metric;
         uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
-        //unsigned int num_reports = num_metric_values/num_metric;
-        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " num reports: " << std::to_string(num_reports) <<
-                  //std::endl;
-
         if (ze_result == ZE_RESULT_SUCCESS) {
-            start = std::chrono::system_clock::now();
-
-
             unsigned int num_reports = num_metric_values / num_metric;
 
             for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
             {
-                std::chrono::time_point<std::chrono::system_clock> start2, end2;
-                std::chrono::duration<double> elapsed_seconds;
-                start2 = std::chrono::system_clock::now();
-////
-
-
                 //TODO: It is possible that simply parsing all the metrics is
                 //      faster than the additional API calls to check the metric
                 //      name.  This should be studied
@@ -853,9 +820,6 @@ namespace geopm
                                 __LINE__);
 
                 std::string metric_name (metric_properties.name);
-                end2 = std::chrono::system_clock::now();
-                elapsed_seconds = end2 - start2;
-                //std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " name find time: " << elapsed_seconds.count() << "s" << std::endl;
 
                 //TODO: check timing impact of only processing metrics supported by IOGroup
                 if(metric_name.compare("XVE_ACTIVE") == 0 ||
@@ -900,40 +864,21 @@ namespace geopm
             m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_ACTIVE") = {};
             m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_STALL") = {};
         }
-        end = std::chrono::system_clock::now();
-        elapsed_seconds = end - start;
-//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
     }
 
     void LevelZeroImp::metric_read(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
         if (m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
             if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
-                std::chrono::time_point<std::chrono::system_clock> start, end;
-                std::chrono::duration<double> elapsed_seconds;
-                start = std::chrono::system_clock::now();
-
                 metric_init(l0_device_idx, l0_domain_idx);
                 m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
-
-                end = std::chrono::system_clock::now();
-                elapsed_seconds = end - start;
-//                std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_init time: " << elapsed_seconds.count() << "s" << std::endl;
             }
 
             ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).subdevice.event.at(l0_domain_idx), 0);
 
             if (ze_host_result != ZE_RESULT_NOT_READY) {
-                std::chrono::time_point<std::chrono::system_clock> start, end;
-                std::chrono::duration<double> elapsed_seconds;
-                start = std::chrono::system_clock::now();
-
                 metric_calc(l0_device_idx, l0_domain_idx,
                             m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
-
-                end = std::chrono::system_clock::now();
-                elapsed_seconds = end - start;
-//                std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_calc time: " << elapsed_seconds.count() << "s" << std::endl;
             }
             else {
                 metric_read(l0_device_idx, l0_domain_idx); //TODO: possible infinite loop
@@ -946,6 +891,12 @@ namespace geopm
                                                     std::string metric_name) const
     {
         std::vector<double> result = {};
+        if (!m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
+            throw Exception("LevelZero::" + std::string(__func__) +
+                            ": Metric groups not cached" ,
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
         if(m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).count(metric_name) == 0) {
             throw Exception("LevelZero::" + std::string(__func__) +
                             ": No metric named " + metric_name  + " found." ,

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -876,7 +876,13 @@ namespace geopm
 
     void LevelZeroImp::metric_read(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-        if (!m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
+        // A GPU that exposes no subdevices is still counted as one GPU_CHIP by
+        // topology, but metric_group_init sets up no per-subdevice metric state
+        // for it, so this vector is empty.  Disable metrics for that domain
+        // rather than support them here.  Revisit if such a GPU is ever expected
+        // to provide valid metrics (see metric_group_init).
+        if (l0_domain_idx >= m_devices.at(l0_device_idx).subdevice.metric_domain_cached.size() ||
+            !m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
             return;
         }
 
@@ -1040,7 +1046,11 @@ namespace geopm
                                                     std::string metric_name) const
     {
         std::vector<double> result = {};
-        if (!m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
+        // See metric_read: a subdeviceless GPU has no cached metric state, so
+        // report the domain as unsupported (a geopm::Exception the IOGroup prunes)
+        // instead of indexing an empty vector.
+        if (l0_domain_idx >= m_devices.at(l0_device_idx).subdevice.metric_domain_cached.size() ||
+            !m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
             throw Exception("LevelZero::" + std::string(__func__) +
                             ": Metric groups not cached" ,
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -141,23 +141,10 @@ namespace geopm
                             m_num_gpu_subdevice += 1;
                         }
 
-                        // We create a context to support the ZET commands
-                        // NOTE: a context is being created per subdevice, making this context
-                        // unnecessary. Commenting out for now.
-                        // TODO: Explore replacing per-subdevice contexts with a single context
-                        // (per-device or globally)
-                        // ze_context_desc_t context_desc = {
-                        //    ZE_STRUCTURE_TYPE_CONTEXT_DESC,
-                        //    nullptr,
-                        //    0
-                        // };
-                        // ze_context_handle_t context = nullptr;
-                        // ze_result_t ze_result = zeContextCreate(m_levelzero_driver.at(driver),
-                        //                             &context_desc, &context);
-                        // check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                        //                 "LevelZero::" + std::string(__func__) +
-                        //                 ": LevelZero context creation failed",
-                        //                 __LINE__);
+                        // A ZET context is created per subdevice in
+                        // metric_group_init, so no device-level context is needed here.
+                        // TODO: Explore replacing per-subdevice contexts with a single
+                        // context (per-device or globally).
 
                         m_devices.push_back({
                             m_levelzero_driver.at(driver),
@@ -794,12 +781,6 @@ namespace geopm
         // available at this point in time will likely not match the amount of data at any future
         // point in time while sampling. Using a default buffer size for now...
         size_t data_size = DEFAULT_REPORT_BUFFER_SIZE;
-        // ze_result = zetMetricStreamerReadData(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx),
-        //                                       UINT32_MAX, &data_size, nullptr); //TODO: this value should match the report count requested in metric_drain
-        // check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-        //                 "LevelZero::" + std::string(__func__) +
-        //                 ": LevelZero Read Data get size failed",
-        //                 __LINE__);
 
         std::vector<uint8_t> data(data_size);
         m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx) = data_size;
@@ -807,11 +788,9 @@ namespace geopm
         m_devices.at(l0_device_idx).subdevice.report_byte_size.at(l0_domain_idx) = 0;
     }
 
-    // TODO don't pass metric_streamer
     void LevelZeroImp::metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
                                    size_t data_size, const uint8_t *data)
     {
-
         GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) == true,
                            "metric caching for GPU " + std::to_string(l0_device_idx) +
                            ", CHIP " + std::to_string(l0_domain_idx) +
@@ -823,9 +802,7 @@ namespace geopm
                            " not completed prior to metric_calc call.");
 
         ze_result_t ze_result;
-        /////////////////////////////////////
-        // Calculate & convert metric data //
-        /////////////////////////////////////
+        // Calculate and convert the metric data
         uint32_t num_metric_values = 0;
         zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
         ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data, &num_metric_values, nullptr);
@@ -851,7 +828,7 @@ namespace geopm
             std::cerr << "LevelZero::" << std::string(__func__)  <<
                          ": ZET metric_calc call returned a number of metric values "
                          "that is not evenly divisible by the number of metrics.  This "
-                         "may indicate a ZET report erroor, skipping data processing." << std::endl;
+                         "may indicate a ZET report error, skipping data processing." << std::endl;
 #endif
             return;
         }
@@ -1028,9 +1005,6 @@ namespace geopm
         m_devices.at(l0_device_idx).subdevice.metric_last_drain.at(l0_domain_idx) =
             std::chrono::steady_clock::now();
 
-        ///////////////////
-        // Read Raw Data //
-        ///////////////////
         // Request all queued reports; the buffer size caps the bytes read and
         // the last-N processing below bounds the calculation work.
         size_t read_size = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).size();

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -681,15 +681,9 @@ namespace geopm
 
     void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-        GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) == true,
-                           "metric caching for GPU " + std::to_string(l0_device_idx) +
-                           ", CHIP " + std::to_string(l0_domain_idx) +
-                           " not completed prior to metric_destroy call.");
-
-        GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) == true,
-                           "metric initialization for GPU " + std::to_string(l0_device_idx) +
-                           ", CHIP " + std::to_string(l0_domain_idx) +
-                           " not completed prior to metric_destroy call.");
+        if (!m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) ||
+            m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx))
+            return;
 
         ze_result_t ze_result;
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -225,7 +225,7 @@ namespace geopm
     }
 
     LevelZeroImp::~LevelZeroImp() {
-        for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; gpu_idx++) {
+        for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
             for (int subdevice_idx = 0;
              subdevice_idx < m_devices.at(gpu_idx).num_subdevice;
              ++subdevice_idx) {
@@ -597,7 +597,7 @@ namespace geopm
                             __LINE__);
 
             // set metric_notifcation_event sampling period in nanoseconds
-            m_devices.at(device_idx).metric_sampling_period_ns =   1000000;
+            m_devices.at(device_idx).metric_sampling_period_ns = 1000000; // 1 ms
 
             m_devices.at(device_idx).subdevice.metric_data.push_back({});
 
@@ -634,7 +634,7 @@ namespace geopm
                    m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
 
                    //Build metric map
-                   for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+                   for (unsigned int metric_idx = 0; metric_idx < num_metric; ++metric_idx)
                    {
 
                        std::vector<zet_metric_handle_t> metric_handle(num_metric);

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -764,7 +764,8 @@ namespace geopm
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,
-            4, // number of reports to notify on.
+            4, // number of reports to notify on.  Targeting 4 reports, 1 per millisecond as that will, generally, 
+                // fall within the 5ms control loop and is a good tradeoff in terms of overhead vs visibility within the sampling period.
             m_devices.at(l0_device_idx).metric_sampling_period_ns};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -224,9 +224,7 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
-            if (gpu_idx < 1) {
-                metric_group_init(gpu_idx);
-            }
+            metric_group_init(gpu_idx);
         }
     }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -701,12 +701,14 @@ namespace geopm
 
     void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-        if (!m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) ||
-            m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx))
+        // No context was created if the domain was never enumerated.
+        if (!m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx))
             return;
 
         ze_result_t ze_result;
+        ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
 
+        // Close the streamer and deactivate the group only if sampling was started.
         if (m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
             m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = false;
 
@@ -717,17 +719,18 @@ namespace geopm
                             ": LevelZero Metric Streamer Close failed",
                             __LINE__);
 
-            // Deactivate the device context
-            ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
+            // Deactivate the metric group on the same subdevice used to activate it.
             ze_result = zetContextActivateMetricGroups(context,
-                                                       m_devices.at(l0_device_idx).device_handle,
+                                                       m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
                                                        0, nullptr);
             check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                             "LevelZero::" + std::string(__func__) +
                             ": LevelZero Metric Context Deactivation failed",
                             __LINE__);
-            zeContextDestroy(context);
         }
+
+        // The context is always created in metric_group_init, so always destroy it.
+        zeContextDestroy(context);
     }
 
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -153,6 +153,7 @@ namespace geopm
                                         __LINE__);
 
                         m_devices.push_back({
+                            m_levelzero_driver.at(driver),
                             device_handle.at(device_idx),
                             property,
                             num_subdevice, //if there are no subdevices leave this as 0
@@ -160,7 +161,6 @@ namespace geopm
                             {}, //subdevice
                             0, //num_device_power_domain
                             {}, //power domain
-                            context,
                         });
                     }
 #ifdef GEOPM_DEBUG
@@ -536,162 +536,188 @@ namespace geopm
         }
     }
     void LevelZeroImp::metric_group_cache(unsigned int device_idx) {
-        //assume false
-        m_devices.at(device_idx).metric_domain_cached = false;
+        for (int subdevice_idx = 0;
+         subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
+         ++subdevice_idx) {
+            //assume false
+            m_devices.at(device_idx).subdevice.metric_domain_cached.push_back(false);
+            m_devices.at(device_idx).subdevice.metrics_initialized.push_back(false);
 
-        char *zet_enable_metrics = getenv("ZET_ENABLE_METRICS");
-        if (zet_enable_metrics == NULL || strcmp(zet_enable_metrics, "1") != 0) {
+            char *zet_enable_metrics = getenv("ZET_ENABLE_METRICS");
+            if (zet_enable_metrics == NULL || strcmp(zet_enable_metrics, "1") != 0) {
 #ifdef GEOPM_DEBUG
-            std::cerr << "Warning: <geopm>: ZET_ENABLE_METRICS not set to 1.  Skipping metric caching" <<
-                         " for device " << std::to_string(device_idx) << std::endl;
+                std::cerr << "Warning: <geopm>: ZET_ENABLE_METRICS not set to 1.  Skipping metric caching" <<
+                             " for device " << std::to_string(device_idx) << " subdevice " <<
+                             std::to_srting(subdevice_idx) << std::endl;
 #endif
-        }
-        else {
-            ze_result_t ze_result;
+            }
+            else {
+                ze_result_t ze_result;
 
-            //Metric groups
-            uint32_t num_metric_group = 0;
-            ze_result = zetMetricGroupGet(m_devices.at(device_idx).device_handle,
-                                          &num_metric_group, nullptr);
+                // We create a context to support the ZET commands
+                ze_context_desc_t context_desc = {
+                   ZE_STRUCTURE_TYPE_CONTEXT_DESC,
+                   nullptr,
+                   0
+                };
+                ze_context_handle_t context = nullptr;
+                ze_result = zeContextCreate(m_devices.at(device_idx).driver,
+                                            &context_desc, &context);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero context creation failed",
+                                __LINE__);
 
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Group enumeration failed.",
-                             __LINE__);
+                m_devices.at(device_idx).subdevice.context.push_back(context);
 
-            std::vector<zet_metric_group_handle_t> metric_group_handle(num_metric_group);
+                //Metric groups
+                uint32_t num_metric_group = 0;
+                ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
+                                              &num_metric_group, nullptr);
 
-            //TODO: save the relevant per GPU pointers
-            ze_result = zetMetricGroupGet(m_devices.at(device_idx).device_handle,
-                                          &num_metric_group, metric_group_handle.data());
-
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Group handle acquisition failed",
-                            __LINE__);
-
-            //sampling period in nanoseconds
-            m_devices.at(device_idx).metric_sampling_period = 2000000; //2ms
-//            m_devices.at(device_idx).metric_sampling_period = 100000; //0.1ms
-
-
-            for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
-                 metric_group_idx++) {
-                 zet_metric_group_properties_t metric_group_properties;
-                 ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
-                                             &metric_group_properties);
-                 check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
-                                 "LevelZero::" + std::string(__func__) +
-                                 ": LevelZero Metric Group property acquisition failed",
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Metric Group enumeration failed.",
                                  __LINE__);
 
-                 //Confirm metric groups of interest exist
-                 if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
-                     && strcmp(metric_group_properties.name, "ComputeBasic") == 0) {
+                std::vector<zet_metric_group_handle_t> metric_group_handle(num_metric_group);
 
-                    //cache compute basic metric group
-                    m_devices.at(device_idx).metric_group_handle = metric_group_handle.at(metric_group_idx);
+                //TODO: save the relevant per GPU pointers
+                ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
+                                              &num_metric_group, metric_group_handle.data());
 
-                    // could likely use metric_group_properties.metricCount instead
-                    uint32_t num_metric = 0;
-                    ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
-                    check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                    "LevelZero::" + std::string(__func__) +
-                                    ": LevelZero Metric Count query failed",
-                                    __LINE__);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Metric Group handle acquisition failed",
+                                __LINE__);
 
-                    //Cache compute basic number of metrics
-                    m_devices.at(device_idx).num_metric = num_metric;
+                //sampling period in nanoseconds
+                m_devices.at(device_idx).metric_sampling_period = 2000000;
 
-                    //Build metric map
-                    for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
-                    {
+                m_devices.at(device_idx).subdevice.m_metric_data.push_back({});
 
-                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
-                                                 &num_metric, metric_handle.data());
+                for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
+                     metric_group_idx++) {
+                     zet_metric_group_properties_t metric_group_properties;
+                     ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
+                                                 &metric_group_properties);
+                     check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
+                                     "LevelZero::" + std::string(__func__) +
+                                     ": LevelZero Metric Group property acquisition failed",
+                                     __LINE__);
 
+                     //Confirm metric groups of interest exist
+                     if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
+                         && strcmp(metric_group_properties.name, "ComputeBasic") == 0) {
+
+                        //cache compute basic metric group
+                        m_devices.at(device_idx).subdevice.metric_group_handle.push_back(metric_group_handle.at(metric_group_idx));
+
+                        // could likely use metric_group_properties.metricCount instead
+                        uint32_t num_metric = 0;
+                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
                         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                                         "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric handle acquisition failed",
+                                        ": LevelZero Metric Count query failed",
                                         __LINE__);
-                        zet_metric_properties_t metric_properties;
-                        ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
-                        std::string metric_name (metric_properties.name);
 
-                        if(m_devices.at(device_idx).m_metric_data.count(metric_name) == 0) {
-                            m_devices.at(device_idx).m_metric_data[metric_name] = {};
+                        //Cache compute basic number of metrics
+                        //m_devices.at(device_idx).subdevice.num_metric.at(subdevice_idx) = num_metric;
+                        m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
+
+                        //Build metric map
+                        for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+                        {
+
+                            std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                            ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
+                                                     &num_metric, metric_handle.data());
+
+                            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                            "LevelZero::" + std::string(__func__) +
+                                            ": LevelZero Metric handle acquisition failed",
+                                            __LINE__);
+                            zet_metric_properties_t metric_properties;
+                            ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+                            std::string metric_name (metric_properties.name);
+
+                            if(m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) == 0) {
+                                m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
+                            }
                         }
                     }
                 }
+                m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
             }
-            m_devices.at(device_idx).metric_domain_cached = true;
         }
     }
 
     //TODO: need metric destory
-    void LevelZeroImp::metric_destroy(unsigned int l0_device_idx)
+    void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-//        //std::cout << "ZET_DESTROY - gpu " << std::to_string(l0_device_idx) << std::endl;
-        ze_result_t ze_result;
-
-        if (m_devices.at(l0_device_idx).metrics_initialized) {
-            m_devices.at(l0_device_idx).metrics_initialized = false;
-
-            // Close metric streamer
-            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).metric_streamer);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Streamer Close failed",
-                            __LINE__);
-
-            // Destroy Event
-            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).event);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Event Destroy failed",
-                            __LINE__);
-
-            // Destroy Event Pool
-            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).event_pool);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Event Pool Destroy failed",
-                            __LINE__);
-
-            // Deactivate the device context
-            ze_context_handle_t context = m_devices.at(l0_device_idx).context;
-            ze_result = zetContextActivateMetricGroups(context,
-                                                       m_devices.at(l0_device_idx).device_handle,
-                                                       0, nullptr);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Context Deactivation failed",
-                            __LINE__);
-        }
+////        //std::cout << "ZET_DESTROY - gpu " << std::to_string(l0_device_idx) << std::endl;
+//        ze_result_t ze_result;
+//
+//        if (m_devices.at(l0_device_idx).metrics_initialized) {
+//            m_devices.at(l0_device_idx).metrics_initialized = false;
+//
+//            // Close metric streamer
+//            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).metric_streamer);
+//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+//                            "LevelZero::" + std::string(__func__) +
+//                            ": LevelZero Metric Streamer Close failed",
+//                            __LINE__);
+//
+//            // Destroy Event
+//            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).event);
+//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+//                            "LevelZero::" + std::string(__func__) +
+//                            ": LevelZero Metric Event Destroy failed",
+//                            __LINE__);
+//
+//            // Destroy Event Pool
+//            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).event_pool);
+//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+//                            "LevelZero::" + std::string(__func__) +
+//                            ": LevelZero Metric Event Pool Destroy failed",
+//                            __LINE__);
+//
+//            // Deactivate the device context
+//            ze_context_handle_t context = m_devices.at(l0_device_idx).context;
+//            ze_result = zetContextActivateMetricGroups(context,
+//                                                       m_devices.at(l0_device_idx).device_handle,
+//                                                       0, nullptr);
+//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+//                            "LevelZero::" + std::string(__func__) +
+//                            ": LevelZero Metric Context Deactivation failed",
+//                            __LINE__);
+//        }
     }
 
 
-    void LevelZeroImp::metric_init(unsigned int l0_device_idx)
+    void LevelZeroImp::metric_init(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-//        //std::cout << "ZET_INIT - gpu " << std::to_string(l0_device_idx) << std::endl;
         ze_result_t ze_result;
-        ze_context_handle_t context = m_devices.at(l0_device_idx).context;
-        ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).device_handle,
-                                                   1, &m_devices.at(l0_device_idx).metric_group_handle);
+        ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
+        //ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).device_handle,
+        //                                           1, &m_devices.at(l0_device_idx).metric_group_handle);
+        ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
+                                                   1, &m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx));
 
         ze_event_pool_handle_t event_pool_handle = nullptr;
         ze_event_pool_desc_t event_pool_desc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC, nullptr, 0, 1};
 
         ze_result = zeEventPoolCreate(context, &event_pool_desc, 1,
-                                      &m_devices.at(l0_device_idx).device_handle,
+                                      //&m_devices.at(l0_device_idx).device_handle,
+                                      &m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
                                       &event_pool_handle);
 
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Event Pool Create failed",
                         __LINE__);
-        m_devices.at(l0_device_idx).event_pool = event_pool_handle;
+        //m_devices.at(l0_device_idx).event_pool = event_pool_handle;
+        m_devices.at(l0_device_idx).subdevice.event_pool.push_back(event_pool_handle);
 
         ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
                                       ZE_EVENT_SCOPE_FLAG_HOST, ZE_EVENT_SCOPE_FLAG_HOST};
@@ -703,7 +729,10 @@ namespace geopm
                         ": LevelZero Event Create failed",
                         __LINE__);
 
-        m_devices.at(l0_device_idx).event = event;
+        //m_devices.at(l0_device_idx).event = event;
+
+//        std::cout << "ZET_INIT - pushing back event for gpu " << std::to_string(l0_device_idx) << std::endl;
+        m_devices.at(l0_device_idx).subdevice.event.push_back(event);
 
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
@@ -712,17 +741,20 @@ namespace geopm
             m_devices.at(l0_device_idx).metric_sampling_period};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
 
-        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).device_handle, m_devices.at(l0_device_idx).metric_group_handle, &metric_streamer_desc, event, &metric_streamer);
+        //ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).device_handle, m_devices.at(l0_device_idx).metric_group_handle, &metric_streamer_desc, event, &metric_streamer);
+        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx), m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), &metric_streamer_desc, event, &metric_streamer);
 
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric Streamer Open failed",
                         __LINE__);
 
-        m_devices.at(l0_device_idx).metric_streamer = metric_streamer;
+        //m_devices.at(l0_device_idx).metric_streamer = metric_streamer;
+        m_devices.at(l0_device_idx).subdevice.metric_streamer.push_back(metric_streamer);
     }
 
-    void LevelZeroImp::metric_calc(unsigned int l0_device_idx, zet_metric_streamer_handle_t metric_streamer) const
+    void LevelZeroImp::metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
+                                   zet_metric_streamer_handle_t metric_streamer) const
     {
         ze_result_t ze_result;
         //////////////////////
@@ -732,7 +764,7 @@ namespace geopm
         std::chrono::duration<double> elapsed_seconds;
 
         size_t data_size = 0;
-        uint32_t report_count_req = 10;//UINT32_MAX; //100;
+        uint32_t report_count_req = 100;//UINT32_MAX; //100;
         ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr );
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
@@ -752,22 +784,24 @@ namespace geopm
         uint32_t num_metric_values = 0;
         uint32_t data_count = 0;
         zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
-        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
+        //ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
+        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
 
         end = std::chrono::system_clock::now();
         elapsed_seconds = end - start;
-        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " pre-calculate time: " << elapsed_seconds.count() << "s" << std::endl;
+//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " pre-calculate time: " << elapsed_seconds.count() << "s" << std::endl;
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric group calculate metric values to find num metrics failed",
                         __LINE__);
-        //std::cout << "\tNum metric values from calculate metric values: " << std::to_string(num_metric_values) << std::endl;
-        //std::cout << "\tNum data count from calculate metric values: " << std::to_string(data_count) << std::endl;
+//        std::cout << "\t\tNum metric values from calculate metric values: " << std::to_string(num_metric_values) << std::endl;
+//        std::cout << "\t\tNum data count from calculate metric values: " << std::to_string(data_count) << std::endl;
 
         start = std::chrono::system_clock::now();
         std::vector<uint32_t> metric_count(data_count);
         std::vector<zet_typed_value_t> metric_values(num_metric_values);
-        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
+        //ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
+        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
 //        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
 //                        "LevelZero::" + std::string(__func__) +
 //                        ": LevelZero Metric group calculate metric values to calculate data failed",
@@ -777,129 +811,147 @@ namespace geopm
 
         end = std::chrono::system_clock::now();
         elapsed_seconds = end - start;
-        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " calculate time: " << elapsed_seconds.count() << "s" << std::endl;
+//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " calculate time: " << elapsed_seconds.count() << "s" << std::endl;
 
-        uint32_t num_metric = m_devices.at(l0_device_idx).num_metric;
+        //uint32_t num_metric = m_devices.at(l0_device_idx).num_metric;
+        uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
         //unsigned int num_reports = num_metric_values/num_metric;
         //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " num reports: " << std::to_string(num_reports) <<
                   //std::endl;
 
         if (ze_result == ZE_RESULT_SUCCESS) {
-            uint32_t startIndex = 0;
             start = std::chrono::system_clock::now();
-            for (uint32_t data_index = 0; data_index < data_count; ++data_index) {
-    //            //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " data count: " << std::to_string(data_count) <<
-    //                      std::endl;
-                const uint32_t metricCountForDataIndex = metric_count[data_index];
-                const uint32_t reportCount = metricCountForDataIndex / num_metric;
-                for (uint32_t report = 0; report < reportCount; report++) {
-    //                //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " report count: " << std::to_string(reportCount) <<
-    //                          std::endl;
-                    for (uint32_t metric = 0; metric < num_metric; metric++) {
-    //                    //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric count: " << std::to_string(num_metric) <<
-    //                                std::endl;
 
-                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                        ze_result = zetMetricGet(m_devices.at(l0_device_idx).metric_group_handle,
-                                                 &num_metric, metric_handle.data());
-                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                        "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric handle acquisition failed",
-                                        __LINE__);
 
-                        // process metrics
-                        zet_metric_properties_t metric_properties;
-                        ze_result = zetMetricGetProperties(metric_handle.at(metric), &metric_properties);
-                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                        "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric property acquisition failed",
-                                        __LINE__);
+            unsigned int num_reports = num_metric_values / num_metric;
 
-                        std::string metric_name (metric_properties.name);
+            for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+            {
+                std::chrono::time_point<std::chrono::system_clock> start2, end2;
+                std::chrono::duration<double> elapsed_seconds;
+                start2 = std::chrono::system_clock::now();
+////
 
-                        if(metric_name.compare("XVE_ACTIVE") == 0 ||
-                           metric_name.compare("XVE_STALL") == 0) {
-                            double data_double = NAN;
-                            const size_t metricIndex = report * num_metric+ metric;
-                            zet_typed_value_t data = metric_values.at(startIndex + metricIndex);
-                            switch( data.type )
-                            {
-                            case ZET_VALUE_TYPE_UINT32:
-                                data_double = data.value.ui32;
-                                break;
-                            case ZET_VALUE_TYPE_UINT64:
-                                data_double = data.value.ui64;
-                                break;
-                            case ZET_VALUE_TYPE_FLOAT32:
-                                data_double = data.value.fp32;
-                                break;
-                            case ZET_VALUE_TYPE_FLOAT64:
-                                data_double = data.value.fp64;
-                                break;
-                            case ZET_VALUE_TYPE_BOOL8:
-                                data_double = data.value.ui32;
-                            default:
-                                break;
-                            };
 
-                            //Clear cached values
-                            if(report == 0) {
-                                m_devices.at(l0_device_idx).m_metric_data.at(metric_name) = {};
-                            }
-                            m_devices.at(l0_device_idx).m_metric_data.at(metric_name).push_back(data_double);
+                //TODO: It is possible that simply parsing all the metrics is
+                //      faster than the additional API calls to check the metric
+                //      name.  This should be studied
+                std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                ze_result = zetMetricGet(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx),
+                                         &num_metric, metric_handle.data());
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Metric handle acquisition failed",
+                                __LINE__);
+
+                // process metrics
+                zet_metric_properties_t metric_properties;
+                ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Metric property acquisition failed",
+                                __LINE__);
+
+                std::string metric_name (metric_properties.name);
+                end2 = std::chrono::system_clock::now();
+                elapsed_seconds = end2 - start2;
+                //std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " name find time: " << elapsed_seconds.count() << "s" << std::endl;
+
+                //TODO: check timing impact of only processing metrics supported by IOGroup
+                if(metric_name.compare("XVE_ACTIVE") == 0 ||
+                   metric_name.compare("XVE_STALL") == 0) {
+                    for (unsigned int report_idx = 0; report_idx < num_reports; report_idx++)
+                    {
+                        //This is the actual gathering of the data
+                        zet_typed_value_t data = metric_values.at(report_idx*num_metric + metric_idx);
+                        double data_double = NAN;
+                        switch( data.type )
+                        {
+                        case ZET_VALUE_TYPE_UINT32:
+                            data_double = data.value.ui32;
+                            break;
+                        case ZET_VALUE_TYPE_UINT64:
+                            data_double = data.value.ui64;
+                            break;
+                        case ZET_VALUE_TYPE_FLOAT32:
+                            data_double = data.value.fp32;
+                            break;
+                        case ZET_VALUE_TYPE_FLOAT64:
+                            data_double = data.value.fp64;
+                            break;
+                        case ZET_VALUE_TYPE_BOOL8:
+                            data_double = data.value.ui32;
+                            break;
+                        default:
+                            break;
+                        };
+                        //Clear cached values
+                        if(report_idx == 0) {
+                            //m_devices.at(l0_device_idx).m_metric_data.at(metric_name) = {};
+                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
                         }
+                        //m_devices.at(l0_device_idx).m_metric_data.at(metric_name).push_back(data_double);
+                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
                     }
                 }
-                startIndex += metricCountForDataIndex;
             }
         }
         else {
-            m_devices.at(l0_device_idx).m_metric_data.at("XVE_ACTIVE") = {};
-            m_devices.at(l0_device_idx).m_metric_data.at("XVE_STALL") = {};
+            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_ACTIVE") = {};
+            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_STALL") = {};
         }
         end = std::chrono::system_clock::now();
         elapsed_seconds = end - start;
-        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
+//        std::cout << "\t\tgpu " << std::to_string(l0_device_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
     }
 
-    void LevelZeroImp::metric_read(unsigned int l0_device_idx)
+    void LevelZeroImp::metric_read(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-        if (m_devices.at(l0_device_idx).metric_domain_cached) {
-            if (!m_devices.at(l0_device_idx).metrics_initialized) {
-                metric_init(l0_device_idx);
-                m_devices.at(l0_device_idx).metrics_initialized = true;
+        if (m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
+            if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
+                std::chrono::time_point<std::chrono::system_clock> start, end;
+                std::chrono::duration<double> elapsed_seconds;
+                start = std::chrono::system_clock::now();
+
+                metric_init(l0_device_idx, l0_domain_idx);
+                m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
+
+                end = std::chrono::system_clock::now();
+                elapsed_seconds = end - start;
+//                std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_init time: " << elapsed_seconds.count() << "s" << std::endl;
             }
 
-            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).event, 0);
+            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).subdevice.event.at(l0_domain_idx), 0);
 
             if (ze_host_result != ZE_RESULT_NOT_READY) {
                 std::chrono::time_point<std::chrono::system_clock> start, end;
                 std::chrono::duration<double> elapsed_seconds;
                 start = std::chrono::system_clock::now();
 
-                metric_calc(l0_device_idx, m_devices.at(l0_device_idx).metric_streamer);
+                metric_calc(l0_device_idx, l0_domain_idx,
+                            m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
 
                 end = std::chrono::system_clock::now();
                 elapsed_seconds = end - start;
-                //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_calc time: " << elapsed_seconds.count() << "s" << std::endl;
+//                std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_calc time: " << elapsed_seconds.count() << "s" << std::endl;
             }
             else {
-                metric_read(l0_device_idx);
+                metric_read(l0_device_idx, l0_domain_idx); //TODO: possible infinite loop
             }
         }
     }
 
     std::vector<double> LevelZeroImp::metric_sample(unsigned int l0_device_idx,
+                                                    unsigned int l0_domain_idx,
                                                     std::string metric_name) const
     {
-//        //std::cout << "ZET_SAMPLE - gpu " << std::to_string(l0_device_idx) << std::endl;
         std::vector<double> result = {};
-        if(m_devices.at(l0_device_idx).m_metric_data.count(metric_name) == 0) {
+        if(m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).count(metric_name) == 0) {
             throw Exception("LevelZero::" + std::string(__func__) +
                             ": No metric named " + metric_name  + " found." ,
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        result = m_devices.at(l0_device_idx).m_metric_data.at(metric_name);
+        result = m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name);
         return result;
     }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -870,8 +870,8 @@ namespace geopm
         // zetMetricGetProperties on every sample iteration.  Only the mean and
         // report count are exposed, so accumulate a running sum and count online
         // rather than retaining every report; the caller (metric_drain) holds
-        // m_metric_mutex, and the controller reduces this to the mean in
-        // metric_data once per read_batch().
+        // m_metric_mutex, and the read_batch() serving thread reduces this to the
+        // mean in metric_data once per read_batch().
         const auto &name_idx = m_devices.at(l0_device_idx).subdevice.metric_name_idx.at(l0_domain_idx);
         auto &accum = m_devices.at(l0_device_idx).subdevice.metric_data_accum.at(l0_domain_idx);
         for (const auto &kv : name_idx) {
@@ -945,7 +945,7 @@ namespace geopm
             m_devices.at(l0_device_idx).subdevice.metric_active.at(l0_domain_idx) = true;
 
             // Drain now so this sample always has fresh data, regardless of how
-            // the controller period compares to the background drain cadence.
+            // the read_batch() cadence compares to the background drain cadence.
             metric_drain(l0_device_idx, l0_domain_idx);
 
             // Reduce the accumulated reports (this drain plus any the background
@@ -976,8 +976,10 @@ namespace geopm
 
     void LevelZeroImp::metric_thread_start(void)
     {
-        // Called only from the controller thread (metric_read), so the started
-        // flag need not be atomic.
+        // Called only from the single thread that services read_batch() (the
+        // controller directly, or the geopmd batch server when LevelZero is
+        // accessed through the service), never the background sampling thread,
+        // so the started flag need not be atomic.
         if (!m_metric_thread_started) {
             m_metric_thread_started = true;
             m_metric_thread_active.store(true);
@@ -996,11 +998,13 @@ namespace geopm
 
     void LevelZeroImp::metric_sample_thread(void)
     {
-        // Keep-alive draining: the controller drains each chip itself in
-        // metric_read(), so this thread only needs to drain a chip when the
-        // controller hasn't drained it recently.  This keeps the metric streamer
-        // from stalling during long controller periods, while avoiding redundant
-        // draining (and lock contention) when the controller drains frequently.
+        // Keep-alive draining: the read_batch() serving thread (the controller,
+        // or the geopmd batch server when LevelZero is accessed through the
+        // service) drains each chip itself in metric_read(), so this thread only
+        // needs to drain a chip when that serving thread hasn't drained it
+        // recently.  This keeps the metric streamer from stalling when
+        // read_batch() is called infrequently, while avoiding redundant draining
+        // (and lock contention) when it is called frequently.
         while (m_metric_thread_active.load()) {
             auto now = std::chrono::steady_clock::now();
             for (unsigned int l0_device_idx = 0; l0_device_idx < m_num_gpu; ++l0_device_idx) {
@@ -1017,7 +1021,7 @@ namespace geopm
                     if (elapsed >= std::chrono::microseconds(METRIC_DRAIN_PERIOD_US)) {
                         // An exception escaping this thread would std::terminate
                         // the process.  Stop draining the affected chip and hand
-                        // the error to the controller path (metric_read).
+                        // the error to the read_batch() path (metric_read).
                         try {
                             metric_drain(l0_device_idx, l0_domain_idx);
                         }
@@ -1042,7 +1046,7 @@ namespace geopm
             m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
 
         // Record the drain attempt so the keep-alive thread can tell whether the
-        // controller is draining this chip on its own.
+        // read_batch() serving thread is draining this chip on its own.
         m_devices.at(l0_device_idx).subdevice.metric_last_drain.at(l0_domain_idx) =
             std::chrono::steady_clock::now();
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -898,6 +898,13 @@ namespace geopm
         {
             std::lock_guard<std::mutex> lock(m_metric_mutex);
 
+            // Surface any failure the background thread hit while draining.
+            if (m_metric_thread_error) {
+                std::exception_ptr err = m_metric_thread_error;
+                m_metric_thread_error = nullptr;
+                std::rethrow_exception(err);
+            }
+
             // Open the streamer on first use, serialized with the background
             // thread by m_metric_mutex.  metric_execute assigns the streamer by
             // chip index, so this is safe regardless of the order chips are read.
@@ -972,7 +979,18 @@ namespace geopm
                     }
                     auto elapsed = now - sub.metric_last_drain.at(l0_domain_idx);
                     if (elapsed >= std::chrono::microseconds(METRIC_DRAIN_PERIOD_US)) {
-                        metric_drain(l0_device_idx, l0_domain_idx);
+                        // An exception escaping this thread would std::terminate
+                        // the process.  Stop draining the affected chip and hand
+                        // the error to the controller path (metric_read).
+                        try {
+                            metric_drain(l0_device_idx, l0_domain_idx);
+                        }
+                        catch (...) {
+                            sub.metric_active.at(l0_domain_idx) = false;
+                            if (!m_metric_thread_error) {
+                                m_metric_thread_error = std::current_exception();
+                            }
+                        }
                     }
                 }
             }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -11,11 +11,19 @@
 #include <cstdlib>
 #include <utility>
 
+#include <chrono>
+
 #include "geopm/Exception.hpp"
 #include "geopm/Agg.hpp"
 #include "geopm/Helper.hpp"
 
 #include "LevelZeroImp.hpp"
+
+static void __attribute__((constructor)) geopm_levelzero_init(void)
+{
+    setenv("ZES_ENABLE_SYSMAN", "1", 1);
+    setenv("ZET_ENABLE_METRICS", "1", 1);
+}
 
 namespace geopm
 {
@@ -26,7 +34,8 @@ namespace geopm
         }
         return result;
     }
-    const LevelZero &levelzero()
+
+    LevelZero &levelzero()
     {
         static LevelZeroImp instance;
         return instance;
@@ -129,7 +138,20 @@ namespace geopm
                             m_num_gpu_subdevice += 1;
                         }
 
-                        //NOTE: We're only supporting Board GPUs to start with
+                        // We create a context to support the ZET commands
+                        ze_context_desc_t context_desc = {
+                           ZE_STRUCTURE_TYPE_CONTEXT_DESC,
+                           nullptr,
+                           0
+                        };
+                        ze_context_handle_t context = nullptr;
+                        ze_result_t ze_result = zeContextCreate(m_levelzero_driver.at(driver),
+                                                    &context_desc, &context);
+                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                        "LevelZero::" + std::string(__func__) +
+                                        ": LevelZero context creation failed",
+                                        __LINE__);
+
                         m_devices.push_back({
                             device_handle.at(device_idx),
                             property,
@@ -138,7 +160,7 @@ namespace geopm
                             {}, //subdevice
                             0, //num_device_power_domain
                             {}, //power domain
-                            0, // cached_energy_timestamp
+                            context,
                         });
                     }
 #ifdef GEOPM_DEBUG
@@ -199,6 +221,7 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
+            metric_group_cache(gpu_idx);
         }
     }
 
@@ -511,6 +534,373 @@ namespace geopm
                 }
             }
         }
+    }
+    void LevelZeroImp::metric_group_cache(unsigned int device_idx) {
+        //assume false
+        m_devices.at(device_idx).metric_domain_cached = false;
+
+        char *zet_enable_metrics = getenv("ZET_ENABLE_METRICS");
+        if (zet_enable_metrics == NULL || strcmp(zet_enable_metrics, "1") != 0) {
+#ifdef GEOPM_DEBUG
+            std::cerr << "Warning: <geopm>: ZET_ENABLE_METRICS not set to 1.  Skipping metric caching" <<
+                         " for device " << std::to_string(device_idx) << std::endl;
+#endif
+        }
+        else {
+            ze_result_t ze_result;
+
+            //Metric groups
+            uint32_t num_metric_group = 0;
+            ze_result = zetMetricGroupGet(m_devices.at(device_idx).device_handle,
+                                          &num_metric_group, nullptr);
+
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Group enumeration failed.",
+                             __LINE__);
+
+            std::vector<zet_metric_group_handle_t> metric_group_handle(num_metric_group);
+
+            //TODO: save the relevant per GPU pointers
+            ze_result = zetMetricGroupGet(m_devices.at(device_idx).device_handle,
+                                          &num_metric_group, metric_group_handle.data());
+
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Group handle acquisition failed",
+                            __LINE__);
+
+            //sampling period in nanoseconds
+            m_devices.at(device_idx).metric_sampling_period = 2000000; //2ms
+//            m_devices.at(device_idx).metric_sampling_period = 100000; //0.1ms
+
+
+            for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
+                 metric_group_idx++) {
+                 zet_metric_group_properties_t metric_group_properties;
+                 ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
+                                             &metric_group_properties);
+                 check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
+                                 "LevelZero::" + std::string(__func__) +
+                                 ": LevelZero Metric Group property acquisition failed",
+                                 __LINE__);
+
+                 //Confirm metric groups of interest exist
+                 if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
+                     && strcmp(metric_group_properties.name, "ComputeBasic") == 0) {
+
+                    //cache compute basic metric group
+                    m_devices.at(device_idx).metric_group_handle = metric_group_handle.at(metric_group_idx);
+
+                    // could likely use metric_group_properties.metricCount instead
+                    uint32_t num_metric = 0;
+                    ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
+                    check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                    "LevelZero::" + std::string(__func__) +
+                                    ": LevelZero Metric Count query failed",
+                                    __LINE__);
+
+                    //Cache compute basic number of metrics
+                    m_devices.at(device_idx).num_metric = num_metric;
+
+                    //Build metric map
+                    for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+                    {
+
+                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
+                                                 &num_metric, metric_handle.data());
+
+                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                        "LevelZero::" + std::string(__func__) +
+                                        ": LevelZero Metric handle acquisition failed",
+                                        __LINE__);
+                        zet_metric_properties_t metric_properties;
+                        ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+                        std::string metric_name (metric_properties.name);
+
+                        if(m_devices.at(device_idx).m_metric_data.count(metric_name) == 0) {
+                            m_devices.at(device_idx).m_metric_data[metric_name] = {};
+                        }
+                    }
+                }
+            }
+            m_devices.at(device_idx).metric_domain_cached = true;
+        }
+    }
+
+    //TODO: need metric destory
+    void LevelZeroImp::metric_destroy(unsigned int l0_device_idx)
+    {
+//        //std::cout << "ZET_DESTROY - gpu " << std::to_string(l0_device_idx) << std::endl;
+        ze_result_t ze_result;
+
+        if (m_devices.at(l0_device_idx).metrics_initialized) {
+            m_devices.at(l0_device_idx).metrics_initialized = false;
+
+            // Close metric streamer
+            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).metric_streamer);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Streamer Close failed",
+                            __LINE__);
+
+            // Destroy Event
+            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).event);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Event Destroy failed",
+                            __LINE__);
+
+            // Destroy Event Pool
+            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).event_pool);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Event Pool Destroy failed",
+                            __LINE__);
+
+            // Deactivate the device context
+            ze_context_handle_t context = m_devices.at(l0_device_idx).context;
+            ze_result = zetContextActivateMetricGroups(context,
+                                                       m_devices.at(l0_device_idx).device_handle,
+                                                       0, nullptr);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Context Deactivation failed",
+                            __LINE__);
+        }
+    }
+
+
+    void LevelZeroImp::metric_init(unsigned int l0_device_idx)
+    {
+//        //std::cout << "ZET_INIT - gpu " << std::to_string(l0_device_idx) << std::endl;
+        ze_result_t ze_result;
+        ze_context_handle_t context = m_devices.at(l0_device_idx).context;
+        ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).device_handle,
+                                                   1, &m_devices.at(l0_device_idx).metric_group_handle);
+
+        ze_event_pool_handle_t event_pool_handle = nullptr;
+        ze_event_pool_desc_t event_pool_desc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC, nullptr, 0, 1};
+
+        ze_result = zeEventPoolCreate(context, &event_pool_desc, 1,
+                                      &m_devices.at(l0_device_idx).device_handle,
+                                      &event_pool_handle);
+
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Event Pool Create failed",
+                        __LINE__);
+        m_devices.at(l0_device_idx).event_pool = event_pool_handle;
+
+        ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
+                                      ZE_EVENT_SCOPE_FLAG_HOST, ZE_EVENT_SCOPE_FLAG_HOST};
+
+        ze_event_handle_t event = nullptr;
+        ze_result = zeEventCreate(event_pool_handle, &event_desc, &event);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Event Create failed",
+                        __LINE__);
+
+        m_devices.at(l0_device_idx).event = event;
+
+        zet_metric_streamer_desc_t metric_streamer_desc = {
+            ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
+            nullptr,
+            32768, /* reports to collect before notify */
+            m_devices.at(l0_device_idx).metric_sampling_period};
+        zet_metric_streamer_handle_t metric_streamer = nullptr;
+
+        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).device_handle, m_devices.at(l0_device_idx).metric_group_handle, &metric_streamer_desc, event, &metric_streamer);
+
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Metric Streamer Open failed",
+                        __LINE__);
+
+        m_devices.at(l0_device_idx).metric_streamer = metric_streamer;
+    }
+
+    void LevelZeroImp::metric_calc(unsigned int l0_device_idx, zet_metric_streamer_handle_t metric_streamer) const
+    {
+        ze_result_t ze_result;
+        //////////////////////
+        // Convert Raw Data //
+        //////////////////////
+        std::chrono::time_point<std::chrono::system_clock> start, end;
+        std::chrono::duration<double> elapsed_seconds;
+
+        size_t data_size = 0;
+        uint32_t report_count_req = 10;//UINT32_MAX; //100;
+        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr );
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Read Data get size failed",
+                        __LINE__);
+
+        std::vector<uint8_t> data(data_size);
+        zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Read Data failed",
+                        __LINE__);
+
+        /////////////////////////////////////
+        // Calculate & convert metric data //
+        /////////////////////////////////////
+        uint32_t num_metric_values = 0;
+        uint32_t data_count = 0;
+        zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
+        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
+
+        end = std::chrono::system_clock::now();
+        elapsed_seconds = end - start;
+        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " pre-calculate time: " << elapsed_seconds.count() << "s" << std::endl;
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Metric group calculate metric values to find num metrics failed",
+                        __LINE__);
+        //std::cout << "\tNum metric values from calculate metric values: " << std::to_string(num_metric_values) << std::endl;
+        //std::cout << "\tNum data count from calculate metric values: " << std::to_string(data_count) << std::endl;
+
+        start = std::chrono::system_clock::now();
+        std::vector<uint32_t> metric_count(data_count);
+        std::vector<zet_typed_value_t> metric_values(num_metric_values);
+        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).metric_group_handle, calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
+//        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+//                        "LevelZero::" + std::string(__func__) +
+//                        ": LevelZero Metric group calculate metric values to calculate data failed",
+//                        __LINE__);
+//        //std::cout << "\tmetric group calculate metric values: " << std::to_string(num_metric_values) << std::endl;
+//        ze_result = ZE_RESULT_ERROR_UNKNOWN;
+
+        end = std::chrono::system_clock::now();
+        elapsed_seconds = end - start;
+        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " calculate time: " << elapsed_seconds.count() << "s" << std::endl;
+
+        uint32_t num_metric = m_devices.at(l0_device_idx).num_metric;
+        //unsigned int num_reports = num_metric_values/num_metric;
+        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " num reports: " << std::to_string(num_reports) <<
+                  //std::endl;
+
+        if (ze_result == ZE_RESULT_SUCCESS) {
+            uint32_t startIndex = 0;
+            start = std::chrono::system_clock::now();
+            for (uint32_t data_index = 0; data_index < data_count; ++data_index) {
+    //            //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " data count: " << std::to_string(data_count) <<
+    //                      std::endl;
+                const uint32_t metricCountForDataIndex = metric_count[data_index];
+                const uint32_t reportCount = metricCountForDataIndex / num_metric;
+                for (uint32_t report = 0; report < reportCount; report++) {
+    //                //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " report count: " << std::to_string(reportCount) <<
+    //                          std::endl;
+                    for (uint32_t metric = 0; metric < num_metric; metric++) {
+    //                    //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric count: " << std::to_string(num_metric) <<
+    //                                std::endl;
+
+                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                        ze_result = zetMetricGet(m_devices.at(l0_device_idx).metric_group_handle,
+                                                 &num_metric, metric_handle.data());
+                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                        "LevelZero::" + std::string(__func__) +
+                                        ": LevelZero Metric handle acquisition failed",
+                                        __LINE__);
+
+                        // process metrics
+                        zet_metric_properties_t metric_properties;
+                        ze_result = zetMetricGetProperties(metric_handle.at(metric), &metric_properties);
+                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                        "LevelZero::" + std::string(__func__) +
+                                        ": LevelZero Metric property acquisition failed",
+                                        __LINE__);
+
+                        std::string metric_name (metric_properties.name);
+
+                        if(metric_name.compare("XVE_ACTIVE") == 0 ||
+                           metric_name.compare("XVE_STALL") == 0) {
+                            double data_double = NAN;
+                            const size_t metricIndex = report * num_metric+ metric;
+                            zet_typed_value_t data = metric_values.at(startIndex + metricIndex);
+                            switch( data.type )
+                            {
+                            case ZET_VALUE_TYPE_UINT32:
+                                data_double = data.value.ui32;
+                                break;
+                            case ZET_VALUE_TYPE_UINT64:
+                                data_double = data.value.ui64;
+                                break;
+                            case ZET_VALUE_TYPE_FLOAT32:
+                                data_double = data.value.fp32;
+                                break;
+                            case ZET_VALUE_TYPE_FLOAT64:
+                                data_double = data.value.fp64;
+                                break;
+                            case ZET_VALUE_TYPE_BOOL8:
+                                data_double = data.value.ui32;
+                            default:
+                                break;
+                            };
+
+                            //Clear cached values
+                            if(report == 0) {
+                                m_devices.at(l0_device_idx).m_metric_data.at(metric_name) = {};
+                            }
+                            m_devices.at(l0_device_idx).m_metric_data.at(metric_name).push_back(data_double);
+                        }
+                    }
+                }
+                startIndex += metricCountForDataIndex;
+            }
+        }
+        else {
+            m_devices.at(l0_device_idx).m_metric_data.at("XVE_ACTIVE") = {};
+            m_devices.at(l0_device_idx).m_metric_data.at("XVE_STALL") = {};
+        }
+        end = std::chrono::system_clock::now();
+        elapsed_seconds = end - start;
+        //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
+    }
+
+    void LevelZeroImp::metric_read(unsigned int l0_device_idx)
+    {
+        if (m_devices.at(l0_device_idx).metric_domain_cached) {
+            if (!m_devices.at(l0_device_idx).metrics_initialized) {
+                metric_init(l0_device_idx);
+                m_devices.at(l0_device_idx).metrics_initialized = true;
+            }
+
+            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).event, 0);
+
+            if (ze_host_result != ZE_RESULT_NOT_READY) {
+                std::chrono::time_point<std::chrono::system_clock> start, end;
+                std::chrono::duration<double> elapsed_seconds;
+                start = std::chrono::system_clock::now();
+
+                metric_calc(l0_device_idx, m_devices.at(l0_device_idx).metric_streamer);
+
+                end = std::chrono::system_clock::now();
+                elapsed_seconds = end - start;
+                //std::cout << "\tgpu " << std::to_string(l0_device_idx) << " metric_calc time: " << elapsed_seconds.count() << "s" << std::endl;
+            }
+            else {
+                metric_read(l0_device_idx);
+            }
+        }
+    }
+
+    std::vector<double> LevelZeroImp::metric_sample(unsigned int l0_device_idx,
+                                                    std::string metric_name) const
+    {
+//        //std::cout << "ZET_SAMPLE - gpu " << std::to_string(l0_device_idx) << std::endl;
+        std::vector<double> result = {};
+        if(m_devices.at(l0_device_idx).m_metric_data.count(metric_name) == 0) {
+            throw Exception("LevelZero::" + std::string(__func__) +
+                            ": No metric named " + metric_name  + " found." ,
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+        result = m_devices.at(l0_device_idx).m_metric_data.at(metric_name);
+        return result;
     }
 
     void LevelZeroImp::ras_domain_cache(unsigned int device_idx)
@@ -1076,6 +1466,26 @@ namespace geopm
         check_ze_result(zesPerformanceFactorSetConfig(handle, setting),
                         GEOPM_ERROR_RUNTIME, "LevelZero::" + std::string(__func__) +
                         ": Sysman failed to set performance factor values", __LINE__);
+    }
+
+    uint32_t LevelZeroImp::metric_update_rate(unsigned int l0_device_idx) const
+    {
+        return m_devices.at(l0_device_idx).metric_sampling_period;
+    }
+
+    void LevelZeroImp::metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting)
+    {
+        m_devices.at(l0_device_idx).metric_sampling_period = setting;
+    }
+
+    uint32_t LevelZeroImp::metric_update_rate(unsigned int l0_device_idx) const
+    {
+        return m_devices.at(l0_device_idx).metric_sampling_period;
+    }
+
+    void LevelZeroImp::metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting)
+    {
+        m_devices.at(l0_device_idx).metric_sampling_period = setting;
     }
 
     void LevelZeroImp::check_ze_result(ze_result_t ze_result, int error,

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -741,6 +741,11 @@ namespace geopm
         ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
                                                    1, &m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx));
 
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Metric Group Activation failed",
+                        __LINE__);
+
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "geopm/Exception.hpp"
+#include "geopm/Helper.hpp"
 #include "geopm_debug.hpp"
 
 #include "LevelZeroImp.hpp"

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -758,11 +758,12 @@ namespace geopm
         std::vector<uint8_t> data(data_size);
         m_devices.at(l0_device_idx).subdevice.zet_data_size.push_back(data_size);
         m_devices.at(l0_device_idx).subdevice.zet_data.push_back(data);
+        m_devices.at(l0_device_idx).subdevice.report_byte_size.push_back(0);
     }
 
     // TODO don't pass metric_streamer
     void LevelZeroImp::metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
-                                   size_t data_size, const std::vector<uint8_t> &data)
+                                   size_t data_size, const uint8_t *data)
     {
 
         GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) == true,
@@ -781,14 +782,14 @@ namespace geopm
         /////////////////////////////////////
         uint32_t num_metric_values = 0;
         zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
-        ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &num_metric_values, nullptr);
+        ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data, &num_metric_values, nullptr);
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric group calculate metric values to find num metrics failed",
                         __LINE__);
 
         std::vector<zet_typed_value_t> metric_values(num_metric_values);
-        ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &num_metric_values, metric_values.data());
+        ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data, &num_metric_values, metric_values.data());
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric group calculate metric values to calculate data failed",
@@ -869,19 +870,46 @@ namespace geopm
             ///////////////////
             // Read Raw Data //
             ///////////////////
+            // Always read with full buffer to drain the FIFO completely
+            size_t read_size = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).size();
             ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req,
-                                                  &m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
+                                                  &read_size,
                                                   m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data());
-// Skip when no data is available
-            if (ze_result != ZE_RESULT_NOT_READY &&
-                m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx) > 0) {
+
+            // Skip when no data is available
+            if (ze_result != ZE_RESULT_NOT_READY && read_size > 0) {
                 check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                                 "LevelZero::" + std::string(__func__) +
                                 ": LevelZero Read Data failed",
                                 __LINE__);
-                metric_calc(l0_device_idx, l0_domain_idx,
-                            m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
-                            m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx));
+
+                // Learn per-report byte size from first successful read
+                size_t &report_byte_size = m_devices.at(l0_device_idx).subdevice.report_byte_size.at(l0_domain_idx);
+                if (report_byte_size == 0) {
+                    uint32_t tmp_num_values = 0;
+                    zet_metric_group_calculation_type_t tmp_calc_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
+                    zetMetricGroupCalculateMetricValues(
+                        m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx),
+                        tmp_calc_type, read_size,
+                        m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data(),
+                        &tmp_num_values, nullptr);
+                    uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
+                    size_t first_num_reports = (num_metric > 0) ? tmp_num_values / num_metric : 1;
+                    if (first_num_reports > 0) {
+                        report_byte_size = read_size / first_num_reports;
+                    }
+                }
+
+                // Only process the most recent DEFAULT_MAX_REPORTS_PER_READ reports
+                size_t process_size = read_size;
+                const uint8_t *process_data = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data();
+                if (report_byte_size > 0 && read_size > report_byte_size * DEFAULT_MAX_REPORTS_PER_READ) {
+                    process_size = report_byte_size * DEFAULT_MAX_REPORTS_PER_READ;
+                    process_data = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data()
+                                   + (read_size - process_size);
+                }
+
+                metric_calc(l0_device_idx, l0_domain_idx, process_size, process_data);
             }
         }
     }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -224,7 +224,9 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
-            metric_group_init(gpu_idx);
+            if (gpu_idx < 1) {
+                metric_group_init(gpu_idx);
+            }
         }
     }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -762,7 +762,7 @@ namespace geopm
 
     // TODO don't pass metric_streamer
     void LevelZeroImp::metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
-                                   size_t data_size, std::vector<uint8_t> data)
+                                   size_t data_size, const std::vector<uint8_t> &data)
     {
 
         GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) == true,

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -980,6 +980,16 @@ namespace geopm
                                               &read_size,
                                               m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data());
 
+        // Dropped-data is a warning with still-valid reports (FIFO overran); not a fault.
+        if (ze_result == ZE_RESULT_WARNING_DROPPED_DATA) {
+#ifdef GEOPM_DEBUG
+            std::cerr << "Warning: <geopm> LevelZero::" << std::string(__func__)
+                      << ": metric streamer dropped data; processing remaining reports."
+                      << std::endl;
+#endif
+            ze_result = ZE_RESULT_SUCCESS;
+        }
+
         // Skip when no data is available
         if (ze_result != ZE_RESULT_NOT_READY && read_size > 0) {
             check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -748,26 +748,24 @@ namespace geopm
 
     void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-        // No context was created if the domain was never enumerated.
-        if (!m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx))
-            return;
+        auto &sub = m_devices.at(l0_device_idx).subdevice;
 
-        ze_result_t ze_result;
-        ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
-
-        // Close the streamer and deactivate the group only if sampling was started.
-        if (m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
-            m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = false;
+        // The streamer and metric-group activation exist only once sampling was
+        // started for this chip.
+        if (l0_domain_idx < sub.metrics_initialized.size() &&
+            sub.metrics_initialized.at(l0_domain_idx)) {
+            sub.metrics_initialized.at(l0_domain_idx) = false;
 
             // Close metric streamer
-            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
+            ze_result_t ze_result =
+                zetMetricStreamerClose(sub.metric_streamer.at(l0_domain_idx));
             check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                             "LevelZero::" + std::string(__func__) +
                             ": LevelZero Metric Streamer Close failed",
                             __LINE__);
 
             // Deactivate the metric group on the same subdevice used to activate it.
-            ze_result = zetContextActivateMetricGroups(context,
+            ze_result = zetContextActivateMetricGroups(sub.context.at(l0_domain_idx),
                                                        m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
                                                        0, nullptr);
             check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
@@ -776,8 +774,14 @@ namespace geopm
                             __LINE__);
         }
 
-        // The context is always created in metric_group_init, so always destroy it.
-        zeContextDestroy(context);
+        // metric_group_init creates the context before searching for the
+        // ComputeBasic group, so a context can exist even when the domain is
+        // left uncached.  Destroy it whenever one was created for this chip.
+        if (l0_domain_idx < sub.context.size() &&
+            sub.context.at(l0_domain_idx) != nullptr) {
+            zeContextDestroy(sub.context.at(l0_domain_idx));
+            sub.context.at(l0_domain_idx) = nullptr;
+        }
     }
 
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -160,6 +160,7 @@ namespace geopm
                             {}, //subdevice
                             0, //num_device_power_domain
                             {}, //power domain
+                            0, // cached_energy_timestamp
                         });
                     }
 #ifdef GEOPM_DEBUG

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -240,13 +240,35 @@ namespace geopm
     }
 
     LevelZeroImp::~LevelZeroImp() {
-        // Stop the background sampling thread before tearing down streamers.
-        metric_thread_stop();
+        // The destructor is implicitly noexcept, so a cleanup failure that
+        // escaped would call std::terminate() during shutdown.  Contain errors
+        // and continue tearing down every chip.
+        try {
+            // Stop the background sampling thread before tearing down streamers.
+            metric_thread_stop();
+        }
+        catch (const std::exception &ex) {
+#ifdef GEOPM_DEBUG
+            std::cerr << "Warning: <geopm> LevelZero::~LevelZeroImp(): "
+                      << "failed to stop the metric thread: " << ex.what()
+                      << std::endl;
+#endif
+        }
         for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
             for (unsigned int subdevice_idx = 0;
              subdevice_idx < m_devices.at(gpu_idx).num_subdevice;
              ++subdevice_idx) {
-                metric_destroy(gpu_idx, subdevice_idx);
+                try {
+                    metric_destroy(gpu_idx, subdevice_idx);
+                }
+                catch (const std::exception &ex) {
+#ifdef GEOPM_DEBUG
+                    std::cerr << "Warning: <geopm> LevelZero::~LevelZeroImp(): "
+                              << "metric cleanup failed for GPU " << gpu_idx
+                              << " chip " << subdevice_idx << ": " << ex.what()
+                              << std::endl;
+#endif
+                }
             }
         }
     }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -667,7 +667,7 @@ namespace geopm
                        m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)[metric_name] = {};
                        m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
                    }
-                   // Break out of the metric group for loop once we've found the group of interest (ComputeBasic, time based sampling).  
+                   // Break out of the metric group for loop once we've found the group of interest (ComputeBasic, time based sampling).
                    break;
                 }
             }
@@ -781,7 +781,7 @@ namespace geopm
         // Allocate memory for future reads
         size_t data_size = 0;
         ze_result = zetMetricStreamerReadData(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx),
-                                              UINT32_MAX, &data_size, nullptr);
+                                              UINT32_MAX, &data_size, nullptr); //TODO: this value should match the report_count_req in metric_read
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Read Data get size failed",
@@ -937,14 +937,6 @@ namespace geopm
                                 "LevelZero::" + std::string(__func__) +
                                 ": LevelZero Read Data failed",
                                 __LINE__);
-
-                if (report_count_req != UINT32_MAX) {
-                    // Dump all other reports if we're not gathering them
-                    size_t temp_data_size = 0;
-                    ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, nullptr );
-                    std::vector<uint8_t>temp_data(temp_data_size);
-                    ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, temp_data.data());
-                }
 
                 metric_calc(l0_device_idx, l0_domain_idx,
                             m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -601,7 +601,7 @@ namespace geopm
                             __LINE__);
 
             // set metric_notifcation_event sampling period in nanoseconds
-            m_devices.at(device_idx).metric_sampling_period_ns = 1000000; // 1 ms
+            m_devices.at(device_idx).metric_sampling_period_ns = SAMPLING_PERIOD_NS;
 
             m_devices.at(device_idx).subdevice.metric_data.push_back({});
 
@@ -637,18 +637,18 @@ namespace geopm
                    //Cache compute basic number of metrics
                    m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
 
+                   std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                   ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
+                                            &num_metric, metric_handle.data());
+
+                   check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                   "LevelZero::" + std::string(__func__) +
+                                   ": LevelZero Metric handle acquisition failed",
+                                   __LINE__);
+
                    //Build metric map
                    for (unsigned int metric_idx = 0; metric_idx < num_metric; ++metric_idx)
                    {
-
-                       std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                       ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
-                                                &num_metric, metric_handle.data());
-
-                       check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                       "LevelZero::" + std::string(__func__) +
-                                       ": LevelZero Metric handle acquisition failed",
-                                       __LINE__);
                        zet_metric_properties_t metric_properties;
                        ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
 
@@ -697,20 +697,6 @@ namespace geopm
                             ": LevelZero Metric Streamer Close failed",
                             __LINE__);
 
-            // Destroy metric_notifcation_event
-            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).subdevice.metric_notifcation_event.at(l0_domain_idx));
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Event Destroy failed",
-                            __LINE__);
-
-            // Destroy Event Pool
-            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).subdevice.event_pool.at(l0_domain_idx));
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric Event Pool Destroy failed",
-                            __LINE__);
-
             // Deactivate the device context
             ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
             ze_result = zetContextActivateMetricGroups(context,
@@ -732,43 +718,14 @@ namespace geopm
         ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
                                                    1, &m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx));
 
-        ze_event_pool_handle_t event_pool_handle = nullptr;
-        ze_event_pool_desc_t event_pool_desc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC, nullptr, 0, 1};
-
-        ze_result = zeEventPoolCreate(context, &event_pool_desc, 1,
-                                      &m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
-                                      &event_pool_handle);
-
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                        "LevelZero::" + std::string(__func__) +
-                        ": LevelZero Event Pool Create failed",
-                        __LINE__);
-
-        // TODO: nothing guarantees CHIP 0 was called first
-        m_devices.at(l0_device_idx).subdevice.event_pool.push_back(event_pool_handle);
-
-        ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
-                                      ZE_EVENT_SCOPE_FLAG_HOST, ZE_EVENT_SCOPE_FLAG_HOST};
-
-        ze_event_handle_t metric_notifcation_event = nullptr;
-        ze_result = zeEventCreate(event_pool_handle, &event_desc, &metric_notifcation_event);
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                        "LevelZero::" + std::string(__func__) +
-                        ": LevelZero Event Create failed",
-                        __LINE__);
-
-        // TODO: nothing guarantees CHIP 0 was called first
-        m_devices.at(l0_device_idx).subdevice.metric_notifcation_event.push_back(metric_notifcation_event);
-
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,
-            4, // number of reports to notify on.  Targeting 4 reports, 1 per millisecond as that will, generally,
-                // fall within the 5ms control loop and is a good tradeoff in terms of overhead vs visibility within the sampling period.
+            NOTIFY_EVERY_N_REPORTS, // number of reports to notify on.
             m_devices.at(l0_device_idx).metric_sampling_period_ns};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
 
-        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx), m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), &metric_streamer_desc, metric_notifcation_event, &metric_streamer);
+        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx), m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), &metric_streamer_desc, nullptr, &metric_streamer);
 
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
@@ -779,13 +736,16 @@ namespace geopm
         m_devices.at(l0_device_idx).subdevice.metric_streamer.push_back(metric_streamer);
 
         // Allocate memory for future reads
-        size_t data_size = 0;
-        ze_result = zetMetricStreamerReadData(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx),
-                                              UINT32_MAX, &data_size, nullptr); //TODO: this value should match the report_count_req in metric_read
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                        "LevelZero::" + std::string(__func__) +
-                        ": LevelZero Read Data get size failed",
-                        __LINE__);
+        // Doing a read might not be the best way to set a buffer size, as the amount of data
+        // available at this point in time will likely not match the amount of data at any future
+        // point in time while sampling. Using a default buffer size for now...
+        size_t data_size = DEFAULT_REPORT_BUFFER_SIZE;
+        // ze_result = zetMetricStreamerReadData(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx),
+        //                                       UINT32_MAX, &data_size, nullptr); //TODO: this value should match the report_count_req in metric_read
+        // check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+        //                 "LevelZero::" + std::string(__func__) +
+        //                 ": LevelZero Read Data get size failed",
+        //                 __LINE__);
 
         std::vector<uint8_t> data(data_size);
         m_devices.at(l0_device_idx).subdevice.zet_data_size.push_back(data_size);
@@ -920,24 +880,21 @@ namespace geopm
                 m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
             }
 
-            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).subdevice.metric_notifcation_event.at(l0_domain_idx), 0);
+            ze_result_t ze_result;
+            uint32_t report_count_req = 1;
+            zet_metric_streamer_handle_t metric_streamer = m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
 
-            if (ze_host_result != ZE_RESULT_NOT_READY) {
-                ze_result_t ze_result;
-                uint32_t report_count_req = UINT32_MAX;
-                zet_metric_streamer_handle_t metric_streamer = m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
-
-                ///////////////////
-                // Read Raw Data //
-                ///////////////////
-                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req,
-                                                      &m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
-                                                      m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data());
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Read Data failed",
-                                __LINE__);
-
+            ///////////////////
+            // Read Raw Data //
+            ///////////////////
+            ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req,
+                                                  &m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
+                                                  m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Read Data failed",
+                            __LINE__);
+            if (m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx) > 0) {
                 metric_calc(l0_device_idx, l0_domain_idx,
                             m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
                             m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx));

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -20,7 +20,7 @@
 static void __attribute__((constructor)) geopm_levelzero_init(void)
 {
     setenv("ZES_ENABLE_SYSMAN", "1", 1);
-    setenv("ZET_ENABLE_METRICS", "1", 1);
+//    setenv("ZET_ENABLE_METRICS", "1", 1);
 }
 
 namespace geopm
@@ -546,7 +546,7 @@ namespace geopm
 #ifdef GEOPM_DEBUG
                 std::cerr << "Warning: <geopm>: ZET_ENABLE_METRICS not set to 1.  Skipping metric caching" <<
                              " for device " << std::to_string(device_idx) << " subdevice " <<
-                             std::to_srting(subdevice_idx) << std::endl;
+                             std::to_string(subdevice_idx) << std::endl;
 #endif
             }
             else {
@@ -620,7 +620,6 @@ namespace geopm
                                         __LINE__);
 
                         //Cache compute basic number of metrics
-                        //m_devices.at(device_idx).subdevice.num_metric.at(subdevice_idx) = num_metric;
                         m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
 
                         //Build metric map
@@ -696,8 +695,6 @@ namespace geopm
     {
         ze_result_t ze_result;
         ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
-        //ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).device_handle,
-        //                                           1, &m_devices.at(l0_device_idx).metric_group_handle);
         ze_result = zetContextActivateMetricGroups(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
                                                    1, &m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx));
 
@@ -705,7 +702,6 @@ namespace geopm
         ze_event_pool_desc_t event_pool_desc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC, nullptr, 0, 1};
 
         ze_result = zeEventPoolCreate(context, &event_pool_desc, 1,
-                                      //&m_devices.at(l0_device_idx).device_handle,
                                       &m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx),
                                       &event_pool_handle);
 
@@ -713,7 +709,6 @@ namespace geopm
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Event Pool Create failed",
                         __LINE__);
-        //m_devices.at(l0_device_idx).event_pool = event_pool_handle;
         m_devices.at(l0_device_idx).subdevice.event_pool.push_back(event_pool_handle);
 
         ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
@@ -726,19 +721,15 @@ namespace geopm
                         ": LevelZero Event Create failed",
                         __LINE__);
 
-        //m_devices.at(l0_device_idx).event = event;
-
-//        std::cout << "ZET_INIT - pushing back event for gpu " << std::to_string(l0_device_idx) << std::endl;
         m_devices.at(l0_device_idx).subdevice.event.push_back(event);
 
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,
-            32768, /* reports to collect before notify */
+            32768,
             m_devices.at(l0_device_idx).metric_sampling_period};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
 
-        //ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).device_handle, m_devices.at(l0_device_idx).metric_group_handle, &metric_streamer_desc, event, &metric_streamer);
         ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx), m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), &metric_streamer_desc, event, &metric_streamer);
 
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
@@ -746,7 +737,6 @@ namespace geopm
                         ": LevelZero Metric Streamer Open failed",
                         __LINE__);
 
-        //m_devices.at(l0_device_idx).metric_streamer = metric_streamer;
         m_devices.at(l0_device_idx).subdevice.metric_streamer.push_back(metric_streamer);
     }
 
@@ -758,7 +748,7 @@ namespace geopm
         // Convert Raw Data //
         //////////////////////
         size_t data_size = 0;
-        uint32_t report_count_req = 100;//UINT32_MAX; //100;
+        uint32_t report_count_req = 100;
         ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr );
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
@@ -851,10 +841,8 @@ namespace geopm
                         };
                         //Clear cached values
                         if(report_idx == 0) {
-                            //m_devices.at(l0_device_idx).m_metric_data.at(metric_name) = {};
                             m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
                         }
-                        //m_devices.at(l0_device_idx).m_metric_data.at(metric_name).push_back(data_double);
                         m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
                     }
                 }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -14,13 +14,14 @@
 #include "geopm/Exception.hpp"
 #include "geopm/Agg.hpp"
 #include "geopm/Helper.hpp"
+#include "geopm_debug.hpp"
 
 #include "LevelZeroImp.hpp"
 
 static void __attribute__((constructor)) geopm_levelzero_init(void)
 {
     setenv("ZES_ENABLE_SYSMAN", "1", 1);
-//    setenv("ZET_ENABLE_METRICS", "1", 1);
+    setenv("ZET_ENABLE_METRICS", "1", 1);
 }
 
 namespace geopm
@@ -219,8 +220,16 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
-            if (gpu_idx < 1) {
-                metric_group_cache(gpu_idx);
+            metric_group_cache(gpu_idx);
+        }
+    }
+
+    LevelZeroImp::~LevelZeroImp() {
+        for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; gpu_idx++) {
+            for (int subdevice_idx = 0;
+             subdevice_idx < m_devices.at(gpu_idx).m_num_subdevice;
+             ++subdevice_idx) {
+                metric_destroy(gpu_idx, subdevice_idx);
             }
         }
     }
@@ -536,179 +545,172 @@ namespace geopm
         }
     }
 
+    //  Cache the following per gpu_idx:
+    //      - caching & initialization tracking variable
+    //      - L0 context
+    //      - metric group handle
+    //      - sampling period
+    //      - data storage for the ComputeBasics metric group
     void LevelZeroImp::metric_group_cache(unsigned int device_idx) {
         for (int subdevice_idx = 0;
-         subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
-         ++subdevice_idx) {
-            //assume false
+             subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
+             ++subdevice_idx) {
+            // Setup tracking of the caching and initilization steps
             m_devices.at(device_idx).subdevice.metric_domain_cached.push_back(false);
             m_devices.at(device_idx).subdevice.metrics_initialized.push_back(false);
 
-            char *zet_enable_metrics = getenv("ZET_ENABLE_METRICS");
-            if (zet_enable_metrics == NULL || strcmp(zet_enable_metrics, "1") != 0) {
-#ifdef GEOPM_DEBUG
-                std::cerr << "Warning: <geopm>: ZET_ENABLE_METRICS not set to 1.  Skipping metric caching" <<
-                             " for device " << std::to_string(device_idx) << " subdevice " <<
-                             std::to_string(subdevice_idx) << std::endl;
-#endif
-            }
-            else {
-                ze_result_t ze_result;
+            ze_result_t ze_result;
 
-                // We create a context to support the ZET commands
-                ze_context_desc_t context_desc = {
-                   ZE_STRUCTURE_TYPE_CONTEXT_DESC,
-                   nullptr,
-                   0
-                };
-                ze_context_handle_t context = nullptr;
-                ze_result = zeContextCreate(m_devices.at(device_idx).driver,
-                                            &context_desc, &context);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero context creation failed",
-                                __LINE__);
+            // We create a context to support the ZET commands
+            ze_context_desc_t context_desc = {
+               ZE_STRUCTURE_TYPE_CONTEXT_DESC,
+               nullptr,
+               0
+            };
+            ze_context_handle_t context = nullptr;
+            ze_result = zeContextCreate(m_devices.at(device_idx).driver,
+                                        &context_desc, &context);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero context creation failed",
+                            __LINE__);
 
-                m_devices.at(device_idx).subdevice.context.push_back(context);
+            m_devices.at(device_idx).subdevice.context.push_back(context);
 
-                //Metric groups
-                uint32_t num_metric_group = 0;
-                ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
-                                              &num_metric_group, nullptr);
+            //Metric groups
+            uint32_t num_metric_group = 0;
+            ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
+                                          &num_metric_group, nullptr);
 
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Metric Group enumeration failed.",
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Group enumeration failed.",
+                             __LINE__);
+
+            std::vector<zet_metric_group_handle_t> metric_group_handle(num_metric_group);
+            ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
+                                          &num_metric_group, metric_group_handle.data());
+
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Group handle acquisition failed",
+                            __LINE__);
+
+            // set metric_notifcation_event sampling period in nanoseconds
+            m_devices.at(device_idx).metric_sampling_period_ns =   1000000;
+
+            m_devices.at(device_idx).subdevice.m_metric_data.push_back({});
+
+            for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
+                 metric_group_idx++) {
+                 zet_metric_group_properties_t metric_group_properties;
+                 ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
+                                             &metric_group_properties);
+                 check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
+                                 "LevelZero::" + std::string(__func__) +
+                                 ": LevelZero Metric Group property acquisition failed",
                                  __LINE__);
 
-                std::vector<zet_metric_group_handle_t> metric_group_handle(num_metric_group);
+                 std::string metric_group_name (metric_group_properties.name);
 
-                //TODO: save the relevant per GPU pointers
-                ze_result = zetMetricGroupGet(m_devices.at(device_idx).subdevice_handle.at(subdevice_idx),
-                                              &num_metric_group, metric_group_handle.data());
+                 //Confirm metric groups of interest exist
+                 if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
+                     && metric_group_name == "ComputeBasic") {
 
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Metric Group handle acquisition failed",
-                                __LINE__);
+                    //cache compute basic metric group
+                    m_devices.at(device_idx).subdevice.metric_group_handle.push_back(metric_group_handle.at(metric_group_idx));
 
-                //sampling period in nanoseconds
-                //m_devices.at(device_idx).metric_sampling_period = 2000000;
-                m_devices.at(device_idx).metric_sampling_period =   1000000;
+                    // could likely use metric_group_properties.metricCount instead
+                    uint32_t num_metric = 0;
+                    ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
+                    check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                    "LevelZero::" + std::string(__func__) +
+                                    ": LevelZero Metric Count query failed",
+                                    __LINE__);
 
-                m_devices.at(device_idx).subdevice.m_metric_data.push_back({});
+                    //Cache compute basic number of metrics
+                    m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
 
-                for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
-                     metric_group_idx++) {
-                     zet_metric_group_properties_t metric_group_properties;
-                     ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
-                                                 &metric_group_properties);
-                     check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
-                                     "LevelZero::" + std::string(__func__) +
-                                     ": LevelZero Metric Group property acquisition failed",
-                                     __LINE__);
+                    //Build metric map
+                    for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+                    {
 
-                     //Confirm metric groups of interest exist
-                     if (metric_group_properties.samplingType == ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED
-                         && strcmp(metric_group_properties.name, "ComputeBasic") == 0) {
+                        std::vector<zet_metric_handle_t> metric_handle(num_metric);
+                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
+                                                 &num_metric, metric_handle.data());
 
-                        //cache compute basic metric group
-                        m_devices.at(device_idx).subdevice.metric_group_handle.push_back(metric_group_handle.at(metric_group_idx));
-
-                        // could likely use metric_group_properties.metricCount instead
-                        uint32_t num_metric = 0;
-                        ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx), &num_metric, nullptr );
                         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                                         "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero Metric Count query failed",
+                                        ": LevelZero Metric handle acquisition failed",
+                                        __LINE__);
+                        zet_metric_properties_t metric_properties;
+                        ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+
+                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                        "LevelZero::" + std::string(__func__) +
+                                        ": LevelZero Metric Property acquisition failed",
                                         __LINE__);
 
-                        //Cache compute basic number of metrics
-                        m_devices.at(device_idx).subdevice.num_metric.push_back(num_metric);
+                        std::string metric_name (metric_properties.name);
 
-                        //Build metric map
-                        for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
-                        {
-
-                            std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                            ze_result = zetMetricGet(metric_group_handle.at(metric_group_idx),
-                                                     &num_metric, metric_handle.data());
-
-                            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                            "LevelZero::" + std::string(__func__) +
-                                            ": LevelZero Metric handle acquisition failed",
-                                            __LINE__);
-                            zet_metric_properties_t metric_properties;
-                            ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
-
-                            // TODO: confirm we get the metric name
-                            //check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            //                "LevelZero::" + std::string(__func__) +
-                            //                ": LevelZero Metric handle acquisition failed",
-                            //                __LINE__);
-                            std::string metric_name (metric_properties.name);
-
-                            //m_devices is a std::vector of structs, indexed by GPU
-                            // subdevice is a struct inside of it.  One per GPU
-                            //  m_metric_data is a vector, indexed by CHIP
-                            //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
-
-                            if(m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
-                                throw Exception("LevelZero::" + std::string(__func__) +
-                                                ": Metric group has two metrics with the same name",
-                                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-                            }
-                            m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
-                            m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
+                        //m_devices is a std::vector of structs, indexed by GPU
+                        // subdevice is a struct inside of it.  One per GPU
+                        //  m_metric_data is a vector, indexed by CHIP
+                        //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
+                        if (m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
+                            throw Exception("LevelZero::" + std::string(__func__) +
+                                            ": Metric group has two metrics with the same name",
+                                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                         }
-                        // Break out of loop once we've found the group of interest
-                        break;
+                        m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
+                        m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
                     }
+                    // Break out of loop once we've found the group of interest
+                    break;
                 }
-                m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
             }
+            m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
         }
     }
 
     void LevelZeroImp::metric_destroy(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-////        //std::cout << "ZET_DESTROY - gpu " << std::to_string(l0_device_idx) << std::endl;
-//        ze_result_t ze_result;
-//
-//        if (m_devices.at(l0_device_idx).metrics_initialized) {
-//            m_devices.at(l0_device_idx).metrics_initialized = false;
-//
-//            // Close metric streamer
-//            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).metric_streamer);
-//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-//                            "LevelZero::" + std::string(__func__) +
-//                            ": LevelZero Metric Streamer Close failed",
-//                            __LINE__);
-//
-//            // Destroy Event
-//            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).event);
-//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-//                            "LevelZero::" + std::string(__func__) +
-//                            ": LevelZero Metric Event Destroy failed",
-//                            __LINE__);
-//
-//            // Destroy Event Pool
-//            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).event_pool);
-//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-//                            "LevelZero::" + std::string(__func__) +
-//                            ": LevelZero Metric Event Pool Destroy failed",
-//                            __LINE__);
-//
-//            // Deactivate the device context
-//            ze_context_handle_t context = m_devices.at(l0_device_idx).context;
-//            ze_result = zetContextActivateMetricGroups(context,
-//                                                       m_devices.at(l0_device_idx).device_handle,
-//                                                       0, nullptr);
-//            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-//                            "LevelZero::" + std::string(__func__) +
-//                            ": LevelZero Metric Context Deactivation failed",
-//                            __LINE__);
-//        }
+        ze_result_t ze_result;
+
+        if (m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
+            m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = false;
+
+            // Close metric streamer
+            ze_result = zetMetricStreamerClose(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Streamer Close failed",
+                            __LINE__);
+
+            // Destroy metric_notifcation_event
+            ze_result = zeEventDestroy(m_devices.at(l0_device_idx).subdevice.metric_notifcation_event.at(l0_domain_idx));
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Event Destroy failed",
+                            __LINE__);
+
+            // Destroy Event Pool
+            ze_result = zeEventPoolDestroy(m_devices.at(l0_device_idx).subdevice.event_pool.at(l0_domain_idx));
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Event Pool Destroy failed",
+                            __LINE__);
+
+            // Deactivate the device context
+            ze_context_handle_t context = m_devices.at(l0_device_idx).subdevice.context.at(l0_domain_idx);
+            ze_result = zetContextActivateMetricGroups(context,
+                                                       m_devices.at(l0_device_idx).device_handle,
+                                                       0, nullptr);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric Context Deactivation failed",
+                            __LINE__);
+        }
     }
 
 
@@ -737,24 +739,24 @@ namespace geopm
         ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
                                       ZE_EVENT_SCOPE_FLAG_HOST, ZE_EVENT_SCOPE_FLAG_HOST};
 
-        ze_event_handle_t event = nullptr;
-        ze_result = zeEventCreate(event_pool_handle, &event_desc, &event);
+        ze_event_handle_t metric_notifcation_event = nullptr;
+        ze_result = zeEventCreate(event_pool_handle, &event_desc, &metric_notifcation_event);
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Event Create failed",
                         __LINE__);
 
         // TODO: nothing guarantees CHIP 0 was called first
-        m_devices.at(l0_device_idx).subdevice.event.push_back(event);
+        m_devices.at(l0_device_idx).subdevice.metric_notifcation_event.push_back(metric_notifcation_event);
 
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,
-            32768,
-            m_devices.at(l0_device_idx).metric_sampling_period};
+            4, // number of reports to notify on.
+            m_devices.at(l0_device_idx).metric_sampling_period_ns};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
 
-        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx), m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), &metric_streamer_desc, event, &metric_streamer);
+        ze_result = zetMetricStreamerOpen(context, m_devices.at(l0_device_idx).subdevice_handle.at(l0_domain_idx), m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), &metric_streamer_desc, metric_notifcation_event, &metric_streamer);
 
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
@@ -767,49 +769,23 @@ namespace geopm
 
     // TODO don't pass metric_streamer
     void LevelZeroImp::metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
-                                   zet_metric_streamer_handle_t metric_streamer) const
+                                   size_t data_size, std::vector<uint8_t> data)
     {
-//        std::chrono::time_point<std::chrono::system_clock> start, end;
-//        std::chrono::duration<double> elapsed_seconds;
-//        start = std::chrono::system_clock::now();
+
+        GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) == true,
+                           "metric caching for GPU " + std::to_string(l0_device_idx) +
+                           ", CHIP " + std::to_string(l0_domain_idx) +
+                           " not completed prior to metric_calc call.");
+
+        GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) == true,
+                           "metric initialization for GPU " + std::to_string(l0_device_idx) +
+                           ", CHIP " + std::to_string(l0_domain_idx) +
+                           " not completed prior to metric_calc call.");
+
         ze_result_t ze_result;
-        //////////////////////
-        // Convert Raw Data //
-        //////////////////////
-        size_t data_size = 0;
-        uint32_t report_count_req = UINT32_MAX;//10;
-        //ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &data_size, nullptr);
-        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr);
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                        "LevelZero::" + std::string(__func__) +
-                        ": LevelZero Read Data get size failed",
-                        __LINE__);
-
-        std::vector<uint8_t> data(data_size);
-        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
-        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                        "LevelZero::" + std::string(__func__) +
-                        ": LevelZero Read Data failed",
-                        __LINE__);
-
-        // Dump all other reports
-//        size_t temp_data_size = 0;
-//        ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, nullptr );
-//        std::vector<uint8_t>temp_data(temp_data_size);
-//        ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, temp_data.data());
-
-//        end = std::chrono::system_clock::now();
-//        elapsed_seconds = end - start;
-//        std::cout << "MetricStreamerReadData Time: " <<
-//                     elapsed_seconds.count() << "s, report req is: " << std::to_string(report_count_req) <<
-//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
-//                     std::to_string(l0_domain_idx) << std::endl;
-
-
         /////////////////////////////////////
         // Calculate & convert metric data //
         /////////////////////////////////////
-//        start = std::chrono::system_clock::now();
         uint32_t num_metric_values = 0;
         zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
         ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &num_metric_values, nullptr);
@@ -824,90 +800,78 @@ namespace geopm
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric group calculate metric values to calculate data failed",
                         __LINE__);
-//        end = std::chrono::system_clock::now();
-//        elapsed_seconds = end - start;
-//        std::cout << "CalculateMetric Time: " <<
-//                     elapsed_seconds.count() << "s" <<
-//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
-//                     std::to_string(l0_domain_idx) << std::endl;
-        //std::cout << "\tmetric group calculate metric values: " << std::to_string(num_metric_values) << std::endl;
-        //ze_result = ZE_RESULT_ERROR_UNKNOWN;
 
-//        start = std::chrono::system_clock::now();
         uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
-        //if (ze_result == ZE_RESULT_SUCCESS) {
-            unsigned int num_reports = num_metric_values / num_metric;
+        unsigned int num_reports = num_metric_values / num_metric;
+        for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
+        {
+            //TODO: It is possible that simply parsing all the metrics is
+            //      faster than the additional API calls to check the metric
+            //      name.  This should be studied
+            std::vector<zet_metric_handle_t> metric_handle(num_metric);
+            ze_result = zetMetricGet(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx),
+                                     &num_metric, metric_handle.data());
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric handle acquisition failed",
+                            __LINE__);
 
-            for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
-            {
-                //TODO: It is possible that simply parsing all the metrics is
-                //      faster than the additional API calls to check the metric
-                //      name.  This should be studied
-                std::vector<zet_metric_handle_t> metric_handle(num_metric);
-                ze_result = zetMetricGet(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx),
-                                         &num_metric, metric_handle.data());
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Metric handle acquisition failed",
-                                __LINE__);
+            // process metrics
+            zet_metric_properties_t metric_properties;
+            ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Metric property acquisition failed",
+                            __LINE__);
 
-                // process metrics
-                zet_metric_properties_t metric_properties;
-                ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Metric property acquisition failed",
-                                __LINE__);
+            std::string metric_name (metric_properties.name);
 
-                std::string metric_name (metric_properties.name);
+            //TODO: check timing impact of only processing metrics supported by IOGroup
+            if (metric_name == "XVE_ACTIVE" ||
+                metric_name == "XVE_STALL") {
+                for (unsigned int report_idx = 0; report_idx < num_reports; report_idx++) {
+                    // Each report contains num_metric entries of data.  We need to access
+                    // this metric (metric_idx) from each report ( report_idx * num_metric)
+                    zet_typed_value_t data = metric_values.at(report_idx * num_metric + metric_idx);
+                    double data_double = metric_data_convert(data);
 
-                //TODO: check timing impact of only processing metrics supported by IOGroup
-                if(metric_name.compare("XVE_ACTIVE") == 0 ||
-                   metric_name.compare("XVE_STALL") == 0) {
-                    for (unsigned int report_idx = 0; report_idx < num_reports; report_idx++)
-                    {
-                        //This is the actual gathering of the data
-                        zet_typed_value_t data = metric_values.at(report_idx*num_metric + metric_idx);
-                        double data_double = NAN;
-                        switch( data.type )
-                        {
-                        case ZET_VALUE_TYPE_UINT32:
-                            data_double = data.value.ui32;
-                            break;
-                        case ZET_VALUE_TYPE_UINT64:
-                            data_double = data.value.ui64;
-                            break;
-                        case ZET_VALUE_TYPE_FLOAT32:
-                            data_double = data.value.fp32;
-                            break;
-                        case ZET_VALUE_TYPE_FLOAT64:
-                            data_double = data.value.fp64;
-                            break;
-                        case ZET_VALUE_TYPE_BOOL8:
-                            data_double = data.value.ui32;
-                            break;
-                        default:
-                            break;
-                        };
-                        //Clear cached values
-                        if(report_idx == 0) {
-                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
-                            //m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).clear();
-                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
-                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
-                        }
-                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
-                        if(report_idx == 1) {
-                        }
+                    if (report_idx == 0) {
+                        // Clear cached values
+                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
+                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
+
+                        // Update num_reports
+                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
                     }
+                    m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
                 }
             }
-//        end = std::chrono::system_clock::now();
-//        elapsed_seconds = end - start;
-//        std::cout << "Process Time: " <<
-//                     elapsed_seconds.count() << "s" <<
-//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
-//                     std::to_string(l0_domain_idx) << std::endl;
+        }
+    }
+
+    double LevelZeroImp::metric_data_convert(zet_typed_value_t data) const
+    {
+        double data_double = NAN;
+        switch(data.type) {
+        case ZET_VALUE_TYPE_UINT32:
+            data_double = data.value.ui32;
+            break;
+        case ZET_VALUE_TYPE_UINT64:
+            data_double = data.value.ui64;
+            break;
+        case ZET_VALUE_TYPE_FLOAT32:
+            data_double = data.value.fp32;
+            break;
+        case ZET_VALUE_TYPE_FLOAT64:
+            data_double = data.value.fp64;
+            break;
+        case ZET_VALUE_TYPE_BOOL8:
+            data_double = data.value.ui32;
+            break;
+        default:
+            break;
+        };
+        return data_double;
     }
 
     void LevelZeroImp::metric_read(unsigned int l0_device_idx, unsigned int l0_domain_idx)
@@ -918,11 +882,39 @@ namespace geopm
                 m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
             }
 
-            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).subdevice.event.at(l0_domain_idx), 0);
+            ze_result_t ze_host_result = zeEventHostSynchronize(m_devices.at(l0_device_idx).subdevice.metric_notifcation_event.at(l0_domain_idx), 0);
 
             if (ze_host_result != ZE_RESULT_NOT_READY) {
-                metric_calc(l0_device_idx, l0_domain_idx,
-                            m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
+                ze_result_t ze_result;
+                zet_metric_streamer_handle_t metric_streamer = m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
+
+                ///////////////////
+                // Read Raw Data //
+                ///////////////////
+                size_t data_size = 0;
+                uint32_t report_count_req = UINT32_MAX; //10; using UINT32_MAX is a temporary workaround
+                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr);
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Read Data get size failed",
+                                __LINE__);
+
+                std::vector<uint8_t> data(data_size);
+                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Read Data failed",
+                                __LINE__);
+
+                if (report_count_req != UINT32_MAX) {
+                    // Dump all other reports if we're not gathering them
+                    size_t temp_data_size = 0;
+                    ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, nullptr );
+                    std::vector<uint8_t>temp_data(temp_data_size);
+                    ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, temp_data.data());
+                }
+
+                metric_calc(l0_device_idx, l0_domain_idx, data_size, data);
             }
         }
     }
@@ -938,7 +930,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if(m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).count(metric_name) == 0) {
+        if (m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).count(metric_name) == 0) {
             throw Exception("LevelZero::" + std::string(__func__) +
                             ": No metric named " + metric_name  + " found." ,
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -1385,11 +1377,11 @@ namespace geopm
     {
         uint64_t timestamp = 0;
         //PACKAGE
-        if(geopm_domain == GEOPM_DOMAIN_GPU) {
+        if (geopm_domain == GEOPM_DOMAIN_GPU) {
             timestamp = m_devices.at(l0_device_idx).cached_energy_timestamp;
         }
         //TILE
-        else if(geopm_domain == GEOPM_DOMAIN_GPU_CHIP) {
+        else if (geopm_domain == GEOPM_DOMAIN_GPU_CHIP) {
             timestamp = m_devices.at(l0_device_idx).subdevice.cached_energy_timestamp.at(l0_domain_idx);
         }
         return timestamp;
@@ -1524,12 +1516,7 @@ namespace geopm
 
     uint32_t LevelZeroImp::metric_update_rate(unsigned int l0_device_idx) const
     {
-        return m_devices.at(l0_device_idx).metric_sampling_period;
-    }
-
-    void LevelZeroImp::metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting)
-    {
-        m_devices.at(l0_device_idx).metric_sampling_period = setting;
+        return m_devices.at(l0_device_idx).metric_sampling_period_ns;
     }
 
     void LevelZeroImp::check_ze_result(ze_result_t ze_result, int error,

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -631,7 +631,8 @@ namespace geopm
 
             for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
                  metric_group_idx++) {
-                zet_metric_group_properties_t metric_group_properties;
+                zet_metric_group_properties_t metric_group_properties = {};
+                metric_group_properties.stype = ZET_STRUCTURE_TYPE_METRIC_GROUP_PROPERTIES;
                 ze_result = zetMetricGroupGetProperties(metric_group_handle.at(metric_group_idx),
                                             &metric_group_properties);
                 check_ze_result(ze_result,GEOPM_ERROR_RUNTIME,
@@ -674,7 +675,8 @@ namespace geopm
                    std::map<std::string, size_t> name_idx;
                    for (unsigned int metric_idx = 0; metric_idx < num_metric; ++metric_idx)
                    {
-                       zet_metric_properties_t metric_properties;
+                       zet_metric_properties_t metric_properties = {};
+                       metric_properties.stype = ZET_STRUCTURE_TYPE_METRIC_PROPERTIES;
                        ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
 
                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -1035,13 +1035,18 @@ namespace geopm
             ze_result = ZE_RESULT_SUCCESS;
         }
 
-        // Skip when no data is available
-        if (ze_result != ZE_RESULT_NOT_READY && read_size > 0) {
+        // NOT_READY just means no reports are queued yet; validate every other
+        // result (e.g. device loss) even when read_size == 0 so errors reach the
+        // background-thread error path instead of silently disabling telemetry.
+        if (ze_result != ZE_RESULT_NOT_READY) {
             check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                             "LevelZero::" + std::string(__func__) +
                             ": LevelZero Read Data failed",
                             __LINE__);
+        }
 
+        // Skip when no data is available
+        if (ze_result != ZE_RESULT_NOT_READY && read_size > 0) {
             // Learn per-report byte size from first successful read
             size_t &report_byte_size = m_devices.at(l0_device_idx).subdevice.report_byte_size.at(l0_domain_idx);
             if (report_byte_size == 0) {

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -890,11 +890,13 @@ namespace geopm
             ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req,
                                                   &m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
                                                   m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Read Data failed",
-                            __LINE__);
-            if (m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx) > 0) {
+// Skip when no data is available
+            if (ze_result != ZE_RESULT_NOT_READY &&
+                m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx) > 0) {
+                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                                "LevelZero::" + std::string(__func__) +
+                                ": LevelZero Read Data failed",
+                                __LINE__);
                 metric_calc(l0_device_idx, l0_domain_idx,
                             m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
                             m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx));
@@ -1524,7 +1526,13 @@ namespace geopm
               {ZE_RESULT_ERROR_INVALID_NULL_POINTER,
                "ZE_RESULT_ERROR_INVALID_NULL_POINTER"},
               {ZE_RESULT_ERROR_UNKNOWN,
-               "ZE_RESULT_ERROR_UNKNOWN"}
+               "ZE_RESULT_ERROR_UNKNOWN"},
+              {ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY,
+               "ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY"},
+              {ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY,
+               "ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY"},
+              {ZE_RESULT_WARNING_DROPPED_DATA,
+               "ZE_RESULT_WARNING_DROPPED_DATA"}
         };
 
         std::string error_string = std::to_string(ze_result);

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -777,6 +777,19 @@ namespace geopm
 
         // TODO: nothing guarantees CHIP 0 was called first
         m_devices.at(l0_device_idx).subdevice.metric_streamer.push_back(metric_streamer);
+
+        // Allocate memory for future reads
+        size_t data_size = 0;
+        ze_result = zetMetricStreamerReadData(m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx),
+                                              UINT32_MAX, &data_size, nullptr);
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Read Data get size failed",
+                        __LINE__);
+
+        std::vector<uint8_t> data(data_size);
+        m_devices.at(l0_device_idx).subdevice.zet_data_size.push_back(data_size);
+        m_devices.at(l0_device_idx).subdevice.zet_data.push_back(data);
     }
 
     // TODO don't pass metric_streamer
@@ -911,21 +924,15 @@ namespace geopm
 
             if (ze_host_result != ZE_RESULT_NOT_READY) {
                 ze_result_t ze_result;
+                uint32_t report_count_req = UINT32_MAX;
                 zet_metric_streamer_handle_t metric_streamer = m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
 
                 ///////////////////
                 // Read Raw Data //
                 ///////////////////
-                size_t data_size = 0;
-                uint32_t report_count_req = UINT32_MAX; //10; using UINT32_MAX is a temporary workaround
-                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr);
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Read Data get size failed",
-                                __LINE__);
-
-                std::vector<uint8_t> data(data_size);
-                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
+                ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req,
+                                                      &m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
+                                                      m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data());
                 check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                                 "LevelZero::" + std::string(__func__) +
                                 ": LevelZero Read Data failed",
@@ -939,7 +946,9 @@ namespace geopm
                     ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, temp_data.data());
                 }
 
-                metric_calc(l0_device_idx, l0_domain_idx, data_size, data);
+                metric_calc(l0_device_idx, l0_domain_idx,
+                            m_devices.at(l0_device_idx).subdevice.zet_data_size.at(l0_domain_idx),
+                            m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx));
             }
         }
     }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -646,7 +646,8 @@ namespace geopm
                                    ": LevelZero Metric handle acquisition failed",
                                    __LINE__);
 
-                   //Build metric map
+                   //Build metric map and name-to-index cache
+                   std::map<std::string, size_t> name_idx;
                    for (unsigned int metric_idx = 0; metric_idx < num_metric; ++metric_idx)
                    {
                        zet_metric_properties_t metric_properties;
@@ -670,7 +671,14 @@ namespace geopm
                        }
                        m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)[metric_name] = {};
                        m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
+
+                       // Cache index for metrics we process in metric_calc
+                       if (metric_name == "XVE_ACTIVE" ||
+                           metric_name == "XVE_STALL") {
+                           name_idx[metric_name] = metric_idx;
+                       }
                    }
+                   m_devices.at(device_idx).subdevice.metric_name_idx.push_back(std::move(name_idx));
                    // Break out of the metric group for loop once we've found the group of interest (ComputeBasic, time based sampling).
                    break;
                 }
@@ -798,51 +806,25 @@ namespace geopm
                          "that is not evenly divisible by the number of metrics.  This "
                          "may indicate a ZET report erroor, skipping data processing." << std::endl;
 #endif
-            num_metric = 0;
+            return;
         }
 
-        for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
-        {
-            //TODO: It is possible that simply parsing all the metrics is
-            //      faster than the additional API calls to check the metric
-            //      name.  This should be studied
-            std::vector<zet_metric_handle_t> metric_handle(num_metric);
-            ze_result = zetMetricGet(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx),
-                                     &num_metric, metric_handle.data());
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric handle acquisition failed",
-                            __LINE__);
+        // Use the cached name→index map to avoid calling zetMetricGet and
+        // zetMetricGetProperties on every sample iteration.
+        const auto &name_idx = m_devices.at(l0_device_idx).subdevice.metric_name_idx.at(l0_domain_idx);
+        for (const auto &kv : name_idx) {
+            const std::string &metric_name = kv.first;
+            size_t metric_idx = kv.second;
 
-            // process metrics
-            zet_metric_properties_t metric_properties;
-            ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
-            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                            "LevelZero::" + std::string(__func__) +
-                            ": LevelZero Metric property acquisition failed",
-                            __LINE__);
+            // Clear cached values and update num_reports on first metric
+            m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name) = {};
+            m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
+            m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
 
-            std::string metric_name (metric_properties.name);
-
-            //TODO: check timing impact of only processing metrics supported by IOGroup
-            if (metric_name == "XVE_ACTIVE" ||
-                metric_name == "XVE_STALL") {
-                for (unsigned int report_idx = 0; report_idx < num_reports; report_idx++) {
-                    // Each report contains num_metric entries of data.  We need to access
-                    // this metric (metric_idx) from each report ( report_idx * num_metric)
-                    zet_typed_value_t data = metric_values.at(report_idx * num_metric + metric_idx);
-                    double data_double = metric_data_convert(data);
-
-                    if (report_idx == 0) {
-                        // Clear cached values
-                        m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name) = {};
-                        m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
-
-                        // Update num_reports
-                        m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
-                    }
-                    m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
-                }
+            for (unsigned int report_idx = 0; report_idx < num_reports; report_idx++) {
+                zet_typed_value_t data = metric_values.at(report_idx * num_metric + metric_idx);
+                double data_double = metric_data_convert(data);
+                m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
             }
         }
     }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -230,7 +230,25 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
-            metric_group_init(gpu_idx);
+            // Metrics are optional: ZET may be unsupported by the hardware or
+            // driver.  Do not let an enumeration failure abort the whole Level
+            // Zero backend.  Pad the per-chip tracking vectors the drain thread
+            // and metric guards index so uninitialized domains are left uncached
+            // and pruned like any other unsupported signal.
+            try {
+                metric_group_init(gpu_idx);
+            }
+            catch (const Exception &ex) {
+                auto &sub = m_devices.at(gpu_idx).subdevice;
+                unsigned int num_subdevice = m_devices.at(gpu_idx).num_subdevice;
+                sub.metric_domain_cached.resize(num_subdevice, false);
+                sub.metrics_initialized.resize(num_subdevice, false);
+                sub.metric_active.resize(num_subdevice, false);
+                sub.metric_last_drain.resize(num_subdevice,
+                                             std::chrono::steady_clock::time_point{});
+                std::cerr << "Warning: <geopm> LevelZero metrics unavailable for GPU "
+                          << gpu_idx << ": " << ex.what() << std::endl;
+            }
         }
     }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -831,12 +831,12 @@ namespace geopm
         uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
         unsigned int num_reports = num_metric_values / num_metric;
 
-        // If num_metric_values is not evenly divisble by num_metrics
+        // If num_metric_values is not evenly divisible by num_metrics
         // skip the metric and report processing for this sample
         if (num_metric_values % num_metric != 0) {
 #ifdef GEOPM_DEBUG
             std::cerr << "LevelZero::" << std::string(__func__)  <<
-                         ": ZET metric_calc call retunred a number of metric values "
+                         ": ZET metric_calc call returned a number of metric values "
                          "that is not evenly divisible by the number of metrics.  This "
                          "may indicate a ZET report erroor, skipping data processing." << std::endl;
 #endif

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -667,7 +667,7 @@ namespace geopm
                        m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)[metric_name] = {};
                        m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
                    }
-                   // Break out of loop once we've found the group of interest
+                   // Break out of the metric group for loop once we've found the group of interest (ComputeBasic, time based sampling).  
                    break;
                 }
             }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -219,7 +219,9 @@ namespace geopm
             engine_domain_cache(gpu_idx);
             temperature_domain_cache(gpu_idx);
             ras_domain_cache(gpu_idx);
-            metric_group_cache(gpu_idx);
+            if (gpu_idx < 1) {
+                metric_group_cache(gpu_idx);
+            }
         }
     }
 
@@ -533,6 +535,7 @@ namespace geopm
             }
         }
     }
+
     void LevelZeroImp::metric_group_cache(unsigned int device_idx) {
         for (int subdevice_idx = 0;
          subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
@@ -590,7 +593,8 @@ namespace geopm
                                 __LINE__);
 
                 //sampling period in nanoseconds
-                m_devices.at(device_idx).metric_sampling_period = 2000000;
+                //m_devices.at(device_idx).metric_sampling_period = 2000000;
+                m_devices.at(device_idx).metric_sampling_period =   1000000;
 
                 m_devices.at(device_idx).subdevice.m_metric_data.push_back({});
 
@@ -636,12 +640,29 @@ namespace geopm
                                             __LINE__);
                             zet_metric_properties_t metric_properties;
                             ze_result = zetMetricGetProperties(metric_handle.at(metric_idx), &metric_properties);
+
+                            // TODO: confirm we get the metric name
+                            //check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            //                "LevelZero::" + std::string(__func__) +
+                            //                ": LevelZero Metric handle acquisition failed",
+                            //                __LINE__);
                             std::string metric_name (metric_properties.name);
 
-                            if(m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) == 0) {
-                                m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
+                            //m_devices is a std::vector of structs, indexed by GPU
+                            // subdevice is a struct inside of it.  One per GPU
+                            //  m_metric_data is a vector, indexed by CHIP
+                            //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
+
+                            if(m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
+                                throw Exception("LevelZero::" + std::string(__func__) +
+                                                ": Metric group has two metrics with the same name",
+                                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                             }
+                            m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
+                            m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
                         }
+                        // Break out of loop once we've found the group of interest
+                        break;
                     }
                 }
                 m_devices.at(device_idx).subdevice.metric_domain_cached.at(subdevice_idx) = true;
@@ -709,6 +730,8 @@ namespace geopm
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Event Pool Create failed",
                         __LINE__);
+
+        // TODO: nothing guarantees CHIP 0 was called first
         m_devices.at(l0_device_idx).subdevice.event_pool.push_back(event_pool_handle);
 
         ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, 0,
@@ -721,6 +744,7 @@ namespace geopm
                         ": LevelZero Event Create failed",
                         __LINE__);
 
+        // TODO: nothing guarantees CHIP 0 was called first
         m_devices.at(l0_device_idx).subdevice.event.push_back(event);
 
         zet_metric_streamer_desc_t metric_streamer_desc = {
@@ -737,55 +761,81 @@ namespace geopm
                         ": LevelZero Metric Streamer Open failed",
                         __LINE__);
 
+        // TODO: nothing guarantees CHIP 0 was called first
         m_devices.at(l0_device_idx).subdevice.metric_streamer.push_back(metric_streamer);
     }
 
+    // TODO don't pass metric_streamer
     void LevelZeroImp::metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
                                    zet_metric_streamer_handle_t metric_streamer) const
     {
+//        std::chrono::time_point<std::chrono::system_clock> start, end;
+//        std::chrono::duration<double> elapsed_seconds;
+//        start = std::chrono::system_clock::now();
         ze_result_t ze_result;
         //////////////////////
         // Convert Raw Data //
         //////////////////////
         size_t data_size = 0;
-        uint32_t report_count_req = 100;
-        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr );
+        uint32_t report_count_req = UINT32_MAX;//10;
+        //ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &data_size, nullptr);
+        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, nullptr);
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Read Data get size failed",
                         __LINE__);
 
         std::vector<uint8_t> data(data_size);
-        zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
+        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req, &data_size, data.data());
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Read Data failed",
                         __LINE__);
 
+        // Dump all other reports
+//        size_t temp_data_size = 0;
+//        ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, nullptr );
+//        std::vector<uint8_t>temp_data(temp_data_size);
+//        ze_result = zetMetricStreamerReadData(metric_streamer, UINT32_MAX, &temp_data_size, temp_data.data());
+
+//        end = std::chrono::system_clock::now();
+//        elapsed_seconds = end - start;
+//        std::cout << "MetricStreamerReadData Time: " <<
+//                     elapsed_seconds.count() << "s, report req is: " << std::to_string(report_count_req) <<
+//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
+//                     std::to_string(l0_domain_idx) << std::endl;
+
+
         /////////////////////////////////////
         // Calculate & convert metric data //
         /////////////////////////////////////
+//        start = std::chrono::system_clock::now();
         uint32_t num_metric_values = 0;
-        uint32_t data_count = 0;
         zet_metric_group_calculation_type_t calculation_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
-        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, nullptr, nullptr);
+        ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &num_metric_values, nullptr);
         check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
                         "LevelZero::" + std::string(__func__) +
                         ": LevelZero Metric group calculate metric values to find num metrics failed",
                         __LINE__);
 
-        std::vector<uint32_t> metric_count(data_count);
         std::vector<zet_typed_value_t> metric_values(num_metric_values);
-        ze_result = zetMetricGroupCalculateMultipleMetricValuesExp(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &data_count, &num_metric_values, metric_count.data(), metric_values.data());
-//        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-//                        "LevelZero::" + std::string(__func__) +
-//                        ": LevelZero Metric group calculate metric values to calculate data failed",
-//                        __LINE__);
-//        //std::cout << "\tmetric group calculate metric values: " << std::to_string(num_metric_values) << std::endl;
-//        ze_result = ZE_RESULT_ERROR_UNKNOWN;
+        ze_result = zetMetricGroupCalculateMetricValues(m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx), calculation_type, data_size, data.data(), &num_metric_values, metric_values.data());
+        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        "LevelZero::" + std::string(__func__) +
+                        ": LevelZero Metric group calculate metric values to calculate data failed",
+                        __LINE__);
+//        end = std::chrono::system_clock::now();
+//        elapsed_seconds = end - start;
+//        std::cout << "CalculateMetric Time: " <<
+//                     elapsed_seconds.count() << "s" <<
+//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
+//                     std::to_string(l0_domain_idx) << std::endl;
+        //std::cout << "\tmetric group calculate metric values: " << std::to_string(num_metric_values) << std::endl;
+        //ze_result = ZE_RESULT_ERROR_UNKNOWN;
 
+//        start = std::chrono::system_clock::now();
         uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
-        if (ze_result == ZE_RESULT_SUCCESS) {
+        //if (ze_result == ZE_RESULT_SUCCESS) {
             unsigned int num_reports = num_metric_values / num_metric;
 
             for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
@@ -842,16 +892,22 @@ namespace geopm
                         //Clear cached values
                         if(report_idx == 0) {
                             m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
+                            //m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).clear();
+                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
+                            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
                         }
                         m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
+                        if(report_idx == 1) {
+                        }
                     }
                 }
             }
-        }
-        else {
-            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_ACTIVE") = {};
-            m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at("XVE_STALL") = {};
-        }
+//        end = std::chrono::system_clock::now();
+//        elapsed_seconds = end - start;
+//        std::cout << "Process Time: " <<
+//                     elapsed_seconds.count() << "s" <<
+//                    "\tgpu " << std::to_string(l0_device_idx) << " chip " <<
+//                     std::to_string(l0_domain_idx) << std::endl;
     }
 
     void LevelZeroImp::metric_read(unsigned int l0_device_idx, unsigned int l0_domain_idx)
@@ -867,9 +923,6 @@ namespace geopm
             if (ze_host_result != ZE_RESULT_NOT_READY) {
                 metric_calc(l0_device_idx, l0_domain_idx,
                             m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx));
-            }
-            else {
-                metric_read(l0_device_idx, l0_domain_idx); //TODO: possible infinite loop
             }
         }
     }

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -9,6 +9,10 @@
 #include <map>
 #include <cstdlib>
 #include <utility>
+#include <thread>
+#include <mutex>
+#include <atomic>
+#include <chrono>
 
 #include "geopm/Exception.hpp"
 #include "geopm/Helper.hpp"
@@ -41,6 +45,8 @@ namespace geopm
     LevelZeroImp::LevelZeroImp()
         : m_num_gpu(0)
         , m_num_gpu_subdevice(0)
+        , m_metric_thread_active(false)
+        , m_metric_thread_started(false)
     {
         if (getenv("ZE_AFFINITY_MASK") != nullptr) {
             throw Exception("LevelZero: Cannot be used directly when ZE_AFFINITY_MASK environment "
@@ -229,6 +235,8 @@ namespace geopm
     }
 
     LevelZeroImp::~LevelZeroImp() {
+        // Stop the background sampling thread before tearing down streamers.
+        metric_thread_stop();
         for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
             for (unsigned int subdevice_idx = 0;
              subdevice_idx < m_devices.at(gpu_idx).num_subdevice;
@@ -604,6 +612,8 @@ namespace geopm
             m_devices.at(device_idx).metric_sampling_period_ns = SAMPLING_PERIOD_NS;
 
             m_devices.at(device_idx).subdevice.metric_data.push_back({});
+            m_devices.at(device_idx).subdevice.metric_data_accum.push_back({});
+            m_devices.at(device_idx).subdevice.metric_active.push_back(false);
 
             for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
                  metric_group_idx++) {
@@ -811,21 +821,20 @@ namespace geopm
         }
 
         // Use the cached name→index map to avoid calling zetMetricGet and
-        // zetMetricGetProperties on every sample iteration.
+        // zetMetricGetProperties on every sample iteration.  The report values
+        // are appended to the accumulator under lock; the controller snapshots
+        // (moves) the accumulator into metric_data once per read_batch().
         const auto &name_idx = m_devices.at(l0_device_idx).subdevice.metric_name_idx.at(l0_domain_idx);
+        std::lock_guard<std::mutex> lock(m_metric_mutex);
+        auto &accum = m_devices.at(l0_device_idx).subdevice.metric_data_accum.at(l0_domain_idx);
         for (const auto &kv : name_idx) {
             const std::string &metric_name = kv.first;
             size_t metric_idx = kv.second;
 
-            // Clear cached values and update num_reports on first metric
-            m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name) = {};
-            m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
-            m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
-
+            std::vector<double> &values = accum[metric_name];
             for (unsigned int report_idx = 0; report_idx < num_reports; report_idx++) {
                 zet_typed_value_t data = metric_values.at(report_idx * num_metric + metric_idx);
-                double data_double = metric_data_convert(data);
-                m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
+                values.push_back(metric_data_convert(data));
             }
         }
     }
@@ -857,60 +866,134 @@ namespace geopm
 
     void LevelZeroImp::metric_read(unsigned int l0_device_idx, unsigned int l0_domain_idx)
     {
-        if (m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
-            if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
-                metric_execute(l0_device_idx, l0_domain_idx);
-                m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
+        if (!m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
+            return;
+        }
+
+        // Snapshot the reports accumulated by the background thread since the
+        // last read_batch() into metric_data, marking the chip active so the
+        // thread drains it.  metric_data therefore holds every report gathered
+        // over the controller period (averaged later by metric_sample).
+        const auto &name_idx = m_devices.at(l0_device_idx).subdevice.metric_name_idx.at(l0_domain_idx);
+        {
+            std::lock_guard<std::mutex> lock(m_metric_mutex);
+            m_devices.at(l0_device_idx).subdevice.metric_active.at(l0_domain_idx) = true;
+
+            auto &accum = m_devices.at(l0_device_idx).subdevice.metric_data_accum.at(l0_domain_idx);
+            auto &current = m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx);
+            size_t num_reports = 0;
+            for (const auto &kv : name_idx) {
+                const std::string &metric_name = kv.first;
+                current[metric_name] = std::move(accum[metric_name]);
+                accum[metric_name].clear();
+                num_reports = current[metric_name].size();
             }
+            current["NUM_REPORTS"] = std::vector<double>{ static_cast<double>(num_reports) };
+        }
 
-            ze_result_t ze_result;
-            uint32_t report_count_req = 1;
-            zet_metric_streamer_handle_t metric_streamer = m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
+        // Launch the background sampling thread on first use.
+        metric_thread_start();
+    }
 
-            ///////////////////
-            // Read Raw Data //
-            ///////////////////
-            // Always read with full buffer to drain the FIFO completely
-            size_t read_size = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).size();
-            ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req,
-                                                  &read_size,
-                                                  m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data());
+    void LevelZeroImp::metric_thread_start(void)
+    {
+        // Called only from the controller thread (metric_read), so the started
+        // flag need not be atomic.
+        if (!m_metric_thread_started) {
+            m_metric_thread_started = true;
+            m_metric_thread_active.store(true);
+            m_metric_thread = std::thread(&LevelZeroImp::metric_sample_thread, this);
+        }
+    }
 
-            // Skip when no data is available
-            if (ze_result != ZE_RESULT_NOT_READY && read_size > 0) {
-                check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                "LevelZero::" + std::string(__func__) +
-                                ": LevelZero Read Data failed",
-                                __LINE__);
+    void LevelZeroImp::metric_thread_stop(void)
+    {
+        if (m_metric_thread_active.exchange(false)) {
+            if (m_metric_thread.joinable()) {
+                m_metric_thread.join();
+            }
+        }
+    }
 
-                // Learn per-report byte size from first successful read
-                size_t &report_byte_size = m_devices.at(l0_device_idx).subdevice.report_byte_size.at(l0_domain_idx);
-                if (report_byte_size == 0) {
-                    uint32_t tmp_num_values = 0;
-                    zet_metric_group_calculation_type_t tmp_calc_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
-                    zetMetricGroupCalculateMetricValues(
-                        m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx),
-                        tmp_calc_type, read_size,
-                        m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data(),
-                        &tmp_num_values, nullptr);
-                    uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
-                    size_t first_num_reports = (num_metric > 0) ? tmp_num_values / num_metric : 1;
-                    if (first_num_reports > 0) {
-                        report_byte_size = read_size / first_num_reports;
+    void LevelZeroImp::metric_sample_thread(void)
+    {
+        while (m_metric_thread_active.load()) {
+            for (unsigned int l0_device_idx = 0; l0_device_idx < m_num_gpu; ++l0_device_idx) {
+                unsigned int num_subdevice = m_devices.at(l0_device_idx).num_subdevice;
+                for (unsigned int l0_domain_idx = 0; l0_domain_idx < num_subdevice; ++l0_domain_idx) {
+                    bool active;
+                    {
+                        std::lock_guard<std::mutex> lock(m_metric_mutex);
+                        active = m_devices.at(l0_device_idx).subdevice.metric_active.at(l0_domain_idx);
                     }
-                }
+                    if (!active ||
+                        !m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx)) {
+                        continue;
+                    }
 
-                // Only process the most recent DEFAULT_MAX_REPORTS_PER_READ reports
-                size_t process_size = read_size;
-                const uint8_t *process_data = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data();
-                if (report_byte_size > 0 && read_size > report_byte_size * DEFAULT_MAX_REPORTS_PER_READ) {
-                    process_size = report_byte_size * DEFAULT_MAX_REPORTS_PER_READ;
-                    process_data = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data()
-                                   + (read_size - process_size);
-                }
+                    // Open the streamer on first use (thread owns the streamers).
+                    if (!m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx)) {
+                        metric_execute(l0_device_idx, l0_domain_idx);
+                        m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) = true;
+                    }
 
-                metric_calc(l0_device_idx, l0_domain_idx, process_size, process_data);
+                    metric_drain(l0_device_idx, l0_domain_idx);
+                }
             }
+            std::this_thread::sleep_for(std::chrono::microseconds(METRIC_DRAIN_PERIOD_US));
+        }
+    }
+
+    void LevelZeroImp::metric_drain(unsigned int l0_device_idx, unsigned int l0_domain_idx)
+    {
+        ze_result_t ze_result;
+        uint32_t report_count_req = 1;
+        zet_metric_streamer_handle_t metric_streamer =
+            m_devices.at(l0_device_idx).subdevice.metric_streamer.at(l0_domain_idx);
+
+        ///////////////////
+        // Read Raw Data //
+        ///////////////////
+        // Always read with full buffer to drain the FIFO completely
+        size_t read_size = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).size();
+        ze_result = zetMetricStreamerReadData(metric_streamer, report_count_req,
+                                              &read_size,
+                                              m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data());
+
+        // Skip when no data is available
+        if (ze_result != ZE_RESULT_NOT_READY && read_size > 0) {
+            check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                            "LevelZero::" + std::string(__func__) +
+                            ": LevelZero Read Data failed",
+                            __LINE__);
+
+            // Learn per-report byte size from first successful read
+            size_t &report_byte_size = m_devices.at(l0_device_idx).subdevice.report_byte_size.at(l0_domain_idx);
+            if (report_byte_size == 0) {
+                uint32_t tmp_num_values = 0;
+                zet_metric_group_calculation_type_t tmp_calc_type = ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
+                zetMetricGroupCalculateMetricValues(
+                    m_devices.at(l0_device_idx).subdevice.metric_group_handle.at(l0_domain_idx),
+                    tmp_calc_type, read_size,
+                    m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data(),
+                    &tmp_num_values, nullptr);
+                uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
+                size_t first_num_reports = (num_metric > 0) ? tmp_num_values / num_metric : 1;
+                if (first_num_reports > 0) {
+                    report_byte_size = read_size / first_num_reports;
+                }
+            }
+
+            // Only process the most recent DEFAULT_MAX_REPORTS_PER_READ reports
+            size_t process_size = read_size;
+            const uint8_t *process_data = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data();
+            if (report_byte_size > 0 && read_size > report_byte_size * DEFAULT_MAX_REPORTS_PER_READ) {
+                process_size = report_byte_size * DEFAULT_MAX_REPORTS_PER_READ;
+                process_data = m_devices.at(l0_device_idx).subdevice.zet_data.at(l0_domain_idx).data()
+                               + (read_size - process_size);
+            }
+
+            metric_calc(l0_device_idx, l0_domain_idx, process_size, process_data);
         }
     }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -4,7 +4,6 @@
  */
 
 
-#include <unistd.h>
 #include <string>
 #include <iostream>
 #include <map>
@@ -12,8 +11,6 @@
 #include <utility>
 
 #include "geopm/Exception.hpp"
-#include "geopm/Agg.hpp"
-#include "geopm/Helper.hpp"
 #include "geopm_debug.hpp"
 
 #include "LevelZeroImp.hpp"
@@ -138,18 +135,22 @@ namespace geopm
                         }
 
                         // We create a context to support the ZET commands
-                        ze_context_desc_t context_desc = {
-                           ZE_STRUCTURE_TYPE_CONTEXT_DESC,
-                           nullptr,
-                           0
-                        };
-                        ze_context_handle_t context = nullptr;
-                        ze_result_t ze_result = zeContextCreate(m_levelzero_driver.at(driver),
-                                                    &context_desc, &context);
-                        check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
-                                        "LevelZero::" + std::string(__func__) +
-                                        ": LevelZero context creation failed",
-                                        __LINE__);
+                        // NOTE: a context is being created per subdevice, making this context
+                        // unnecessary. Commenting out for now.
+                        // TODO: Explore replacing per-subdevice contexts with a single context
+                        // (per-device or globally)
+                        // ze_context_desc_t context_desc = {
+                        //    ZE_STRUCTURE_TYPE_CONTEXT_DESC,
+                        //    nullptr,
+                        //    0
+                        // };
+                        // ze_context_handle_t context = nullptr;
+                        // ze_result_t ze_result = zeContextCreate(m_levelzero_driver.at(driver),
+                        //                             &context_desc, &context);
+                        // check_ze_result(ze_result, GEOPM_ERROR_RUNTIME,
+                        //                 "LevelZero::" + std::string(__func__) +
+                        //                 ": LevelZero context creation failed",
+                        //                 __LINE__);
 
                         m_devices.push_back({
                             m_levelzero_driver.at(driver),
@@ -724,6 +725,7 @@ namespace geopm
                             "LevelZero::" + std::string(__func__) +
                             ": LevelZero Metric Context Deactivation failed",
                             __LINE__);
+            zeContextDestroy(context);
         }
     }
 
@@ -766,7 +768,7 @@ namespace geopm
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,
-            4, // number of reports to notify on.  Targeting 4 reports, 1 per millisecond as that will, generally, 
+            4, // number of reports to notify on.  Targeting 4 reports, 1 per millisecond as that will, generally,
                 // fall within the 5ms control loop and is a good tradeoff in terms of overhead vs visibility within the sampling period.
             m_devices.at(l0_device_idx).metric_sampling_period_ns};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
@@ -971,7 +973,7 @@ namespace geopm
     void LevelZeroImp::ras_domain_cache(unsigned int device_idx)
     {
         uint32_t ras_handle_count = 0;
-        uint32_t num_subdevice = m_devices.at(device_idx).m_num_subdevice;
+        uint32_t num_subdevice = m_devices.at(device_idx).num_subdevice;
         // Find number of RAS error sets for the GPU
         uint32_t num_errset = 0;
         ze_result_t ze_result = zesDeviceEnumRasErrorSets(m_devices.at(device_idx).device_handle,
@@ -991,8 +993,8 @@ namespace geopm
                             GEOPM_ERROR_RUNTIME, "LevelZero::" + std::string(__func__) +
                             ": Sysman failed to get errorset handle(s).", __LINE__);
 
-	    // Note: RAS domain errorset handles are being stored in a 2D vector with
-	    //       dimensions := (number of subdevices) x (number of RAS error types)
+	        // Note: RAS domain errorset handles are being stored in a 2D vector with
+	        //       dimensions := (number of subdevices) x (number of RAS error types)
 
             // Allocate size for a 2D vector to store all the RAS domain handles for errorsets:
             //       m_num_subdevice = number of subdevices on specific GPU device

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -201,7 +201,7 @@ namespace geopm
             // If we have more than one device confirm all devices have the same
             // number of subdevices
             for (unsigned int idx = 1; idx < m_devices.size(); ++idx) {
-                if (m_devices.at(idx).m_num_subdevice != m_devices.at(idx - 1).m_num_subdevice) {
+                if (m_devices.at(idx).num_subdevice != m_devices.at(idx - 1).num_subdevice) {
                     throw Exception("LevelZero::" + std::string(__func__) +
                                     ": GEOPM Requires the number of subdevices to be" +
                                     " the same on all devices. " +
@@ -227,7 +227,7 @@ namespace geopm
     LevelZeroImp::~LevelZeroImp() {
         for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; gpu_idx++) {
             for (int subdevice_idx = 0;
-             subdevice_idx < m_devices.at(gpu_idx).m_num_subdevice;
+             subdevice_idx < m_devices.at(gpu_idx).num_subdevice;
              ++subdevice_idx) {
                 metric_destroy(gpu_idx, subdevice_idx);
             }
@@ -265,7 +265,7 @@ namespace geopm
                                 GEOPM_ERROR_RUNTIME, "LevelZero::" + std::string(__func__) +
                                 ": Sysman failed to get domain properties.", __LINE__);
 
-                if (property.onSubdevice == 0 && m_devices.at(device_idx).m_num_subdevice != 0) {
+                if (property.onSubdevice == 0 && m_devices.at(device_idx).num_subdevice != 0) {
 #ifdef GEOPM_DEBUG
                     std::cerr << "Warning: <geopm> LevelZero: A device level "
                               << "frequency domain was found but is not currently supported.\n";
@@ -341,12 +341,12 @@ namespace geopm
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
 
-            if (num_subdevice_power_domain > m_devices.at(device_idx).m_num_subdevice) {
+            if (num_subdevice_power_domain > m_devices.at(device_idx).num_subdevice) {
                 throw Exception("LevelZero::" + std::string(__func__) +
                                 ": Number of subdevice power domains (" +
                                 std::to_string(num_device_power_domain) +
                                 ") exceeds the number of subdevices (" +
-                                std::to_string(m_devices.at(device_idx).m_num_subdevice) + ").",
+                                std::to_string(m_devices.at(device_idx).num_subdevice) + ").",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
 
@@ -440,7 +440,7 @@ namespace geopm
                                 GEOPM_ERROR_RUNTIME, "LevelZero::" + std::string(__func__) +
                                 ": Sysman failed to get domain engine properties", __LINE__);
 
-                if (property.onSubdevice == 0 && m_devices.at(device_idx).m_num_subdevice != 0) {
+                if (property.onSubdevice == 0 && m_devices.at(device_idx).num_subdevice != 0) {
 #ifdef GEOPM_DEBUG
                     std::cerr << "Warning: <geopm> LevelZero: A device level "
                               << "engine domain was found but is not currently supported.\n";
@@ -553,7 +553,7 @@ namespace geopm
     //      - data storage for the ComputeBasics metric group
     void LevelZeroImp::metric_group_init(unsigned int device_idx) {
         for (int subdevice_idx = 0;
-             subdevice_idx < m_devices.at(device_idx).m_num_subdevice;
+             subdevice_idx < m_devices.at(device_idx).num_subdevice;
              ++subdevice_idx) {
             // Setup tracking of the caching and initialization steps
             m_devices.at(device_idx).subdevice.metric_domain_cached.push_back(false);
@@ -599,7 +599,7 @@ namespace geopm
             // set metric_notifcation_event sampling period in nanoseconds
             m_devices.at(device_idx).metric_sampling_period_ns =   1000000;
 
-            m_devices.at(device_idx).subdevice.m_metric_data.push_back({});
+            m_devices.at(device_idx).subdevice.metric_data.push_back({});
 
             for (unsigned int metric_group_idx = 0; metric_group_idx < num_metric_group;
                  metric_group_idx++) {
@@ -657,15 +657,15 @@ namespace geopm
 
                        //m_devices is a std::vector of structs, indexed by GPU
                        // subdevice is a struct inside of it.  One per GPU
-                       //  m_metric_data is a vector, indexed by CHIP
+                       //  metric_data is a vector, indexed by CHIP
                        //    it contains a map of metric name (string) -> report data for N reports (vector<double>)
-                       if (m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx).count(metric_name) != 0) {
+                       if (m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx).count(metric_name) != 0) {
                            throw Exception("LevelZero::" + std::string(__func__) +
                                            ": Metric group has two metrics with the same name",
                                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
                        }
-                       m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)[metric_name] = {};
-                       m_devices.at(device_idx).subdevice.m_metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
+                       m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)[metric_name] = {};
+                       m_devices.at(device_idx).subdevice.metric_data.at(subdevice_idx)["NUM_REPORTS"] = {};
                    }
                    // Break out of loop once we've found the group of interest
                    break;
@@ -680,12 +680,12 @@ namespace geopm
         GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metric_domain_cached.at(l0_domain_idx) == true,
                            "metric caching for GPU " + std::to_string(l0_device_idx) +
                            ", CHIP " + std::to_string(l0_domain_idx) +
-                           " not completed prior to metric_calc call.");
+                           " not completed prior to metric_destroy call.");
 
         GEOPM_DEBUG_ASSERT(m_devices.at(l0_device_idx).subdevice.metrics_initialized.at(l0_domain_idx) == true,
                            "metric initialization for GPU " + std::to_string(l0_device_idx) +
                            ", CHIP " + std::to_string(l0_domain_idx) +
-                           " not completed prior to metric_calc call.");
+                           " not completed prior to metric_destroy call.");
 
         ze_result_t ze_result;
 
@@ -815,6 +815,19 @@ namespace geopm
 
         uint32_t num_metric = m_devices.at(l0_device_idx).subdevice.num_metric.at(l0_domain_idx);
         unsigned int num_reports = num_metric_values / num_metric;
+
+        // If num_metric_values is not evenly divisble by num_metrics
+        // skip the metric and report processing for this sample
+        if (num_metric_values % num_metric != 0) {
+#ifdef GEOPM_DEBUG
+            std::cerr << "LevelZero::" << std::string(__func__)  <<
+                         ": ZET metric_calc call retunred a number of metric values "
+                         "that is not evenly divisible by the number of metrics.  This "
+                         "may indicate a ZET report erroor, skipping data processing." << std::endl;
+#endif
+            num_metric = 0;
+        }
+
         for (unsigned int metric_idx = 0; metric_idx < num_metric; metric_idx++)
         {
             //TODO: It is possible that simply parsing all the metrics is
@@ -849,13 +862,13 @@ namespace geopm
 
                     if (report_idx == 0) {
                         // Clear cached values
-                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name) = {};
-                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
+                        m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name) = {};
+                        m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx)["NUM_REPORTS"] = {};
 
                         // Update num_reports
-                        m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
+                        m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx)["NUM_REPORTS"].push_back(num_reports);
                     }
-                    m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
+                    m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name).push_back(data_double);
                 }
             }
         }
@@ -942,12 +955,12 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).count(metric_name) == 0) {
+        if (m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).count(metric_name) == 0) {
             throw Exception("LevelZero::" + std::string(__func__) +
                             ": No metric named " + metric_name  + " found." ,
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
-        result = m_devices.at(l0_device_idx).subdevice.m_metric_data.at(l0_domain_idx).at(metric_name);
+        result = m_devices.at(l0_device_idx).subdevice.metric_data.at(l0_domain_idx).at(metric_name);
         return result;
     }
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -729,7 +729,7 @@ namespace geopm
         zet_metric_streamer_desc_t metric_streamer_desc = {
             ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC,
             nullptr,
-            NOTIFY_EVERY_N_REPORTS, // number of reports to notify on.
+            0, // notifyEveryNReports: unused (no event handle registered)
             m_devices.at(l0_device_idx).metric_sampling_period_ns};
         zet_metric_streamer_handle_t metric_streamer = nullptr;
 

--- a/libgeopmd/src/LevelZero.cpp
+++ b/libgeopmd/src/LevelZero.cpp
@@ -161,6 +161,7 @@ namespace geopm
                             0, //num_device_power_domain
                             {}, //power domain
                             0, // cached_energy_timestamp
+                            0, // metric_sampling_period_ns
                         });
                     }
 #ifdef GEOPM_DEBUG
@@ -227,7 +228,7 @@ namespace geopm
 
     LevelZeroImp::~LevelZeroImp() {
         for (unsigned int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
-            for (int subdevice_idx = 0;
+            for (unsigned int subdevice_idx = 0;
              subdevice_idx < m_devices.at(gpu_idx).num_subdevice;
              ++subdevice_idx) {
                 metric_destroy(gpu_idx, subdevice_idx);
@@ -553,7 +554,7 @@ namespace geopm
     //      - sampling period
     //      - data storage for the ComputeBasics metric group
     void LevelZeroImp::metric_group_init(unsigned int device_idx) {
-        for (int subdevice_idx = 0;
+        for (unsigned int subdevice_idx = 0;
              subdevice_idx < m_devices.at(device_idx).num_subdevice;
              ++subdevice_idx) {
             // Setup tracking of the caching and initialization steps
@@ -1534,17 +1535,12 @@ namespace geopm
 
     uint32_t LevelZeroImp::metric_update_rate(unsigned int l0_device_idx) const
     {
-        return m_devices.at(l0_device_idx).metric_sampling_period;
+        return m_devices.at(l0_device_idx).metric_sampling_period_ns;
     }
 
     void LevelZeroImp::metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting)
     {
-        m_devices.at(l0_device_idx).metric_sampling_period = setting;
-    }
-
-    uint32_t LevelZeroImp::metric_update_rate(unsigned int l0_device_idx) const
-    {
-        return m_devices.at(l0_device_idx).metric_sampling_period_ns;
+        m_devices.at(l0_device_idx).metric_sampling_period_ns = setting;
     }
 
     void LevelZeroImp::check_ze_result(ze_result_t ze_result, int error,

--- a/libgeopmd/src/LevelZero.hpp
+++ b/libgeopmd/src/LevelZero.hpp
@@ -358,6 +358,7 @@ namespace geopm
                                                       unsigned int l0_domain_idx,
                                                       std::string metric_name) const = 0;
             virtual uint32_t metric_update_rate(unsigned int l0_device_idx) const = 0;
+            virtual void metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting) = 0;
 
             virtual void metric_read(unsigned int l0_device_idx,
                                      unsigned int l0_domain_idx) = 0;

--- a/libgeopmd/src/LevelZero.hpp
+++ b/libgeopmd/src/LevelZero.hpp
@@ -355,11 +355,16 @@ namespace geopm
 
             //Level Zero Tools/ZET
             virtual std::vector<double> metric_sample(unsigned int l0_device_idx,
+                                                      unsigned int l0_domain_idx,
                                                       std::string metric_name) const = 0;
             virtual uint32_t metric_update_rate(unsigned int l0_device_idx) const = 0;
-            virtual void metric_read(unsigned int l0_device_idx) = 0;
-            virtual void metric_init(unsigned int l0_device_idx) = 0;
-            virtual void metric_destroy(unsigned int l0_device_idx) = 0;
+
+            virtual void metric_read(unsigned int l0_device_idx,
+                                     unsigned int l0_domain_idx) = 0;
+            virtual void metric_init(unsigned int l0_device_idx,
+                                     unsigned int l0_domain_idx) = 0;
+            virtual void metric_destroy(unsigned int l0_device_idx,
+                                        unsigned int l0_domain_idx) = 0;
             virtual void metric_update_rate_control(unsigned int l0_device_idx,
                                                     uint32_t setting) = 0;
     };

--- a/libgeopmd/src/LevelZero.hpp
+++ b/libgeopmd/src/LevelZero.hpp
@@ -361,12 +361,6 @@ namespace geopm
 
             virtual void metric_read(unsigned int l0_device_idx,
                                      unsigned int l0_domain_idx) = 0;
-            virtual void metric_init(unsigned int l0_device_idx,
-                                     unsigned int l0_domain_idx) = 0;
-            virtual void metric_destroy(unsigned int l0_device_idx,
-                                        unsigned int l0_domain_idx) = 0;
-            virtual void metric_update_rate_control(unsigned int l0_device_idx,
-                                                    uint32_t setting) = 0;
     };
 
     LevelZero &levelzero();

--- a/libgeopmd/src/LevelZero.hpp
+++ b/libgeopmd/src/LevelZero.hpp
@@ -352,8 +352,18 @@ namespace geopm
             /// @return Display Error Count
             virtual double ras_display_errcount_uncorrectable(unsigned int l0_device_idx,
                                                 int l0_domain, int l0_domain_idx) const = 0;
+
+            //Level Zero Tools/ZET
+            virtual std::vector<double> metric_sample(unsigned int l0_device_idx,
+                                                      std::string metric_name) const = 0;
+            virtual uint32_t metric_update_rate(unsigned int l0_device_idx) const = 0;
+            virtual void metric_read(unsigned int l0_device_idx) = 0;
+            virtual void metric_init(unsigned int l0_device_idx) = 0;
+            virtual void metric_destroy(unsigned int l0_device_idx) = 0;
+            virtual void metric_update_rate_control(unsigned int l0_device_idx,
+                                                    uint32_t setting) = 0;
     };
 
-    const LevelZero &levelzero();
+    LevelZero &levelzero();
 }
 #endif

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -808,10 +808,12 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        if (domain_idx < 1) {
+            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
+            m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
+        }
     }
 
     double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
@@ -825,17 +827,19 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        if (domain_idx < 1) {
+            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
-                                                             dev_subdev_idx_pair.second,
-                                                             metric_name);
+            std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
+                                                                 dev_subdev_idx_pair.second,
+                                                                 metric_name);
 
-        if (data.size() > 0) {
-            //TODO: add min, max, avg etc handling.
-            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
-            //result = data.at(data.size()-1);
+            if (data.size() > 0) {
+                //TODO: add min, max, avg etc handling.
+                result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+                //result = data.at(data.size()-1);
+            }
         }
         return result;
     }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -849,6 +849,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
+        check_idx_range(GEOPM_DOMAIN_GPU, domain_idx);
         return m_levelzero.metric_update_rate(domain_idx);
     }
 }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -7,6 +7,13 @@
 #include <algorithm>
 #include <string>
 #include <cstdint>
+#include <numeric>
+
+//DELETEME
+#include <iostream>
+#include <chrono>
+#include <ctime>
+//DELETEME
 
 #include "geopm/Exception.hpp"
 #include "geopm/Agg.hpp"
@@ -17,13 +24,13 @@
 
 namespace geopm
 {
-    const LevelZeroDevicePool &levelzero_device_pool()
+    LevelZeroDevicePool &levelzero_device_pool()
     {
         static LevelZeroDevicePoolImp instance(levelzero());
         return instance;
     }
 
-    LevelZeroDevicePoolImp::LevelZeroDevicePoolImp(const LevelZero &levelzero)
+    LevelZeroDevicePoolImp::LevelZeroDevicePoolImp(LevelZero &levelzero)
         : m_levelzero(levelzero)
     {
     }
@@ -793,4 +800,85 @@ namespace geopm
     }
 
 
+    //TODO: consider adding 'group_name' parameter?
+    void LevelZeroDevicePoolImp::metric_read(int domain, unsigned int domain_idx) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for metrics.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        std::chrono::time_point<std::chrono::system_clock> start, end;
+        start = std::chrono::system_clock::now();
+
+        m_levelzero.metric_read(domain_idx);
+
+        end = std::chrono::system_clock::now();
+        std::chrono::duration<double> elapsed_seconds = end - start;
+        std::cout << "metric_read - gpu " << std::to_string(domain_idx) << " read time: " << elapsed_seconds.count() << "s" << std::endl;
+    }
+
+    double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
+                                                 std::string metric_name) const
+    {
+        double result = NAN;
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for metrics.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        //std::chrono::time_point<std::chrono::system_clock> start, end;
+
+        std::vector<double> data = m_levelzero.metric_sample(domain_idx, metric_name);
+
+        //std::cout << "Data size is: " << std::to_string(data.size()) << std::endl;
+        //start = std::chrono::system_clock::now();
+        if (data.size() > 0) {
+            //TODO: add min, max, avg etc handling.
+            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+            //result = data.at(data.size()-1);
+        }
+        //end = std::chrono::system_clock::now();
+        //elapsed_seconds = end - start;
+        //std::cout << "gpu " << std::to_string(domain_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
+
+        return result;
+    }
+
+    uint32_t LevelZeroDevicePoolImp::metric_update_rate(int domain, unsigned int domain_idx) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for metrics.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        return m_levelzero.metric_update_rate(domain_idx);
+    }
+
+//    void LevelZeroDevicePoolImp::metric_polling_disable()
+//    {
+//        unsigned int num_device = num_gpu(GEOPM_DOMAIN_GPU);
+//        for (unsigned int l0_device_idx = 0; l0_device_idx < num_device; l0_device_idx++) {
+//            m_levelzero.metric_destroy(l0_device_idx);
+//        }
+//    }
+
+    void LevelZeroDevicePoolImp::metric_update_rate_control(int domain, unsigned int domain_idx,
+                                                            uint32_t setting) const
+    {
+        if (domain != GEOPM_DOMAIN_GPU) {
+            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
+                            ": domain " + std::to_string(domain) +
+                            " is not supported for metrics.",
+                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+        }
+
+        m_levelzero.metric_update_rate_control(domain_idx, setting);
+    }
 }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -808,12 +808,10 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 2) {
-            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
-        }
+        m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
     }
 
     double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
@@ -827,19 +825,17 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 2) {
-            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
-                                                                 dev_subdev_idx_pair.second,
-                                                                 metric_name);
+        std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
+                                                             dev_subdev_idx_pair.second,
+                                                             metric_name);
 
-            if (data.size() > 0) {
-                //TODO: add min, max, avg etc handling.
-                result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
-                //result = data.at(data.size()-1);
-            }
+        if (data.size() > 0) {
+            //TODO: add min, max, avg etc handling.
+            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+            //result = data.at(data.size()-1);
         }
         return result;
     }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -835,7 +835,6 @@ namespace geopm
         if (data.size() > 0) {
             //TODO: add min, max, avg etc handling.
             result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
-            //result = data.at(data.size()-1);
         }
         return result;
     }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -803,37 +803,44 @@ namespace geopm
     //TODO: consider adding 'group_name' parameter?
     void LevelZeroDevicePoolImp::metric_read(int domain, unsigned int domain_idx) const
     {
-        if (domain != GEOPM_DOMAIN_GPU) {
+        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
             throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
                             ": domain " + std::to_string(domain) +
                             " is not supported for metrics.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::chrono::time_point<std::chrono::system_clock> start, end;
-        start = std::chrono::system_clock::now();
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        m_levelzero.metric_read(domain_idx);
+//        std::chrono::time_point<std::chrono::system_clock> start, end;
+//        start = std::chrono::system_clock::now();
 
-        end = std::chrono::system_clock::now();
-        std::chrono::duration<double> elapsed_seconds = end - start;
-        std::cout << "metric_read - gpu " << std::to_string(domain_idx) << " read time: " << elapsed_seconds.count() << "s" << std::endl;
+        m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
+
+//        end = std::chrono::system_clock::now();
+//        std::chrono::duration<double> elapsed_seconds = end - start;
+//        std::cout << "metric_read - gpu " << std::to_string(domain_idx) << " read time: " << elapsed_seconds.count() << "s" << std::endl;
     }
 
     double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
                                                  std::string metric_name) const
     {
         double result = NAN;
-        if (domain != GEOPM_DOMAIN_GPU) {
+        if (domain != GEOPM_DOMAIN_GPU_CHIP) {
             throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
                             ": domain " + std::to_string(domain) +
                             " is not supported for metrics.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
         //std::chrono::time_point<std::chrono::system_clock> start, end;
 
-        std::vector<double> data = m_levelzero.metric_sample(domain_idx, metric_name);
+        std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
+                                                             dev_subdev_idx_pair.second,
+                                                             metric_name);
 
         //std::cout << "Data size is: " << std::to_string(data.size()) << std::endl;
         //start = std::chrono::system_clock::now();

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -808,10 +808,12 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        if (domain_idx < 2) {
+            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
+            m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
+        }
     }
 
     double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
@@ -825,17 +827,19 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        if (domain_idx < 2) {
+            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-        std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
-                                                             dev_subdev_idx_pair.second,
-                                                             metric_name);
+            std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
+                                                                 dev_subdev_idx_pair.second,
+                                                                 metric_name);
 
-        if (data.size() > 0) {
-            //TODO: add min, max, avg etc handling.
-            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
-            //result = data.at(data.size()-1);
+            if (data.size() > 0) {
+                //TODO: add min, max, avg etc handling.
+                result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+                //result = data.at(data.size()-1);
+            }
         }
         return result;
     }
@@ -850,26 +854,5 @@ namespace geopm
         }
 
         return m_levelzero.metric_update_rate(domain_idx);
-    }
-
-//    void LevelZeroDevicePoolImp::metric_polling_disable()
-//    {
-//        unsigned int num_device = num_gpu(GEOPM_DOMAIN_GPU);
-//        for (unsigned int l0_device_idx = 0; l0_device_idx < num_device; l0_device_idx++) {
-//            m_levelzero.metric_destroy(l0_device_idx);
-//        }
-//    }
-
-    void LevelZeroDevicePoolImp::metric_update_rate_control(int domain, unsigned int domain_idx,
-                                                            uint32_t setting) const
-    {
-        if (domain != GEOPM_DOMAIN_GPU) {
-            throw Exception("LevelZeroDevicePool::" + std::string(__func__) +
-                            ": domain " + std::to_string(domain) +
-                            " is not supported for metrics.",
-                            GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-        }
-
-        m_levelzero.metric_update_rate_control(domain_idx, setting);
     }
 }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -9,10 +9,6 @@
 #include <cstdint>
 #include <numeric>
 
-//DELETEME
-#include <iostream>
-//DELETEME
-
 #include "geopm/Exception.hpp"
 #include "geopm/Agg.hpp"
 #include "geopm/Helper.hpp"

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -808,7 +808,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 2) {
+        if (domain_idx < 12) {
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
@@ -827,7 +827,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 2) {
+        if (domain_idx < 12) {
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -808,7 +808,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 1) {
+        if (domain_idx < 12) {
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
@@ -827,7 +827,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 1) {
+        if (domain_idx < 12) {
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -808,7 +808,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 12) {
+        if (domain_idx < 2) {
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
@@ -827,7 +827,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 12) {
+        if (domain_idx < 2) {
             std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
             dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -834,7 +834,7 @@ namespace geopm
 
         if (data.size() > 0) {
             //TODO: add min, max, avg etc handling.
-            result = std::reduce(data.begin(), data.end(), 0.0) / data.size();
+            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
             //result = data.at(data.size()-1);
         }
         return result;

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -834,7 +834,7 @@ namespace geopm
 
         if (data.size() > 0) {
             //TODO: add min, max, avg etc handling.
-            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+            result = std::reduce(data.begin(), data.end(), 0.0) / data.size();
             //result = data.at(data.size()-1);
         }
         return result;

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -808,12 +808,10 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 12) {
-            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
-        }
+        m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
     }
 
     double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
@@ -827,19 +825,17 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
 
-        if (domain_idx < 12) {
-            std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
-            dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
+        std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
+        dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-            std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
-                                                                 dev_subdev_idx_pair.second,
-                                                                 metric_name);
+        std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
+                                                             dev_subdev_idx_pair.second,
+                                                             metric_name);
 
-            if (data.size() > 0) {
-                //TODO: add min, max, avg etc handling.
-                result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
-                //result = data.at(data.size()-1);
-            }
+        if (data.size() > 0) {
+            //TODO: add min, max, avg etc handling.
+            result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+            //result = data.at(data.size()-1);
         }
         return result;
     }

--- a/libgeopmd/src/LevelZeroDevicePool.cpp
+++ b/libgeopmd/src/LevelZeroDevicePool.cpp
@@ -11,8 +11,6 @@
 
 //DELETEME
 #include <iostream>
-#include <chrono>
-#include <ctime>
 //DELETEME
 
 #include "geopm/Exception.hpp"
@@ -813,14 +811,7 @@ namespace geopm
         std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
         dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
 
-//        std::chrono::time_point<std::chrono::system_clock> start, end;
-//        start = std::chrono::system_clock::now();
-
         m_levelzero.metric_read(dev_subdev_idx_pair.first, dev_subdev_idx_pair.second);
-
-//        end = std::chrono::system_clock::now();
-//        std::chrono::duration<double> elapsed_seconds = end - start;
-//        std::cout << "metric_read - gpu " << std::to_string(domain_idx) << " read time: " << elapsed_seconds.count() << "s" << std::endl;
     }
 
     double LevelZeroDevicePoolImp::metric_sample(int domain, unsigned int domain_idx,
@@ -836,23 +827,16 @@ namespace geopm
 
         std::pair<unsigned int, unsigned int> dev_subdev_idx_pair;
         dev_subdev_idx_pair = subdevice_device_conversion(domain_idx);
-        //std::chrono::time_point<std::chrono::system_clock> start, end;
 
         std::vector<double> data = m_levelzero.metric_sample(dev_subdev_idx_pair.first,
                                                              dev_subdev_idx_pair.second,
                                                              metric_name);
 
-        //std::cout << "Data size is: " << std::to_string(data.size()) << std::endl;
-        //start = std::chrono::system_clock::now();
         if (data.size() > 0) {
             //TODO: add min, max, avg etc handling.
             result = std::accumulate(data.begin(), data.end(), 0.0) / data.size();
             //result = data.at(data.size()-1);
         }
-        //end = std::chrono::system_clock::now();
-        //elapsed_seconds = end - start;
-        //std::cout << "gpu " << std::to_string(domain_idx) << " process time: " << elapsed_seconds.count() << "s" << std::endl;
-
         return result;
     }
 

--- a/libgeopmd/src/LevelZeroDevicePool.hpp
+++ b/libgeopmd/src/LevelZeroDevicePool.hpp
@@ -312,9 +312,18 @@ namespace geopm
             /// @return Display Error Count
             virtual double ras_display_errcount_uncorrectable(int domain, unsigned int domain_idx,
                                                 int l0_domain) const = 0;
+
+            //ZET Metrics
+            virtual double metric_sample(int domain, unsigned int domain_idx,
+                                         std::string metric) const = 0;
+            virtual uint32_t metric_update_rate(int domain, unsigned int domain_idx) const = 0;
+            virtual void metric_read(int domain, unsigned int domain_idx) const = 0;
+//            virtual void metric_polling_disable(void) = 0;
+            virtual void metric_update_rate_control(int domain, unsigned int domain_idx,
+                                                    uint32_t setting) const = 0;
         private:
     };
 
-    const LevelZeroDevicePool &levelzero_device_pool();
+    LevelZeroDevicePool &levelzero_device_pool();
 }
 #endif

--- a/libgeopmd/src/LevelZeroDevicePool.hpp
+++ b/libgeopmd/src/LevelZeroDevicePool.hpp
@@ -318,9 +318,6 @@ namespace geopm
                                          std::string metric) const = 0;
             virtual uint32_t metric_update_rate(int domain, unsigned int domain_idx) const = 0;
             virtual void metric_read(int domain, unsigned int domain_idx) const = 0;
-//            virtual void metric_polling_disable(void) = 0;
-            virtual void metric_update_rate_control(int domain, unsigned int domain_idx,
-                                                    uint32_t setting) const = 0;
         private:
     };
 

--- a/libgeopmd/src/LevelZeroDevicePoolImp.hpp
+++ b/libgeopmd/src/LevelZeroDevicePoolImp.hpp
@@ -103,9 +103,6 @@ namespace geopm
             uint32_t metric_update_rate(int domain, unsigned int domain_idx) const override;
 
             void metric_read(int domain, unsigned int domain_idx) const override;
-//            void metric_polling_disable(void) override;
-            void metric_update_rate_control(int domain, unsigned int domain_idx,
-                                            uint32_t setting) const override;
 
         private:
             LevelZero &m_levelzero;

--- a/libgeopmd/src/LevelZeroDevicePoolImp.hpp
+++ b/libgeopmd/src/LevelZeroDevicePoolImp.hpp
@@ -21,7 +21,7 @@ namespace geopm
     {
         public:
             LevelZeroDevicePoolImp();
-            LevelZeroDevicePoolImp(const LevelZero &levelzero);
+            LevelZeroDevicePoolImp(LevelZero &levelzero);
             virtual ~LevelZeroDevicePoolImp() = default;
             int num_gpu(int domain_type) const override;
             double frequency_status(int domain, unsigned int domain_idx,
@@ -96,8 +96,19 @@ namespace geopm
                                       int l0_domain) const override;
             double ras_display_errcount_uncorrectable(int domain, unsigned int domain_idx,
                                         int l0_domain) const override;
+
+            //ZET Metrics
+            double metric_sample(int domain, unsigned int domain_idx,
+                                 std::string metric_name) const override;
+            uint32_t metric_update_rate(int domain, unsigned int domain_idx) const override;
+
+            void metric_read(int domain, unsigned int domain_idx) const override;
+//            void metric_polling_disable(void) override;
+            void metric_update_rate_control(int domain, unsigned int domain_idx,
+                                            uint32_t setting) const override;
+
         private:
-            const LevelZero &m_levelzero;
+            LevelZero &m_levelzero;
 
             void check_idx_range(int domain, unsigned int domain_idx) const;
             void check_domain_exists(int size, const char *func, int line) const;

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -913,8 +913,26 @@ namespace geopm
         catch (const geopm::Exception &ex) {
         }
 
+        // GEOPM signal availability is per name, so an unsupported chip disables
+        // a metric signal node-wide; note that decision under debug builds.
+        auto warn_metric_pruned = [](bool is_metric, const std::string &signal_name,
+                                     int domain_idx) {
+#ifdef GEOPM_DEBUG
+            if (is_metric && domain_idx != 0) {
+                std::cerr << "Warning: <geopm> LevelZeroIOGroup: disabling "
+                          << signal_name << " on all GPU chips because chip "
+                          << domain_idx << " does not support Level Zero metrics."
+                          << std::endl;
+            }
+#endif
+        };
+
         // populate signals for each domain
         for (auto &sv : m_signal_available) {
+            // Level Zero metric (ZET) initialization is per GPU chip, so a metric
+            // signal must be probed on every chip; other signals are homogeneous
+            // and represented by chip 0.
+            bool is_metric = sv.first.find(":METRIC:") != std::string::npos;
             std::vector<std::shared_ptr<Signal> > result;
             for (int domain_idx = 0;
                  domain_idx < m_platform_topo.num_domain(signal_domain_type(sv.first));
@@ -926,10 +944,12 @@ namespace geopm
                     }
                     // Skip the RAS counters because they are very slow
                     // (0.5 seconds to read each).
-                    // Note: only check signals on GPU zero.
-                    if (domain_idx == 0 && sv.first.find("_RAS_") == std::string::npos) {
+                    // Non-metric signals are homogeneous, so only chip 0 is
+                    // probed; metric signals are probed on every chip.
+                    if ((domain_idx == 0 || is_metric) && sv.first.find("_RAS_") == std::string::npos) {
                         double init_setting = sv.second.m_devpool_func(domain_idx);
                         if (init_setting == -1) {
+                            warn_metric_pruned(is_metric, sv.first, domain_idx);
                             unsupported_signal_names.push_back(sv.first);
                             break;
                         }
@@ -945,6 +965,7 @@ namespace geopm
                         ex.err_value() != GEOPM_ERROR_INVALID) {
                         throw;
                     }
+                    warn_metric_pruned(is_metric, sv.first, domain_idx);
                     unsupported_signal_names.push_back(sv.first);
                     break;
                 }

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1007,7 +1007,7 @@ namespace geopm
         register_signal_alias(M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR_CONTROL",
                               M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR");
 
-        // popluate tracking structure for L0 metrics
+        // populate tracking structure for L0 metrics
         for (int domain_idx = 0; domain_idx <
              m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
             m_metric_signal_pushed.push_back(false);

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -42,7 +42,7 @@ namespace geopm
 
     // Set up mapping between signal and control names and corresponding indices
     LevelZeroIOGroup::LevelZeroIOGroup(const PlatformTopo &platform_topo,
-                                       const LevelZeroDevicePool &device_pool,
+                                       LevelZeroDevicePool &device_pool,
                                        std::shared_ptr<SaveControl> save_control_test)
         : m_platform_topo(platform_topo)
         , m_levelzero_device_pool(device_pool)
@@ -764,8 +764,43 @@ namespace geopm
                                                    geopm::LevelZero::M_DOMAIN_ALL);
                                   },
                                   1
+                                  }},
+                              {M_NAME_PREFIX + "METRIC:XVE_ACTIVE", {
+                                  //TODO: pull from L0 metrics programatically
+                                  "Percentage of time in which at least one pipe is active in XVE",
+                                  GEOPM_DOMAIN_GPU, //TODO: GPU_CHIP is possible, this is a simplification
+                                  M_UNITS_NONE,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.metric_sample(
+                                                   GEOPM_DOMAIN_GPU,
+                                                   domain_idx,
+                                                   "XVE_ACTIVE");
+                                  },
+                                  .01
+                                  }},
+                              {M_NAME_PREFIX + "METRIC:XVE_STALL", {
+                                  //TODO: pull from L0 metrics programatically
+                                  "Percentage of time in which any threads are loaded but not even a single pipe is active in XVE",
+                                  GEOPM_DOMAIN_GPU, //TODO: GPU_CHIP is possible, this is a simplification
+                                  M_UNITS_NONE,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.metric_sample(
+                                                   GEOPM_DOMAIN_GPU,
+                                                   domain_idx,
+                                                   "XVE_STALL");
+                                  },
+                                  .01
                                   }}
-
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
                                     "Sets the minimum frequency request for the GPU Compute Hardware.",
@@ -933,6 +968,12 @@ namespace geopm
         // Used for control trimming and save/restore.  See man page for more info.
         register_signal_alias(M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR_CONTROL",
                               M_NAME_PREFIX + "GPU_CORE_PERFORMANCE_FACTOR");
+
+        // popluate tracking structure for L0 metrics
+        for (int domain_idx = 0; domain_idx <
+             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
+            m_metric_signal_pushed.push_back(false);
+        }
 
         // populate controls for each domain
         for (auto &sv : m_control_available) {
@@ -1118,6 +1159,15 @@ namespace geopm
         }
 
         int result = -1;
+        bool is_found = false;
+
+        if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
+            //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&
+            domain_type == GEOPM_DOMAIN_GPU) {
+
+            m_metric_signal_pushed.at(domain_idx) = true;
+        }
+
         // Guarantee base signal was pushed before any timestamp signals
         if (string_ends_with(signal_name, "_TIMESTAMP")) {
             std::string base_signal_name = signal_name.substr(
@@ -1221,6 +1271,13 @@ namespace geopm
                 m_signal_pushed[ii]->set_sample(m_signal_pushed[ii]->read());
             }
         }
+
+        for (int domain_idx = 0; domain_idx <
+             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
+            if (m_metric_signal_pushed.at(domain_idx)) {
+                m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU, domain_idx);
+            }
+        }
     }
 
     // Write all controls that have been pushed and adjusted
@@ -1322,6 +1379,17 @@ namespace geopm
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {
+
+            if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
+                //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&
+                domain_type == GEOPM_DOMAIN_GPU) {
+
+                for (int domain_idx = 0; domain_idx <
+                     m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
+                    m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU, domain_idx);
+                }
+            }
+
             result = (it->second.m_signals.at(domain_idx))->read();
         }
         else {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -816,7 +816,7 @@ namespace geopm
                                                    domain_idx,
                                                    "NUM_REPORTS");
                                   },
-                                  .01
+                                  1
                                   }},
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
@@ -1398,15 +1398,6 @@ namespace geopm
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {
-            if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
-                //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&
-                domain_type == GEOPM_DOMAIN_GPU_CHIP) {
-                for (int domain_idx = 0; domain_idx <
-                     m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
-                    m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU_CHIP, domain_idx);
-                }
-            }
-
             result = (it->second.m_signals.at(domain_idx))->read();
         }
         else {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -800,7 +800,24 @@ namespace geopm
                                                    "XVE_STALL");
                                   },
                                   .01
-                                  }}
+                                  }},
+                              {M_NAME_PREFIX + "METRIC:NUM_REPORTS", {
+                                  //TODO: pull from L0 metrics programmatically
+                                  "Number of Level Zero Tools reports processed this sample",
+                                  GEOPM_DOMAIN_GPU_CHIP,
+                                  Agg::average,
+                                  IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
+                                  string_format_double,
+                                  {},
+                                  [this](unsigned int domain_idx) -> double
+                                  {
+                                      return this->m_levelzero_device_pool.metric_sample(
+                                                   GEOPM_DOMAIN_GPU_CHIP,
+                                                   domain_idx,
+                                                   "NUM_REPORTS");
+                                  },
+                                  .01
+                                  }},
                              })
         , m_control_available({{M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL", {
                                     "Sets the minimum frequency request for the GPU Compute Hardware.",

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1176,7 +1176,6 @@ namespace geopm
         }
 
         int result = -1;
-        bool is_found = false;
 
         if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
             //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1397,13 +1397,11 @@ namespace geopm
 
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
-        if (it != m_signal_available.end()) {
-            if (signal_name.find(":METRIC:") != std::string::npos) {
-                throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
-                                ": " + signal_name + " only supports batch access.",
-                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
-            }
-
+        if (it != m_signal_available.end()
+            && signal_name.find(":METRIC:") == std::string::npos) {
+            // PlatformIO will try and read a METRIC signal in some instances before
+            // allowing a push_signal & read batch to occur, so we can't just error
+            // on METRIC signals.  We can skip them though.
             result = (it->second.m_signals.at(domain_idx))->read();
         }
         else {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1280,6 +1280,9 @@ namespace geopm
     {
         m_is_batch_read = true;
 
+        // Snapshot the metrics gathered by the background sampling thread for
+        // each pushed chip (draining happens continuously in that thread,
+        // independent of this controller loop).
         for (int domain_idx = 0; domain_idx <
              m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
             if (m_metric_signal_pushed.at(domain_idx)) {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1398,6 +1398,12 @@ namespace geopm
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {
+            if (signal_name.find(":METRIC:") != std::string::npos) {
+                throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
+                                ":l " + signal_name + " only supports batch access.",
+                                GEOPM_ERROR_INVALID, __FILE__, __LINE__);
+            }
+
             result = (it->second.m_signals.at(domain_idx))->read();
         }
         else {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -766,9 +766,9 @@ namespace geopm
                                   1
                                   }},
                               {M_NAME_PREFIX + "METRIC:XVE_ACTIVE", {
-                                  //TODO: pull from L0 metrics programatically
+                                  //TODO: pull from L0 metrics programmatically
                                   "Percentage of time in which at least one pipe is active in XVE",
-                                  GEOPM_DOMAIN_GPU, //TODO: GPU_CHIP is possible, this is a simplification
+                                  GEOPM_DOMAIN_GPU_CHIP,
                                   M_UNITS_NONE,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -777,16 +777,16 @@ namespace geopm
                                   [this](unsigned int domain_idx) -> double
                                   {
                                       return this->m_levelzero_device_pool.metric_sample(
-                                                   GEOPM_DOMAIN_GPU,
+                                                   GEOPM_DOMAIN_GPU_CHIP,
                                                    domain_idx,
                                                    "XVE_ACTIVE");
                                   },
                                   .01
                                   }},
                               {M_NAME_PREFIX + "METRIC:XVE_STALL", {
-                                  //TODO: pull from L0 metrics programatically
+                                  //TODO: pull from L0 metrics programmatically
                                   "Percentage of time in which any threads are loaded but not even a single pipe is active in XVE",
-                                  GEOPM_DOMAIN_GPU, //TODO: GPU_CHIP is possible, this is a simplification
+                                  GEOPM_DOMAIN_GPU_CHIP,
                                   M_UNITS_NONE,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
@@ -795,7 +795,7 @@ namespace geopm
                                   [this](unsigned int domain_idx) -> double
                                   {
                                       return this->m_levelzero_device_pool.metric_sample(
-                                                   GEOPM_DOMAIN_GPU,
+                                                   GEOPM_DOMAIN_GPU_CHIP,
                                                    domain_idx,
                                                    "XVE_STALL");
                                   },
@@ -971,7 +971,7 @@ namespace geopm
 
         // popluate tracking structure for L0 metrics
         for (int domain_idx = 0; domain_idx <
-             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
+             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
             m_metric_signal_pushed.push_back(false);
         }
 
@@ -1163,7 +1163,7 @@ namespace geopm
 
         if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
             //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&
-            domain_type == GEOPM_DOMAIN_GPU) {
+            domain_type == GEOPM_DOMAIN_GPU_CHIP) {
 
             m_metric_signal_pushed.at(domain_idx) = true;
         }
@@ -1263,19 +1263,21 @@ namespace geopm
     void LevelZeroIOGroup::read_batch(void)
     {
         m_is_batch_read = true;
+
+        // Consider doing this first vs second
+        for (int domain_idx = 0; domain_idx <
+             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
+            if (m_metric_signal_pushed.at(domain_idx)) {
+                m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU_CHIP, domain_idx);
+            }
+        }
+
         for (size_t ii = 0; ii < m_signal_pushed.size(); ++ii) {
             // If the current signal index (ii) is in the derivative_signal_pushed_set do not read().
             // Derivative signals are comprised of base signals, and thus cannot be read directly.
             // The base signals are automatically pushed when a derivative signal is requested.
             if (m_derivative_signal_pushed_set.find(ii) == m_derivative_signal_pushed_set.end()) {
                 m_signal_pushed[ii]->set_sample(m_signal_pushed[ii]->read());
-            }
-        }
-
-        for (int domain_idx = 0; domain_idx <
-             m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
-            if (m_metric_signal_pushed.at(domain_idx)) {
-                m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU, domain_idx);
             }
         }
     }
@@ -1379,14 +1381,12 @@ namespace geopm
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {
-
             if ((signal_name.find(":METRIC:") != std::string::npos ) && //||
                 //m_metric_alias_set.find(signal_name) != m_metric_alias_set.end()) &&
-                domain_type == GEOPM_DOMAIN_GPU) {
-
+                domain_type == GEOPM_DOMAIN_GPU_CHIP) {
                 for (int domain_idx = 0; domain_idx <
-                     m_platform_topo.num_domain(GEOPM_DOMAIN_GPU); ++domain_idx) {
-                    m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU, domain_idx);
+                     m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
+                    m_levelzero_device_pool.metric_read(GEOPM_DOMAIN_GPU_CHIP, domain_idx);
                 }
             }
 

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1281,7 +1281,6 @@ namespace geopm
     {
         m_is_batch_read = true;
 
-        // Consider doing this first vs second
         for (int domain_idx = 0; domain_idx <
              m_platform_topo.num_domain(GEOPM_DOMAIN_GPU_CHIP); ++domain_idx) {
             if (m_metric_signal_pushed.at(domain_idx)) {
@@ -1395,6 +1394,7 @@ namespace geopm
         if (string_ends_with(signal_name, "_TIMESTAMP")) {
             return NAN;
         }
+
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
         if (it != m_signal_available.end()) {

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -805,6 +805,7 @@ namespace geopm
                                   //TODO: pull from L0 metrics programmatically
                                   "Number of Level Zero Tools reports processed this sample",
                                   GEOPM_DOMAIN_GPU_CHIP,
+                                  M_UNITS_NONE,
                                   Agg::average,
                                   IOGroup::M_SIGNAL_BEHAVIOR_VARIABLE,
                                   string_format_double,
@@ -910,14 +911,14 @@ namespace geopm
             m_is_perf_factor_enabled = true;
         }
         catch (const geopm::Exception &ex) {
-
         }
 
         // populate signals for each domain
         for (auto &sv : m_signal_available) {
             std::vector<std::shared_ptr<Signal> > result;
-            for (int domain_idx = 0; domain_idx < m_platform_topo.num_domain(
-                                     signal_domain_type(sv.first)); ++domain_idx) {
+            for (int domain_idx = 0;
+                 domain_idx < m_platform_topo.num_domain(signal_domain_type(sv.first));
+                 ++domain_idx) {
                 try {
                     if (sv.first.find("_PERFORMANCE_") != std::string::npos && !m_is_perf_factor_enabled) {
                         unsupported_signal_names.push_back(sv.first);
@@ -957,7 +958,6 @@ namespace geopm
         }
 
         register_derivative_signals();
-
 
         register_signal_alias("GPU_CORE_FREQUENCY_STATUS", M_NAME_PREFIX + "GPU_CORE_FREQUENCY_STATUS");
         register_signal_alias("GPU_ENERGY", M_NAME_PREFIX + "GPU_ENERGY");
@@ -1440,7 +1440,7 @@ namespace geopm
         }
 
         if (control_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL" ||
-           control_name == "GPU_CORE_FREQUENCY_MIN_CONTROL") {
+            control_name == "GPU_CORE_FREQUENCY_MIN_CONTROL") {
             double curr_max = read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL",
                                           domain_type, domain_idx);
             m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
@@ -1448,7 +1448,7 @@ namespace geopm
                                                       setting / 1e6, curr_max / 1e6);
         }
         else if (control_name == M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MAX_CONTROL" ||
-                control_name == "GPU_CORE_FREQUENCY_MAX_CONTROL") {
+                 control_name == "GPU_CORE_FREQUENCY_MAX_CONTROL") {
             double curr_min = read_signal(M_NAME_PREFIX + "GPU_CORE_FREQUENCY_MIN_CONTROL",
                                           domain_type, domain_idx);
             m_levelzero_device_pool.frequency_control(domain_type, domain_idx,
@@ -1682,7 +1682,7 @@ namespace geopm
     {
         if (m_control_available.find(alias_name) != m_control_available.end()) {
             throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
-                            ": contro1_name " + alias_name +
+                            ": control_name " + alias_name +
                             " was previously registered.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1397,12 +1397,13 @@ namespace geopm
 
         double result = NAN;
         auto it = m_signal_available.find(signal_name);
-        if (it != m_signal_available.end()
-            && signal_name.find(":METRIC:") == std::string::npos) {
-            // PlatformIO will try and read a METRIC signal in some instances before
-            // allowing a push_signal & read batch to occur, so we can't just error
-            // on METRIC signals.  We can skip them though.
-            result = (it->second.m_signals.at(domain_idx))->read();
+        if (it != m_signal_available.end()) {
+            if (signal_name.find(":METRIC:") == std::string::npos) {
+                // PlatformIO will try and read a METRIC signal in some instances before
+                // allowing a push_signal & read batch to occur, so we can't just error
+                // on METRIC signals.  We can skip them though.
+                result = (it->second.m_signals.at(domain_idx))->read();
+            } // else: skip "METRIC" signals for now
         }
         else {
     #ifdef GEOPM_DEBUG

--- a/libgeopmd/src/LevelZeroIOGroup.cpp
+++ b/libgeopmd/src/LevelZeroIOGroup.cpp
@@ -1400,7 +1400,7 @@ namespace geopm
         if (it != m_signal_available.end()) {
             if (signal_name.find(":METRIC:") != std::string::npos) {
                 throw Exception("LevelZeroIOGroup::" + std::string(__func__) +
-                                ":l " + signal_name + " only supports batch access.",
+                                ": " + signal_name + " only supports batch access.",
                                 GEOPM_ERROR_INVALID, __FILE__, __LINE__);
             }
 

--- a/libgeopmd/src/LevelZeroIOGroup.hpp
+++ b/libgeopmd/src/LevelZeroIOGroup.hpp
@@ -27,7 +27,7 @@ namespace geopm
         public:
             LevelZeroIOGroup();
             LevelZeroIOGroup(const PlatformTopo &platform_topo,
-                             const LevelZeroDevicePool &device_pool,
+                             LevelZeroDevicePool &device_pool,
                              std::shared_ptr<SaveControl> save_control_test);
             virtual ~LevelZeroIOGroup() = default;
             std::set<std::string> signal_names(void) const override;
@@ -113,7 +113,7 @@ namespace geopm
             static const std::string M_PLUGIN_NAME;
             static const std::string M_NAME_PREFIX;
             const PlatformTopo &m_platform_topo;
-            const LevelZeroDevicePool &m_levelzero_device_pool;
+            LevelZeroDevicePool &m_levelzero_device_pool;
             bool m_is_batch_read;
             int m_native_domain;
 
@@ -124,6 +124,7 @@ namespace geopm
             const std::set<std::string> m_special_signal_set;
             std::map<std::string, derivative_signal_info> m_derivative_signal_map;
             std::set<int> m_derivative_signal_pushed_set;
+            std::vector<bool> m_metric_signal_pushed;
 
             //GEOPM Domain indexed
             std::vector<std::pair<double,double> > m_frequency_range;

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -191,6 +191,11 @@ namespace geopm
                 std::vector<size_t> zet_data_size;
                 std::vector<std::vector<uint8_t>> zet_data;
 
+                // Cached metric name -> index within a report. Chip indexed.
+                // Populated once during metric_group_init, used in metric_calc
+                // to avoid repeated zetMetricGet/zetMetricGetProperties calls.
+                std::vector<std::map<std::string, size_t>> metric_name_idx;
+
                 // required for L0 metric result tracking.  Chip indexed
                 mutable std::vector<std::map<std::string, std::vector<double>>> metric_data;
                 mutable std::vector<bool> metrics_initialized;

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -204,11 +204,16 @@ namespace geopm
 
                 // required for L0 metric result tracking.  Chip indexed
                 mutable std::vector<std::map<std::string, std::vector<double>>> metric_data;
-                // Accumulator written by the background sampling thread; the
-                // controller snapshots (moves) this into metric_data once per
-                // read_batch() so metric_data holds all reports gathered over the
-                // controller period.  Chip indexed.
-                mutable std::vector<std::map<std::string, std::vector<double>>> metric_data_accum;
+                // Online per-metric aggregate written by the background sampling
+                // thread: the running sum and report count over the controller
+                // period.  Bounded regardless of the consumer's read cadence; the
+                // controller reduces this to the mean in metric_data once per
+                // read_batch().  Chip indexed.
+                struct m_metric_aggregate {
+                    double sum = 0.0;
+                    uint64_t count = 0;
+                };
+                mutable std::vector<std::map<std::string, m_metric_aggregate>> metric_data_accum;
                 // Whether the background thread should drain this chip's
                 // streamer (set when the controller first reads the chip).
                 // Chip indexed.

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -220,6 +220,9 @@ namespace geopm
             };
 
             void ras_domain_cache(unsigned int l0_device_idx);
+            //size_t zet_temp_data_size;
+            //std::vector<uint8_t> zet_temp_data;
+
             void frequency_domain_cache(unsigned int l0_device_idx);
             void power_domain_cache(unsigned int l0_device_idx);
             void perf_domain_cache(unsigned int l0_device_idx);

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -128,12 +128,16 @@ namespace geopm
                                                       int l0_domain,
                                                       int l0_domain_idx) const override;
             std::vector<double> metric_sample(unsigned int l0_device_idx,
+                                              unsigned int l0_domain_idx,
                                               std::string metric_name) const override;
             uint32_t metric_update_rate(unsigned int l0_device_idx) const override;
 
-            void metric_read(unsigned int l0_device_idx) override;
-            void metric_init(unsigned int l0_device_idx) override;
-            void metric_destroy(unsigned int l0_device_idx) override;
+            void metric_read(unsigned int l0_device_idx,
+                             unsigned int l0_domain_idx) override;
+            void metric_init(unsigned int l0_device_idx,
+                             unsigned int l0_domain_idx) override;
+            void metric_destroy(unsigned int l0_device_idx,
+                                unsigned int l0_domain_idx) override;
             void metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting) override;
 
         private:
@@ -179,9 +183,25 @@ namespace geopm
                 // then by error set type (correctable vs uncorrectable)
                 std::vector<zes_ras_handle_t> ras_domain;
 
+                //ZE Context used for ZET data collection
+                std::vector<ze_context_handle_t> context;
+
+                // required for L0 metric querying
+                std::vector<uint32_t> num_metric;
+                std::vector<uint32_t> num_reports;
+                std::vector<bool> metric_domain_cached;
+                std::vector<ze_event_pool_handle_t> event_pool;
+                std::vector<ze_event_handle_t> event; //TODO: rename metric_notification_event?
+                std::vector<zet_metric_streamer_handle_t> metric_streamer;
+                std::vector<zet_metric_group_handle_t> metric_group_handle; //compute basic only
+
+                // required for L0 metric result tracking
+                mutable std::vector<std::map<std::string, std::vector<double>>> m_metric_data;
+                mutable std::vector<bool> metrics_initialized;
             };
 
             struct m_device_info_s {
+                ze_driver_handle_t driver;
                 zes_device_handle_t device_handle;
                 ze_device_properties_t property;
                 uint32_t m_num_subdevice;
@@ -195,25 +215,11 @@ namespace geopm
 
                 // Device/Package domains
                 zes_pwr_handle_t power_domain;
-                //ZE Context used for ZET data collection
-                ze_context_handle_t context;
 
                 uint32_t num_device_power_domain;
                 mutable uint64_t cached_energy_timestamp;
 
-                // required for L0 metric result tracking
-                mutable std::map<std::string, std::vector<double>> m_metric_data;
-                mutable bool metrics_initialized;
-
-                // required for L0 metric querying
-                uint32_t num_metric;
-                uint32_t num_reports;
                 uint32_t metric_sampling_period;
-                bool metric_domain_cached;
-                ze_event_pool_handle_t event_pool;
-                ze_event_handle_t event; //TODO: rename metric_notification_event?
-                zet_metric_streamer_handle_t metric_streamer;
-                zet_metric_group_handle_t metric_group_handle; //compute basic only
             };
 
             void ras_domain_cache(unsigned int l0_device_idx);
@@ -245,7 +251,7 @@ namespace geopm
             std::vector<m_device_info_s> m_devices;
 
             void metric_group_cache(unsigned int l0_device_idx);
-            void metric_calc(unsigned int l0_device_idx,
+            void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
                              zet_metric_streamer_handle_t metric_streamer) const;
     };
 }

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -186,7 +186,7 @@ namespace geopm
                 //ZE Context used for ZET data collection
                 std::vector<ze_context_handle_t> context;
 
-                // required for L0 metric querying
+                // required for L0 metric querying.  Chip indexed
                 std::vector<uint32_t> num_metric;
                 std::vector<uint32_t> num_reports;
                 std::vector<bool> metric_domain_cached;
@@ -195,7 +195,7 @@ namespace geopm
                 std::vector<zet_metric_streamer_handle_t> metric_streamer;
                 std::vector<zet_metric_group_handle_t> metric_group_handle; //compute basic only
 
-                // required for L0 metric result tracking
+                // required for L0 metric result tracking.  Chip indexed
                 mutable std::vector<std::map<std::string, std::vector<double>>> m_metric_data;
                 mutable std::vector<bool> metrics_initialized;
             };

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -186,8 +186,6 @@ namespace geopm
                 std::vector<uint32_t> num_metric;
                 std::vector<uint32_t> num_reports;
                 std::vector<bool> metric_domain_cached;
-                std::vector<ze_event_pool_handle_t> event_pool;
-                std::vector<ze_event_handle_t> metric_notifcation_event;
                 std::vector<zet_metric_streamer_handle_t> metric_streamer;
                 std::vector<zet_metric_group_handle_t> metric_group_handle; //ComputeBasic only
                 std::vector<size_t> zet_data_size;
@@ -250,6 +248,10 @@ namespace geopm
 
             std::vector<ze_driver_handle_t> m_levelzero_driver;
             std::vector<m_device_info_s> m_devices;
+
+            static constexpr uint32_t NOTIFY_EVERY_N_REPORTS = 1;
+            static constexpr uint32_t SAMPLING_PERIOD_NS = 500000; // 0.5 ms
+            static constexpr size_t DEFAULT_REPORT_BUFFER_SIZE = 16 * 1024 * 1024; // 16 MB
 
             void metric_group_init(unsigned int l0_device_idx);
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -10,6 +10,7 @@
 #include <thread>
 #include <mutex>
 #include <atomic>
+#include <chrono>
 
 #include <level_zero/ze_api.h>
 #include <level_zero/zes_api.h>
@@ -211,6 +212,11 @@ namespace geopm
                 // streamer (set when the controller first reads the chip).
                 // Chip indexed.
                 std::vector<bool> metric_active;
+                // Time the chip's streamer was last drained (by either the
+                // controller or the background thread).  Used so the thread only
+                // drains as a keep-alive when the controller isn't draining
+                // frequently enough on its own.  Chip indexed.
+                std::vector<std::chrono::steady_clock::time_point> metric_last_drain;
                 mutable std::vector<bool> metrics_initialized;
             };
 

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -10,6 +10,7 @@
 
 #include <level_zero/ze_api.h>
 #include <level_zero/zes_api.h>
+#include <level_zero/zet_api.h>
 
 #include "LevelZero.hpp"
 
@@ -126,6 +127,14 @@ namespace geopm
             double ras_display_errcount_uncorrectable(unsigned int l0_device_idx,
                                                       int l0_domain,
                                                       int l0_domain_idx) const override;
+            std::vector<double> metric_sample(unsigned int l0_device_idx,
+                                              std::string metric_name) const override;
+            uint32_t metric_update_rate(unsigned int l0_device_idx) const override;
+
+            void metric_read(unsigned int l0_device_idx) override;
+            void metric_init(unsigned int l0_device_idx) override;
+            void metric_destroy(unsigned int l0_device_idx) override;
+            void metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting) override;
 
         private:
             enum m_error_type {
@@ -185,9 +194,26 @@ namespace geopm
                 m_subdevice_s subdevice;
 
                 // Device/Package domains
-                uint32_t num_device_power_domain;
                 zes_pwr_handle_t power_domain;
+                //ZE Context used for ZET data collection
+                ze_context_handle_t context;
+
+                uint32_t num_device_power_domain;
                 mutable uint64_t cached_energy_timestamp;
+
+                // required for L0 metric result tracking
+                mutable std::map<std::string, std::vector<double>> m_metric_data;
+                mutable bool metrics_initialized;
+
+                // required for L0 metric querying
+                uint32_t num_metric;
+                uint32_t num_reports;
+                uint32_t metric_sampling_period;
+                bool metric_domain_cached;
+                ze_event_pool_handle_t event_pool;
+                ze_event_handle_t event; //TODO: rename metric_notification_event?
+                zet_metric_streamer_handle_t metric_streamer;
+                zet_metric_group_handle_t metric_group_handle; //compute basic only
             };
 
             void ras_domain_cache(unsigned int l0_device_idx);
@@ -217,6 +243,10 @@ namespace geopm
 
             std::vector<ze_driver_handle_t> m_levelzero_driver;
             std::vector<m_device_info_s> m_devices;
+
+            void metric_group_cache(unsigned int l0_device_idx);
+            void metric_calc(unsigned int l0_device_idx,
+                             zet_metric_streamer_handle_t metric_streamer) const;
     };
 }
 #endif

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -249,8 +249,8 @@ namespace geopm
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
                              size_t data_size, std::vector<uint8_t> data);
 
-            void metric_init(unsigned int l0_device_idx,
-                             unsigned int l0_domain_idx);
+            void metric_execute(unsigned int l0_device_idx,
+                                unsigned int l0_domain_idx);
             void metric_destroy(unsigned int l0_device_idx,
                                 unsigned int l0_domain_idx);
 

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -131,6 +131,7 @@ namespace geopm
                                               unsigned int l0_domain_idx,
                                               std::string metric_name) const override;
             uint32_t metric_update_rate(unsigned int l0_device_idx) const override;
+            void metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting) override;
 
             void metric_read(unsigned int l0_device_idx,
                              unsigned int l0_domain_idx) override;

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -255,7 +255,6 @@ namespace geopm
             std::vector<ze_driver_handle_t> m_levelzero_driver;
             std::vector<m_device_info_s> m_devices;
 
-            static constexpr uint32_t NOTIFY_EVERY_N_REPORTS = 1;
             static constexpr uint32_t SAMPLING_PERIOD_NS = 500000; // 0.5 ms
             static constexpr size_t DEFAULT_REPORT_BUFFER_SIZE = 16 * 1024 * 1024; // 16 MB
             static constexpr uint32_t DEFAULT_MAX_REPORTS_PER_READ = 30;

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -191,7 +191,7 @@ namespace geopm
                 std::vector<zet_metric_group_handle_t> metric_group_handle; //compute basic only
 
                 // required for L0 metric result tracking.  Chip indexed
-                std::vector<std::map<std::string, std::vector<double>>> m_metric_data;
+                std::vector<std::map<std::string, std::vector<double>>> metric_data;
                 mutable std::vector<bool> metrics_initialized;
             };
 
@@ -199,7 +199,7 @@ namespace geopm
                 ze_driver_handle_t driver;
                 zes_device_handle_t device_handle;
                 ze_device_properties_t property;
-                uint32_t m_num_subdevice;
+                uint32_t num_subdevice;
                 std::vector<zes_device_handle_t> subdevice_handle;
 
                 // Sub-Device domain tracking.  Because levelzero returns ALL handles for a

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <atomic>
 #include <chrono>
+#include <exception>
 
 #include <level_zero/ze_api.h>
 #include <level_zero/zes_api.h>
@@ -288,6 +289,10 @@ namespace geopm
             std::mutex m_metric_mutex;
             std::atomic<bool> m_metric_thread_active;
             bool m_metric_thread_started;
+            // Captures an exception thrown by metric_drain on the background
+            // thread so the controller path can rethrow it, rather than the
+            // thread terminating the process.  Protected by m_metric_mutex.
+            std::exception_ptr m_metric_thread_error;
 
             void metric_group_init(unsigned int l0_device_idx);
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -190,6 +190,7 @@ namespace geopm
                 std::vector<zet_metric_group_handle_t> metric_group_handle; //ComputeBasic only
                 std::vector<size_t> zet_data_size;
                 std::vector<std::vector<uint8_t>> zet_data;
+                std::vector<size_t> report_byte_size;  // Learned per-report byte size (0 until first read)
 
                 // Cached metric name -> index within a report. Chip indexed.
                 // Populated once during metric_group_init, used in metric_calc
@@ -257,10 +258,11 @@ namespace geopm
             static constexpr uint32_t NOTIFY_EVERY_N_REPORTS = 1;
             static constexpr uint32_t SAMPLING_PERIOD_NS = 500000; // 0.5 ms
             static constexpr size_t DEFAULT_REPORT_BUFFER_SIZE = 16 * 1024 * 1024; // 16 MB
+            static constexpr uint32_t DEFAULT_MAX_REPORTS_PER_READ = 30;
 
             void metric_group_init(unsigned int l0_device_idx);
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
-                             size_t data_size, const std::vector<uint8_t> &data);
+                             size_t data_size, const uint8_t *data);
 
             void metric_execute(unsigned int l0_device_idx,
                                 unsigned int l0_domain_idx);

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -244,8 +244,6 @@ namespace geopm
             };
 
             void ras_domain_cache(unsigned int l0_device_idx);
-            //size_t zet_temp_data_size;
-            //std::vector<uint8_t> zet_temp_data;
 
             void frequency_domain_cache(unsigned int l0_device_idx);
             void power_domain_cache(unsigned int l0_device_idx);

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -245,7 +245,7 @@ namespace geopm
             std::vector<ze_driver_handle_t> m_levelzero_driver;
             std::vector<m_device_info_s> m_devices;
 
-            void metric_group_cache(unsigned int l0_device_idx);
+            void metric_group_init(unsigned int l0_device_idx);
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
                              size_t data_size, std::vector<uint8_t> data);
 

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -186,9 +186,11 @@ namespace geopm
                 std::vector<uint32_t> num_reports;
                 std::vector<bool> metric_domain_cached;
                 std::vector<ze_event_pool_handle_t> event_pool;
-                std::vector<ze_event_handle_t> metric_notifcation_event; //TODO: rename metric_notification_event?
+                std::vector<ze_event_handle_t> metric_notifcation_event;
                 std::vector<zet_metric_streamer_handle_t> metric_streamer;
-                std::vector<zet_metric_group_handle_t> metric_group_handle; //compute basic only
+                std::vector<zet_metric_group_handle_t> metric_group_handle; //ComputeBasic only
+                std::vector<size_t> zet_data_size;
+                std::vector<std::vector<uint8_t>> zet_data;
 
                 // required for L0 metric result tracking.  Chip indexed
                 std::vector<std::map<std::string, std::vector<double>>> metric_data;

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -260,7 +260,7 @@ namespace geopm
 
             void metric_group_init(unsigned int l0_device_idx);
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
-                             size_t data_size, std::vector<uint8_t> data);
+                             size_t data_size, const std::vector<uint8_t> &data);
 
             void metric_execute(unsigned int l0_device_idx,
                                 unsigned int l0_domain_idx);

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -179,7 +179,7 @@ namespace geopm
                 // then by error set type (correctable vs uncorrectable)
                 std::vector<zes_ras_handle_t> ras_domain;
 
-                //ZE Context used for ZET data collection
+                //ZE Context used for ZET data collection.  Chip indexed
                 std::vector<ze_context_handle_t> context;
 
                 // required for L0 metric querying.  Chip indexed
@@ -194,7 +194,7 @@ namespace geopm
                 std::vector<std::vector<uint8_t>> zet_data;
 
                 // required for L0 metric result tracking.  Chip indexed
-                std::vector<std::map<std::string, std::vector<double>>> metric_data;
+                mutable std::vector<std::map<std::string, std::vector<double>>> metric_data;
                 mutable std::vector<bool> metrics_initialized;
             };
 

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -22,7 +22,7 @@ namespace geopm
     {
         public:
             LevelZeroImp();
-            virtual ~LevelZeroImp() = default;
+            virtual ~LevelZeroImp();
             int num_gpu(void) const override;
             int num_gpu(int domain) const override;
             int frequency_domain_count(unsigned int l0_device_idx,
@@ -134,11 +134,6 @@ namespace geopm
 
             void metric_read(unsigned int l0_device_idx,
                              unsigned int l0_domain_idx) override;
-            void metric_init(unsigned int l0_device_idx,
-                             unsigned int l0_domain_idx) override;
-            void metric_destroy(unsigned int l0_device_idx,
-                                unsigned int l0_domain_idx) override;
-            void metric_update_rate_control(unsigned int l0_device_idx, uint32_t setting) override;
 
         private:
             enum m_error_type {
@@ -191,12 +186,12 @@ namespace geopm
                 std::vector<uint32_t> num_reports;
                 std::vector<bool> metric_domain_cached;
                 std::vector<ze_event_pool_handle_t> event_pool;
-                std::vector<ze_event_handle_t> event; //TODO: rename metric_notification_event?
+                std::vector<ze_event_handle_t> metric_notifcation_event; //TODO: rename metric_notification_event?
                 std::vector<zet_metric_streamer_handle_t> metric_streamer;
                 std::vector<zet_metric_group_handle_t> metric_group_handle; //compute basic only
 
                 // required for L0 metric result tracking.  Chip indexed
-                mutable std::vector<std::map<std::string, std::vector<double>>> m_metric_data;
+                std::vector<std::map<std::string, std::vector<double>>> m_metric_data;
                 mutable std::vector<bool> metrics_initialized;
             };
 
@@ -219,7 +214,7 @@ namespace geopm
                 uint32_t num_device_power_domain;
                 mutable uint64_t cached_energy_timestamp;
 
-                uint32_t metric_sampling_period;
+                uint32_t metric_sampling_period_ns;
             };
 
             void ras_domain_cache(unsigned int l0_device_idx);
@@ -252,7 +247,14 @@ namespace geopm
 
             void metric_group_cache(unsigned int l0_device_idx);
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
-                             zet_metric_streamer_handle_t metric_streamer) const;
+                             size_t data_size, std::vector<uint8_t> data);
+
+            void metric_init(unsigned int l0_device_idx,
+                             unsigned int l0_domain_idx);
+            void metric_destroy(unsigned int l0_device_idx,
+                                unsigned int l0_domain_idx);
+
+            double metric_data_convert(zet_typed_value_t data) const;
     };
 }
 #endif

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -205,23 +205,23 @@ namespace geopm
                 // required for L0 metric result tracking.  Chip indexed
                 mutable std::vector<std::map<std::string, std::vector<double>>> metric_data;
                 // Online per-metric aggregate written by the background sampling
-                // thread: the running sum and report count over the controller
-                // period.  Bounded regardless of the consumer's read cadence; the
-                // controller reduces this to the mean in metric_data once per
-                // read_batch().  Chip indexed.
+                // thread: the running sum and report count between read_batch()
+                // calls.  Bounded regardless of the consumer's read cadence; the
+                // read_batch() serving thread reduces this to the mean in
+                // metric_data once per read_batch().  Chip indexed.
                 struct m_metric_aggregate {
                     double sum = 0.0;
                     uint64_t count = 0;
                 };
                 mutable std::vector<std::map<std::string, m_metric_aggregate>> metric_data_accum;
                 // Whether the background thread should drain this chip's
-                // streamer (set when the controller first reads the chip).
+                // streamer (set when the chip is first read via read_batch()).
                 // Chip indexed.
                 std::vector<bool> metric_active;
                 // Time the chip's streamer was last drained (by either the
-                // controller or the background thread).  Used so the thread only
-                // drains as a keep-alive when the controller isn't draining
-                // frequently enough on its own.  Chip indexed.
+                // read_batch() serving thread or the background thread).  Used so
+                // the thread only drains as a keep-alive when read_batch() isn't
+                // draining frequently enough on its own.  Chip indexed.
                 std::vector<std::chrono::steady_clock::time_point> metric_last_drain;
                 mutable std::vector<bool> metrics_initialized;
             };
@@ -281,19 +281,21 @@ namespace geopm
             static constexpr size_t DEFAULT_REPORT_BUFFER_SIZE = 16 * 1024 * 1024; // 16 MB
             static constexpr uint32_t DEFAULT_MAX_REPORTS_PER_READ = 30;
             // Fixed cadence at which the background thread drains the metric
-            // streamers, independent of the controller loop period.  Frequent
+            // streamers, independent of the read_batch() cadence.  Frequent
             // draining keeps the Intel metric streamer delivering continuously
             // (a slow drain interval stalls it into multi-second NOT_READY bursts).
             static constexpr uint64_t METRIC_DRAIN_PERIOD_US = 20000; // 20 ms
 
             // Background metric sampling thread and the state it shares with the
-            // controller thread (metric_data_accum, protected by m_metric_mutex).
+            // read_batch() serving thread -- the controller, or the geopmd batch
+            // server when LevelZero is accessed through the service
+            // (metric_data_accum, protected by m_metric_mutex).
             std::thread m_metric_thread;
             std::mutex m_metric_mutex;
             std::atomic<bool> m_metric_thread_active;
             bool m_metric_thread_started;
             // Captures an exception thrown by metric_drain on the background
-            // thread so the controller path can rethrow it, rather than the
+            // thread so the read_batch() path can rethrow it, rather than the
             // thread terminating the process.  Protected by m_metric_mutex.
             std::exception_ptr m_metric_thread_error;
 

--- a/libgeopmd/src/LevelZeroImp.hpp
+++ b/libgeopmd/src/LevelZeroImp.hpp
@@ -7,6 +7,9 @@
 #define LEVELZEROIMP_HPP_INCLUDE
 
 #include <string>
+#include <thread>
+#include <mutex>
+#include <atomic>
 
 #include <level_zero/ze_api.h>
 #include <level_zero/zes_api.h>
@@ -199,6 +202,15 @@ namespace geopm
 
                 // required for L0 metric result tracking.  Chip indexed
                 mutable std::vector<std::map<std::string, std::vector<double>>> metric_data;
+                // Accumulator written by the background sampling thread; the
+                // controller snapshots (moves) this into metric_data once per
+                // read_batch() so metric_data holds all reports gathered over the
+                // controller period.  Chip indexed.
+                mutable std::vector<std::map<std::string, std::vector<double>>> metric_data_accum;
+                // Whether the background thread should drain this chip's
+                // streamer (set when the controller first reads the chip).
+                // Chip indexed.
+                std::vector<bool> metric_active;
                 mutable std::vector<bool> metrics_initialized;
             };
 
@@ -258,6 +270,18 @@ namespace geopm
             static constexpr uint32_t SAMPLING_PERIOD_NS = 500000; // 0.5 ms
             static constexpr size_t DEFAULT_REPORT_BUFFER_SIZE = 16 * 1024 * 1024; // 16 MB
             static constexpr uint32_t DEFAULT_MAX_REPORTS_PER_READ = 30;
+            // Fixed cadence at which the background thread drains the metric
+            // streamers, independent of the controller loop period.  Frequent
+            // draining keeps the Intel metric streamer delivering continuously
+            // (a slow drain interval stalls it into multi-second NOT_READY bursts).
+            static constexpr uint64_t METRIC_DRAIN_PERIOD_US = 20000; // 20 ms
+
+            // Background metric sampling thread and the state it shares with the
+            // controller thread (metric_data_accum, protected by m_metric_mutex).
+            std::thread m_metric_thread;
+            std::mutex m_metric_mutex;
+            std::atomic<bool> m_metric_thread_active;
+            bool m_metric_thread_started;
 
             void metric_group_init(unsigned int l0_device_idx);
             void metric_calc(unsigned int l0_device_idx, unsigned int l0_domain_idx,
@@ -267,6 +291,14 @@ namespace geopm
                                 unsigned int l0_domain_idx);
             void metric_destroy(unsigned int l0_device_idx,
                                 unsigned int l0_domain_idx);
+
+            // Background sampling thread: drains active streamers every
+            // METRIC_DRAIN_PERIOD_US and accumulates reports.
+            void metric_sample_thread(void);
+            // Read one chip's streamer and append the reports to the accumulator.
+            void metric_drain(unsigned int l0_device_idx, unsigned int l0_domain_idx);
+            void metric_thread_start(void);
+            void metric_thread_stop(void);
 
             double metric_data_convert(zet_typed_value_t data) const;
     };

--- a/libgeopmd/src/LevelZeroThrow.cpp
+++ b/libgeopmd/src/LevelZeroThrow.cpp
@@ -9,7 +9,7 @@
 
 namespace geopm
 {
-    const LevelZero &levelzero()
+    LevelZero &levelzero()
     {
         throw Exception("LevelZeroThrow::" + std::string(__func__) +
                         ": GEOPM configured without Level Zero library support.  Please configure with --enable-levelzero",

--- a/libgeopmd/src/PlatformTopo.cpp
+++ b/libgeopmd/src/PlatformTopo.cpp
@@ -469,14 +469,6 @@ namespace geopm
         }
 
         if (is_file_ok == false) {
-            mode_t perms;
-            if (cache_file_name == M_SERVICE_CACHE_FILE_NAME) {
-                perms = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH; // 0o644
-            }
-            else {
-                perms = S_IRUSR | S_IWUSR; // 0o600
-            }
-
             std::string tmp_string = cache_file_name + "XXXXXX";
             char tmp_path[PATH_MAX];
             tmp_path[PATH_MAX - 1] = '\0';

--- a/libgeopmd/src/PlatformTopo.cpp
+++ b/libgeopmd/src/PlatformTopo.cpp
@@ -469,6 +469,14 @@ namespace geopm
         }
 
         if (is_file_ok == false) {
+            mode_t perms;
+            if (cache_file_name == M_SERVICE_CACHE_FILE_NAME) {
+                perms = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH; // 0o644
+            }
+            else {
+                perms = S_IRUSR | S_IWUSR; // 0o600
+            }
+
             std::string tmp_string = cache_file_name + "XXXXXX";
             char tmp_path[PATH_MAX];
             tmp_path[PATH_MAX - 1] = '\0';

--- a/libgeopmd/test/LevelZeroDevicePoolTest.cpp
+++ b/libgeopmd/test/LevelZeroDevicePoolTest.cpp
@@ -7,6 +7,7 @@
 
 #include <fstream>
 #include <string>
+#include <numeric>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
@@ -124,6 +125,8 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
     std::vector<double> temp_value_chip_compute = {99, 12, 25, 356, 58, 79, 76, 21};
     std::vector<double> temp_value_chip_mem = {42, 59, 66, 78, 92, 88, 1, 16};
 
+    std::vector<std::vector<double> > metric_value_chip = {{41, 41}, {51, 53}, {16}, {71}, {12, 13, 14}, {18}, {11}, {1,6,1}};
+
     int offset = 0;
     int domain_count = 1; //any non-zero number to ensure we don't throw
     for (int dev_idx = 0; dev_idx < num_gpu; ++dev_idx) {
@@ -168,6 +171,9 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
 
             EXPECT_CALL(*m_levelzero, temperature_max(dev_idx, MockLevelZero::M_DOMAIN_COMPUTE, sub_idx)).WillOnce(Return(temp_value_chip_compute[offset]));
             EXPECT_CALL(*m_levelzero, temperature_max(dev_idx, MockLevelZero::M_DOMAIN_MEMORY, sub_idx)).WillOnce(Return(temp_value_chip_mem[offset]));
+
+            EXPECT_CALL(*m_levelzero, metric_sample(dev_idx, sub_idx, "NUM_REPORTS")).WillOnce(Return(metric_value_chip[offset]));
+            EXPECT_CALL(*m_levelzero, metric_read(dev_idx, sub_idx));
             ++offset;
         }
     }
@@ -208,6 +214,12 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
 
         EXPECT_EQ(temp_value_chip_compute[sub_idx], m_device_pool.temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_EQ(temp_value_chip_mem[sub_idx], m_device_pool.temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
+
+        double expected = (double) std::reduce(metric_value_chip[sub_idx].begin(),
+                                               metric_value_chip[sub_idx].end(), 0) /  metric_value_chip[sub_idx].size();
+        EXPECT_EQ(expected,
+                  m_device_pool.metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
+        EXPECT_NO_THROW(m_device_pool.metric_read(GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
 }
 
@@ -282,6 +294,10 @@ TEST_F(LevelZeroDevicePoolTest, domain_error)
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_tdp(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU_CHIP) + " is not supported for the power domain");
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_min(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU_CHIP) + " is not supported for the power domain");
     GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.power_limit_max(GEOPM_DOMAIN_GPU_CHIP, dev_idx, MockLevelZero::M_DOMAIN_ALL), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU_CHIP) + " is not supported for the power domain");
+
+    //ZET
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.metric_read(GEOPM_DOMAIN_GPU, dev_idx), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for metrics");
+    GEOPM_EXPECT_THROW_MESSAGE(m_device_pool.metric_sample(GEOPM_DOMAIN_GPU, dev_idx, "NUM_REPORTS"), GEOPM_ERROR_INVALID, "domain " + std::to_string(GEOPM_DOMAIN_GPU) + " is not supported for metrics");
 }
 
 TEST_F(LevelZeroDevicePoolTest, subdevice_range_check)

--- a/libgeopmd/test/LevelZeroDevicePoolTest.cpp
+++ b/libgeopmd/test/LevelZeroDevicePoolTest.cpp
@@ -215,8 +215,9 @@ TEST_F(LevelZeroDevicePoolTest, subdevice_conversion_and_function)
         EXPECT_EQ(temp_value_chip_compute[sub_idx], m_device_pool.temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
         EXPECT_EQ(temp_value_chip_mem[sub_idx], m_device_pool.temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
 
-        double expected = (double) std::reduce(metric_value_chip[sub_idx].begin(),
-                                               metric_value_chip[sub_idx].end(), 0) /  metric_value_chip[sub_idx].size();
+        double expected = (double)std::accumulate(metric_value_chip[sub_idx].begin(),
+                                                  metric_value_chip[sub_idx].end(), 0) /
+                                                      metric_value_chip[sub_idx].size();
         EXPECT_EQ(expected,
                   m_device_pool.metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
         EXPECT_NO_THROW(m_device_pool.metric_read(GEOPM_DOMAIN_GPU_CHIP, sub_idx));

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -210,9 +210,22 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
         // 1. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR_CONTROL
         // 2. Per gpu-chip / control pruning: GPU_CORE_PERFORMANCE_FACTOR_CONTROL (Alias to PERFORMANCE_FACTOR)
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
-                    performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(2);
+                    performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(3);
+        EXPECT_CALL(*m_device_pool, // GPU_CORE_TEMPERATURE_MAXIMUM
+                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
+        EXPECT_CALL(*m_device_pool, // GPU_MEMORY_TEMPERATURE_MAXIMUM
+                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
 
-        // GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL, and the restore_control() call
+        // ZET testing
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE"));
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL"));
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
+
+        // control pruning expectations
+        // GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL, and the restore_control() direct call.
         EXPECT_CALL(*m_device_pool,
                     frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE,
                                       0, 0)).Times(3);
@@ -889,6 +902,14 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
         //                               0, 0)).Times(3);
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
                     performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+
+        // ZET testing
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE"));
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL"));
+        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
+                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
     }
 
     // Expectations for signal pruning code in the constructor

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -142,7 +142,7 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
     // EXPECT_CALLS for domain idx = 0
     EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
                 performance_factor(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(4);
-    // Times(2) explanation:
+    // Times(4) explanation:
     // 1. check if perf factor is enabled
     // 2. signal pruning
     // 3. save_control
@@ -850,7 +850,7 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
     // EXPECT_CALLS for domain idx = 0
     EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
                 performance_factor(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(4);
-    // Times(2) explanation:
+    // Times(4) explanation:
     // 1. check if perf factor is enabled
     // 2. signal pruning
     // 3. save_control

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -370,6 +370,11 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
                                           6, 12, 22, 15};
     std::vector<double> mock_energy_chip = {4000000, 5000000, 1100000, 2621000000,
                                             4200000, 5200000, 1120000, 2621200000,};
+
+    std::vector<double> mock_zet_num_reports = {23, 70, 50, 2, 5, 57, 88, 93};
+    std::vector<double> mock_zet_stall = {10, 9, 150, 510, 13, 14, 51, 45};
+    std::vector<double> mock_zet_active = {124, 12, 23, 42, 45, 54, 68, 97};
+
     std::vector<int> batch_idx;
 
     LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool, nullptr);
@@ -389,6 +394,14 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
         EXPECT_CALL(*m_device_pool, energy_timestamp(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_time_chip.at(sub_idx)));
         batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::GPU_CORE_ENERGY", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
+
+    for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
+        // On live systems we do not support read_signal of ZET signals.
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS")).WillOnce(Return(mock_zet_num_reports.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE")).WillOnce(Return(mock_zet_active.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL")).WillOnce(Return(mock_zet_stall.at(sub_idx)));
+    }
+
 
     for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(gpu_idx)));
@@ -420,6 +433,14 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
 
         EXPECT_DOUBLE_EQ(energy_chip, mock_energy_chip.at(sub_idx)/1e6);
         EXPECT_DOUBLE_EQ(energy_chip, energy_chip_batch);
+
+        //ZET
+        double num_reps = levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(num_reps, mock_zet_num_reports.at(sub_idx));
+        double zet_stall = levelzero_io.read_signal("LEVELZERO::METRIC:XVE_STALL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(zet_stall, mock_zet_stall.at(sub_idx) / 100);
+        double zet_active = levelzero_io.read_signal("LEVELZERO::METRIC:XVE_ACTIVE", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        EXPECT_DOUBLE_EQ(zet_active, mock_zet_active.at(sub_idx) / 100);
     }
 
     for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
@@ -913,18 +934,19 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
     }
 
     // Expectations for signal pruning code in the constructor
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
-                energy(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
-                energy_timestamp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
-                power_limit_tdp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
-                power_limit_max(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
-                power_limit_min(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-
-    // End copy/paste from SetUpDefualtExpectCalls
+    for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
+        EXPECT_CALL(*m_device_pool, // GPU_ENERGY
+                    energy(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
+        EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
+                    energy_timestamp(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
+        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
+                    power_limit_tdp(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
+        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
+                    power_limit_max(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
+        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
+                    power_limit_min(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
+    }
+    // End copy/paste from SetUpDefaultExpectCalls
 
     // The implementation of the pruning code only tests each control on a
     // single domain index if a problem is encountered.  If there is a problem

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -139,14 +139,31 @@ void LevelZeroIOGroupTest::SetUp()
 
 void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
 {
-    // Expectations for domain_idx 0 on calls made in the constructor
+    // EXPECT_CALLS for domain idx = 0
     EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
                 performance_factor(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(4);
-    // Times(4) explanation:
-    //   1. Per gpu-chip / signal pruning: GPU_CORE_PERFORMANCE_FACTOR
-    //   2. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR_CONTROL
-    //   3. Per gpu-chip / control pruning: GPU_CORE_PERFORMANCE_FACTOR_CONTROL (Alias to PERFORMANCE_FACTOR)
-    //   4. Check if perf factor is enabled
+    // Times(2) explanation:
+    // 1. check if perf factor is enabled
+    // 2. signal pruning
+    // 3. save_control
+    // 4. control pruning
+    EXPECT_CALL(*m_device_pool,
+                frequency_range(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(7);
+    // Times(7) explanation:
+    // 1. signal pruning = 2 (GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL)
+    // 2. save_control = 1
+    // 3. control pruning = 2
+    // 4. write_control = 2 (it reads min and max freq. before writing)
+    EXPECT_CALL(*m_device_pool,
+                frequency_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE, 0, 0)).Times(3);
+    // Times(3) explanation:
+    // 1. control pruning = 2 (GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL)
+    // 2. restore_control
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
+                performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+    // Times(2) explanation:
+    // 1. control pruning
+    // 2. restore_control
 
     // The EXPECT_CALLS below are default Times(1) for the signal pruning code
     EXPECT_CALL(*m_device_pool, // GPU_ACTIVE_TIME
@@ -161,26 +178,20 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
                 active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_ACTIVE_TIME_TIMESTAMP
                 active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_ENERGY
                 energy(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
+    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
+                energy(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_ENERGY_TIMESTAMP
                 energy_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
+                energy_timestamp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_EFFICIENT
                 frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MAX_AVAIL
                 frequency_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_FREQUENCY_MAX_AVAIL
                 frequency_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
-    EXPECT_CALL(*m_device_pool,
-                frequency_range(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(7);
-    // Times(7) explanation:
-    // 1. Per gpu-chip / signal_pruning: GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 2. Per gpu-chip / signal_pruning: GPU_CORE_FREQUENCY_MIN_CONTROL
-    // 3. Per gpu-chip save_control() call,
-    // 4. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 5. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 6. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MIN_CONTROL
-    // 7. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MIN_CONTROL
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MIN_AVAIL
                 frequency_min(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_FREQUENCY_MIN_AVAIL
@@ -197,37 +208,30 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
                 temperature_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_THROTTLE_REASONS
                 frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
-    EXPECT_CALL(*m_device_pool,
-                frequency_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE,
-                                  0, 0)).Times(3);
-    EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
-                performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
+                power_limit_tdp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
+                power_limit_max(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
+                power_limit_min(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "XVE_ACTIVE"));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "XVE_STALL"));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "NUM_REPORTS"));
 
     // Expectations for save_control() and control pruning code in the constructor
     for (int sub_idx = 1; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
-        // the save_control() call, GPU_CORE_FREQUENCY_MAX_CONTROL (control pruning) * 2,
-        // and GPU_CORE_FREQUENCY_MIN_CONTROL (control pruning) * 2 = 5 times
+        // Doesn't include signal pruning
         EXPECT_CALL(*m_device_pool,
                     frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(5);
 
-        // 1. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR_CONTROL
+        // 1. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR
         // 2. Per gpu-chip / control pruning: GPU_CORE_PERFORMANCE_FACTOR_CONTROL (Alias to PERFORMANCE_FACTOR)
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
-                    performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(3);
-        EXPECT_CALL(*m_device_pool, // GPU_CORE_TEMPERATURE_MAXIMUM
-                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE));
-        EXPECT_CALL(*m_device_pool, // GPU_MEMORY_TEMPERATURE_MAXIMUM
-                    temperature_max(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_MEMORY));
+                    performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(2);
 
-        // ZET testing
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE"));
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL"));
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
-
-        // control pruning expectations
         // GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL, and the restore_control() direct call.
         EXPECT_CALL(*m_device_pool,
                     frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE,
@@ -235,18 +239,6 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
                     performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
     }
-
-    // Expectations for signal pruning code in the constructor
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
-                energy(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
-                energy_timestamp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
-                power_limit_tdp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
-                power_limit_max(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
-                power_limit_min(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
 }
 
 void LevelZeroIOGroupTest::TearDown()
@@ -263,7 +255,6 @@ TEST_F(LevelZeroIOGroupTest, valid_signals)
         EXPECT_LT(-1, levelzero_io.signal_behavior(sig));
     }
 }
-
 
 TEST_F(LevelZeroIOGroupTest, save_restore)
 {
@@ -843,11 +834,12 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU_CHIP, -1, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+
     EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, 0)));
     EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:XVE_ACTIVE", GEOPM_DOMAIN_GPU_CHIP, 0)));
     EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:XVE_STALL", GEOPM_DOMAIN_GPU_CHIP, 0)));
@@ -855,18 +847,26 @@ TEST_F(LevelZeroIOGroupTest, error_path)
 
 TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
 {
-    // The following was copy/pasted from SetUpDefaultExpect calls, with the lines commented out that will be
-    // specifically examined by this test.
-
-    // BEGIN COPY/PASTE
-    // Expectations for domain_idx 0 on calls made in the constructor
+    // EXPECT_CALLS for domain idx = 0
     EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
                 performance_factor(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(4);
-    // Times(4) explanation:
-    //   1. Per gpu-chip / signal pruning: GPU_CORE_PERFORMANCE_FACTOR
-    //   2. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR_CONTROL
-    //   3. Per gpu-chip / control pruning: GPU_CORE_PERFORMANCE_FACTOR_CONTROL (Alias to PERFORMANCE_FACTOR)
-    //   4. Check once at the beginning of the constructor to see if perf factor is supported
+    // Times(2) explanation:
+    // 1. check if perf factor is enabled
+    // 2. signal pruning
+    // 3. save_control
+    // 4. control pruning
+    EXPECT_CALL(*m_device_pool,
+                frequency_range(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(7);
+    // Times(7) explanation:
+    // 1. signal pruning = 2 (GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL)
+    // 2. save_control = 1
+    // 3. control pruning = 2
+    // 4. write_control = 2 (it reads min and max freq. before writing)
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
+                performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+    // Times(2) explanation:
+    // 1. control pruning
+    // 2. restore_control
 
     // The EXPECT_CALLS below are default Times(1) for the signal pruning code
     EXPECT_CALL(*m_device_pool, // GPU_ACTIVE_TIME
@@ -881,34 +881,24 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
                 active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_ACTIVE_TIME_TIMESTAMP
                 active_time_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_ENERGY
                 energy(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_ALL));
-    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
+    EXPECT_CALL(*m_device_pool, // GPU_ENERGY
+                energy(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_CORE_ENERGY_TIMESTAMP
                 energy_timestamp(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
+                energy_timestamp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_EFFICIENT
                 frequency_efficient(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MAX_AVAIL
                 frequency_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_FREQUENCY_MAX_AVAIL
                 frequency_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
-    // EXPECT_CALL(*m_device_pool,
-    //             frequency_range(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).Times(7);
-    // Times(7) explanation:
-    // 1. Per gpu-chip / signal_pruning: GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 2. Per gpu-chip / signal_pruning: GPU_CORE_FREQUENCY_MIN_CONTROL
-    // 3. Per gpu-chip save_control() call,
-    // 4. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 5. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 6. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MIN_CONTROL
-    // 7. Per gpu-chip / control_pruning GPU_CORE_FREQUENCY_MIN_CONTROL
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MIN_AVAIL
                 frequency_min(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_UNCORE_FREQUENCY_MIN_AVAIL
                 frequency_min(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
-    // EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_STATUS
-    //             frequency_status(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
-    // EXPECT_CALL(*m_device_pool, // GPU_UNCORE_FREQUENCY_STATUS
-    //             frequency_status(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_FREQUENCY_MAX_AVAIL
                 frequency_step(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_TEMPERATURE_MAXIMUM
@@ -917,64 +907,40 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
                 temperature_max(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY));
     EXPECT_CALL(*m_device_pool, // GPU_CORE_THROTTLE_REASONS
                 frequency_throttle_reasons(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE));
-    // EXPECT_CALL(*m_device_pool,
-    //             frequency_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE,
-    //                               0, 0)).Times(3);
-    // Times(3) explanation:
-    // 1. Per gpu-chip / control_pruning: GPU_CORE_FREQUENCY_MAX_CONTROL
-    // 2. Per gpu-chip / control_pruning: GPU_CORE_FREQUENCY_MIN_CONTROL
-    // 3. Per_gpu-chip restore_control() call.
-    EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
-                performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
+                power_limit_tdp(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
+                power_limit_max(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
+                power_limit_min(GEOPM_DOMAIN_GPU, 0, MockLevelZero::M_DOMAIN_ALL));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "XVE_ACTIVE"));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "XVE_STALL"));
+    EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
+                metric_sample(GEOPM_DOMAIN_GPU_CHIP, 0, "NUM_REPORTS"));
 
     // Expectations for save_control() and control pruning code in the constructor
     for (int sub_idx = 1; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
-        // the save_control() call, GPU_CORE_FREQUENCY_MAX_CONTROL (control pruning) * 2,
-        // and GPU_CORE_FREQUENCY_MIN_CONTROL (control pruning) * 2 = 5 times
-        // EXPECT_CALL(*m_device_pool,
-        //             frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(5);
+        // Only expecting the call from save_control() for domain idx > 0. The control pruning code
+        // will give up at the first exception thrown when checking
+        // GPU_CORE_FREQUENCY_[MIN|MAX]_CONTROL with domain idx = 0
+        EXPECT_CALL(*m_device_pool,
+                    frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(1);
 
-        // 1. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR_CONTROL
+        // 1. Per gpu-chip / save_control: GPU_CORE_PERFORMANCE_FACTOR
         // 2. Per gpu-chip / control pruning: GPU_CORE_PERFORMANCE_FACTOR_CONTROL (Alias to PERFORMANCE_FACTOR)
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR
                     performance_factor(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(2);
 
-        // GPU_CORE_FREQUENCY_MAX_CONTROL, GPU_CORE_FREQUENCY_MIN_CONTROL, and the restore_control() call
-        // EXPECT_CALL(*m_device_pool,
-        //             frequency_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE,
-        //                               0, 0)).Times(3);
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
                     performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
-
-        // ZET testing
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_ACTIVE
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE"));
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::XVE_STALL
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL"));
-        EXPECT_CALL(*m_device_pool, // LEVELZERO::METRIC::NUM_REPORTS
-                    metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
     }
-
-    // Expectations for signal pruning code in the constructor
-    for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
-        EXPECT_CALL(*m_device_pool, // GPU_ENERGY
-                    energy(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
-        EXPECT_CALL(*m_device_pool, // GPU_ENERGY_TIMESTAMP
-                    energy_timestamp(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
-        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_DEFAULT
-                    power_limit_tdp(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
-        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MAX_AVAIL
-                    power_limit_max(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
-        EXPECT_CALL(*m_device_pool, // GPU_POWER_LIMIT_MIN_AVAIL
-                    power_limit_min(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL));
-    }
-    // End copy/paste from SetUpDefaultExpectCalls
 
     // The implementation of the pruning code only tests each control on a
     // single domain index if a problem is encountered.  If there is a problem
     // on any chip, the signal is pruned and the remaining GPU_CHIPs are not
     // checked.
-    //Frequency
     EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_COMPUTE)).
                 WillOnce(Throw(geopm::Exception("Not Supported", GEOPM_ERROR_RUNTIME, __FILE__, __LINE__)));
     EXPECT_CALL(*m_device_pool, frequency_status(GEOPM_DOMAIN_GPU_CHIP, 0, MockLevelZero::M_DOMAIN_MEMORY)).
@@ -982,12 +948,6 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
 
     EXPECT_CALL(*m_device_pool, frequency_control(GEOPM_DOMAIN_GPU_CHIP, _, MockLevelZero::M_DOMAIN_COMPUTE, _, _)).
                 WillRepeatedly(Throw(geopm::Exception("Not Supported", GEOPM_ERROR_RUNTIME, __FILE__, __LINE__)));
-    for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
-        // frequency_range is called a non-standard number of times due to the implementation of the pruning code.
-        // Only one chip is checked if there is a failure.
-        EXPECT_CALL(*m_device_pool,
-                    frequency_range(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE)).Times(AtLeast(1));
-    }
 
     LevelZeroIOGroup levelzero_io(*m_platform_topo, *m_device_pool, nullptr);
 

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -372,7 +372,6 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
                                             4200000, 5200000, 1120000, 2621200000,};
 
     std::vector<double> mock_zet_num_reports = {23, 70, 50, 2, 5, 57, 88, 93};
-    std::vector<double> mock_zet_stall = {10, 9, 150, 510, 13, 14, 51, 45};
     std::vector<double> mock_zet_active = {124, 12, 23, 42, 45, 54, 68, 97};
 
     std::vector<int> batch_idx;
@@ -398,8 +397,13 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
     for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
         // On live systems we do not support read_signal of ZET signals.
         EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS")).WillOnce(Return(mock_zet_num_reports.at(sub_idx)));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+        EXPECT_CALL(*m_device_pool, metric_read(GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+    }
+
+    for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
         EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE")).WillOnce(Return(mock_zet_active.at(sub_idx)));
-        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL")).WillOnce(Return(mock_zet_stall.at(sub_idx)));
+        batch_idx.push_back(levelzero_io.push_signal("LEVELZERO::METRIC:XVE_ACTIVE", GEOPM_DOMAIN_GPU_CHIP, sub_idx));
     }
 
 
@@ -431,21 +435,19 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
         double energy_chip = levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
         double energy_chip_batch = levelzero_io.sample(batch_idx.at(sub_idx + 2 * m_num_gpu_subdevice));
 
-        EXPECT_DOUBLE_EQ(energy_chip, mock_energy_chip.at(sub_idx)/1e6);
+        EXPECT_DOUBLE_EQ(energy_chip, mock_energy_chip.at(sub_idx) / 1e6);
         EXPECT_DOUBLE_EQ(energy_chip, energy_chip_batch);
 
         //ZET
-        double num_reps = levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double num_reps = levelzero_io.sample(batch_idx.at(sub_idx + 3 * m_num_gpu_subdevice));
         EXPECT_DOUBLE_EQ(num_reps, mock_zet_num_reports.at(sub_idx));
-        double zet_stall = levelzero_io.read_signal("LEVELZERO::METRIC:XVE_STALL", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
-        EXPECT_DOUBLE_EQ(zet_stall, mock_zet_stall.at(sub_idx) / 100);
-        double zet_active = levelzero_io.read_signal("LEVELZERO::METRIC:XVE_ACTIVE", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
+        double zet_active = levelzero_io.sample(batch_idx.at(sub_idx + 4 * m_num_gpu_subdevice));
         EXPECT_DOUBLE_EQ(zet_active, mock_zet_active.at(sub_idx) / 100);
     }
 
     for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
         double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_GPU, gpu_idx);
-        double energy_batch = levelzero_io.sample(batch_idx.at(3 * m_num_gpu_subdevice + gpu_idx));
+        double energy_batch = levelzero_io.sample(batch_idx.at(5 * m_num_gpu_subdevice + gpu_idx));
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(gpu_idx)/1e6);
         EXPECT_DOUBLE_EQ(energy, energy_batch);
     }
@@ -470,6 +472,14 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
         EXPECT_CALL(*m_device_pool, energy(GEOPM_DOMAIN_GPU, gpu_idx, MockLevelZero::M_DOMAIN_ALL)).WillRepeatedly(Return(mock_energy.at(gpu_idx)));
     }
 
+    for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
+        // On live systems we do not support read_signal of ZET signals.
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS")).WillOnce(Return(mock_zet_num_reports.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE")).WillOnce(Return(mock_zet_active.at(sub_idx)));
+        //EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL")).WillOnce(Return(mock_zet_stall.at(sub_idx)));
+        EXPECT_CALL(*m_device_pool, metric_read(GEOPM_DOMAIN_GPU_CHIP, sub_idx));
+    }
+
     levelzero_io.read_batch();
     for (int sub_idx = 0; sub_idx < m_num_gpu_subdevice; ++sub_idx) {
         double frequency = levelzero_io.read_signal("LEVELZERO::GPU_CORE_FREQUENCY_STATUS", GEOPM_DOMAIN_GPU_CHIP, sub_idx);
@@ -487,11 +497,17 @@ TEST_F(LevelZeroIOGroupTest, read_signal_and_batch)
 
         EXPECT_DOUBLE_EQ(energy_chip, mock_energy_chip.at(sub_idx)/1e6);
         EXPECT_DOUBLE_EQ(energy_chip, energy_chip_batch);
+
+        //ZET
+        double num_reps = levelzero_io.sample(batch_idx.at(sub_idx + 3 * m_num_gpu_subdevice));
+        EXPECT_DOUBLE_EQ(num_reps, mock_zet_num_reports.at(sub_idx));
+        double zet_active = levelzero_io.sample(batch_idx.at(sub_idx + 4 * m_num_gpu_subdevice));
+        EXPECT_DOUBLE_EQ(zet_active, mock_zet_active.at(sub_idx) / 100);
     }
 
     for (int gpu_idx = 0; gpu_idx < m_num_gpu; ++gpu_idx) {
         double energy = levelzero_io.read_signal("LEVELZERO::GPU_ENERGY", GEOPM_DOMAIN_GPU, gpu_idx);
-        double energy_batch = levelzero_io.sample(batch_idx.at(3 * m_num_gpu_subdevice + gpu_idx));
+        double energy_batch = levelzero_io.sample(batch_idx.at(5 * m_num_gpu_subdevice + gpu_idx));
         EXPECT_DOUBLE_EQ(energy, mock_energy.at(gpu_idx) / 1e6);
         EXPECT_DOUBLE_EQ(energy, energy_batch);
     }
@@ -824,11 +840,12 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.write_control("LEVELZERO::GPU_CORE_FREQUENCY_MAX_CONTROL", GEOPM_DOMAIN_GPU_CHIP, -1, 1530000000),
                                GEOPM_ERROR_INVALID, "domain_idx out of range");
 
-    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
-    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
-    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
-    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0)));
-    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_UNCORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
+    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "only supports batch access.");
 }
 
 TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -5,6 +5,9 @@
 
 
 #include <unistd.h>
+#include <limits.h>
+
+#include <cmath>
 #include <fstream>
 #include <string>
 #include <cmath>
@@ -845,7 +848,9 @@ TEST_F(LevelZeroIOGroupTest, error_path)
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ACTIVE_TIME_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
     GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::GPU_CORE_ENERGY_TIMESTAMP", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "TIMESTAMP Signals are for batch use only.");
-    GEOPM_EXPECT_THROW_MESSAGE(levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, 0), GEOPM_ERROR_INVALID, "only supports batch access.");
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:NUM_REPORTS", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:XVE_ACTIVE", GEOPM_DOMAIN_GPU_CHIP, 0)));
+    EXPECT_TRUE(std::isnan(levelzero_io.read_signal("LEVELZERO::METRIC:XVE_STALL", GEOPM_DOMAIN_GPU_CHIP, 0)));
 }
 
 TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)

--- a/libgeopmd/test/LevelZeroIOGroupTest.cpp
+++ b/libgeopmd/test/LevelZeroIOGroupTest.cpp
@@ -35,6 +35,7 @@ using testing::Throw;
 using testing::AtLeast;
 using testing::_;
 using testing::StrictMock;
+using testing::NiceMock;
 
 class LevelZeroIOGroupTest : public :: testing :: Test
 {
@@ -238,6 +239,11 @@ void LevelZeroIOGroupTest::SetUpDefaultExpectCalls()
                                       0, 0)).Times(3);
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
                     performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+
+        // Metric signals are now probed on every GPU chip, not just chip 0.
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE"));
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL"));
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
     }
 }
 
@@ -935,6 +941,11 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
 
         EXPECT_CALL(*m_device_pool, // GPU_CORE_PERFORMANCE_FACTOR_CONTROL
                     performance_factor_control(GEOPM_DOMAIN_GPU_CHIP, sub_idx, MockLevelZero::M_DOMAIN_COMPUTE, 0)).Times(2);
+
+        // Metric signals are now probed on every GPU chip, not just chip 0.
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_ACTIVE"));
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "XVE_STALL"));
+        EXPECT_CALL(*m_device_pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, sub_idx, "NUM_REPORTS"));
     }
 
     // The implementation of the pruning code only tests each control on a
@@ -955,6 +966,30 @@ TEST_F(LevelZeroIOGroupTest, signal_and_control_trimming)
     EXPECT_FALSE(levelzero_io.is_valid_signal("LEVELZERO::GPU_UNCORE_FREQUENCY_STATUS"));
     EXPECT_FALSE(levelzero_io.is_valid_control("LEVELZERO::GPU_CORE_FREQUENCY_MIN_CONTROL"));
     EXPECT_FALSE(levelzero_io.is_valid_control("LEVELZERO::GPU_CORE_FREQUENCY_MAX_CONTROL"));
+}
+
+TEST_F(LevelZeroIOGroupTest, metric_heterogeneous_support)
+{
+    // A GPU chip whose Level Zero metrics failed to initialize makes
+    // metric_sample() throw for that chip.  Because GEOPM signal availability is
+    // per name, the metric signals must be pruned for every chip rather than
+    // left registered and throwing later from read_batch().  Probe chip 1 as the
+    // unsupported chip; all other probes return a valid value.
+    auto pool = std::make_shared<NiceMock<MockLevelZeroDevicePool> >();
+    ON_CALL(*pool, num_gpu(GEOPM_DOMAIN_GPU)).WillByDefault(Return(m_num_gpu));
+    ON_CALL(*pool, num_gpu(GEOPM_DOMAIN_GPU_CHIP)).WillByDefault(Return(m_num_gpu_subdevice));
+    ON_CALL(*pool, metric_sample(GEOPM_DOMAIN_GPU_CHIP, 1, _))
+        .WillByDefault(Throw(geopm::Exception("LevelZero::metric_sample: Metric groups not cached",
+                                              GEOPM_ERROR_INVALID, __FILE__, __LINE__)));
+
+    LevelZeroIOGroup levelzero_io(*m_platform_topo, *pool, nullptr);
+
+    // One unsupported chip disables the metric signals node-wide.
+    EXPECT_FALSE(levelzero_io.is_valid_signal("LEVELZERO::METRIC:XVE_ACTIVE"));
+    EXPECT_FALSE(levelzero_io.is_valid_signal("LEVELZERO::METRIC:XVE_STALL"));
+    EXPECT_FALSE(levelzero_io.is_valid_signal("LEVELZERO::METRIC:NUM_REPORTS"));
+    // Non-metric signals remain available.
+    EXPECT_TRUE(levelzero_io.is_valid_signal("LEVELZERO::GPU_UTILIZATION"));
 }
 
 TEST_F(LevelZeroIOGroupTest, save_restore_control)

--- a/libgeopmd/test/MockLevelZero.hpp
+++ b/libgeopmd/test/MockLevelZero.hpp
@@ -105,6 +105,12 @@ class MockLevelZero : public geopm::LevelZero
                     (unsigned int, int, int, double, double), (const, override));
         MOCK_METHOD(void, performance_factor_control,
                     (unsigned int, int, int, double), (const, override));
+
+        MOCK_METHOD(std::vector<double>, metric_sample,
+                    (unsigned int, unsigned int, std::string),
+                    (const, override));
+        MOCK_METHOD(uint32_t, metric_update_rate, (unsigned int), (const, override));
+        MOCK_METHOD(void, metric_read, (unsigned int, unsigned int), (override));
 };
 
 #endif

--- a/libgeopmd/test/MockLevelZero.hpp
+++ b/libgeopmd/test/MockLevelZero.hpp
@@ -110,6 +110,7 @@ class MockLevelZero : public geopm::LevelZero
                     (unsigned int, unsigned int, std::string),
                     (const, override));
         MOCK_METHOD(uint32_t, metric_update_rate, (unsigned int), (const, override));
+        MOCK_METHOD(void, metric_update_rate_control, (unsigned int, uint32_t), (override));
         MOCK_METHOD(void, metric_read, (unsigned int, unsigned int), (override));
 };
 

--- a/libgeopmd/test/MockLevelZeroDevicePool.hpp
+++ b/libgeopmd/test/MockLevelZeroDevicePool.hpp
@@ -91,6 +91,11 @@ class MockLevelZeroDevicePool : public geopm::LevelZeroDevicePool
                     (int, unsigned int, int, double, double),(const, override));
         MOCK_METHOD(void, performance_factor_control,
                     (int, unsigned int, int, double),(const, override));
+
+        MOCK_METHOD(double, metric_sample,
+                    (int, unsigned int, std::string), (const, override));
+        MOCK_METHOD(uint32_t, metric_update_rate, (int, unsigned int), (const, override));
+        MOCK_METHOD(void, metric_read, (int, unsigned int), (const, override));
 };
 
 #endif


### PR DESCRIPTION
## Summary

Adds LevelZero Tools & Metrics (ZET) support to GEOPM, exposing per-chip GPU activity signals sourced from the LevelZero metric streamer, and builds out the sampling path so telemetry stays accurate and cheap across a range of controller/monitor sampling periods. Also extends the GPU activity agent to use the new stall signal in its frequency decision and to react to idle GPUs.

## New capabilities

**LevelZero Tools & Metrics (ZET) signals.**
Introduces metric-streamer-backed signals on the existing `GPU_CHIP` domain, including `LEVELZERO::METRIC:XVE_ACTIVE`, `LEVELZERO::METRIC:XVE_STALL`, and `LEVELZERO::METRIC:NUM_REPORTS`, derived from time-based streamer reports via `CalculateMetricValues`. Collection spans all available GPU chips.

**IOGroup / DevicePool plumbing.**
Extends `LevelZeroIOGroup`, `LevelZeroDevicePool`, and the LevelZero implementation to register, read, and reduce the new metric signals, with accompanying mocks and unit tests.

**GPU activity agent: stall-aware frequency selection.**
When the `LEVELZERO::METRIC:XVE_STALL` signal is available, the agent discounts compute activity by the stall fraction (`gpu_core_activity *= (1 - stall)`) before selecting a frequency, so stall-heavy phases request a lower frequency for energy savings. It falls back to compute-activity-only selection when the stall signal is absent.

**GPU activity agent: idle reaction and tracking.**
Adds a debounced idle detector (per-chip idle timer) that drives GPUs to the minimum frequency after sustained idle when energy-biased, plus GPU on-time/on-energy and active-region tracking surfaced in the agent report.

## Sampling path robustness & performance

**Metric quality was coupled to the consumer's sampling period.**
The cost of turning raw streamer reports into metric values scales with the number of reports accumulated in the FIFO, and accumulation grows with the read period. A short period stayed healthy, but a slower consumer let the FIFO back up, stalling the streamer into multi-second `NOT_READY` bursts so telemetry stopped updating. The safe operating point was accidental, not guaranteed.

**Under-drained FIFO from a stale read-size.**
The read-buffer size was reused as the streamer's in/out byte count, so it collapsed to a single report after the first read and never recovered — every later read drained only ~1 report, leaving the FIFO to overflow and produce stale / misaligned data.

**Fix — decouple draining from computing ("read all, process last N").**
Each read now drains the entire FIFO using the full buffer, so freshness no longer depends on the read period, while only the most recent `DEFAULT_MAX_REPORTS_PER_READ` (30) reports are passed to `CalculateMetricValues`, bounding compute cost independent of period.

**Background keep-alive drain thread.**
A background thread drains active streamers on a fixed cadence (`METRIC_DRAIN_PERIOD_US`, 20 ms), independent of the controller loop, keeping the LevelZero metric streamer delivering continuously even when the controller reads infrequently; the controller's own reads count as drains so the two never fight.

**Robustness to dropped / empty data.**
Reads no longer throw on dropped data from the FIFO or on empty reports, avoiding spurious failures under overflow or idle GPUs.

**Per-sample overhead reductions.**
Pass the report buffer by reference instead of by value, and cache the metric name → report-index map rather than rebuilding it each sample.