### PR TITLE
geopmopt: force performance governor and use sticker frequency as cpu-freq default max

### DIFF
--- a/geopmdpy/geopmdpy/grid.py
+++ b/geopmdpy/geopmdpy/grid.py
@@ -27,11 +27,16 @@ _PREFETCHER_CONTROL_SEQUENCE = (
 # _MAX_PREFETCH_DISABLE_LEVEL represents the number of available prefetchers.
 #  Selecting the max value disables all prefetchers.
 _MAX_PREFETCH_DISABLE_LEVEL = len(_PREFETCHER_CONTROL_SEQUENCE)
+# CPU_FREQUENCY_MAX_CONTROL only caps the frequency; other governors (e.g.
+# powersave, schedutil) may still scale below the cap, so cpu_frequency
+# sweeps force the "performance" governor to make the requested value stick.
+_GOVERNOR_CONTROL = "CPU_FREQUENCY_GOVERNOR_CONTROL"
+_GOVERNOR_PERFORMANCE = 0
 _CLI_FLAG_TO_CONTROL = {
     "cpu_frequency": (
         "CPU_FREQUENCY_MAX_CONTROL",
         "CPU_FREQUENCY_MIN_AVAIL",
-        "CPU_FREQUENCY_MAX_AVAIL",
+        "CPU_FREQUENCY_STICKER", # Sticker (base) frequency, not the turbo max, is the default upper bound.
         "CPU_FREQUENCY_STEP",
     ),
     "cpu_uncore_frequency": (
@@ -703,6 +708,8 @@ class ControlGrid:
             min_control = dim["control"].replace("_MAX_", "_MIN_")
             if min_control != dim["control"] and min_control in pio.control_names() and min_control != "CPU_FREQUENCY_MIN_CONTROL":
                 result.append((min_control, dim["domain"], dim["domain_idx"], value))
+        if "cpu_frequency" in self.control_name:
+            result.insert(0, (_GOVERNOR_CONTROL, "board", 0, _GOVERNOR_PERFORMANCE))
         return result
 
     def get_config_str(self, coordinate: Optional[List[int]] = None):

--- a/geopmdpy/test/TestControlGrid.py
+++ b/geopmdpy/test/TestControlGrid.py
@@ -26,7 +26,7 @@ class TestControlGrid(TestCase):
         # Set up pio.read_signal to return consistent values for min, max, step
         self.mock_pio.read_signal.side_effect = lambda signal, domain, idx: float({
             'CPU_FREQUENCY_MIN_AVAIL': 1000000,
-            'CPU_FREQUENCY_MAX_AVAIL': 2000000,
+            'CPU_FREQUENCY_STICKER': 2000000,
             'CPU_FREQUENCY_STEP': 100000,
             'CPU_POWER_MIN_AVAIL': 100,
             'CPU_POWER_LIMIT_DEFAULT': 200,
@@ -164,7 +164,7 @@ class TestControlGrid(TestCase):
         # Mock values that don't divide evenly
         self.mock_pio.read_signal.side_effect = lambda signal, domain, idx: float({
             'CPU_FREQUENCY_MIN_AVAIL': 1000000,
-            'CPU_FREQUENCY_MAX_AVAIL': 2050000,  # Doesn't divide evenly by 100000
+            'CPU_FREQUENCY_STICKER': 2050000,  # Doesn't divide evenly by 100000
             'CPU_FREQUENCY_STEP': 100000,
         }.get(signal, 1000.0))
 
@@ -177,7 +177,7 @@ class TestControlGrid(TestCase):
         # Mock values where max < min
         self.mock_pio.read_signal.side_effect = lambda signal, domain, idx: float({
             'CPU_FREQUENCY_MIN_AVAIL': 2000000,
-            'CPU_FREQUENCY_MAX_AVAIL': 1000000,  # Max < min
+            'CPU_FREQUENCY_STICKER': 1000000,  # Max < min
             'CPU_FREQUENCY_STEP': 100000,
         }.get(signal, 1000.0))
 
@@ -242,9 +242,11 @@ class TestControlGrid(TestCase):
     def test_get_config(self):
         """Test getting configuration for specific coordinate"""
         config = self.grid.get_config([0, 1])
-        self.assertEqual(len(config), 2)
+        # 2 dimensions plus the forced performance-governor entry
+        self.assertEqual(len(config), 3)
         # Each config item should be a tuple with (control, domain, domain_idx, value)
         self.assertEqual(len(config[0]), 4)
+        self.assertEqual(config[0], ('CPU_FREQUENCY_GOVERNOR_CONTROL', 'board', 0, 0))
 
     def test_get_config_no_grid(self):
         """Test error when getting config with no grid configured"""
@@ -268,9 +270,10 @@ class TestControlGrid(TestCase):
         """Test write_config method with proper pio mocking"""
         self.grid.write_config([0, 1])
 
-        # Verify pio methods were called correctly
-        self.assertEqual(self.mock_pio.push_control.call_count, 2)
-        self.assertEqual(self.mock_pio.adjust.call_count, 2)
+        # Verify pio methods were called correctly: 2 dimensions plus the
+        # forced performance-governor entry
+        self.assertEqual(self.mock_pio.push_control.call_count, 3)
+        self.assertEqual(self.mock_pio.adjust.call_count, 3)
         self.mock_pio.write_batch.assert_called_once()
 
     def test_cli_flag_to_control_mappings(self):
@@ -321,7 +324,7 @@ class TestControlGrid(TestCase):
                         mock_topo.DOMAIN_BOARD = 0
                         mock_pio.read_signal.side_effect = lambda signal, domain, idx: float({
                             'CPU_FREQUENCY_MIN_AVAIL': 1000000,
-                            'CPU_FREQUENCY_MAX_AVAIL': 2000000,
+                            'CPU_FREQUENCY_STICKER': 2000000,
                             'CPU_FREQUENCY_STEP': 100000,
                         }.get(signal, 1000.0))
                         mock_pio.control_domain_type.return_value = 'package'
@@ -410,7 +413,8 @@ class TestControlGrid(TestCase):
         self.grid.coordinate = [0, 1]
 
         config = self.grid.get_config()  # No coordinate argument
-        self.assertEqual(len(config), 2)
+        # 2 dimensions plus the forced performance-governor entry
+        self.assertEqual(len(config), 3)
 
     def test_native_domain_resolves_domain(self):
         """native_domain maps the control signal to its native domain name"""


### PR DESCRIPTION
## Summary

Two related changes to the `geopmopt`/`ControlGrid` `cpu-freq` sweep dimension (`geopmdpy/geopmdpy/grid.py`):

1. **Force the `performance` governor when sweeping `cpu-freq`.**
   `CPU_FREQUENCY_MAX_CONTROL` only caps the frequency; under governors such as `powersave` or `schedutil` the CPU may still scale below the requested cap, making the sweep non-deterministic. `ControlGrid.get_config()` now prepends a `CPU_FREQUENCY_GOVERNOR_CONTROL` (board domain, value `0` = `performance`) entry whenever `cpu_frequency` is one of the swept dimensions, so both `--write` and the per-trial config file used by `geopmopt` set the governor before applying the frequency control.

2. **Default `cpu-freq` upper bound now uses the sticker (base) frequency instead of the turbo max.**
   The auto-detected range previously used `CPU_FREQUENCY_MAX_AVAIL` (opportunistic/turbo max) as the upper bound. It now uses `CPU_FREQUENCY_STICKER` (nominal/base frequency), which is more representative of a sustained, boost-free operating point. Users can still override the range explicitly, e.g. `--sweep cpu-freq=1.2GHz:3GHz`.

## Testing

- `python -m unittest test.TestControlGrid test.TestOptimizer` — 233 tests pass.
- Updated `TestControlGrid.py` mocks/assertions to reflect the new `CPU_FREQUENCY_STICKER` signal lookup and the extra governor-control entry emitted by `get_config()`/`write_config()`.
